### PR TITLE
called out the explicit models + some docs/links

### DIFF
--- a/hugging-face/deployment/src/main/java/io/quarkiverse/langchain4j/huggingface/deployment/ChatModelBuildConfig.java
+++ b/hugging-face/deployment/src/main/java/io/quarkiverse/langchain4j/huggingface/deployment/ChatModelBuildConfig.java
@@ -9,7 +9,7 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 public interface ChatModelBuildConfig {
 
     /**
-     * Whether the model should be enabled
+     * Whether the chat model should be enabled
      */
     @ConfigDocDefault("true")
     Optional<Boolean> enabled();

--- a/hugging-face/deployment/src/main/java/io/quarkiverse/langchain4j/huggingface/deployment/EmbeddingModelBuildConfig.java
+++ b/hugging-face/deployment/src/main/java/io/quarkiverse/langchain4j/huggingface/deployment/EmbeddingModelBuildConfig.java
@@ -9,7 +9,7 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 public interface EmbeddingModelBuildConfig {
 
     /**
-     * Whether the model should be enabled
+     * Whether the embedding model should be enabled
      */
     @ConfigDocDefault("true")
     Optional<Boolean> enabled();

--- a/hugging-face/deployment/src/main/java/io/quarkiverse/langchain4j/huggingface/deployment/ModerationModelBuildConfig.java
+++ b/hugging-face/deployment/src/main/java/io/quarkiverse/langchain4j/huggingface/deployment/ModerationModelBuildConfig.java
@@ -9,7 +9,8 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 public interface ModerationModelBuildConfig {
 
     /**
-     * Whether the model should be enabled
+     * Whether the moderation model should be enabled.
+     * 
      */
     @ConfigDocDefault("true")
     Optional<Boolean> enabled();

--- a/ollama/deployment/src/main/java/io/quarkiverse/langchain4j/ollama/deployment/ChatModelBuildConfig.java
+++ b/ollama/deployment/src/main/java/io/quarkiverse/langchain4j/ollama/deployment/ChatModelBuildConfig.java
@@ -9,7 +9,7 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 public interface ChatModelBuildConfig {
 
     /**
-     * Whether the model should be enabled
+     * Whether the chat model should be enabled
      */
     @ConfigDocDefault("true")
     Optional<Boolean> enabled();

--- a/openai/azure-openai/deployment/src/main/java/io/quarkiverse/langchain4j/azure/openai/deployment/ChatModelBuildConfig.java
+++ b/openai/azure-openai/deployment/src/main/java/io/quarkiverse/langchain4j/azure/openai/deployment/ChatModelBuildConfig.java
@@ -9,7 +9,7 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 public interface ChatModelBuildConfig {
 
     /**
-     * Whether the model should be enabled
+     * Whether the chat model should be enabled
      */
     @ConfigDocDefault("true")
     Optional<Boolean> enabled();

--- a/openai/azure-openai/deployment/src/main/java/io/quarkiverse/langchain4j/azure/openai/deployment/EmbeddingModelBuildConfig.java
+++ b/openai/azure-openai/deployment/src/main/java/io/quarkiverse/langchain4j/azure/openai/deployment/EmbeddingModelBuildConfig.java
@@ -9,7 +9,7 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 public interface EmbeddingModelBuildConfig {
 
     /**
-     * Whether the model should be enabled
+     * Whether the embedding model should be enabled
      */
     @ConfigDocDefault("true")
     Optional<Boolean> enabled();

--- a/openai/azure-openai/deployment/src/main/java/io/quarkiverse/langchain4j/azure/openai/deployment/ModerationModelBuildConfig.java
+++ b/openai/azure-openai/deployment/src/main/java/io/quarkiverse/langchain4j/azure/openai/deployment/ModerationModelBuildConfig.java
@@ -9,7 +9,7 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 public interface ModerationModelBuildConfig {
 
     /**
-     * Whether the model should be enabled
+     * Whether the moderation model should be enabled
      */
     @ConfigDocDefault("true")
     Optional<Boolean> enabled();

--- a/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/ChatModelBuildConfig.java
+++ b/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/ChatModelBuildConfig.java
@@ -9,7 +9,7 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 public interface ChatModelBuildConfig {
 
     /**
-     * Whether the model should be enabled
+     * Whether the chat model should be enabled
      */
     @ConfigDocDefault("true")
     Optional<Boolean> enabled();

--- a/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/EmbeddingModelBuildConfig.java
+++ b/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/EmbeddingModelBuildConfig.java
@@ -9,7 +9,7 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 public interface EmbeddingModelBuildConfig {
 
     /**
-     * Whether the model should be enabled
+     * Whether the embedding model should be enabled
      */
     @ConfigDocDefault("true")
     Optional<Boolean> enabled();

--- a/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/ModerationModelBuildConfig.java
+++ b/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/ModerationModelBuildConfig.java
@@ -9,7 +9,7 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 public interface ModerationModelBuildConfig {
 
     /**
-     * Whether the model should be enabled
+     * Whether the moderation model should be enabled
      */
     @ConfigDocDefault("true")
     Optional<Boolean> enabled();

--- a/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/ChatModelConfig.java
+++ b/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/ChatModelConfig.java
@@ -9,7 +9,9 @@ import io.smallrye.config.WithDefault;
 public interface ChatModelConfig {
 
     /**
-     * Model name to use
+     * Chat model name to use.
+     * 
+     * See https://platform.openai.com/docs/models/overview for a list of available models. 
      */
     @WithDefault("gpt-3.5-turbo")
     String modelName();

--- a/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/EmbeddingModelConfig.java
+++ b/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/EmbeddingModelConfig.java
@@ -7,7 +7,9 @@ import io.smallrye.config.WithDefault;
 public interface EmbeddingModelConfig {
 
     /**
-     * Model name to use
+     * Embedding Model name to use
+     * 
+     * See https://platform.openai.com/docs/guides/embeddings/embedding-models for a list of available models.
      */
     @WithDefault("text-embedding-ada-002")
     String modelName();

--- a/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/ModerationModelConfig.java
+++ b/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/ModerationModelConfig.java
@@ -7,7 +7,9 @@ import io.smallrye.config.WithDefault;
 public interface ModerationModelConfig {
 
     /**
-     * Model name to use
+     * Moderation Model name to use. 
+     *
+     * See https://platform.openai.com/docs/guides/moderation/overview for a list of available models.
      */
     @WithDefault("text-moderation-latest")
     String modelName();


### PR DESCRIPTION
wanted to just add links to the openai model config keys but then saw all the repeated "model" in docs that I was not finding when searching for i.e. "moderation model" so started adding them.

but then realized this will have to be duplicated for all the various models....not sure if any better way but at least with this ctrl+F works for me :) 