### PR TITLE
Bump to LangChain4j 0.27.1

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
@@ -783,8 +783,7 @@ public class AiServicesProcessor {
     }
 
     private AiServiceMethodCreateInfo.UserMessageInfo gatherUserMessageInfo(MethodInfo method,
-            List<TemplateParameterInfo> templateParams,
-            Class<?> returnType) {
+            List<TemplateParameterInfo> templateParams, Class<?> returnType) {
         String outputFormatInstructions = outputFormatInstructions(returnType);
 
         Optional<Integer> userNameParamName = method.annotations(Langchain4jDotNames.USER_NAME).stream().filter(
@@ -794,8 +793,7 @@ public class AiServicesProcessor {
         if (userMessageInstance != null) {
             AnnotationValue delimiterValue = userMessageInstance.value("delimiter");
             String delimiter = delimiterValue != null ? delimiterValue.asString() : DEFAULT_DELIMITER;
-            String userMessageTemplate = String.join(delimiter, userMessageInstance.value().asStringArray())
-                    + outputFormatInstructions;
+            String userMessageTemplate = String.join(delimiter, userMessageInstance.value().asStringArray());
 
             if (userMessageTemplate.contains("{{it}}")) {
                 if (method.parametersCount() != 1) {
@@ -810,7 +808,7 @@ public class AiServicesProcessor {
             return AiServiceMethodCreateInfo.UserMessageInfo.fromTemplate(
                     new AiServiceMethodCreateInfo.TemplateInfo(userMessageTemplate,
                             TemplateParameterInfo.toNameToArgsPositionMap(templateParams)),
-                    userNameParamName);
+                    userNameParamName, outputFormatInstructions);
         } else {
             Optional<AnnotationInstance> userMessageOnMethodParam = method.annotations(Langchain4jDotNames.USER_MESSAGE)
                     .stream()
@@ -818,17 +816,14 @@ public class AiServicesProcessor {
             if (userMessageOnMethodParam.isPresent()) {
                 return AiServiceMethodCreateInfo.UserMessageInfo.fromMethodParam(
                         userMessageOnMethodParam.get().target().asMethodParameter().position(),
-                        outputFormatInstructions,
-                        userNameParamName);
+                        userNameParamName, outputFormatInstructions);
             } else {
                 if (method.parametersCount() == 0) {
                     throw illegalConfigurationForMethod("Method should have at least one argument", method);
                 }
                 if (method.parametersCount() == 1) {
-                    return AiServiceMethodCreateInfo.UserMessageInfo.fromMethodParam(
-                            0,
-                            outputFormatInstructions,
-                            userNameParamName);
+                    return AiServiceMethodCreateInfo.UserMessageInfo.fromMethodParam(0, userNameParamName,
+                            outputFormatInstructions);
                 }
 
                 throw illegalConfigurationForMethod(

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ChatMessageSerializerTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ChatMessageSerializerTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ChatMessageSerializer;
+import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.data.message.UserMessage;
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -55,6 +56,16 @@ class ChatMessageSerializerTest {
     }
 
     @Test
+    void should_serialize_and_deserialize_user_message_with_image_content() {
+        UserMessage message = UserMessage.from(ImageContent.from("http://image.url"));
+
+        String json = messageToJson(message);
+        ChatMessage deserializedMessage = messageFromJson(json);
+
+        assertThat(deserializedMessage).isEqualTo(message);
+    }
+
+    @Test
     void should_serialize_and_deserialize_empty_list() {
 
         List<ChatMessage> messages = emptyList();
@@ -76,7 +87,7 @@ class ChatMessageSerializerTest {
         List<ChatMessage> messages = singletonList(userMessage("hello"));
 
         String json = messagesToJson(messages);
-        assertThat(json).isEqualTo("[{\"text\":\"hello\",\"type\":\"USER\"}]");
+        assertThat(json).isEqualTo("[{\"contents\":[{\"text\":\"hello\",\"type\":\"TEXT\"}],\"type\":\"USER\"}]");
 
         List<ChatMessage> deserializedMessages = messagesFromJson(json);
         assertThat(deserializedMessages).isEqualTo(messages);
@@ -99,8 +110,8 @@ class ChatMessageSerializerTest {
         String json = ChatMessageSerializer.messagesToJson(messages);
         assertThat(json).isEqualTo("[" +
                 "{\"text\":\"Hello from system\",\"type\":\"SYSTEM\"}," +
-                "{\"text\":\"Hello from user\",\"type\":\"USER\"}," +
-                "{\"name\":\"Klaus\",\"text\":\"Hello from Klaus\",\"type\":\"USER\"}," +
+                "{\"contents\":[{\"text\":\"Hello from user\",\"type\":\"TEXT\"}],\"type\":\"USER\"}," +
+                "{\"name\":\"Klaus\",\"contents\":[{\"text\":\"Hello from Klaus\",\"type\":\"TEXT\"}],\"type\":\"USER\"}," +
                 "{\"text\":\"Hello from AI\",\"type\":\"AI\"}," +
                 "{\"toolExecutionRequests\":[{\"name\":\"calculator\",\"arguments\":\"{}\"}],\"type\":\"AI\"}," +
                 "{\"text\":\"4\",\"id\":\"12345\",\"toolName\":\"calculator\",\"type\":\"TOOL_EXECUTION_RESULT\"}" +

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodCreateInfo.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodCreateInfo.java
@@ -85,26 +85,28 @@ public class AiServiceMethodCreateInfo {
     public static class UserMessageInfo {
         private final Optional<TemplateInfo> template;
         private final Optional<Integer> paramPosition;
-        private final Optional<String> instructions;
         private final Optional<Integer> userNameParamPosition;
+        private final String outputFormatInstructions;
 
         @RecordableConstructor
-        public UserMessageInfo(Optional<TemplateInfo> template, Optional<Integer> paramPosition, Optional<String> instructions,
-                Optional<Integer> userNameParamPosition) {
+        public UserMessageInfo(Optional<TemplateInfo> template, Optional<Integer> paramPosition,
+                Optional<Integer> userNameParamPosition, String outputFormatInstructions) {
             this.template = template;
             this.paramPosition = paramPosition;
-            this.instructions = instructions;
             this.userNameParamPosition = userNameParamPosition;
+            this.outputFormatInstructions = outputFormatInstructions == null ? "" : outputFormatInstructions;
         }
 
-        public static UserMessageInfo fromMethodParam(int paramPosition, String instructions,
-                Optional<Integer> userNameParamPosition) {
-            return new UserMessageInfo(Optional.empty(), Optional.of(paramPosition), Optional.of(instructions),
-                    userNameParamPosition);
+        public static UserMessageInfo fromMethodParam(int paramPosition, Optional<Integer> userNameParamPosition,
+                String outputFormatInstructions) {
+            return new UserMessageInfo(Optional.empty(), Optional.of(paramPosition),
+                    userNameParamPosition, outputFormatInstructions);
         }
 
-        public static UserMessageInfo fromTemplate(TemplateInfo templateInfo, Optional<Integer> userNameParamPosition) {
-            return new UserMessageInfo(Optional.of(templateInfo), Optional.empty(), Optional.empty(), userNameParamPosition);
+        public static UserMessageInfo fromTemplate(TemplateInfo templateInfo, Optional<Integer> userNameParamPosition,
+                String outputFormatInstructions) {
+            return new UserMessageInfo(Optional.of(templateInfo), Optional.empty(), userNameParamPosition,
+                    outputFormatInstructions);
         }
 
         public Optional<TemplateInfo> getTemplate() {
@@ -115,12 +117,12 @@ public class AiServiceMethodCreateInfo {
             return paramPosition;
         }
 
-        public Optional<String> getInstructions() {
-            return instructions;
-        }
-
         public Optional<Integer> getUserNameParamPosition() {
             return userNameParamPosition;
+        }
+
+        public String getOutputFormatInstructions() {
+            return outputFormatInstructions;
         }
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/jackson/ContextMixin.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/jackson/ContextMixin.java
@@ -1,0 +1,25 @@
+package io.quarkiverse.langchain4j.runtime.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.ContentType;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.TextContent;
+import io.quarkus.jackson.JacksonMixin;
+
+@JacksonMixin(Content.class)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = TextContent.class, name = "TEXT"),
+        @JsonSubTypes.Type(value = ImageContent.class, name = "IMAGE"),
+})
+public abstract class ContextMixin {
+
+    @JsonProperty
+    public abstract ContentType type();
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/jackson/ImageBuilderMixin.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/jackson/ImageBuilderMixin.java
@@ -1,0 +1,11 @@
+package io.quarkiverse.langchain4j.runtime.jackson;
+
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import dev.langchain4j.data.image.Image;
+import io.quarkus.jackson.JacksonMixin;
+
+@JacksonMixin(Image.Builder.class)
+@JsonPOJOBuilder(withPrefix = "")
+public abstract class ImageBuilderMixin {
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/jackson/ImageContentMixin.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/jackson/ImageContentMixin.java
@@ -1,0 +1,17 @@
+package io.quarkiverse.langchain4j.runtime.jackson;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import dev.langchain4j.data.image.Image;
+import dev.langchain4j.data.message.ImageContent;
+import io.quarkus.jackson.JacksonMixin;
+
+@JacksonMixin(ImageContent.class)
+public abstract class ImageContentMixin {
+
+    @JsonCreator
+    public ImageContentMixin(@JsonProperty("image") Image image,
+            @JsonProperty("detailLevel") ImageContent.DetailLevel detailLevel) {
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/jackson/ImageMixin.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/jackson/ImageMixin.java
@@ -1,0 +1,14 @@
+package io.quarkiverse.langchain4j.runtime.jackson;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import dev.langchain4j.data.image.Image;
+import io.quarkus.jackson.JacksonMixin;
+
+@JacksonMixin(Image.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonDeserialize(builder = Image.Builder.class)
+public abstract class ImageMixin {
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/jackson/TextContentDeserializer.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/jackson/TextContentDeserializer.java
@@ -1,0 +1,24 @@
+package io.quarkiverse.langchain4j.runtime.jackson;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import dev.langchain4j.data.message.TextContent;
+
+public class TextContentDeserializer extends StdDeserializer<TextContent> {
+
+    public TextContentDeserializer() {
+        super(TextContent.class);
+    }
+
+    @Override
+    public TextContent deserialize(JsonParser p, DeserializationContext deserializationContext)
+            throws IOException {
+        JsonNode node = p.getCodec().readTree(p);
+        return new TextContent(node.get("text").asText());
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/jackson/TextContentMixin.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/jackson/TextContentMixin.java
@@ -1,0 +1,12 @@
+package io.quarkiverse.langchain4j.runtime.jackson;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import dev.langchain4j.data.message.TextContent;
+import io.quarkus.jackson.JacksonMixin;
+
+@JacksonMixin(TextContent.class)
+@JsonDeserialize(using = TextContentDeserializer.class)
+public abstract class TextContentMixin {
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/jackson/ToolExecutionResultMessageMixin.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/jackson/ToolExecutionResultMessageMixin.java
@@ -17,7 +17,7 @@ public class ToolExecutionResultMessageMixin {
 
     @JsonCreator
     public ToolExecutionResultMessageMixin(@JsonProperty("id") String id, @JsonProperty("toolName") String toolName,
-            @JsonProperty("toolExecutionResult") String toolExecutionResult) {
+            @JsonProperty("text") String text) {
 
     }
 }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/jackson/UserMessageDeserializer.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/jackson/UserMessageDeserializer.java
@@ -1,0 +1,76 @@
+package io.quarkiverse.langchain4j.runtime.jackson;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
+
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.UserMessage;
+
+public class UserMessageDeserializer extends StdDeserializer<UserMessage> {
+
+    public UserMessageDeserializer() {
+        super(UserMessage.class);
+    }
+
+    @Override
+    public UserMessage deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+
+        String text = null;
+        String name = null;
+        List<Content> contents = null;
+        while (p.nextToken() != JsonToken.END_OBJECT) {
+            String key = p.getCurrentName();
+            switch (key) {
+                case "text":
+                    text = p.getText();
+                    break;
+                case "name":
+                    name = p.getText();
+                    break;
+                case "contents":
+                    if (p.currentToken() == JsonToken.FIELD_NAME) {
+                        p.nextToken();
+                    }
+                    if (p.currentToken() != JsonToken.START_ARRAY) {
+                        throw ValueInstantiationException.from(p,
+                                "Cannot construct instance of `dev.langchain4j.data.message.UserMessage`, problem: expected `"
+                                        + p.currentToken() + "` to be start of array",
+                                ctxt.constructType(UserMessage.class));
+                    }
+                    contents = new ArrayList<>();
+                    while (p.nextToken() != JsonToken.END_ARRAY) {
+                        contents.add(ctxt.readValue(p, Content.class));
+                    }
+                    break;
+                default:
+                    // ignore unknown properties
+            }
+        }
+
+        if (text != null) {
+            if (name == null) {
+                return new UserMessage(text);
+            } else {
+                return new UserMessage(name, text);
+            }
+        } else if (contents != null) {
+            if (name == null) {
+                return new UserMessage(contents);
+            } else {
+                return new UserMessage(name, contents);
+            }
+        } else {
+            throw ValueInstantiationException.from(p,
+                    "Cannot construct instance of `dev.langchain4j.data.message.UserMessage`, problem: No `text` or `contents` field present",
+                    ctxt.constructType(
+                            UserMessage.class));
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/jackson/UserMessageMixin.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/jackson/UserMessageMixin.java
@@ -1,9 +1,8 @@
 package io.quarkiverse.langchain4j.runtime.jackson;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import dev.langchain4j.data.message.UserMessage;
 import io.quarkus.jackson.JacksonMixin;
@@ -11,11 +10,7 @@ import io.quarkus.jackson.JacksonMixin;
 @JacksonMixin(UserMessage.class)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE)
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonDeserialize(using = UserMessageDeserializer.class)
 public abstract class UserMessageMixin {
-
-    @JsonCreator
-    public UserMessageMixin(@JsonProperty("name") String name, @JsonProperty("text") String text) {
-
-    }
 
 }

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,3 +1,3 @@
 :project-version: 0.7.1
-:langchain4j-version: 0.25.0
+:langchain4j-version: 0.27.0-SNAPSHOT
 :examples-dir: ./../examples/

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-chroma.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-chroma.adoc
@@ -10,7 +10,7 @@ h|[[quarkus-langchain4j-chroma_configuration]]link:#quarkus-langchain4j-chroma_c
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus.langchain4j.chroma.devservices.enabled]]`link:#quarkus-langchain4j-chroma_quarkus.langchain4j.chroma.devservices.enabled[quarkus.langchain4j.chroma.devservices.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-devservices-enabled]]`link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-devservices-enabled[quarkus.langchain4j.chroma.devservices.enabled]`
 
 
 [.description]
@@ -29,7 +29,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus.langchain4j.chroma.devservices.image-name]]`link:#quarkus-langchain4j-chroma_quarkus.langchain4j.chroma.devservices.image-name[quarkus.langchain4j.chroma.devservices.image-name]`
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-devservices-image-name]]`link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-devservices-image-name[quarkus.langchain4j.chroma.devservices.image-name]`
 
 
 [.description]
@@ -46,7 +46,7 @@ endif::add-copy-button-to-env-var[]
 |`ghcr.io/chroma-core/chroma:0.4.15`
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus.langchain4j.chroma.devservices.port]]`link:#quarkus-langchain4j-chroma_quarkus.langchain4j.chroma.devservices.port[quarkus.langchain4j.chroma.devservices.port]`
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-devservices-port]]`link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-devservices-port[quarkus.langchain4j.chroma.devservices.port]`
 
 
 [.description]
@@ -65,7 +65,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus.langchain4j.chroma.devservices.shared]]`link:#quarkus-langchain4j-chroma_quarkus.langchain4j.chroma.devservices.shared[quarkus.langchain4j.chroma.devservices.shared]`
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-devservices-shared]]`link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-devservices-shared[quarkus.langchain4j.chroma.devservices.shared]`
 
 
 [.description]
@@ -86,7 +86,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus.langchain4j.chroma.devservices.service-name]]`link:#quarkus-langchain4j-chroma_quarkus.langchain4j.chroma.devservices.service-name[quarkus.langchain4j.chroma.devservices.service-name]`
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-devservices-service-name]]`link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-devservices-service-name[quarkus.langchain4j.chroma.devservices.service-name]`
 
 
 [.description]
@@ -105,7 +105,7 @@ endif::add-copy-button-to-env-var[]
 |`chroma`
 
 
-a| [[quarkus-langchain4j-chroma_quarkus.langchain4j.chroma.url]]`link:#quarkus-langchain4j-chroma_quarkus.langchain4j.chroma.url[quarkus.langchain4j.chroma.url]`
+a| [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-url]]`link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-url[quarkus.langchain4j.chroma.url]`
 
 
 [.description]
@@ -122,7 +122,7 @@ endif::add-copy-button-to-env-var[]
 |required icon:exclamation-circle[title=Configuration property is required]
 
 
-a| [[quarkus-langchain4j-chroma_quarkus.langchain4j.chroma.collection-name]]`link:#quarkus-langchain4j-chroma_quarkus.langchain4j.chroma.collection-name[quarkus.langchain4j.chroma.collection-name]`
+a| [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-collection-name]]`link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-collection-name[quarkus.langchain4j.chroma.collection-name]`
 
 
 [.description]
@@ -139,7 +139,7 @@ endif::add-copy-button-to-env-var[]
 |`default`
 
 
-a| [[quarkus-langchain4j-chroma_quarkus.langchain4j.chroma.timeout]]`link:#quarkus-langchain4j-chroma_quarkus.langchain4j.chroma.timeout[quarkus.langchain4j.chroma.timeout]`
+a| [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-timeout]]`link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-timeout[quarkus.langchain4j.chroma.timeout]`
 
 
 [.description]
@@ -157,7 +157,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus.langchain4j.chroma.devservices.container-env-container-env]]`link:#quarkus-langchain4j-chroma_quarkus.langchain4j.chroma.devservices.container-env-container-env[quarkus.langchain4j.chroma.devservices.container-env]`
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-devservices-container-env-container-env]]`link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-devservices-container-env-container-env[quarkus.langchain4j.chroma.devservices.container-env]`
 
 
 [.description]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-huggingface.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-huggingface.adoc
@@ -10,7 +10,7 @@ h|[[quarkus-langchain4j-huggingface_configuration]]link:#quarkus-langchain4j-hug
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.chat-model.enabled]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.chat-model.enabled[quarkus.langchain4j.huggingface.chat-model.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-chat-model-enabled]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-chat-model-enabled[quarkus.langchain4j.huggingface.chat-model.enabled]`
 
 
 [.description]
@@ -27,7 +27,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.embedding-model.enabled]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.embedding-model.enabled[quarkus.langchain4j.huggingface.embedding-model.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-embedding-model-enabled]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-embedding-model-enabled[quarkus.langchain4j.huggingface.embedding-model.enabled]`
 
 
 [.description]
@@ -44,7 +44,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.moderation-model.enabled]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.moderation-model.enabled[quarkus.langchain4j.huggingface.moderation-model.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-moderation-model-enabled]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-moderation-model-enabled[quarkus.langchain4j.huggingface.moderation-model.enabled]`
 
 
 [.description]
@@ -61,7 +61,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.api-key]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.api-key[quarkus.langchain4j.huggingface.api-key]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-api-key]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-api-key[quarkus.langchain4j.huggingface.api-key]`
 
 
 [.description]
