### PR TITLE
Adding the user config property for openai embedding model

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai.adoc
@@ -385,6 +385,23 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
+a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.embedding-model.user]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.embedding-model.user[quarkus.langchain4j.openai.embedding-model.user]`
+
+
+[.description]
+--
+A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_EMBEDDING_MODEL_USER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_EMBEDDING_MODEL_USER+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|`default`
+
+
 a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.moderation-model.model-name]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.moderation-model.model-name[quarkus.langchain4j.openai.moderation-model.model-name]`
 
 

--- a/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
+++ b/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
@@ -103,7 +103,8 @@ public class OpenAiRecorder {
                 .maxRetries(runtimeConfig.maxRetries())
                 .logRequests(firstOrDefault(false, embeddingModelConfig.logRequests(), runtimeConfig.logRequests()))
                 .logResponses(firstOrDefault(false, embeddingModelConfig.logResponses(), runtimeConfig.logResponses()))
-                .modelName(embeddingModelConfig.modelName());
+                .modelName(embeddingModelConfig.modelName())
+                .user(embeddingModelConfig.user());
 
         runtimeConfig.organizationId().ifPresent(builder::organizationId);
 

--- a/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/EmbeddingModelConfig.java
+++ b/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/EmbeddingModelConfig.java
@@ -26,4 +26,10 @@ public interface EmbeddingModelConfig {
      */
     @ConfigDocDefault("false")
     Optional<Boolean> logResponses();
+
+    /**
+     * A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+     */
+    @WithDefault("default")
+    String user();
 }


### PR DESCRIPTION
This fixes a regression that appeared with `0.5.1` , the OpenAI Embedding request is failing because an user with `null` value was passed to the request. 
This add the `user` property , I added a default value because that was the only way to get the request passed. 

