### PR TITLE
Introduce quarkus-langchain4j-bom

### DIFF
--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -39,7 +39,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
-            <version>${langchain4j.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.squareup.retrofit2</groupId>

--- a/hugging-face/runtime/pom.xml
+++ b/hugging-face/runtime/pom.xml
@@ -26,7 +26,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-hugging-face</artifactId>
-            <version>${langchain4j.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.squareup.retrofit2</groupId>

--- a/milvus/deployment/pom.xml
+++ b/milvus/deployment/pom.xml
@@ -26,7 +26,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-milvus</artifactId>
-            <version>${langchain4j.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/milvus/runtime/pom.xml
+++ b/milvus/runtime/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-milvus</artifactId>
-            <version>${langchain4j.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/openai/openai-common/runtime/pom.xml
+++ b/openai/openai-common/runtime/pom.xml
@@ -30,7 +30,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-open-ai</artifactId>
-            <version>${langchain4j.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.squareup.retrofit2</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,30 @@
                   <extraDependencies>
                     <dependency>
                       <groupId>dev.langchain4j</groupId>
+                      <artifactId>langchain4j-milvus</artifactId>
+                      <version>${langchain4j.version}</version>
+                      <exclusions>
+                        <exclusion>
+                          <groupId>com.google.android</groupId>
+                          <artifactId>annotations</artifactId>
+                        </exclusion>
+                        <exclusion>
+                          <groupId>org.apache.logging.log4j</groupId>
+                          <artifactId>log4j-slf4j-impl</artifactId>
+                        </exclusion>
+                        <exclusion>
+                          <groupId>org.checkerframework</groupId>
+                          <artifactId>checker-qual</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <artifactId>animal-sniffer-annotations</artifactId>
+                        </exclusion>
+                      </exclusions>
+                    </dependency>
+
+                    <dependency>
+                      <groupId>dev.langchain4j</groupId>
                       <artifactId>langchain4j-bom</artifactId>
                       <version>${langchain4j.version}</version>
                       <type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-bom</artifactId>
+        <version>${langchain4j.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,15 @@
                       <exclude>*:quarkus-langchain4j-sample-*</exclude>
                     </excludes>
                   </modules>
+                  <extraDependencies>
+                    <dependency>
+                      <groupId>dev.langchain4j</groupId>
+                      <artifactId>langchain4j-bom</artifactId>
+                      <version>${langchain4j.version}</version>
+                      <type>pom</type>
+                      <scope>import</scope>
+                    </dependency>
+                  </extraDependencies>
                 </bom>
               </boms>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <assertj.version>3.25.2</assertj.version>
     <wiremock.version>3.3.1</wiremock.version>
     <pgvector-java.version>0.1.4</pgvector-java.version>
+    <sundrio.version>0.103.1</sundrio.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -85,6 +86,40 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>io.sundr</groupId>
+        <artifactId>sundr-maven-plugin</artifactId>
+        <version>${sundrio.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate-bom</goal>
+            </goals>
+            <configuration>
+              <boms>
+                <bom>
+                  <artifactId>quarkus-langchain4j-bom</artifactId>
+                  <name>Quarkus LangChain4j : BOM</name>
+                  <description>Centralized dependencyManagement for the Quarkus LangChain4j Project</description>
+                  <properties>
+                    <skipStagingRepositoryClose>true</skipStagingRepositoryClose>
+                    <sonar.skip>true</sonar.skip>
+                  </properties>
+                  <modules>
+                    <excludes>
+                      <exclude>*:quarkus-langchain4j-integration-test*</exclude>
+                      <exclude>*:quarkus-langchain4j-docs</exclude>
+                      <exclude>*:quarkus-langchain4j-sample-*</exclude>
+                    </excludes>
+                  </modules>
+                </bom>
+              </boms>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
   <profiles>
     <profile>


### PR DESCRIPTION
- Closes https://github.com/quarkiverse/quarkus-langchain4j/pull/252
- Closes https://github.com/quarkiverse/quarkus-langchain4j/pull/215

Unlike the other PRs, this doesn't require any maintenance when introducing a new module. 
For reference, this plugin is also used in https://github.com/smallrye/smallrye-common/blob/main/pom.xml#L203 and https://github.com/smallrye/smallrye-reactive-messaging/blob/main/pom.xml#L609
