### PR TITLE
Attempt to make CI run Pinecone tests more reliably

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -1,0 +1,50 @@
+name: Build nightly
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }} - ${{ matrix.java }}
+    strategy:
+      # PineconeEmbeddingStoreTest uses a single shared index, we can't run multiple CI runs on it at once
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        java: [17, 21]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Prepare git
+        run: git config --global core.autocrlf false
+        if: startsWith(matrix.os, 'windows')
+
+      - uses: actions/checkout@v3
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+          cache: 'maven'
+
+      - name: Build with Maven
+        run: mvn -B clean install -Dno-format
+        env:
+          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+          PINECONE_ENVIRONMENT: ${{ secrets.PINECONE_ENVIRONMENT }}
+          PINECONE_INDEX_NAME: ${{ secrets.PINECONE_INDEX_NAME }}
+          PINECONE_PROJECT_ID: ${{ secrets.PINECONE_PROJECT_ID }}
+
+      - name: Build with Maven (Native)
+        run: mvn -B install -Dnative -Dquarkus.native.container-build -Dnative.surefire.skip
+        env:
+          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+          PINECONE_ENVIRONMENT: ${{ secrets.PINECONE_ENVIRONMENT }}
+          PINECONE_INDEX_NAME: ${{ secrets.PINECONE_INDEX_NAME }}
+          PINECONE_PROJECT_ID: ${{ secrets.PINECONE_PROJECT_ID }}

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -1,17 +1,6 @@
-name: Build
+name: Build (on pull request)
 
 on:
-  push:
-    branches:
-      - "main"
-    paths-ignore:
-      - '.gitignore'
-      - 'CODEOWNERS'
-      - 'LICENSE'
-      - '*.md'
-      - '*.adoc'
-      - '*.txt'
-      - '.all-contributorsrc'
   pull_request:
     paths-ignore:
       - '.gitignore'

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -1,0 +1,50 @@
+name: Build (on push)
+
+on:
+  push:
+    branches:
+      - "main"
+    paths-ignore:
+      - '.gitignore'
+      - 'CODEOWNERS'
+      - 'LICENSE'
+      - '*.md'
+      - '*.adoc'
+      - '*.txt'
+      - '.all-contributorsrc'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }} - ${{ matrix.java }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        java: [17, 21]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Prepare git
+        run: git config --global core.autocrlf false
+        if: startsWith(matrix.os, 'windows')
+
+      - uses: actions/checkout@v3
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+          cache: 'maven'
+
+      - name: Build with Maven
+        run: mvn -B clean install -Dno-format
+
+      - name: Build with Maven (Native)
+        run: mvn -B install -Dnative -Dquarkus.native.container-build -Dnative.surefire.skip

--- a/pinecone/deployment/src/test/java/io/quarkiverse/langchain4j/pinecone/deployment/PineconeEmbeddingStoreTest.java
+++ b/pinecone/deployment/src/test/java/io/quarkiverse/langchain4j/pinecone/deployment/PineconeEmbeddingStoreTest.java
@@ -80,12 +80,13 @@ public class PineconeEmbeddingStoreTest {
         // Normally we would use deleteAll=true for deleting all vectors,
         // but that doesn't work in the gcp-starter environment,
         // so make it a two-step process instead by querying for all vectors, and then removing them.
+        Log.info("About to delete all embeddings");
         PineconeVectorOperationsApi client = embeddingStore.getUnderlyingClient();
         float[] vector = new float[384];
         QueryRequest allRequest = new QueryRequest(null, 10000L, false, false, vector);
         List<String> existingEntries = client.query(allRequest).getMatches().stream().map(VectorMatch::getId).toList();
         if (!existingEntries.isEmpty()) {
-            Log.info("Deleting " + existingEntries.size() + " embeddings");
+            Log.info("Deleting " + existingEntries.size() + " embeddings: " + existingEntries);
             client.delete(new DeleteRequest(existingEntries, false, null, null));
         }
 
@@ -97,7 +98,9 @@ public class PineconeEmbeddingStoreTest {
      */
     private static void delay() {
         try {
-            TimeUnit.SECONDS.sleep(30);
+            int timeout = 40;
+            Log.info("Waiting " + timeout + " seconds to allow Pinecone time to process deletions");
+            TimeUnit.SECONDS.sleep(timeout);
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
- split the workflow for pull_request/push to two workflows, where the one for 'push' (to main) doesn't include Pinecone tests
- introduce a new nightly workflow that runs Pinecone tests
- add a few more logging statements to make the Pinecone test troubleshooting easier in case all else fails