### PR TITLE
Refactor retriever use in `@RegisterAiService`

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/DeclarativeAiServiceBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/DeclarativeAiServiceBuildItem.java
@@ -18,7 +18,7 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
     private final List<DotName> toolDotNames;
 
     private final DotName chatMemoryProviderSupplierClassDotName;
-    private final DotName retrieverSupplierClassDotName;
+    private final DotName retrieverClassDotName;
     private final DotName auditServiceClassSupplierDotName;
     private final DotName moderationModelSupplierDotName;
     private final ScopeInfo cdiScope;
@@ -26,7 +26,7 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
     public DeclarativeAiServiceBuildItem(ClassInfo serviceClassInfo, DotName languageModelSupplierClassDotName,
             List<DotName> toolDotNames,
             DotName chatMemoryProviderSupplierClassDotName,
-            DotName retrieverSupplierClassDotName,
+            DotName retrieverClassDotName,
             DotName auditServiceClassSupplierDotName,
             DotName moderationModelSupplierDotName,
             ScopeInfo cdiScope) {
@@ -34,7 +34,7 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
         this.languageModelSupplierClassDotName = languageModelSupplierClassDotName;
         this.toolDotNames = toolDotNames;
         this.chatMemoryProviderSupplierClassDotName = chatMemoryProviderSupplierClassDotName;
-        this.retrieverSupplierClassDotName = retrieverSupplierClassDotName;
+        this.retrieverClassDotName = retrieverClassDotName;
         this.auditServiceClassSupplierDotName = auditServiceClassSupplierDotName;
         this.moderationModelSupplierDotName = moderationModelSupplierDotName;
         this.cdiScope = cdiScope;
@@ -56,8 +56,8 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
         return chatMemoryProviderSupplierClassDotName;
     }
 
