### PR TITLE
Note about asking for valid and unwrapped JSON

### DIFF
--- a/docs/modules/ROOT/pages/prompt-engineering.adoc
+++ b/docs/modules/ROOT/pages/prompt-engineering.adoc
@@ -105,7 +105,16 @@ Provided Data: John Doe, 30, john@example.com, 123 Main St, New York, 10001
 In this example, the prompt specifies the expected structure for the JSON response, comprising keys like `name`, `age`, `email`, and `address`, with their respective value types. The `Provided Data` segment serves as the input to be formatted into the requested JSON structure.
 
 Being able to describe the JSON output is essential when an xref:ai-services.adoc#_ai_method_return_type[AI method] returns an object.
-The Quarkus LangChain4j extension will use the JSON structure to create an instance of the return type.
+
+Even if a JSON format is not directly provided by the developer in the prompt, the LangChain4j will automatically add it, and the Quarkus LangChain4j extension will use the JSON structure to create an instance of the return type.
+
+In this case, when working with JSON formats, it's good to specify this fact in a prompt and always ask for a valid and unwrapped JSON, for example:
+
+[source, text]
+----
+You must respond in a valid JSON format.
+You must not wrap JSON response in backticks, markdown, or in any other way, but return it as plain text.
+----
 
 == Control tokens and prefixes
 


### PR DESCRIPTION
Hi,

This is a small edit to include a hint in a `prompt-engineering.adoc` guide for devs to ask for a valid, unwrapped JSON when working with DTO classes.

# The Background

I was working with the following AI service:

```java
@ApplicationScoped
@RegisterAiService
public interface Translator {

	@SystemMessage("""
			You are a professional translator.
			You translate provided text lines from a source language to a target language. 

			Objective: Translate provided text lines from {sourceLang} to {targetLang}.
		""")
	@Timeout(value = 2, unit = MINUTES)
	Translation translate(String sourceLang, String targetLang, @UserMessage String texts);

	public static @Data class Translation {
		private List<String> translatedTextLines;
	}
}
```

To my surprise, it didn't work as intended and I was getting HTTP 500 when requesting my endpoint.

In the requests log I found the JSON requirement appended automatically by LangChain4j to my prompt:

```
You must answer strictly in the following JSON format: {\n\"translatedTextLines\": (type: array of string),\n}
```

However, the GPT-4 model in Azure was not kind enough to understand that it would be the JSON parser that consumes its output, and got me a markdown.

# The Problem

HTTP 500 error was caused by an exception from `JsonParser`.

```
Caused by: com.fasterxml.jackson.core.JsonParseException: Unexpected character ('`' (code 96)): expected a valid value (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
 at [Source: (String)"```json
{
"translatedTextLines": [
"Lithuania, my homeland! You are like health;",
"How much you must be valued, will only discover,"
]
}
```"; line: 1, column: 2]
	at com.fasterxml.jackson.core.JsonParser._constructError(JsonParser.java:2477)
```

It failed because JSON was wrapped in the markdown the parser was unable to handle:

![image](https://github.com/quarkiverse/quarkus-langchain4j/assets/472658/b8749770-e331-4cc6-9b57-9d8d0a1ddef0)

Not only that. When I modified the prompt and asked for a plain text I got an invalid JSON with additional unwanted commas :D

```
{
"translatedTextLines": [
"Lithuania, my homeland! You are like health;",
"How much you must be valued, will only discover,", <--- HERE
]
}
```

I fixed these problems by adding two more lines in the system message, one to get valid JSON and a second one to get a plain text:

```plain
You must respond in a valid JSON format.
You must not wrap JSON response in backticks, markdown, or in any other way, but return it as plain text.
```

Since I spent some time debugging this issue, I decided to include this in the `prompt-engineering.adoc` for the next generations to come.

Just FYI, the LangChains4j is decorating the prompt by adding JSON conversion requirement here:

https://github.com/langchain4j/langchain4j/blob/f17f8349ac3597f9804bfe835554e4e618b15fa8/langchain4j/src/main/java/dev/langchain4j/service/ServiceOutputParser.java#L118

I was thinking if I should create a separate PR against the LangChains4j but I was afraid to mess on the low-level prompts there and accidentally break the JSON prompting compatibility.

If one is interested, I thought about change their prompt from:

```java
return "\nYou must answer strictly in the following JSON format: " + jsonStructure(returnType);
```

To:

```java
return "\nYou must answer with valid JSON strictly in the following format: " + jsonStructure(returnType);
```