@@ -78,7 +78,7 @@ endif::add-copy-button-to-env-var[]
 |`dummy`
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.timeout]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.timeout[quarkus.langchain4j.huggingface.timeout]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-timeout]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-timeout[quarkus.langchain4j.huggingface.timeout]`
 
 
 [.description]
@@ -96,7 +96,7 @@ endif::add-copy-button-to-env-var[]
 |`10S`
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.chat-model.inference-endpoint-url]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.chat-model.inference-endpoint-url[quarkus.langchain4j.huggingface.chat-model.inference-endpoint-url]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-chat-model-inference-endpoint-url]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-chat-model-inference-endpoint-url[quarkus.langchain4j.huggingface.chat-model.inference-endpoint-url]`
 
 
 [.description]
@@ -118,7 +118,7 @@ endif::add-copy-button-to-env-var[]
 |`https://api-inference.huggingface.co/models/tiiuae/falcon-7b-instruct`
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.chat-model.temperature]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.chat-model.temperature[quarkus.langchain4j.huggingface.chat-model.temperature]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-chat-model-temperature]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-chat-model-temperature[quarkus.langchain4j.huggingface.chat-model.temperature]`
 
 
 [.description]
@@ -135,7 +135,7 @@ endif::add-copy-button-to-env-var[]
 |`1.0`
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.chat-model.max-new-tokens]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.chat-model.max-new-tokens[quarkus.langchain4j.huggingface.chat-model.max-new-tokens]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-chat-model-max-new-tokens]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-chat-model-max-new-tokens[quarkus.langchain4j.huggingface.chat-model.max-new-tokens]`
 
 
 [.description]
