### PR TITLE
Get rid of warning by removing duplicate micrometer dependency

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=17.0.9-tem

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -31,11 +31,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-core</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
             <artifactId>opentelemetry-instrumentation-api</artifactId>
             <optional>true</optional>


### PR DESCRIPTION
Also add a .sdkmanrc in passing.