### PR TITLE
Only pass Authorization/api-key headers when necessary

### DIFF
--- a/integration-tests/openai/src/main/java/org/acme/example/openai/QuarkusRestApiResource.java
+++ b/integration-tests/openai/src/main/java/org/acme/example/openai/QuarkusRestApiResource.java
@@ -66,7 +66,7 @@ public class QuarkusRestApiResource {
         return restApi.blockingChatCompletion(
                 createChatCompletionRequest("Write a short 1 paragraph funny poem about segmentation fault"),
                 OpenAiRestApi.ApiMetadata.builder()
-                        .apiKey(token)
+                        .openAiApiKey(token)
                         .organizationId(organizationId)
                         .build())
                 .content();
@@ -78,7 +78,7 @@ public class QuarkusRestApiResource {
         return restApi
                 .createChatCompletion(createChatCompletionRequest("Write a short 1 paragraph funny poem about Unicode"),
                         OpenAiRestApi.ApiMetadata.builder()
-                                .apiKey(token)
+                                .openAiApiKey(token)
                                 .organizationId(organizationId)
                                 .build())
                 .map(ChatCompletionResponse::content);
@@ -91,7 +91,7 @@ public class QuarkusRestApiResource {
         return restApi.streamingChatCompletion(
                 createChatCompletionRequest("Write a short 1 paragraph funny poem about Enterprise Java"),
                 OpenAiRestApi.ApiMetadata.builder()
-                        .apiKey(token)
+                        .openAiApiKey(token)
                         .organizationId(organizationId)
                         .build())
                 .map(r -> {
@@ -124,7 +124,7 @@ public class QuarkusRestApiResource {
         return restApi.blockingCompletion(
                 createCompletionRequest("Write a short 1 paragraph funny poem about segmentation fault"),
                 OpenAiRestApi.ApiMetadata.builder()
-                        .apiKey(token)
+                        .openAiApiKey(token)
                         .organizationId(organizationId)
                         .build())
                 .text();
@@ -136,7 +136,7 @@ public class QuarkusRestApiResource {
         return restApi
                 .completion(createCompletionRequest("Write a short 1 paragraph funny poem about Unicode"),
                         OpenAiRestApi.ApiMetadata.builder()
-                                .apiKey(token)
+                                .openAiApiKey(token)
                                 .organizationId(organizationId)
                                 .build())
                 .map(CompletionResponse::text);
@@ -149,7 +149,7 @@ public class QuarkusRestApiResource {
         return restApi.streamingCompletion(
                 createCompletionRequest("Write a short 1 paragraph funny poem about Enterprise Java"),
                 OpenAiRestApi.ApiMetadata.builder()
-                        .apiKey(token)
+                        .openAiApiKey(token)
                         .organizationId(organizationId)
                         .build())
                 .map(r -> {
@@ -171,7 +171,7 @@ public class QuarkusRestApiResource {
     public List<Float> embeddingSync() {
         return restApi.blockingEmbedding(createEmbeddingRequest("Your text string goes here"),
                 OpenAiRestApi.ApiMetadata.builder()
-                        .apiKey(token)
+                        .openAiApiKey(token)
                         .organizationId(organizationId)
                         .build())
                 .embedding();
@@ -183,7 +183,7 @@ public class QuarkusRestApiResource {
         return restApi
                 .embedding(createEmbeddingRequest("Your text string goes here"),
                         OpenAiRestApi.ApiMetadata.builder()
-                                .apiKey(token)
+                                .openAiApiKey(token)
                                 .organizationId(organizationId)
                                 .build())
                 .map(EmbeddingResponse::embedding);

--- a/openai/openai-common/runtime/src/main/java/io/quarkiverse/langchain4j/openai/OpenAiRestApi.java
+++ b/openai/openai-common/runtime/src/main/java/io/quarkiverse/langchain4j/openai/OpenAiRestApi.java
@@ -416,17 +416,17 @@ public interface OpenAiRestApi {
         public final String authorization;
 
         @HeaderParam("api-key")
-        public final String apiKey;
+        public final String azureApiKey;
         @QueryParam("api-version")
         public final String apiVersion;
 
         @HeaderParam("OpenAI-Organization")
         public final String organizationId;
 
-        private ApiMetadata(String authorization, String apiKey,
+        private ApiMetadata(String openaiApiKey, String azureApiKey,
                 String apiVersion, String organizationId) {
-            this.authorization = authorization;
-            this.apiKey = apiKey;
+            this.authorization = (openaiApiKey != null) ? "Bearer " + openaiApiKey : null;
+            this.azureApiKey = azureApiKey;
             this.apiVersion = apiVersion;
             this.organizationId = organizationId;
         }
@@ -436,20 +436,30 @@ public interface OpenAiRestApi {
         }
 
         public static class Builder {
-            private String apiKey;
+            private String azureApiKey;
+            private String openAiApiKey;
             private String apiVersion;
             private String organizationId;
 
             public ApiMetadata build() {
-                return (apiKey == null) ? new ApiMetadata(null, null, apiVersion, organizationId)
-                        : new ApiMetadata(
-                                "Bearer " + apiKey, // typical OpenAI authentication
-                                apiKey, // used by AzureAI
-                                apiVersion, organizationId);
+                if ((azureApiKey != null) && (openAiApiKey != null)) {
+                    return new ApiMetadata(openAiApiKey, azureApiKey, apiVersion, organizationId);
+                } else if (azureApiKey != null) {
+                    return new ApiMetadata(null, azureApiKey, apiVersion, organizationId);
+                } else if (openAiApiKey != null) {
+                    return new ApiMetadata(openAiApiKey, null, apiVersion, organizationId);
+                }
+
+                return new ApiMetadata(null, null, apiVersion, organizationId);
             }
 
-            public ApiMetadata.Builder apiKey(String apiKey) {
-                this.apiKey = apiKey;
+            public ApiMetadata.Builder azureApiKey(String azureApiKey) {
+                this.azureApiKey = azureApiKey;
+                return this;
+            }
+
+            public ApiMetadata.Builder openAiApiKey(String openAiApiKey) {
+                this.openAiApiKey = openAiApiKey;
                 return this;
             }
 

--- a/openai/openai-common/runtime/src/main/java/io/quarkiverse/langchain4j/openai/QuarkusOpenAiClient.java
+++ b/openai/openai-common/runtime/src/main/java/io/quarkiverse/langchain4j/openai/QuarkusOpenAiClient.java
@@ -48,7 +48,8 @@ import io.smallrye.mutiny.subscription.Cancellable;
  */
 public class QuarkusOpenAiClient extends OpenAiClient {
 
-    private final String apiKey;
+    private final String azureApiKey;
+    private final String openaiApiKey;
     private final String apiVersion;
     private final String organizationId;
 
@@ -56,8 +57,8 @@ public class QuarkusOpenAiClient extends OpenAiClient {
 
     private static final Map<Builder, OpenAiRestApi> cache = new ConcurrentHashMap<>();
 
-    public QuarkusOpenAiClient(String apiKey) {
-        this(new Builder().openAiApiKey(apiKey));
+    public QuarkusOpenAiClient(String openaiApiKey) {
+        this(new Builder().openAiApiKey(openaiApiKey));
     }
 
     public static Builder builder() {
@@ -69,7 +70,8 @@ public class QuarkusOpenAiClient extends OpenAiClient {
     }
 
     private QuarkusOpenAiClient(Builder builder) {
-        this.apiKey = determineApiKey(builder);
+        this.azureApiKey = builder.azureApiKey;
+        this.openaiApiKey = builder.openAiApiKey;
         this.apiVersion = builder.apiVersion;
         this.organizationId = builder.organizationId;
         // cache the client the builder could be called with the same parameters from multiple models
@@ -106,15 +108,6 @@ public class QuarkusOpenAiClient extends OpenAiClient {
 
     }
 
-    private static String determineApiKey(Builder builder) {
-        var result = builder.openAiApiKey;
-        if (result != null) {
-            return result;
-        }
-        result = builder.azureApiKey;
-        return result;
-    }
-
     @Override
     public SyncOrAsyncOrStreaming<CompletionResponse> completion(CompletionRequest request) {
         return new SyncOrAsyncOrStreaming<>() {
@@ -123,7 +116,8 @@ public class QuarkusOpenAiClient extends OpenAiClient {
                 return restApi.blockingCompletion(
                         CompletionRequest.builder().from(request).stream(null).build(),
                         OpenAiRestApi.ApiMetadata.builder()
-                                .apiKey(apiKey)
+                                .azureApiKey(azureApiKey)
+                                .openAiApiKey(openaiApiKey)
                                 .apiVersion(apiVersion)
                                 .organizationId(organizationId)
                                 .build());
@@ -137,7 +131,8 @@ public class QuarkusOpenAiClient extends OpenAiClient {
                             public Uni<CompletionResponse> get() {
                                 return restApi.completion(request,
                                         OpenAiRestApi.ApiMetadata.builder()
-                                                .apiKey(apiKey)
+                                                .azureApiKey(azureApiKey)
+                                                .openAiApiKey(openaiApiKey)
                                                 .apiVersion(apiVersion)
                                                 .organizationId(organizationId)
                                                 .build());
@@ -155,7 +150,8 @@ public class QuarkusOpenAiClient extends OpenAiClient {
                             public Multi<CompletionResponse> get() {
                                 return restApi.streamingCompletion(request,
                                         OpenAiRestApi.ApiMetadata.builder()
-                                                .apiKey(apiKey)
+                                                .azureApiKey(azureApiKey)
+                                                .openAiApiKey(openaiApiKey)
                                                 .apiVersion(apiVersion)
                                                 .organizationId(organizationId)
                                                 .build());
@@ -178,7 +174,8 @@ public class QuarkusOpenAiClient extends OpenAiClient {
                 return restApi.blockingChatCompletion(
                         ChatCompletionRequest.builder().from(request).stream(null).build(),
                         OpenAiRestApi.ApiMetadata.builder()
-                                .apiKey(apiKey)
+                                .azureApiKey(azureApiKey)
+                                .openAiApiKey(openaiApiKey)
                                 .apiVersion(apiVersion)
                                 .organizationId(organizationId)
                                 .build());
@@ -192,7 +189,8 @@ public class QuarkusOpenAiClient extends OpenAiClient {
                             public Uni<ChatCompletionResponse> get() {
                                 return restApi.createChatCompletion(request,
                                         OpenAiRestApi.ApiMetadata.builder()
-                                                .apiKey(apiKey)
+                                                .azureApiKey(azureApiKey)
+                                                .openAiApiKey(openaiApiKey)
                                                 .apiVersion(apiVersion)
                                                 .organizationId(organizationId)
                                                 .build());
@@ -210,7 +208,8 @@ public class QuarkusOpenAiClient extends OpenAiClient {
                             public Multi<ChatCompletionResponse> get() {
                                 return restApi.streamingChatCompletion(request,
                                         OpenAiRestApi.ApiMetadata.builder()
-                                                .apiKey(apiKey)
+                                                .azureApiKey(azureApiKey)
+                                                .openAiApiKey(openaiApiKey)
                                                 .apiVersion(apiVersion)
                                                 .organizationId(organizationId)
                                                 .build());
@@ -232,7 +231,8 @@ public class QuarkusOpenAiClient extends OpenAiClient {
                 return restApi
                         .blockingChatCompletion(request,
                                 OpenAiRestApi.ApiMetadata.builder()
-                                        .apiKey(apiKey)
+                                        .azureApiKey(azureApiKey)
+                                        .openAiApiKey(openaiApiKey)
                                         .apiVersion(apiVersion)
                                         .organizationId(organizationId)
                                         .build())
@@ -249,7 +249,8 @@ public class QuarkusOpenAiClient extends OpenAiClient {
                                         .createChatCompletion(
                                                 ChatCompletionRequest.builder().from(request).stream(null).build(),
                                                 OpenAiRestApi.ApiMetadata.builder()
-                                                        .apiKey(apiKey)
+                                                        .azureApiKey(azureApiKey)
+                                                        .openAiApiKey(openaiApiKey)
                                                         .apiVersion(apiVersion)
                                                         .organizationId(organizationId)
                                                         .build())
@@ -270,7 +271,8 @@ public class QuarkusOpenAiClient extends OpenAiClient {
                                         .streamingChatCompletion(
                                                 ChatCompletionRequest.builder().from(request).stream(true).build(),
                                                 OpenAiRestApi.ApiMetadata.builder()
-                                                        .apiKey(apiKey)
+                                                        .azureApiKey(azureApiKey)
+                                                        .openAiApiKey(openaiApiKey)
                                                         .apiVersion(apiVersion)
                                                         .organizationId(organizationId)
                                                         .build())
@@ -300,7 +302,8 @@ public class QuarkusOpenAiClient extends OpenAiClient {
             public EmbeddingResponse execute() {
                 return restApi.blockingEmbedding(request,
                         OpenAiRestApi.ApiMetadata.builder()
-                                .apiKey(apiKey)
+                                .azureApiKey(azureApiKey)
+                                .openAiApiKey(openaiApiKey)
                                 .apiVersion(apiVersion)
                                 .organizationId(organizationId)
                                 .build());
@@ -314,7 +317,8 @@ public class QuarkusOpenAiClient extends OpenAiClient {
                             public Uni<EmbeddingResponse> get() {
                                 return restApi.embedding(request,
                                         OpenAiRestApi.ApiMetadata.builder()
-                                                .apiKey(apiKey)
+                                                .azureApiKey(azureApiKey)
+                                                .openAiApiKey(openaiApiKey)
                                                 .apiVersion(apiVersion)
                                                 .organizationId(organizationId)
                                                 .build());
@@ -335,7 +339,8 @@ public class QuarkusOpenAiClient extends OpenAiClient {
             public List<Float> execute() {
                 return restApi.blockingEmbedding(request,
                         OpenAiRestApi.ApiMetadata.builder()
-                                .apiKey(apiKey)
+                                .azureApiKey(azureApiKey)
+                                .openAiApiKey(openaiApiKey)
                                 .apiVersion(apiVersion)
                                 .organizationId(organizationId)
                                 .build())
@@ -350,7 +355,8 @@ public class QuarkusOpenAiClient extends OpenAiClient {
                             public Uni<List<Float>> get() {
                                 return restApi.embedding(request,
                                         OpenAiRestApi.ApiMetadata.builder()
-                                                .apiKey(apiKey)
+                                                .azureApiKey(azureApiKey)
+                                                .openAiApiKey(openaiApiKey)
                                                 .apiVersion(apiVersion)
                                                 .organizationId(organizationId)
                                                 .build())
@@ -369,7 +375,8 @@ public class QuarkusOpenAiClient extends OpenAiClient {
             public ModerationResponse execute() {
                 return restApi.blockingModeration(request,
                         OpenAiRestApi.ApiMetadata.builder()
-                                .apiKey(apiKey)
+                                .azureApiKey(azureApiKey)
+                                .openAiApiKey(openaiApiKey)
                                 .apiVersion(apiVersion)
                                 .organizationId(organizationId)
                                 .build());
@@ -383,7 +390,8 @@ public class QuarkusOpenAiClient extends OpenAiClient {
                             public Uni<ModerationResponse> get() {
                                 return restApi.moderation(request,
                                         OpenAiRestApi.ApiMetadata.builder()
-                                                .apiKey(apiKey)
+                                                .azureApiKey(azureApiKey)
+                                                .openAiApiKey(openaiApiKey)
                                                 .apiVersion(apiVersion)
                                                 .organizationId(organizationId)
                                                 .build());
@@ -405,7 +413,8 @@ public class QuarkusOpenAiClient extends OpenAiClient {
             public ModerationResult execute() {
                 return restApi.blockingModeration(request,
                         OpenAiRestApi.ApiMetadata.builder()
-                                .apiKey(apiKey)
+                                .azureApiKey(azureApiKey)
+                                .openAiApiKey(openaiApiKey)
                                 .apiVersion(apiVersion)
                                 .organizationId(organizationId)
                                 .build())
@@ -420,7 +429,8 @@ public class QuarkusOpenAiClient extends OpenAiClient {
                             public Uni<ModerationResult> get() {
                                 return restApi.moderation(request,
                                         OpenAiRestApi.ApiMetadata.builder()
-                                                .apiKey(apiKey)
+                                                .azureApiKey(azureApiKey)
+                                                .openAiApiKey(openaiApiKey)
                                                 .apiVersion(apiVersion)
                                                 .organizationId(organizationId)
                                                 .build())
@@ -439,7 +449,8 @@ public class QuarkusOpenAiClient extends OpenAiClient {
             public GenerateImagesResponse execute() {
                 return restApi.blockingImagesGenerations(generateImagesRequest,
                         OpenAiRestApi.ApiMetadata.builder()
-                                .apiKey(apiKey)
+                                .azureApiKey(azureApiKey)
+                                .openAiApiKey(openaiApiKey)
                                 .apiVersion(apiVersion)
                                 .organizationId(organizationId)
                                 .build());
@@ -453,7 +464,8 @@ public class QuarkusOpenAiClient extends OpenAiClient {
                             public Uni<GenerateImagesResponse> get() {
                                 return restApi.imagesGenerations(generateImagesRequest,
                                         OpenAiRestApi.ApiMetadata.builder()
-                                                .apiKey(apiKey)
+                                                .azureApiKey(azureApiKey)
+                                                .openAiApiKey(openaiApiKey)
                                                 .apiVersion(apiVersion)
                                                 .organizationId(organizationId)
                                                 .build());

--- a/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/OpenAiRestApiSmokeTest.java
+++ b/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/OpenAiRestApiSmokeTest.java
@@ -52,7 +52,7 @@ public class OpenAiRestApiSmokeTest {
         OpenAiRestApi restApi = createClient();
 
         ChatCompletionResponse response = restApi.blockingChatCompletion(ChatCompletionRequest.builder().build(),
-                OpenAiRestApi.ApiMetadata.builder().apiKey(TOKEN).organizationId(ORGANIZATION).build());
+                OpenAiRestApi.ApiMetadata.builder().openAiApiKey(TOKEN).organizationId(ORGANIZATION).build());
         assertThat(response).isNotNull();
 
         wireMockServer.verify(WiremockUtils.chatCompletionRequestPattern(TOKEN, ORGANIZATION));
@@ -69,7 +69,7 @@ public class OpenAiRestApiSmokeTest {
         OpenAiRestApi restApi = createClient();
 
         assertThatThrownBy(() -> restApi.blockingChatCompletion(ChatCompletionRequest.builder().build(),
-                OpenAiRestApi.ApiMetadata.builder().apiKey(TOKEN).build()))
+                OpenAiRestApi.ApiMetadata.builder().openAiApiKey(TOKEN).build()))
                 .isInstanceOf(
                         OpenAiHttpException.class)
                 .hasMessage("This is a dummy error message");
@@ -100,7 +100,7 @@ public class OpenAiRestApiSmokeTest {
         OpenAiRestApi restApi = createClient();
 
         assertThatThrownBy(() -> restApi.blockingChatCompletion(ChatCompletionRequest.builder().build(),
-                OpenAiRestApi.ApiMetadata.builder().apiKey(TOKEN).build()))
+                OpenAiRestApi.ApiMetadata.builder().openAiApiKey(TOKEN).build()))
                 .isInstanceOf(
                         OpenAiApiException.class);
     }


### PR DESCRIPTION
Only send the `Authorization` header for OpenAI requests and only send the `api-key` header on Azure OpenAI requests.

- Fixes #264 