@@ -152,7 +152,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.chat-model.return-full-text]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.chat-model.return-full-text[quarkus.langchain4j.huggingface.chat-model.return-full-text]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-chat-model-return-full-text]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-chat-model-return-full-text[quarkus.langchain4j.huggingface.chat-model.return-full-text]`
 
 
 [.description]
@@ -169,7 +169,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.chat-model.wait-for-model]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.chat-model.wait-for-model[quarkus.langchain4j.huggingface.chat-model.wait-for-model]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-chat-model-wait-for-model]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-chat-model-wait-for-model[quarkus.langchain4j.huggingface.chat-model.wait-for-model]`
 
 
 [.description]
@@ -186,7 +186,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.chat-model.do-sample]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.chat-model.do-sample[quarkus.langchain4j.huggingface.chat-model.do-sample]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-chat-model-do-sample]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-chat-model-do-sample[quarkus.langchain4j.huggingface.chat-model.do-sample]`
 
 
 [.description]
@@ -203,7 +203,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.chat-model.top-k]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.chat-model.top-k[quarkus.langchain4j.huggingface.chat-model.top-k]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-chat-model-top-k]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-chat-model-top-k[quarkus.langchain4j.huggingface.chat-model.top-k]`
 
 
 [.description]
@@ -220,7 +220,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.chat-model.top-p]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.chat-model.top-p[quarkus.langchain4j.huggingface.chat-model.top-p]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-chat-model-top-p]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-chat-model-top-p[quarkus.langchain4j.huggingface.chat-model.top-p]`
 
 
 [.description]
@@ -237,7 +237,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.chat-model.repetition-penalty]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.chat-model.repetition-penalty[quarkus.langchain4j.huggingface.chat-model.repetition-penalty]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-chat-model-repetition-penalty]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-chat-model-repetition-penalty[quarkus.langchain4j.huggingface.chat-model.repetition-penalty]`
 
 
 [.description]
@@ -254,7 +254,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.chat-model.log-requests]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.chat-model.log-requests[quarkus.langchain4j.huggingface.chat-model.log-requests]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-chat-model-log-requests]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-chat-model-log-requests[quarkus.langchain4j.huggingface.chat-model.log-requests]`
 
 
 [.description]
@@ -271,7 +271,7 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.chat-model.log-responses]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.chat-model.log-responses[quarkus.langchain4j.huggingface.chat-model.log-responses]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-chat-model-log-responses]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-chat-model-log-responses[quarkus.langchain4j.huggingface.chat-model.log-responses]`
 
 
 [.description]
@@ -288,7 +288,7 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.embedding-model.inference-endpoint-url]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.embedding-model.inference-endpoint-url[quarkus.langchain4j.huggingface.embedding-model.inference-endpoint-url]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-embedding-model-inference-endpoint-url]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-embedding-model-inference-endpoint-url[quarkus.langchain4j.huggingface.embedding-model.inference-endpoint-url]`
 
 
 [.description]
@@ -310,7 +310,7 @@ endif::add-copy-button-to-env-var[]
 |`https://api-inference.huggingface.co/pipeline/feature-extraction/sentence-transformers/all-MiniLM-L6-v2`
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.embedding-model.wait-for-model]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.embedding-model.wait-for-model[quarkus.langchain4j.huggingface.embedding-model.wait-for-model]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-embedding-model-wait-for-model]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-embedding-model-wait-for-model[quarkus.langchain4j.huggingface.embedding-model.wait-for-model]`
 
 
 [.description]
@@ -327,7 +327,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.log-requests]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.log-requests[quarkus.langchain4j.huggingface.log-requests]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-log-requests]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-log-requests[quarkus.langchain4j.huggingface.log-requests]`
 
 
 [.description]
@@ -344,7 +344,7 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.log-responses]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.log-responses[quarkus.langchain4j.huggingface.log-responses]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-log-responses]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-log-responses[quarkus.langchain4j.huggingface.log-responses]`
 
 
 [.description]
@@ -361,12 +361,12 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-h|[[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.named-config-named-model-config]]link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.named-config-named-model-config[Named model config]
+h|[[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-named-config-named-model-config]]link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-named-config-named-model-config[Named model config]
 
 h|Type
 h|Default
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.api-key]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.api-key[quarkus.langchain4j.huggingface."model-name".api-key]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-api-key]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-api-key[quarkus.langchain4j.huggingface."model-name".api-key]`
 
 
 [.description]
@@ -383,7 +383,7 @@ endif::add-copy-button-to-env-var[]
 |`dummy`
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.timeout]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.timeout[quarkus.langchain4j.huggingface."model-name".timeout]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-timeout]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-timeout[quarkus.langchain4j.huggingface."model-name".timeout]`
 
 
 [.description]
@@ -401,7 +401,7 @@ endif::add-copy-button-to-env-var[]
 |`10S`
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.chat-model.inference-endpoint-url]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.chat-model.inference-endpoint-url[quarkus.langchain4j.huggingface."model-name".chat-model.inference-endpoint-url]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-chat-model-inference-endpoint-url]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-chat-model-inference-endpoint-url[quarkus.langchain4j.huggingface."model-name".chat-model.inference-endpoint-url]`
 
 
 [.description]
@@ -423,7 +423,7 @@ endif::add-copy-button-to-env-var[]
 |`https://api-inference.huggingface.co/models/tiiuae/falcon-7b-instruct`
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.chat-model.temperature]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.chat-model.temperature[quarkus.langchain4j.huggingface."model-name".chat-model.temperature]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-chat-model-temperature]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-chat-model-temperature[quarkus.langchain4j.huggingface."model-name".chat-model.temperature]`
 
 
 [.description]
@@ -440,7 +440,7 @@ endif::add-copy-button-to-env-var[]
 |`1.0`
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.chat-model.max-new-tokens]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.chat-model.max-new-tokens[quarkus.langchain4j.huggingface."model-name".chat-model.max-new-tokens]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-chat-model-max-new-tokens]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-chat-model-max-new-tokens[quarkus.langchain4j.huggingface."model-name".chat-model.max-new-tokens]`
 
 
 [.description]
@@ -457,7 +457,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.chat-model.return-full-text]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.chat-model.return-full-text[quarkus.langchain4j.huggingface."model-name".chat-model.return-full-text]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-chat-model-return-full-text]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-chat-model-return-full-text[quarkus.langchain4j.huggingface."model-name".chat-model.return-full-text]`
 
 
 [.description]
@@ -474,7 +474,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.chat-model.wait-for-model]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.chat-model.wait-for-model[quarkus.langchain4j.huggingface."model-name".chat-model.wait-for-model]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-chat-model-wait-for-model]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-chat-model-wait-for-model[quarkus.langchain4j.huggingface."model-name".chat-model.wait-for-model]`
 
 
 [.description]
@@ -491,7 +491,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.chat-model.do-sample]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.chat-model.do-sample[quarkus.langchain4j.huggingface."model-name".chat-model.do-sample]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-chat-model-do-sample]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-chat-model-do-sample[quarkus.langchain4j.huggingface."model-name".chat-model.do-sample]`
 
 
 [.description]
@@ -508,7 +508,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.chat-model.top-k]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.chat-model.top-k[quarkus.langchain4j.huggingface."model-name".chat-model.top-k]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-chat-model-top-k]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-chat-model-top-k[quarkus.langchain4j.huggingface."model-name".chat-model.top-k]`
 
 
 [.description]
