### PR TITLE
Use previous version of POI extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.version>3.6.1</quarkus.version>
     <langchain4j.version>0.24.0</langchain4j.version>
-    <quarkus-poi.version>2.0.5</quarkus-poi.version>
+    <quarkus-poi.version>2.0.4</quarkus-poi.version> <!-- we need to use this version because langchain4j uses POI 5.2.3 instead of 5.2.5 and the substitution needed is different in the two versions -->
     <assertj.version>3.24.2</assertj.version>
     <wiremock.version>3.3.1</wiremock.version>
     <pgvector-java.version>0.1.4</pgvector-java.version>


### PR DESCRIPTION
This is needed because Langchain4j
used POI 5.2.3 which requires the
substitution present in version 2.0.4
of the extension in order to work
on Mac