### PR TITLE
Ensure correct build order (samples AFTER extensions)

### DIFF
--- a/samples/chatbot/pom.xml
+++ b/samples/chatbot/pom.xml
@@ -6,7 +6,7 @@
         <groupId>io.quarkiverse.langchain4j</groupId>
         <artifactId>quarkus-langchain4j-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../..</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>quarkus-langchain4j-sample-chatbot</artifactId>
@@ -32,7 +32,17 @@
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.langchain4j</groupId>
+            <artifactId>quarkus-langchain4j-openai-deployment</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.langchain4j</groupId>
             <artifactId>quarkus-langchain4j-redis</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.langchain4j</groupId>
+            <artifactId>quarkus-langchain4j-redis-deployment</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/samples/csv-chatbot/pom.xml
+++ b/samples/csv-chatbot/pom.xml
@@ -6,7 +6,7 @@
         <groupId>io.quarkiverse.langchain4j</groupId>
         <artifactId>quarkus-langchain4j-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../..</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>quarkus-langchain4j-sample-csv-chatbot</artifactId>
@@ -32,7 +32,17 @@
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.langchain4j</groupId>
+            <artifactId>quarkus-langchain4j-openai-deployment</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.langchain4j</groupId>
             <artifactId>quarkus-langchain4j-redis</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.langchain4j</groupId>
+            <artifactId>quarkus-langchain4j-redis-deployment</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/samples/email-a-poem/pom.xml
+++ b/samples/email-a-poem/pom.xml
@@ -6,7 +6,7 @@
         <groupId>io.quarkiverse.langchain4j</groupId>
         <artifactId>quarkus-langchain4j-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../..</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>quarkus-langchain4j-sample-poem</artifactId>
@@ -20,6 +20,11 @@
         <dependency>
             <groupId>io.quarkiverse.langchain4j</groupId>
             <artifactId>quarkus-langchain4j-openai</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.langchain4j</groupId>
+            <artifactId>quarkus-langchain4j-openai-deployment</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/samples/fraud-detection/pom.xml
+++ b/samples/fraud-detection/pom.xml
@@ -6,7 +6,7 @@
         <groupId>io.quarkiverse.langchain4j</groupId>
         <artifactId>quarkus-langchain4j-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../..</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>quarkus-langchain4j-sample-fraud-detection</artifactId>
@@ -20,6 +20,11 @@
         <dependency>
             <groupId>io.quarkiverse.langchain4j</groupId>
             <artifactId>quarkus-langchain4j-openai</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.langchain4j</groupId>
+            <artifactId>quarkus-langchain4j-openai-deployment</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/samples/review-triage/pom.xml
+++ b/samples/review-triage/pom.xml
@@ -6,7 +6,7 @@
         <groupId>io.quarkiverse.langchain4j</groupId>
         <artifactId>quarkus-langchain4j-parent</artifactId>
         <version>999-SNAPSHOT</version>
-        <relativePath>../..</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>quarkus-langchain4j-sample-review-triage</artifactId>
@@ -20,6 +20,11 @@
         <dependency>
             <groupId>io.quarkiverse.langchain4j</groupId>
             <artifactId>quarkus-langchain4j-openai</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.langchain4j</groupId>
+            <artifactId>quarkus-langchain4j-openai-deployment</artifactId>
             <version>${project.version}</version>
         </dependency>
 


### PR DESCRIPTION
I've seen some failures (during a parallel build) due to wrong build order - the `parent.relativePath` of samples has to point at an exact pom.xml, otherwise it doesn't make sure that all extensions are built before samples