@@ -525,7 +525,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.chat-model.top-p]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.chat-model.top-p[quarkus.langchain4j.huggingface."model-name".chat-model.top-p]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-chat-model-top-p]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-chat-model-top-p[quarkus.langchain4j.huggingface."model-name".chat-model.top-p]`
 
 
 [.description]
@@ -542,7 +542,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.chat-model.repetition-penalty]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.chat-model.repetition-penalty[quarkus.langchain4j.huggingface."model-name".chat-model.repetition-penalty]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-chat-model-repetition-penalty]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-chat-model-repetition-penalty[quarkus.langchain4j.huggingface."model-name".chat-model.repetition-penalty]`
 
 
 [.description]
@@ -559,7 +559,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.chat-model.log-requests]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.chat-model.log-requests[quarkus.langchain4j.huggingface."model-name".chat-model.log-requests]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-chat-model-log-requests]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-chat-model-log-requests[quarkus.langchain4j.huggingface."model-name".chat-model.log-requests]`
 
 
 [.description]
@@ -576,7 +576,7 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.chat-model.log-responses]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.chat-model.log-responses[quarkus.langchain4j.huggingface."model-name".chat-model.log-responses]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-chat-model-log-responses]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-chat-model-log-responses[quarkus.langchain4j.huggingface."model-name".chat-model.log-responses]`
 
 
 [.description]
@@ -593,7 +593,7 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.embedding-model.inference-endpoint-url]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.embedding-model.inference-endpoint-url[quarkus.langchain4j.huggingface."model-name".embedding-model.inference-endpoint-url]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-embedding-model-inference-endpoint-url]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-embedding-model-inference-endpoint-url[quarkus.langchain4j.huggingface."model-name".embedding-model.inference-endpoint-url]`
 
 
 [.description]
@@ -615,7 +615,7 @@ endif::add-copy-button-to-env-var[]
 |`https://api-inference.huggingface.co/pipeline/feature-extraction/sentence-transformers/all-MiniLM-L6-v2`
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.embedding-model.wait-for-model]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.embedding-model.wait-for-model[quarkus.langchain4j.huggingface."model-name".embedding-model.wait-for-model]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-embedding-model-wait-for-model]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-embedding-model-wait-for-model[quarkus.langchain4j.huggingface."model-name".embedding-model.wait-for-model]`
 
 
 [.description]
@@ -632,7 +632,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.log-requests]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.log-requests[quarkus.langchain4j.huggingface."model-name".log-requests]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-log-requests]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-log-requests[quarkus.langchain4j.huggingface."model-name".log-requests]`
 
 
 [.description]
@@ -649,7 +649,7 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.log-responses]]`link:#quarkus-langchain4j-huggingface_quarkus.langchain4j.huggingface.-model-name-.log-responses[quarkus.langchain4j.huggingface."model-name".log-responses]`
+a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-log-responses]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-log-responses[quarkus.langchain4j.huggingface."model-name".log-responses]`
 
 
 [.description]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai.adoc
@@ -10,7 +10,7 @@ h|[[quarkus-langchain4j-openai_configuration]]link:#quarkus-langchain4j-openai_c
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.chat-model.enabled]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.chat-model.enabled[quarkus.langchain4j.openai.chat-model.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-enabled]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-enabled[quarkus.langchain4j.openai.chat-model.enabled]`
 
 
 [.description]
@@ -27,7 +27,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.embedding-model.enabled]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.embedding-model.enabled[quarkus.langchain4j.openai.embedding-model.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-embedding-model-enabled]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-embedding-model-enabled[quarkus.langchain4j.openai.embedding-model.enabled]`
 
 
 [.description]
@@ -44,7 +44,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.moderation-model.enabled]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.moderation-model.enabled[quarkus.langchain4j.openai.moderation-model.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-moderation-model-enabled]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-moderation-model-enabled[quarkus.langchain4j.openai.moderation-model.enabled]`
 
 
 [.description]
@@ -61,7 +61,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.image-model.enabled]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.image-model.enabled[quarkus.langchain4j.openai.image-model.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-enabled]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-enabled[quarkus.langchain4j.openai.image-model.enabled]`
 
 
 [.description]
@@ -78,7 +78,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.base-url]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.base-url[quarkus.langchain4j.openai.base-url]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-base-url]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-base-url[quarkus.langchain4j.openai.base-url]`
 
 
 [.description]
@@ -95,7 +95,7 @@ endif::add-copy-button-to-env-var[]
 |`https://api.openai.com/v1/`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.api-key]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.api-key[quarkus.langchain4j.openai.api-key]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-api-key]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-api-key[quarkus.langchain4j.openai.api-key]`
 
 
 [.description]
@@ -112,7 +112,7 @@ endif::add-copy-button-to-env-var[]
 |`dummy`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.organization-id]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.organization-id[quarkus.langchain4j.openai.organization-id]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-organization-id]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-organization-id[quarkus.langchain4j.openai.organization-id]`
 
 
 [.description]
@@ -129,7 +129,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.timeout]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.timeout[quarkus.langchain4j.openai.timeout]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-timeout]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-timeout[quarkus.langchain4j.openai.timeout]`
 
 
 [.description]
@@ -147,7 +147,7 @@ endif::add-copy-button-to-env-var[]
 |`10S`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.max-retries]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.max-retries[quarkus.langchain4j.openai.max-retries]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-max-retries]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-max-retries[quarkus.langchain4j.openai.max-retries]`
 
 
 [.description]
@@ -164,7 +164,7 @@ endif::add-copy-button-to-env-var[]
 |`3`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.log-requests]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.log-requests[quarkus.langchain4j.openai.log-requests]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-log-requests]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-log-requests[quarkus.langchain4j.openai.log-requests]`
 
 
 [.description]
@@ -181,7 +181,7 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.log-responses]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.log-responses[quarkus.langchain4j.openai.log-responses]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-log-responses]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-log-responses[quarkus.langchain4j.openai.log-responses]`
 
 
 [.description]
@@ -198,7 +198,7 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.chat-model.model-name]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.chat-model.model-name[quarkus.langchain4j.openai.chat-model.model-name]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-model-name]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-model-name[quarkus.langchain4j.openai.chat-model.model-name]`
 
 
 [.description]
@@ -215,7 +215,7 @@ endif::add-copy-button-to-env-var[]
 |`gpt-3.5-turbo`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.chat-model.temperature]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.chat-model.temperature[quarkus.langchain4j.openai.chat-model.temperature]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-temperature]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-temperature[quarkus.langchain4j.openai.chat-model.temperature]`
 
 
 [.description]
@@ -232,7 +232,7 @@ endif::add-copy-button-to-env-var[]
 |`1.0`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.chat-model.top-p]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.chat-model.top-p[quarkus.langchain4j.openai.chat-model.top-p]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-top-p]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-top-p[quarkus.langchain4j.openai.chat-model.top-p]`
 
 
 [.description]
@@ -249,7 +249,7 @@ endif::add-copy-button-to-env-var[]
 |`1.0`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.chat-model.max-tokens]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.chat-model.max-tokens[quarkus.langchain4j.openai.chat-model.max-tokens]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-max-tokens]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-max-tokens[quarkus.langchain4j.openai.chat-model.max-tokens]`
 
 
 [.description]
@@ -266,7 +266,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.chat-model.presence-penalty]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.chat-model.presence-penalty[quarkus.langchain4j.openai.chat-model.presence-penalty]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-presence-penalty]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-presence-penalty[quarkus.langchain4j.openai.chat-model.presence-penalty]`
 
 
 [.description]
@@ -283,7 +283,7 @@ endif::add-copy-button-to-env-var[]
 |`0`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.chat-model.frequency-penalty]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.chat-model.frequency-penalty[quarkus.langchain4j.openai.chat-model.frequency-penalty]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-frequency-penalty]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-frequency-penalty[quarkus.langchain4j.openai.chat-model.frequency-penalty]`
 
 
 [.description]
@@ -300,7 +300,7 @@ endif::add-copy-button-to-env-var[]
 |`0`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.chat-model.log-requests]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.chat-model.log-requests[quarkus.langchain4j.openai.chat-model.log-requests]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-log-requests]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-log-requests[quarkus.langchain4j.openai.chat-model.log-requests]`
 
 
 [.description]
@@ -317,7 +317,7 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.chat-model.log-responses]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.chat-model.log-responses[quarkus.langchain4j.openai.chat-model.log-responses]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-log-responses]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-log-responses[quarkus.langchain4j.openai.chat-model.log-responses]`
 
 
 [.description]
@@ -351,7 +351,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.embedding-model.model-name]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.embedding-model.model-name[quarkus.langchain4j.openai.embedding-model.model-name]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-embedding-model-model-name]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-embedding-model-model-name[quarkus.langchain4j.openai.embedding-model.model-name]`
 
 
 [.description]
@@ -368,7 +368,7 @@ endif::add-copy-button-to-env-var[]
 |`text-embedding-ada-002`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.embedding-model.log-requests]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.embedding-model.log-requests[quarkus.langchain4j.openai.embedding-model.log-requests]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-embedding-model-log-requests]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-embedding-model-log-requests[quarkus.langchain4j.openai.embedding-model.log-requests]`
 
 
 [.description]
