### PR TITLE
Throw a more meaningful exception instead of NPE when tool is not found

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
@@ -179,6 +179,9 @@ public class AiServiceMethodImplementationSupport {
             for (ToolExecutionRequest toolExecutionRequest : aiMessage.toolExecutionRequests()) {
                 log.debugv("Attempting to execute tool {0}", toolExecutionRequest);
                 ToolExecutor toolExecutor = context.toolExecutors.get(toolExecutionRequest.name());
+                if (toolExecutor == null) {
+                    throw runtime("Tool executor %s not found", toolExecutionRequest.name());
+                }
                 String toolExecutionResult = toolExecutor.execute(toolExecutionRequest, memoryId);
                 log.debugv("Result of {0} is '{1}'", toolExecutionRequest, toolExecutionResult);
                 ToolExecutionResultMessage toolExecutionResultMessage = ToolExecutionResultMessage.from(


### PR DESCRIPTION
Provides a slightly more meaningful exception that includes the name of the tool that was not found.

Fixes: #253 