### PR TITLE
Make @RegisterAiService beans request scoped by default

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/DeclarativeAiServiceBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/DeclarativeAiServiceBuildItem.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 
+import io.quarkus.arc.processor.ScopeInfo;
 import io.quarkus.builder.item.MultiBuildItem;
 
 /**
@@ -19,18 +20,21 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
     private final DotName chatMemoryProviderSupplierClassDotName;
     private final DotName retrieverSupplierClassDotName;
     private final DotName auditServiceClassSupplierDotName;
+    private final ScopeInfo cdiScope;
 
     public DeclarativeAiServiceBuildItem(ClassInfo serviceClassInfo, DotName languageModelSupplierClassDotName,
             List<DotName> toolDotNames,
             DotName chatMemoryProviderSupplierClassDotName,
             DotName retrieverSupplierClassDotName,
-            DotName auditServiceClassSupplierDotName) {
+            DotName auditServiceClassSupplierDotName,
+            ScopeInfo cdiScope) {
         this.serviceClassInfo = serviceClassInfo;
         this.languageModelSupplierClassDotName = languageModelSupplierClassDotName;
         this.toolDotNames = toolDotNames;
         this.chatMemoryProviderSupplierClassDotName = chatMemoryProviderSupplierClassDotName;
         this.retrieverSupplierClassDotName = retrieverSupplierClassDotName;
         this.auditServiceClassSupplierDotName = auditServiceClassSupplierDotName;
+        this.cdiScope = cdiScope;
     }
 
     public ClassInfo getServiceClassInfo() {
@@ -55,5 +59,9 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
 
     public DotName getAuditServiceClassSupplierDotName() {
         return auditServiceClassSupplierDotName;
+    }
+
+    public ScopeInfo getCdiScope() {
+        return cdiScope;
     }
 }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/RegisterAiService.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/RegisterAiService.java
@@ -7,8 +7,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.util.function.Supplier;
 
-import jakarta.enterprise.context.ApplicationScoped;
-
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.ChatMemoryProvider;
@@ -24,7 +22,9 @@ import io.quarkiverse.langchain4j.audit.AuditService;
  * while also providing the builder with the proper {@link ChatLanguageModel} bean (mandatory), {@code tools} bean (optional),
  * {@link ChatMemoryProvider} and {@link Retriever} beans (which by default are configured if such beans exist).
  * <p>
- * NOTE: The resulting CDI bean is {@link ApplicationScoped}.
+ * NOTE: The resulting CDI bean is {@link jakarta.enterprise.context.RequestScoped} by default. If you need to change the scope,
+ * simply annotate the class with a CDI scope.
+ * CAUTION: When using anything other than the request scope, you need to be very careful with the chat memory implementation.
  * <p>
  * NOTE: When the application also contains the {@code quarkus-micrometer} extension, metrics are automatically generated
  * for the method invocations.

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/RemovableChatMemoryProvider.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/RemovableChatMemoryProvider.java
@@ -1,0 +1,13 @@
+package io.quarkiverse.langchain4j;
+
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+
+/**
+ * Extends {@link ChatMemoryProvider} to allow for removing {@link ChatMemory}
+ * when it is no longer needed.
+ */
+public interface RemovableChatMemoryProvider extends ChatMemoryProvider {
+
+    void remove(Object id);
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
@@ -115,6 +115,7 @@ public class AiServiceMethodImplementationSupport {
         }
 
         Object memoryId = memoryId(createInfo, methodArgs).orElse("default");
+        context.usedMemoryIds.add(memoryId);
 
         if (context.hasChatMemory()) {
             ChatMemory chatMemory = context.chatMemory(memoryId);

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/DeclarativeAiServiceBeanDestroyer.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/DeclarativeAiServiceBeanDestroyer.java
@@ -1,0 +1,24 @@
+package io.quarkiverse.langchain4j.runtime.aiservice;
+
+import java.util.Map;
+
+import jakarta.enterprise.context.spi.CreationalContext;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.arc.BeanDestroyer;
+
+public class DeclarativeAiServiceBeanDestroyer implements BeanDestroyer<AutoCloseable> {
+
+    private static final Logger log = Logger.getLogger(DeclarativeAiServiceBeanDestroyer.class);
+
+    @Override
+    public void destroy(AutoCloseable instance, CreationalContext<AutoCloseable> creationalContext,
+            Map<String, Object> params) {
+        try {
+            instance.close();
+        } catch (Exception e) {
+            log.error("Unable to close " + instance);
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceContext.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceContext.java
@@ -1,13 +1,44 @@
 package io.quarkiverse.langchain4j.runtime.aiservice;
 
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 import dev.langchain4j.service.AiServiceContext;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.RemovableChatMemoryProvider;
 import io.quarkiverse.langchain4j.audit.AuditService;
 
 public class QuarkusAiServiceContext extends AiServiceContext {
 
     public AuditService auditService;
 
+    public Set<Object> usedMemoryIds = ConcurrentHashMap.newKeySet();
+
     public QuarkusAiServiceContext(Class<?> aiServiceClass) {
         super(aiServiceClass);
+    }
+
+    /**
+     * This is called by the {@code close} method of AiServices registered with {@link RegisterAiService}
+     * when the bean's scope is closed
+     */
+    public void close() {
+        removeChatMemories();
+    }
+
+    private void removeChatMemories() {
+        if (usedMemoryIds.isEmpty()) {
+            return;
+        }
+        RemovableChatMemoryProvider removableChatMemoryProvider = null;
+        if (chatMemoryProvider instanceof RemovableChatMemoryProvider) {
+            removableChatMemoryProvider = (RemovableChatMemoryProvider) chatMemoryProvider;
+        }
+        for (Object memoryId : usedMemoryIds) {
+            if (removableChatMemoryProvider != null) {
+                removableChatMemoryProvider.remove(memoryId);
+            }
+            chatMemories.remove(memoryId);
+        }
     }
 }

--- a/docs/modules/ROOT/examples/io/quarkiverse/langchain4j/samples/ChatMemoryBean.java
+++ b/docs/modules/ROOT/examples/io/quarkiverse/langchain4j/samples/ChatMemoryBean.java
@@ -3,15 +3,14 @@ package io.quarkiverse.langchain4j.samples;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import jakarta.annotation.PreDestroy;
-import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Singleton;
 
 import dev.langchain4j.memory.ChatMemory;
-import dev.langchain4j.memory.chat.ChatMemoryProvider;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import io.quarkiverse.langchain4j.RemovableChatMemoryProvider;
 
-@RequestScoped
-public class ChatMemoryBean implements ChatMemoryProvider {
+@Singleton
+public class ChatMemoryBean implements RemovableChatMemoryProvider {
 
     private final Map<Object, ChatMemory> memories = new ConcurrentHashMap<>();
 
@@ -23,8 +22,8 @@ public class ChatMemoryBean implements ChatMemoryProvider {
                 .build());
     }
 
-    @PreDestroy
-    public void close() {
-        memories.clear();
+    @Override
+    public void remove(Object id) {
+        memories.remove(id);
     }
 }

--- a/docs/modules/ROOT/examples/io/quarkiverse/langchain4j/samples/MySmallMemoryProvider.java
+++ b/docs/modules/ROOT/examples/io/quarkiverse/langchain4j/samples/MySmallMemoryProvider.java
@@ -7,11 +7,12 @@ import java.util.function.Supplier;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.ChatMemoryProvider;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import io.quarkiverse.langchain4j.RemovableChatMemoryProvider;
 
 public class MySmallMemoryProvider implements Supplier<ChatMemoryProvider> {
     @Override
     public ChatMemoryProvider get() {
-        return new ChatMemoryProvider() {
+        return new RemovableChatMemoryProvider() {
             private final Map<Object, ChatMemory> memories = new ConcurrentHashMap<>();
 
             @Override
@@ -20,6 +21,11 @@ public class MySmallMemoryProvider implements Supplier<ChatMemoryProvider> {
                         .maxMessages(20)
                         .id(memoryId)
                         .build());
+            }
+
+            @Override
+            public void remove(Object id) {
+                memories.remove(id);
             }
         };
     }

--- a/docs/modules/ROOT/pages/agent-and-tools.adoc
+++ b/docs/modules/ROOT/pages/agent-and-tools.adoc
@@ -75,10 +75,7 @@ In the xref:ai-services.adoc[AI Service], you can specify the tools accessible t
 
 [source, java]
 ----
-@RegisterAiService(
-        chatMemoryProviderSupplier = RegisterAiService.BeanChatMemoryProviderSupplier.class,
-        tools = { EmailService.class }
-)
+@RegisterAiService(tools = EmailService.class)
 public interface MyAiService {
     // ...
 }
@@ -115,8 +112,8 @@ import org.jboss.resteasy.reactive.RestQuery;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.ChatMemoryProvider;
-import dev.langchain4j.memory.chat.MessageWindowChatMemory;
 import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.RemovableChatMemoryProvider;
 
 @Path("assistant-with-tool")
 public class AssistantWithToolsResource {
@@ -127,7 +124,7 @@ public class AssistantWithToolsResource {
         this.assistant = assistant;
     }
 
-    @GET  // <4>
+    @GET  // <6>
     public String get(@RestQuery String message) {
         return assistant.chat(message);
     }
@@ -151,8 +148,8 @@ public class AssistantWithToolsResource {
         }
     }
 
-    @RequestScoped // <2>
-    public static class ChatMemoryBean implements ChatMemoryProvider {
+    @Singleton // <2>
+    public static class ChatMemoryBean implements RemovableChatMemoryProvider {   // <3>
 
         private final Map<Object, ChatMemory> memories = new ConcurrentHashMap<>();
 
@@ -164,13 +161,12 @@ public class AssistantWithToolsResource {
                     .build());
         }
 
-        @PreDestroy
-        public void close() {
-            memories.clear();
+        public void remove(Object id) {    // <4>
+            memories.remove(id);
         }
     }
 
-    @RegisterAiService(tools = Calculator.class) // <3>
+    @RegisterAiService(tools = Calculator.class) // <5>
     public interface Assistant {
 
         String chat(String userMessage);
@@ -179,8 +175,10 @@ public class AssistantWithToolsResource {
 ----
 <1> Declare a CDI bean that provides three different tools
 <2> Declare a CDI bean for providing a simple in-memory message store
-<3> Register an AiService that responds to a user's request and has access to the calculator tools. This service is also able to keep track of the session's messages using the CDI message store declared above.
-<4> Declare an HTTP endpoint that retrieves the user's question via a query parameter and simply responds with chatbot's response
+<3> By making the bean implement `RemovableChatMemoryProvider`, the objects used as memory IDs are removed from memory when the service goes out of scope
+<4> The `remove` method is called automatically by Quarkus when an AiService goes out of scope in order to remove the memory objects used by said service
+<5> Register an AiService that responds to a user's request and has access to the calculator tools. This service is also able to keep track of the session's messages using the CDI message store declared above.
+<6> Declare an HTTP endpoint that retrieves the user's question via a query parameter and simply responds with chatbot's response
 
 Now, if we ask the chatbot `What is the square root of the sum of the numbers of letters in the words "hello" and "world"` via:
 

--- a/docs/modules/ROOT/pages/ai-services.adoc
+++ b/docs/modules/ROOT/pages/ai-services.adoc
@@ -27,6 +27,13 @@ Once registered, you can inject the _AI Service_ into your application:
 @Inject MyAiService service;
 ----
 
+[IMPORTANT]
+====
+The beans created by `@RegisterAiService` are `@RequestScoped` by default. The reason for this is that it enables removing chat <<memory>> objects.
+This is a good default when a service is used during when handling an HTTP request, but it's inappropriate in CLIs or in WebSockets (currently, but may change in the future).
+For example when using a service in a CLI, it makes sense to have the service be `@ApplicationScoped` and the extension allows this simply if the service is annotated with `@ApplicationScoped`.
+====
+
 == AI method declaration
 
 Within the interface annotated with `@RegisterAiService`, you model interactions with the LLM using _methods_. These methods accept parameters and are annotated with `@SystemMessage` and `@UserMessage` to define instructions directed to the LLM:
@@ -179,7 +186,7 @@ include::{examples-dir}/io/quarkiverse/langchain4j/samples/ChatMemoryBean.java[]
 
 Notice that the messages are deleted when the scope terminates (as it will call the `close` method).
 
-NOTE: It is recommended that the bean use the `@RequestScoped` scope or a scope not shared between users.
+NOTE: It is recommended to have your chat memory beans implement `RemovableChatMemoryProvider` because the objects used as memory IDs are removed from the memory when the service goes out of scope.
 
 Users can provide their own custom `ChatMemoryProvider` for use in the AiService by implementing `Supplier<ChatMemoryProvider>`, such as:
 

--- a/openai/openai-vanilla/deployment/src/test/java/org/acme/examples/aiservices/AuditingServiceTest.java
+++ b/openai/openai-vanilla/deployment/src/test/java/org/acme/examples/aiservices/AuditingServiceTest.java
@@ -126,6 +126,7 @@ public class AuditingServiceTest {
     }
 
     @RegisterAiService(tools = Calculator.class)
+    @Singleton
     interface Assistant {
 
         String chat(String message);

--- a/openai/openai-vanilla/deployment/src/test/java/org/acme/examples/aiservices/DeclarativeAiServicesTest.java
+++ b/openai/openai-vanilla/deployment/src/test/java/org/acme/examples/aiservices/DeclarativeAiServicesTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -105,6 +106,7 @@ public class DeclarativeAiServicesTest {
     Assistant assistant;
 
     @Test
+    @ActivateRequestContext
     public void test_simple_instruction_with_single_argument_and_no_annotations() throws IOException {
         String result = assistant.chat("Tell me a joke about developers");
         assertThat(result).isNotBlank();
@@ -129,6 +131,7 @@ public class DeclarativeAiServicesTest {
     SentimentAnalyzer sentimentAnalyzer;
 
     @Test
+    @ActivateRequestContext
     void test_extract_enum() throws IOException {
         wireMockServer.stubFor(WiremockUtils.chatCompletionsMessageContent(Optional.empty(), "POSITIVE"));
 
@@ -213,6 +216,7 @@ public class DeclarativeAiServicesTest {
     AssistantWithCalculator assistantWithCalculator;
 
     @Test
+    @ActivateRequestContext
     void should_execute_tool_then_answer() throws IOException {
         var firstResponse = """
                 {
@@ -308,6 +312,7 @@ public class DeclarativeAiServicesTest {
     ChatWithSeparateMemoryForEachUser chatWithSeparateMemoryForEachUser;
 
     @Test
+    @ActivateRequestContext
     void should_keep_separate_chat_memory_for_each_user_in_store() throws IOException {
 
         ChatMemoryStore store = Arc.container().instance(ChatMemoryStore.class).get();

--- a/samples/chatbot/pom.xml
+++ b/samples/chatbot/pom.xml
@@ -22,6 +22,10 @@
             <artifactId>quarkus-websockets</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-context-propagation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkiverse.langchain4j</groupId>
             <artifactId>quarkus-langchain4j-openai</artifactId>
             <version>${project.version}</version>

--- a/samples/chatbot/src/main/java/io/quarkiverse/langchain4j/sample/chatbot/Bot.java
+++ b/samples/chatbot/src/main/java/io/quarkiverse/langchain4j/sample/chatbot/Bot.java
@@ -1,11 +1,14 @@
 package io.quarkiverse.langchain4j.sample.chatbot;
 
+import jakarta.inject.Singleton;
+
 import dev.langchain4j.service.MemoryId;
 import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import io.quarkiverse.langchain4j.RegisterAiService;
 
 @RegisterAiService
+@Singleton // this is singleton because WebSockets currently never closes the scope
 public interface Bot {
 
     @SystemMessage("""

--- a/samples/chatbot/src/main/java/io/quarkiverse/langchain4j/sample/chatbot/ChatBotWebSocket.java
+++ b/samples/chatbot/src/main/java/io/quarkiverse/langchain4j/sample/chatbot/ChatBotWebSocket.java
@@ -6,7 +6,7 @@ import jakarta.inject.Inject;
 import jakarta.websocket.*;
 import jakarta.websocket.server.ServerEndpoint;
 
-import io.smallrye.mutiny.infrastructure.Infrastructure;
+import org.eclipse.microprofile.context.ManagedExecutor;
 
 @ServerEndpoint("/chatbot")
 public class ChatBotWebSocket {
@@ -15,11 +15,14 @@ public class ChatBotWebSocket {
     Bot bot;
 
     @Inject
+    ManagedExecutor managedExecutor;
+
+    @Inject
     ChatMemoryBean chatMemoryBean;
 
     @OnOpen
     public void onOpen(Session session) {
-        Infrastructure.getDefaultExecutor().execute(() -> {
+        managedExecutor.execute(() -> {
             String response = bot.chat(session, "hello");
             try {
                 session.getBasicRemote().sendText(response);
@@ -36,7 +39,7 @@ public class ChatBotWebSocket {
 
     @OnMessage
     public void onMessage(String message, Session session) {
-        Infrastructure.getDefaultExecutor().execute(() -> {
+        managedExecutor.execute(() -> {
             String response = bot.chat(session, message);
             try {
                 session.getBasicRemote().sendText(response);

--- a/samples/csv-chatbot/pom.xml
+++ b/samples/csv-chatbot/pom.xml
@@ -22,6 +22,10 @@
             <artifactId>quarkus-websockets</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-context-propagation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkiverse.langchain4j</groupId>
             <artifactId>quarkus-langchain4j-openai</artifactId>
             <version>${project.version}</version>

--- a/samples/csv-chatbot/src/main/java/io/quarkiverse/langchain4j/sample/chatbot/ChatBotWebSocket.java
+++ b/samples/csv-chatbot/src/main/java/io/quarkiverse/langchain4j/sample/chatbot/ChatBotWebSocket.java
@@ -3,10 +3,13 @@ package io.quarkiverse.langchain4j.sample.chatbot;
 import java.io.IOException;
 
 import jakarta.inject.Inject;
-import jakarta.websocket.*;
+import jakarta.websocket.OnClose;
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.OnOpen;
+import jakarta.websocket.Session;
 import jakarta.websocket.server.ServerEndpoint;
 
-import io.smallrye.mutiny.infrastructure.Infrastructure;
+import org.eclipse.microprofile.context.ManagedExecutor;
 
 @ServerEndpoint("/chatbot")
 public class ChatBotWebSocket {
@@ -15,11 +18,14 @@ public class ChatBotWebSocket {
     MovieMuse bot;
 
     @Inject
+    ManagedExecutor managedExecutor;
+
+    @Inject
     ChatMemoryBean chatMemoryBean;
 
     @OnOpen
     public void onOpen(Session session) {
-        Infrastructure.getDefaultExecutor().execute(() -> {
+        managedExecutor.execute(() -> {
             String response = bot.chat(session, "hello");
             try {
                 session.getBasicRemote().sendText(response);
@@ -36,7 +42,7 @@ public class ChatBotWebSocket {
 
     @OnMessage
     public void onMessage(String message, Session session) {
-        Infrastructure.getDefaultExecutor().execute(() -> {
+        managedExecutor.execute(() -> {
             String response = bot.chat(session, message);
             try {
                 session.getBasicRemote().sendText(response);

--- a/samples/csv-chatbot/src/main/java/io/quarkiverse/langchain4j/sample/chatbot/MovieMuse.java
+++ b/samples/csv-chatbot/src/main/java/io/quarkiverse/langchain4j/sample/chatbot/MovieMuse.java
@@ -1,11 +1,14 @@
 package io.quarkiverse.langchain4j.sample.chatbot;
 
+import jakarta.inject.Singleton;
+
 import dev.langchain4j.service.MemoryId;
 import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import io.quarkiverse.langchain4j.RegisterAiService;
 
 @RegisterAiService
+@Singleton // this is singleton because WebSockets currently never closes the scope
 public interface MovieMuse {
 
     @SystemMessage("""

--- a/samples/email-a-poem/src/main/java/io/quarkiverse/langchain4j/sample/ChatMemoryBean.java
+++ b/samples/email-a-poem/src/main/java/io/quarkiverse/langchain4j/sample/ChatMemoryBean.java
@@ -3,15 +3,14 @@ package io.quarkiverse.langchain4j.sample;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import jakarta.annotation.PreDestroy;
-import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Singleton;
 
 import dev.langchain4j.memory.ChatMemory;
-import dev.langchain4j.memory.chat.ChatMemoryProvider;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import io.quarkiverse.langchain4j.RemovableChatMemoryProvider;
 
-@RequestScoped
-public class ChatMemoryBean implements ChatMemoryProvider {
+@Singleton
+public class ChatMemoryBean implements RemovableChatMemoryProvider {
 
     private final Map<Object, ChatMemory> memories = new ConcurrentHashMap<>();
 
@@ -23,8 +22,8 @@ public class ChatMemoryBean implements ChatMemoryProvider {
                 .build());
     }
 
-    @PreDestroy
-    public void close() {
-        memories.clear();
+    @Override
+    public void remove(Object id) {
+        memories.remove(id);
     }
 }


### PR DESCRIPTION
This is done because otherwise the chat memory
does not get cleared properly.

Fixes: #95

Do we need a docs update to go along with this?