@@ -385,7 +385,7 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.embedding-model.log-responses]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.embedding-model.log-responses[quarkus.langchain4j.openai.embedding-model.log-responses]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-embedding-model-log-responses]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-embedding-model-log-responses[quarkus.langchain4j.openai.embedding-model.log-responses]`
 
 
 [.description]
@@ -402,7 +402,7 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.embedding-model.user]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.embedding-model.user[quarkus.langchain4j.openai.embedding-model.user]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-embedding-model-user]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-embedding-model-user[quarkus.langchain4j.openai.embedding-model.user]`
 
 
 [.description]
@@ -419,7 +419,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.moderation-model.model-name]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.moderation-model.model-name[quarkus.langchain4j.openai.moderation-model.model-name]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-moderation-model-model-name]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-moderation-model-model-name[quarkus.langchain4j.openai.moderation-model.model-name]`
 
 
 [.description]
@@ -436,7 +436,7 @@ endif::add-copy-button-to-env-var[]
 |`text-moderation-latest`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.moderation-model.log-requests]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.moderation-model.log-requests[quarkus.langchain4j.openai.moderation-model.log-requests]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-moderation-model-log-requests]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-moderation-model-log-requests[quarkus.langchain4j.openai.moderation-model.log-requests]`
 
 
 [.description]
@@ -453,7 +453,7 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.moderation-model.log-responses]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.moderation-model.log-responses[quarkus.langchain4j.openai.moderation-model.log-responses]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-moderation-model-log-responses]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-moderation-model-log-responses[quarkus.langchain4j.openai.moderation-model.log-responses]`
 
 
 [.description]
@@ -470,7 +470,7 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.image-model.model-name]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.image-model.model-name[quarkus.langchain4j.openai.image-model.model-name]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-model-name]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-model-name[quarkus.langchain4j.openai.image-model.model-name]`
 
 
 [.description]
@@ -487,7 +487,7 @@ endif::add-copy-button-to-env-var[]
 |`dall-e-3`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.image-model.persist]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.image-model.persist[quarkus.langchain4j.openai.image-model.persist]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-persist]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-persist[quarkus.langchain4j.openai.image-model.persist]`
 
 
 [.description]
@@ -504,7 +504,7 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.image-model.persist-directory]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.image-model.persist-directory[quarkus.langchain4j.openai.image-model.persist-directory]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-persist-directory]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-persist-directory[quarkus.langchain4j.openai.image-model.persist-directory]`
 
 
 [.description]
@@ -521,7 +521,7 @@ endif::add-copy-button-to-env-var[]
 |`${java.io.tmpdir}/dall-e-images`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.image-model.response-format]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.image-model.response-format[quarkus.langchain4j.openai.image-model.response-format]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-response-format]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-response-format[quarkus.langchain4j.openai.image-model.response-format]`
 
 
 [.description]
@@ -540,7 +540,7 @@ endif::add-copy-button-to-env-var[]
 |`url`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.image-model.size]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.image-model.size[quarkus.langchain4j.openai.image-model.size]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-size]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-size[quarkus.langchain4j.openai.image-model.size]`
 
 
 [.description]
@@ -561,7 +561,7 @@ endif::add-copy-button-to-env-var[]
 |`1024x1024`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.image-model.quality]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.image-model.quality[quarkus.langchain4j.openai.image-model.quality]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-quality]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-quality[quarkus.langchain4j.openai.image-model.quality]`
 
 
 [.description]
@@ -582,7 +582,7 @@ endif::add-copy-button-to-env-var[]
 |`standard`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.image-model.number]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.image-model.number[quarkus.langchain4j.openai.image-model.number]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-number]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-number[quarkus.langchain4j.openai.image-model.number]`
 
 
 [.description]
@@ -603,7 +603,7 @@ endif::add-copy-button-to-env-var[]
 |`1`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.image-model.style]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.image-model.style[quarkus.langchain4j.openai.image-model.style]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-style]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-style[quarkus.langchain4j.openai.image-model.style]`
 
 
 [.description]
@@ -624,7 +624,7 @@ endif::add-copy-button-to-env-var[]
 |`vivid`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.image-model.user]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.image-model.user[quarkus.langchain4j.openai.image-model.user]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-user]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-user[quarkus.langchain4j.openai.image-model.user]`
 
 
 [.description]
@@ -641,7 +641,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.image-model.log-requests]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.image-model.log-requests[quarkus.langchain4j.openai.image-model.log-requests]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-log-requests]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-log-requests[quarkus.langchain4j.openai.image-model.log-requests]`
 
 
 [.description]
@@ -658,7 +658,7 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.image-model.log-responses]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.image-model.log-responses[quarkus.langchain4j.openai.image-model.log-responses]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-log-responses]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-log-responses[quarkus.langchain4j.openai.image-model.log-responses]`
 
 
 [.description]
@@ -675,12 +675,12 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-h|[[quarkus-langchain4j-openai_quarkus.langchain4j.openai.named-config-named-model-config]]link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.named-config-named-model-config[Named model config]
+h|[[quarkus-langchain4j-openai_quarkus-langchain4j-openai-named-config-named-model-config]]link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-named-config-named-model-config[Named model config]
 
 h|Type
 h|Default
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.base-url]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.base-url[quarkus.langchain4j.openai."model-name".base-url]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-base-url]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-base-url[quarkus.langchain4j.openai."model-name".base-url]`
 
 
 [.description]
@@ -697,7 +697,7 @@ endif::add-copy-button-to-env-var[]
 |`https://api.openai.com/v1/`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.api-key]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.api-key[quarkus.langchain4j.openai."model-name".api-key]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-api-key]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-api-key[quarkus.langchain4j.openai."model-name".api-key]`
 
 
 [.description]
@@ -714,7 +714,7 @@ endif::add-copy-button-to-env-var[]
 |`dummy`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.organization-id]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.organization-id[quarkus.langchain4j.openai."model-name".organization-id]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-organization-id]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-organization-id[quarkus.langchain4j.openai."model-name".organization-id]`
 
 
 [.description]
@@ -731,7 +731,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.timeout]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.timeout[quarkus.langchain4j.openai."model-name".timeout]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-timeout]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-timeout[quarkus.langchain4j.openai."model-name".timeout]`
 
 
 [.description]
@@ -749,7 +749,7 @@ endif::add-copy-button-to-env-var[]
 |`10S`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.max-retries]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.max-retries[quarkus.langchain4j.openai."model-name".max-retries]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-max-retries]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-max-retries[quarkus.langchain4j.openai."model-name".max-retries]`
 
 
 [.description]
@@ -766,7 +766,7 @@ endif::add-copy-button-to-env-var[]
 |`3`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.log-requests]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.log-requests[quarkus.langchain4j.openai."model-name".log-requests]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-log-requests]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-log-requests[quarkus.langchain4j.openai."model-name".log-requests]`
 
 
 [.description]
@@ -783,7 +783,7 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.log-responses]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.log-responses[quarkus.langchain4j.openai."model-name".log-responses]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-log-responses]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-log-responses[quarkus.langchain4j.openai."model-name".log-responses]`
 
 
 [.description]
@@ -800,7 +800,7 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.chat-model.model-name]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.chat-model.model-name[quarkus.langchain4j.openai."model-name".chat-model.model-name]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-model-name]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-model-name[quarkus.langchain4j.openai."model-name".chat-model.model-name]`
 
 
 [.description]
@@ -817,7 +817,7 @@ endif::add-copy-button-to-env-var[]
 |`gpt-3.5-turbo`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.chat-model.temperature]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.chat-model.temperature[quarkus.langchain4j.openai."model-name".chat-model.temperature]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-temperature]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-temperature[quarkus.langchain4j.openai."model-name".chat-model.temperature]`
 
 
 [.description]
@@ -834,7 +834,7 @@ endif::add-copy-button-to-env-var[]
 |`1.0`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.chat-model.top-p]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.chat-model.top-p[quarkus.langchain4j.openai."model-name".chat-model.top-p]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-top-p]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-top-p[quarkus.langchain4j.openai."model-name".chat-model.top-p]`
 
 
 [.description]
@@ -851,7 +851,7 @@ endif::add-copy-button-to-env-var[]
 |`1.0`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.chat-model.max-tokens]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.chat-model.max-tokens[quarkus.langchain4j.openai."model-name".chat-model.max-tokens]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-max-tokens]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-max-tokens[quarkus.langchain4j.openai."model-name".chat-model.max-tokens]`
 
 
 [.description]
@@ -868,7 +868,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.chat-model.presence-penalty]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.chat-model.presence-penalty[quarkus.langchain4j.openai."model-name".chat-model.presence-penalty]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-presence-penalty]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-presence-penalty[quarkus.langchain4j.openai."model-name".chat-model.presence-penalty]`
 
 
 [.description]
@@ -885,7 +885,7 @@ endif::add-copy-button-to-env-var[]
 |`0`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.chat-model.frequency-penalty]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.chat-model.frequency-penalty[quarkus.langchain4j.openai."model-name".chat-model.frequency-penalty]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-frequency-penalty]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-frequency-penalty[quarkus.langchain4j.openai."model-name".chat-model.frequency-penalty]`
 
 
 [.description]
@@ -902,7 +902,7 @@ endif::add-copy-button-to-env-var[]
 |`0`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.chat-model.log-requests]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.chat-model.log-requests[quarkus.langchain4j.openai."model-name".chat-model.log-requests]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-log-requests]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-log-requests[quarkus.langchain4j.openai."model-name".chat-model.log-requests]`
 
 
 [.description]