-    public DotName getRetrieverSupplierClassDotName() {
-        return retrieverSupplierClassDotName;
+    public DotName getRetrieverClassDotName() {
+        return retrieverClassDotName;
     }
 
     public DotName getAuditServiceClassSupplierDotName() {

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/Langchain4jDotNames.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/Langchain4jDotNames.java
@@ -2,7 +2,6 @@ package io.quarkiverse.langchain4j.deployment;
 
 import org.jboss.jandex.DotName;
 
-import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.memory.chat.ChatMemoryProvider;
 import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
@@ -51,15 +50,10 @@ public class Langchain4jDotNames {
             RegisterAiService.BeanChatMemoryProviderSupplier.class);
 
     static final DotName RETRIEVER = DotName.createSimple(Retriever.class);
-    static final DotName TEXT_SEGMENT = DotName.createSimple(TextSegment.class);
+    static final DotName NO_RETRIEVER = DotName.createSimple(
+            RegisterAiService.NoRetriever.class);
 
     static final DotName AUDIT_SERVICE = DotName.createSimple(AuditService.class);
-
-    static final DotName BEAN_RETRIEVER_SUPPLIER = DotName.createSimple(
-            RegisterAiService.BeanRetrieverSupplier.class);
-
-    static final DotName BEAN_IF_EXISTS_RETRIEVER_SUPPLIER = DotName.createSimple(
-            RegisterAiService.BeanIfExistsRetrieverSupplier.class);
 
     static final DotName BEAN_IF_EXISTS_AUDIT_SERVICE_SUPPLIER = DotName.createSimple(
             RegisterAiService.BeanIfExistsAuditServiceSupplier.class);

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/RegisterAiService.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/RegisterAiService.java
@@ -5,6 +5,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+import java.util.List;
 import java.util.function.Supplier;
 
 import dev.langchain4j.data.segment.TextSegment;
@@ -73,13 +74,10 @@ public @interface RegisterAiService {
     Class<? extends Supplier<ChatMemoryProvider>> chatMemoryProviderSupplier() default BeanChatMemoryProviderSupplier.class;
 
     /**
-     * Configures the way to obtain the {@link Retriever} to use (when using RAG).
+     * Configures the way to obtain the {@link Retriever} to use (when using RAG). All tools are expected to be CDI beans
      * By default, no supplier is used.
-     * If a CDI bean of type {@link ChatMemory} is needed, the value should be {@link BeanRetrieverSupplier}.
-     * If an arbitrary {@link ChatMemory} instance is needed, a custom implementation of {@link Supplier<ChatMemory>}
-     * needs to be provided.
      */
-    Class<? extends Supplier<Retriever<TextSegment>>> retrieverSupplier() default NoRetrieverSupplier.class;
+    Class<? extends Retriever<TextSegment>> retriever() default NoRetriever.class;
 
     /**
      * Configures the way to obtain the {@link AuditService} to use.
@@ -128,35 +126,12 @@ public @interface RegisterAiService {
     }
 
     /**
-     * Marker that is used to tell Quarkus to use the retriever that the user has configured as a CDI bean
-     */
-    final class BeanRetrieverSupplier implements Supplier<Retriever<TextSegment>> {
-
-        @Override
-        public Retriever<TextSegment> get() {
-            throw new UnsupportedOperationException("should never be called");
-        }
-    }
-
-    /**
-     * Marker that is used to tell Quarkus to use the {@link Retriever} that the user has configured as a CDI bean.
-     * If no such bean exists, then no retriever will be used.
-     */
-    final class BeanIfExistsRetrieverSupplier implements Supplier<Retriever<TextSegment>> {
-
-        @Override
-        public Retriever<TextSegment> get() {
-            throw new UnsupportedOperationException("should never be called");
-        }
-    }
-
-    /**
      * Marker class to indicate that no retriever should be used
      */
-    final class NoRetrieverSupplier implements Supplier<Retriever<TextSegment>> {
+    final class NoRetriever implements Retriever<TextSegment> {
 
         @Override
-        public Retriever<TextSegment> get() {
+        public List<TextSegment> findRelevant(String text) {
             throw new UnsupportedOperationException("should never be called");
         }
     }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/AiServicesRecorder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/AiServicesRecorder.java
@@ -113,25 +113,9 @@ public class AiServicesRecorder {
                         }
                     }
 
-                    if (info.getRetrieverSupplierClassName() != null) {
-                        if (RegisterAiService.BeanRetrieverSupplier.class.getName()
-                                .equals(info.getRetrieverSupplierClassName())) {
-                            quarkusAiServices.retriever(creationalContext.getInjectedReference(new TypeLiteral<>() {
-                            }));
-                        } else if (RegisterAiService.BeanIfExistsRetrieverSupplier.class.getName()
-                                .equals(info.getRetrieverSupplierClassName())) {
-                            Instance<Retriever<TextSegment>> instance = creationalContext
-                                    .getInjectedReference(RETRIEVER_INSTANCE_TYPE_LITERAL);
-                            if (instance.isResolvable()) {
-                                quarkusAiServices.retriever(instance.get());
-                            }
-                        } else {
-                            @SuppressWarnings("rawtypes")
-                            Supplier<? extends Retriever> supplier = (Supplier<? extends Retriever>) Thread
-                                    .currentThread().getContextClassLoader().loadClass(info.getRetrieverSupplierClassName())
-                                    .getConstructor().newInstance();
-                            quarkusAiServices.retriever(supplier.get());
-                        }
+                    if (info.getRetrieverClassName() != null) {
+                        quarkusAiServices.retriever((Retriever<TextSegment>) creationalContext.getInjectedReference(
+                                Thread.currentThread().getContextClassLoader().loadClass(info.getRetrieverClassName())));
                     }
 
                     if (info.getAuditServiceClassSupplierName() != null) {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/DeclarativeAiServiceCreateInfo.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/DeclarativeAiServiceCreateInfo.java
@@ -10,7 +10,7 @@ public class DeclarativeAiServiceCreateInfo {
     private final String languageModelSupplierClassName;
     private final List<String> toolsClassNames;
     private final String chatMemoryProviderSupplierClassName;
-    private final String retrieverSupplierClassName;
+    private final String retrieverClassName;
 
     private final String auditServiceClassSupplierName;
     private final String moderationModelSupplierClassName;
@@ -18,14 +18,14 @@ public class DeclarativeAiServiceCreateInfo {
     @RecordableConstructor
     public DeclarativeAiServiceCreateInfo(String serviceClassName, String languageModelSupplierClassName,
             List<String> toolsClassNames, String chatMemoryProviderSupplierClassName,
-            String retrieverSupplierClassName,
+            String retrieverClassName,
             String auditServiceClassSupplierName,
             String moderationModelSupplierClassName) {
         this.serviceClassName = serviceClassName;
         this.languageModelSupplierClassName = languageModelSupplierClassName;
         this.toolsClassNames = toolsClassNames;
         this.chatMemoryProviderSupplierClassName = chatMemoryProviderSupplierClassName;
-        this.retrieverSupplierClassName = retrieverSupplierClassName;
+        this.retrieverClassName = retrieverClassName;
         this.auditServiceClassSupplierName = auditServiceClassSupplierName;
         this.moderationModelSupplierClassName = moderationModelSupplierClassName;
     }
@@ -46,8 +46,8 @@ public class DeclarativeAiServiceCreateInfo {
         return chatMemoryProviderSupplierClassName;
     }
 
-    public String getRetrieverSupplierClassName() {
-        return retrieverSupplierClassName;
+    public String getRetrieverClassName() {
+        return retrieverClassName;
     }
 
     public String getAuditServiceClassSupplierName() {

--- a/docs/modules/ROOT/pages/retrievers.adoc
+++ b/docs/modules/ROOT/pages/retrievers.adoc
@@ -69,7 +69,5 @@ Configure the maximum number of documents to retrieve (e.g., 20 in the example) 
 Make sure that the number of documents is not too high (or document too large).
 More document you have, more data you are adding to the LLM context, and you may exceed the limit.
 
-A retriever is used by default in your AI service, simply by having said retriever configured as a CDI bean,
-
-Alternatively, implement a class implementing `Supplier<Retriever<TextSegment>>` if you prefer not to expose the retriever as a CDI bean.
-Then, configure the `retrieverSupplier` attribute to point to your implementation.
+An AI service does not use a retriever by default, one needs to be configured explicitly via the `retriever` property of `@RegisterAiService` and the configured
+retriever is expected to be a CDI bean.

--- a/samples/chatbot/src/main/java/io/quarkiverse/langchain4j/sample/chatbot/Bot.java
+++ b/samples/chatbot/src/main/java/io/quarkiverse/langchain4j/sample/chatbot/Bot.java
@@ -7,7 +7,7 @@ import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import io.quarkiverse.langchain4j.RegisterAiService;
 
-@RegisterAiService
+@RegisterAiService(retriever = RetrieverExample.class)
 @Singleton // this is singleton because WebSockets currently never closes the scope
 public interface Bot {
 

--- a/samples/csv-chatbot/src/main/java/io/quarkiverse/langchain4j/sample/chatbot/MovieMuse.java
+++ b/samples/csv-chatbot/src/main/java/io/quarkiverse/langchain4j/sample/chatbot/MovieMuse.java
@@ -7,7 +7,7 @@ import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import io.quarkiverse.langchain4j.RegisterAiService;
 
-@RegisterAiService
+@RegisterAiService(retriever = RetrieverExample.class)
 @Singleton // this is singleton because WebSockets currently never closes the scope
 public interface MovieMuse {
 


### PR DESCRIPTION
With this change a retriever is no longer
added by default to an AiService,
but needs to be configured explicitly.

- Closes: #184