@@ -919,7 +919,7 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.chat-model.log-responses]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.chat-model.log-responses[quarkus.langchain4j.openai."model-name".chat-model.log-responses]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-log-responses]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-log-responses[quarkus.langchain4j.openai."model-name".chat-model.log-responses]`
 
 
 [.description]
@@ -953,7 +953,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.embedding-model.model-name]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.embedding-model.model-name[quarkus.langchain4j.openai."model-name".embedding-model.model-name]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-embedding-model-model-name]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-embedding-model-model-name[quarkus.langchain4j.openai."model-name".embedding-model.model-name]`
 
 
 [.description]
@@ -970,7 +970,7 @@ endif::add-copy-button-to-env-var[]
 |`text-embedding-ada-002`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.embedding-model.log-requests]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.embedding-model.log-requests[quarkus.langchain4j.openai."model-name".embedding-model.log-requests]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-embedding-model-log-requests]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-embedding-model-log-requests[quarkus.langchain4j.openai."model-name".embedding-model.log-requests]`
 
 
 [.description]
@@ -987,7 +987,7 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.embedding-model.log-responses]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.embedding-model.log-responses[quarkus.langchain4j.openai."model-name".embedding-model.log-responses]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-embedding-model-log-responses]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-embedding-model-log-responses[quarkus.langchain4j.openai."model-name".embedding-model.log-responses]`
 
 
 [.description]
@@ -1004,7 +1004,7 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.embedding-model.user]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.embedding-model.user[quarkus.langchain4j.openai."model-name".embedding-model.user]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-embedding-model-user]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-embedding-model-user[quarkus.langchain4j.openai."model-name".embedding-model.user]`
 
 
 [.description]
@@ -1021,7 +1021,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.moderation-model.model-name]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.moderation-model.model-name[quarkus.langchain4j.openai."model-name".moderation-model.model-name]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-moderation-model-model-name]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-moderation-model-model-name[quarkus.langchain4j.openai."model-name".moderation-model.model-name]`
 
 
 [.description]
@@ -1038,7 +1038,7 @@ endif::add-copy-button-to-env-var[]
 |`text-moderation-latest`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.moderation-model.log-requests]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.moderation-model.log-requests[quarkus.langchain4j.openai."model-name".moderation-model.log-requests]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-moderation-model-log-requests]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-moderation-model-log-requests[quarkus.langchain4j.openai."model-name".moderation-model.log-requests]`
 
 
 [.description]
@@ -1055,7 +1055,7 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.moderation-model.log-responses]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.moderation-model.log-responses[quarkus.langchain4j.openai."model-name".moderation-model.log-responses]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-moderation-model-log-responses]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-moderation-model-log-responses[quarkus.langchain4j.openai."model-name".moderation-model.log-responses]`
 
 
 [.description]
@@ -1072,7 +1072,7 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.image-model.model-name]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.image-model.model-name[quarkus.langchain4j.openai."model-name".image-model.model-name]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-model-name]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-model-name[quarkus.langchain4j.openai."model-name".image-model.model-name]`
 
 
 [.description]
@@ -1089,7 +1089,7 @@ endif::add-copy-button-to-env-var[]
 |`dall-e-3`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.image-model.persist]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.image-model.persist[quarkus.langchain4j.openai."model-name".image-model.persist]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-persist]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-persist[quarkus.langchain4j.openai."model-name".image-model.persist]`
 
 
 [.description]
@@ -1106,7 +1106,7 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.image-model.persist-directory]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.image-model.persist-directory[quarkus.langchain4j.openai."model-name".image-model.persist-directory]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-persist-directory]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-persist-directory[quarkus.langchain4j.openai."model-name".image-model.persist-directory]`
 
 
 [.description]
@@ -1123,7 +1123,7 @@ endif::add-copy-button-to-env-var[]
 |`${java.io.tmpdir}/dall-e-images`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.image-model.response-format]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.image-model.response-format[quarkus.langchain4j.openai."model-name".image-model.response-format]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-response-format]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-response-format[quarkus.langchain4j.openai."model-name".image-model.response-format]`
 
 
 [.description]
@@ -1142,7 +1142,7 @@ endif::add-copy-button-to-env-var[]
 |`url`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.image-model.size]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.image-model.size[quarkus.langchain4j.openai."model-name".image-model.size]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-size]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-size[quarkus.langchain4j.openai."model-name".image-model.size]`
 
 
 [.description]
@@ -1163,7 +1163,7 @@ endif::add-copy-button-to-env-var[]
 |`1024x1024`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.image-model.quality]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.image-model.quality[quarkus.langchain4j.openai."model-name".image-model.quality]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-quality]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-quality[quarkus.langchain4j.openai."model-name".image-model.quality]`
 
 
 [.description]
@@ -1184,7 +1184,7 @@ endif::add-copy-button-to-env-var[]
 |`standard`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.image-model.number]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.image-model.number[quarkus.langchain4j.openai."model-name".image-model.number]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-number]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-number[quarkus.langchain4j.openai."model-name".image-model.number]`
 
 
 [.description]
@@ -1205,7 +1205,7 @@ endif::add-copy-button-to-env-var[]
 |`1`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.image-model.style]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.image-model.style[quarkus.langchain4j.openai."model-name".image-model.style]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-style]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-style[quarkus.langchain4j.openai."model-name".image-model.style]`
 
 
 [.description]
@@ -1226,7 +1226,7 @@ endif::add-copy-button-to-env-var[]
 |`vivid`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.image-model.user]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.image-model.user[quarkus.langchain4j.openai."model-name".image-model.user]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-user]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-user[quarkus.langchain4j.openai."model-name".image-model.user]`
 
 
 [.description]
@@ -1243,7 +1243,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.image-model.log-requests]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.image-model.log-requests[quarkus.langchain4j.openai."model-name".image-model.log-requests]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-log-requests]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-log-requests[quarkus.langchain4j.openai."model-name".image-model.log-requests]`
 
 
 [.description]
@@ -1260,7 +1260,7 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.image-model.log-responses]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.image-model.log-responses[quarkus.langchain4j.openai."model-name".image-model.log-responses]`
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-log-responses]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-log-responses[quarkus.langchain4j.openai."model-name".image-model.log-responses]`
 
 
 [.description]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-pgvector.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-pgvector.adoc
@@ -10,7 +10,7 @@ h|[[quarkus-langchain4j-pgvector_configuration]]link:#quarkus-langchain4j-pgvect
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-pgvector_quarkus.langchain4j.pgvector.datasource]]`link:#quarkus-langchain4j-pgvector_quarkus.langchain4j.pgvector.datasource[quarkus.langchain4j.pgvector.datasource]`
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-datasource]]`link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-datasource[quarkus.langchain4j.pgvector.datasource]`
 
 
 [.description]
@@ -27,7 +27,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-pgvector_quarkus.langchain4j.pgvector.table]]`link:#quarkus-langchain4j-pgvector_quarkus.langchain4j.pgvector.table[quarkus.langchain4j.pgvector.table]`
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-table]]`link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-table[quarkus.langchain4j.pgvector.table]`
 
 
 [.description]
@@ -44,7 +44,7 @@ endif::add-copy-button-to-env-var[]
 |`embeddings`
 
 
-a| [[quarkus-langchain4j-pgvector_quarkus.langchain4j.pgvector.dimension]]`link:#quarkus-langchain4j-pgvector_quarkus.langchain4j.pgvector.dimension[quarkus.langchain4j.pgvector.dimension]`
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-dimension]]`link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-dimension[quarkus.langchain4j.pgvector.dimension]`
 
 
 [.description]
@@ -61,7 +61,7 @@ endif::add-copy-button-to-env-var[]
 |required icon:exclamation-circle[title=Configuration property is required]
 
 
-a| [[quarkus-langchain4j-pgvector_quarkus.langchain4j.pgvector.use-index]]`link:#quarkus-langchain4j-pgvector_quarkus.langchain4j.pgvector.use-index[quarkus.langchain4j.pgvector.use-index]`
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-use-index]]`link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-use-index[quarkus.langchain4j.pgvector.use-index]`
 
 
 [.description]
@@ -78,7 +78,7 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-langchain4j-pgvector_quarkus.langchain4j.pgvector.index-list-size]]`link:#quarkus-langchain4j-pgvector_quarkus.langchain4j.pgvector.index-list-size[quarkus.langchain4j.pgvector.index-list-size]`
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-index-list-size]]`link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-index-list-size[quarkus.langchain4j.pgvector.index-list-size]`
 
 
 [.description]
@@ -95,7 +95,7 @@ endif::add-copy-button-to-env-var[]
 |`0`
 
 
-a| [[quarkus-langchain4j-pgvector_quarkus.langchain4j.pgvector.create-table]]`link:#quarkus-langchain4j-pgvector_quarkus.langchain4j.pgvector.create-table[quarkus.langchain4j.pgvector.create-table]`
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-create-table]]`link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-create-table[quarkus.langchain4j.pgvector.create-table]`
 
 
 [.description]
@@ -112,7 +112,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a| [[quarkus-langchain4j-pgvector_quarkus.langchain4j.pgvector.drop-table-first]]`link:#quarkus-langchain4j-pgvector_quarkus.langchain4j.pgvector.drop-table-first[quarkus.langchain4j.pgvector.drop-table-first]`
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-drop-table-first]]`link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-drop-table-first[quarkus.langchain4j.pgvector.drop-table-first]`
 
 
 [.description]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-pinecone.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-pinecone.adoc
@@ -10,7 +10,7 @@ h|[[quarkus-langchain4j-pinecone_configuration]]link:#quarkus-langchain4j-pineco
 h|Type
 h|Default
 
-a| [[quarkus-langchain4j-pinecone_quarkus.langchain4j.pinecone.api-key]]`link:#quarkus-langchain4j-pinecone_quarkus.langchain4j.pinecone.api-key[quarkus.langchain4j.pinecone.api-key]`
+a| [[quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-api-key]]`link:#quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-api-key[quarkus.langchain4j.pinecone.api-key]`
 
 
 [.description]
@@ -27,7 +27,7 @@ endif::add-copy-button-to-env-var[]
 |required icon:exclamation-circle[title=Configuration property is required]
 
 
-a| [[quarkus-langchain4j-pinecone_quarkus.langchain4j.pinecone.environment]]`link:#quarkus-langchain4j-pinecone_quarkus.langchain4j.pinecone.environment[quarkus.langchain4j.pinecone.environment]`
+a| [[quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-environment]]`link:#quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-environment[quarkus.langchain4j.pinecone.environment]`
 
 
 [.description]
@@ -44,7 +44,7 @@ endif::add-copy-button-to-env-var[]
 |required icon:exclamation-circle[title=Configuration property is required]
 
 
-a| [[quarkus-langchain4j-pinecone_quarkus.langchain4j.pinecone.project-id]]`link:#quarkus-langchain4j-pinecone_quarkus.langchain4j.pinecone.project-id[quarkus.langchain4j.pinecone.project-id]`
+a| [[quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-project-id]]`link:#quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-project-id[quarkus.langchain4j.pinecone.project-id]`
 
 
 [.description]
@@ -61,7 +61,7 @@ endif::add-copy-button-to-env-var[]
 |required icon:exclamation-circle[title=Configuration property is required]
 
 
-a| [[quarkus-langchain4j-pinecone_quarkus.langchain4j.pinecone.index-name]]`link:#quarkus-langchain4j-pinecone_quarkus.langchain4j.pinecone.index-name[quarkus.langchain4j.pinecone.index-name]`
+a| [[quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-index-name]]`link:#quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-index-name[quarkus.langchain4j.pinecone.index-name]`
 
 
 [.description]
@@ -78,7 +78,7 @@ endif::add-copy-button-to-env-var[]
 |required icon:exclamation-circle[title=Configuration property is required]
 
 
-a| [[quarkus-langchain4j-pinecone_quarkus.langchain4j.pinecone.dimension]]`link:#quarkus-langchain4j-pinecone_quarkus.langchain4j.pinecone.dimension[quarkus.langchain4j.pinecone.dimension]`
+a| [[quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-dimension]]`link:#quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-dimension[quarkus.langchain4j.pinecone.dimension]`
 
 
 [.description]
@@ -95,7 +95,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-pinecone_quarkus.langchain4j.pinecone.pod-type]]`link:#quarkus-langchain4j-pinecone_quarkus.langchain4j.pinecone.pod-type[quarkus.langchain4j.pinecone.pod-type]`
+a| [[quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-pod-type]]`link:#quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-pod-type[quarkus.langchain4j.pinecone.pod-type]`
 
 
 [.description]
@@ -112,7 +112,7 @@ endif::add-copy-button-to-env-var[]
 |`s1.x1`
 
 
-a| [[quarkus-langchain4j-pinecone_quarkus.langchain4j.pinecone.index-readiness-timeout]]`link:#quarkus-langchain4j-pinecone_quarkus.langchain4j.pinecone.index-readiness-timeout[quarkus.langchain4j.pinecone.index-readiness-timeout]`
+a| [[quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-index-readiness-timeout]]`link:#quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-index-readiness-timeout[quarkus.langchain4j.pinecone.index-readiness-timeout]`
 
 
 [.description]
@@ -130,7 +130,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-pinecone_quarkus.langchain4j.pinecone.namespace]]`link:#quarkus-langchain4j-pinecone_quarkus.langchain4j.pinecone.namespace[quarkus.langchain4j.pinecone.namespace]`
+a| [[quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-namespace]]`link:#quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-namespace[quarkus.langchain4j.pinecone.namespace]`
 
 
 [.description]
@@ -147,7 +147,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-pinecone_quarkus.langchain4j.pinecone.text-field-name]]`link:#quarkus-langchain4j-pinecone_quarkus.langchain4j.pinecone.text-field-name[quarkus.langchain4j.pinecone.text-field-name]`
+a| [[quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-text-field-name]]`link:#quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-text-field-name[quarkus.langchain4j.pinecone.text-field-name]`
 
 
 [.description]
@@ -164,7 +164,7 @@ endif::add-copy-button-to-env-var[]
 |`text`
 
 
-a| [[quarkus-langchain4j-pinecone_quarkus.langchain4j.pinecone.timeout]]`link:#quarkus-langchain4j-pinecone_quarkus.langchain4j.pinecone.timeout[quarkus.langchain4j.pinecone.timeout]`
+a| [[quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-timeout]]`link:#quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-timeout[quarkus.langchain4j.pinecone.timeout]`
 
 
 [.description]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-redis.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-redis.adoc
@@ -10,7 +10,7 @@ h|[[quarkus-langchain4j-redis_configuration]]link:#quarkus-langchain4j-redis_con
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-redis_quarkus.langchain4j.redis.client-name]]`link:#quarkus-langchain4j-redis_quarkus.langchain4j.redis.client-name[quarkus.langchain4j.redis.client-name]`
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-redis_quarkus-langchain4j-redis-client-name]]`link:#quarkus-langchain4j-redis_quarkus-langchain4j-redis-client-name[quarkus.langchain4j.redis.client-name]`
 
 
 [.description]
@@ -27,7 +27,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-redis_quarkus.langchain4j.redis.dimension]]`link:#quarkus-langchain4j-redis_quarkus.langchain4j.redis.dimension[quarkus.langchain4j.redis.dimension]`
+a| [[quarkus-langchain4j-redis_quarkus-langchain4j-redis-dimension]]`link:#quarkus-langchain4j-redis_quarkus-langchain4j-redis-dimension[quarkus.langchain4j.redis.dimension]`
 
 
 [.description]
@@ -44,7 +44,7 @@ endif::add-copy-button-to-env-var[]
 |required icon:exclamation-circle[title=Configuration property is required]
 
 
-a| [[quarkus-langchain4j-redis_quarkus.langchain4j.redis.index-name]]`link:#quarkus-langchain4j-redis_quarkus.langchain4j.redis.index-name[quarkus.langchain4j.redis.index-name]`
+a| [[quarkus-langchain4j-redis_quarkus-langchain4j-redis-index-name]]`link:#quarkus-langchain4j-redis_quarkus-langchain4j-redis-index-name[quarkus.langchain4j.redis.index-name]`
 
 
 [.description]
@@ -61,7 +61,7 @@ endif::add-copy-button-to-env-var[]
 |`embedding-index`
 
 
-a| [[quarkus-langchain4j-redis_quarkus.langchain4j.redis.metadata-fields]]`link:#quarkus-langchain4j-redis_quarkus.langchain4j.redis.metadata-fields[quarkus.langchain4j.redis.metadata-fields]`
+a| [[quarkus-langchain4j-redis_quarkus-langchain4j-redis-metadata-fields]]`link:#quarkus-langchain4j-redis_quarkus-langchain4j-redis-metadata-fields[quarkus.langchain4j.redis.metadata-fields]`
 
 
 [.description]
@@ -78,7 +78,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-langchain4j-redis_quarkus.langchain4j.redis.distance-metric]]`link:#quarkus-langchain4j-redis_quarkus.langchain4j.redis.distance-metric[quarkus.langchain4j.redis.distance-metric]`
+a| [[quarkus-langchain4j-redis_quarkus-langchain4j-redis-distance-metric]]`link:#quarkus-langchain4j-redis_quarkus-langchain4j-redis-distance-metric[quarkus.langchain4j.redis.distance-metric]`
 
 
 [.description]
@@ -96,7 +96,7 @@ endif::add-copy-button-to-env-var[]
 |`cosine`
 
 
-a| [[quarkus-langchain4j-redis_quarkus.langchain4j.redis.vector-field-name]]`link:#quarkus-langchain4j-redis_quarkus.langchain4j.redis.vector-field-name[quarkus.langchain4j.redis.vector-field-name]`
+a| [[quarkus-langchain4j-redis_quarkus-langchain4j-redis-vector-field-name]]`link:#quarkus-langchain4j-redis_quarkus-langchain4j-redis-vector-field-name[quarkus.langchain4j.redis.vector-field-name]`
 
 
 [.description]
@@ -113,7 +113,7 @@ endif::add-copy-button-to-env-var[]
 |`vector`
 
 
-a| [[quarkus-langchain4j-redis_quarkus.langchain4j.redis.scalar-field-name]]`link:#quarkus-langchain4j-redis_quarkus.langchain4j.redis.scalar-field-name[quarkus.langchain4j.redis.scalar-field-name]`
+a| [[quarkus-langchain4j-redis_quarkus-langchain4j-redis-scalar-field-name]]`link:#quarkus-langchain4j-redis_quarkus-langchain4j-redis-scalar-field-name[quarkus.langchain4j.redis.scalar-field-name]`
 
 
 [.description]
@@ -130,7 +130,7 @@ endif::add-copy-button-to-env-var[]
 |`scalar`
 
 
-a| [[quarkus-langchain4j-redis_quarkus.langchain4j.redis.prefix]]`link:#quarkus-langchain4j-redis_quarkus.langchain4j.redis.prefix[quarkus.langchain4j.redis.prefix]`
+a| [[quarkus-langchain4j-redis_quarkus-langchain4j-redis-prefix]]`link:#quarkus-langchain4j-redis_quarkus-langchain4j-redis-prefix[quarkus.langchain4j.redis.prefix]`
 
 
 [.description]
@@ -149,7 +149,7 @@ endif::add-copy-button-to-env-var[]
 |`embedding:`
 
 
-a| [[quarkus-langchain4j-redis_quarkus.langchain4j.redis.vector-algorithm]]`link:#quarkus-langchain4j-redis_quarkus.langchain4j.redis.vector-algorithm[quarkus.langchain4j.redis.vector-algorithm]`
+a| [[quarkus-langchain4j-redis_quarkus-langchain4j-redis-vector-algorithm]]`link:#quarkus-langchain4j-redis_quarkus-langchain4j-redis-vector-algorithm[quarkus.langchain4j.redis.vector-algorithm]`
 
 
 [.description]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j.adoc
@@ -5,12 +5,12 @@ icon:lock[title=Fixed at build time] Configuration property fixed at build time 
 [.configuration-reference.searchable, cols="80,.^10,.^10"]
 |===
 
-h|[[quarkus-langchain4j_quarkus.langchain4j.default-config-default-model-config]]link:#quarkus-langchain4j_quarkus.langchain4j.default-config-default-model-config[Default model config]
+h|[[quarkus-langchain4j_quarkus-langchain4j-default-config-default-model-config]]link:#quarkus-langchain4j_quarkus-langchain4j-default-config-default-model-config[Default model config]
 
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j_quarkus.langchain4j.chat-model.provider]]`link:#quarkus-langchain4j_quarkus.langchain4j.chat-model.provider[quarkus.langchain4j.chat-model.provider]`
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j_quarkus-langchain4j-chat-model-provider]]`link:#quarkus-langchain4j_quarkus-langchain4j-chat-model-provider[quarkus.langchain4j.chat-model.provider]`
 
 
 [.description]
@@ -27,7 +27,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j_quarkus.langchain4j.embedding-model.provider]]`link:#quarkus-langchain4j_quarkus.langchain4j.embedding-model.provider[quarkus.langchain4j.embedding-model.provider]`
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j_quarkus-langchain4j-embedding-model-provider]]`link:#quarkus-langchain4j_quarkus-langchain4j-embedding-model-provider[quarkus.langchain4j.embedding-model.provider]`
 
 
 [.description]
@@ -44,7 +44,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j_quarkus.langchain4j.moderation-model.provider]]`link:#quarkus-langchain4j_quarkus.langchain4j.moderation-model.provider[quarkus.langchain4j.moderation-model.provider]`
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j_quarkus-langchain4j-moderation-model-provider]]`link:#quarkus-langchain4j_quarkus-langchain4j-moderation-model-provider[quarkus.langchain4j.moderation-model.provider]`
 
 
 [.description]
@@ -61,7 +61,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j_quarkus.langchain4j.image-model.provider]]`link:#quarkus-langchain4j_quarkus.langchain4j.image-model.provider[quarkus.langchain4j.image-model.provider]`
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j_quarkus-langchain4j-image-model-provider]]`link:#quarkus-langchain4j_quarkus-langchain4j-image-model-provider[quarkus.langchain4j.image-model.provider]`
 
 
 [.description]
@@ -78,12 +78,12 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-h|[[quarkus-langchain4j_quarkus.langchain4j.named-config-named-model-config]]link:#quarkus-langchain4j_quarkus.langchain4j.named-config-named-model-config[Named model config]
+h|[[quarkus-langchain4j_quarkus-langchain4j-named-config-named-model-config]]link:#quarkus-langchain4j_quarkus-langchain4j-named-config-named-model-config[Named model config]
 
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j_quarkus.langchain4j.-model-name-.chat-model.provider]]`link:#quarkus-langchain4j_quarkus.langchain4j.-model-name-.chat-model.provider[quarkus.langchain4j."model-name".chat-model.provider]`
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j_quarkus-langchain4j-model-name-chat-model-provider]]`link:#quarkus-langchain4j_quarkus-langchain4j-model-name-chat-model-provider[quarkus.langchain4j."model-name".chat-model.provider]`
 
 
 [.description]
@@ -100,7 +100,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j_quarkus.langchain4j.-model-name-.embedding-model.provider]]`link:#quarkus-langchain4j_quarkus.langchain4j.-model-name-.embedding-model.provider[quarkus.langchain4j."model-name".embedding-model.provider]`
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j_quarkus-langchain4j-model-name-embedding-model-provider]]`link:#quarkus-langchain4j_quarkus-langchain4j-model-name-embedding-model-provider[quarkus.langchain4j."model-name".embedding-model.provider]`
 
 
 [.description]
@@ -117,7 +117,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j_quarkus.langchain4j.-model-name-.moderation-model.provider]]`link:#quarkus-langchain4j_quarkus.langchain4j.-model-name-.moderation-model.provider[quarkus.langchain4j."model-name".moderation-model.provider]`
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j_quarkus-langchain4j-model-name-moderation-model-provider]]`link:#quarkus-langchain4j_quarkus-langchain4j-model-name-moderation-model-provider[quarkus.langchain4j."model-name".moderation-model.provider]`
 
 
 [.description]
@@ -134,7 +134,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j_quarkus.langchain4j.-model-name-.image-model.provider]]`link:#quarkus-langchain4j_quarkus.langchain4j.-model-name-.image-model.provider[quarkus.langchain4j."model-name".image-model.provider]`
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j_quarkus-langchain4j-model-name-image-model-provider]]`link:#quarkus-langchain4j_quarkus-langchain4j-model-name-image-model-provider[quarkus.langchain4j."model-name".image-model.provider]`
 
 
 [.description]

--- a/openai/openai-vanilla/deployment/src/test/java/org/acme/examples/aiservices/AiServicesTest.java
+++ b/openai/openai-vanilla/deployment/src/test/java/org/acme/examples/aiservices/AiServicesTest.java
@@ -160,7 +160,7 @@ public class AiServicesTest {
         assertThat(result).isEqualTo(LocalDate.of(1968, JULY, 4));
 
         assertSingleRequestMessage(getRequestAsMap(),
-                "Extract date from The tranquility pervaded the evening of 1968, just fifteen minutes shy of midnight, following the celebrations of Independence Day.\nYou must answer strictly in the following format: 2023-12-31");
+                "Extract date from The tranquility pervaded the evening of 1968, just fifteen minutes shy of midnight, following the celebrations of Independence Day.\nYou must answer strictly in the following format: yyyy-MM-dd");
     }
 
     @Test
@@ -173,7 +173,7 @@ public class AiServicesTest {
         assertThat(result).isEqualTo(LocalTime.of(23, 45, 0));
 
         assertSingleRequestMessage(getRequestAsMap(),
-                "Extract time from The tranquility pervaded the evening of 1968, just fifteen minutes shy of midnight, following the celebrations of Independence Day.\nYou must answer strictly in the following format: 23:59:59");
+                "Extract time from The tranquility pervaded the evening of 1968, just fifteen minutes shy of midnight, following the celebrations of Independence Day.\nYou must answer strictly in the following format: HH:mm:ss");
     }
 
     @Test
@@ -186,7 +186,7 @@ public class AiServicesTest {
         assertThat(result).isEqualTo(LocalDateTime.of(1968, JULY, 4, 23, 45, 0));
 
         assertSingleRequestMessage(getRequestAsMap(),
-                "Extract date and time from The tranquility pervaded the evening of 1968, just fifteen minutes shy of midnight, following the celebrations of Independence Day.\nYou must answer strictly in the following format: 2023-12-31T23:59:59");
+                "Extract date and time from The tranquility pervaded the evening of 1968, just fifteen minutes shy of midnight, following the celebrations of Independence Day.\nYou must answer strictly in the following format: yyyy-MM-ddTHH:mm:ss");
     }
 
     enum Sentiment {

--- a/openai/openai-vanilla/deployment/src/test/java/org/acme/examples/aiservices/DeclarativeAiServicesTest.java
+++ b/openai/openai-vanilla/deployment/src/test/java/org/acme/examples/aiservices/DeclarativeAiServicesTest.java
@@ -143,7 +143,7 @@ public class DeclarativeAiServicesTest {
         assertThat(result).isNotBlank();
 
         assertSingleRequestMessage(getRequestAsMap(),
-                "Tell me a joke about developers\n\nHere is some information that might be useful for answering:\n\ndummy");
+                "Tell me a joke about developers\n\nAnswer using the following information:\ndummy");
     }
 
     enum Sentiment {

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
   </scm>
   <properties>
     <quarkus.version>3.7.2</quarkus.version>
-    <langchain4j.version>0.25.0</langchain4j.version>
-    <langchain4j-embeddings.version>0.25.0</langchain4j-embeddings.version>
+    <langchain4j.version>0.27.1</langchain4j.version>
+    <langchain4j-embeddings.version>0.27.1</langchain4j-embeddings.version>
     <quarkus-poi.version>2.0.4</quarkus-poi.version> <!-- we need to use this version because langchain4j uses POI 5.2.3 instead of 5.2.5 and the substitution needed is different in the two versions -->
     <assertj.version>3.25.3</assertj.version>
     <wiremock.version>3.3.1</wiremock.version>


### PR DESCRIPTION
In the future we'll also have to transition to using `retrievalAugmentor` instead of `retriever` in `@RegisterAiService`, but let's not hold up a new release for that