### PR TITLE
Add support for OpenAI response format

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai.adoc
@@ -348,7 +348,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSE_FORMAT+++`
 endif::add-copy-button-to-env-var[]
 --|string 
-|`text`
+|
 
 
 a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.embedding-model.model-name]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.embedding-model.model-name[quarkus.langchain4j.openai.embedding-model.model-name]`
@@ -950,7 +950,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSE_FORMAT+++`
 endif::add-copy-button-to-env-var[]
 --|string 
-|`text`
+|
 
 
 a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.embedding-model.model-name]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.embedding-model.model-name[quarkus.langchain4j.openai."model-name".embedding-model.model-name]`

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai.adoc
@@ -334,6 +334,23 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
+a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.chat-model.response-format]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.chat-model.response-format[quarkus.langchain4j.openai.chat-model.response-format]`
+
+
+[.description]
+--
+The response format the model should use. Some models are not compatible with some response formats, make sure to review OpenAI documentation.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSE_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSE_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|`text`
+
+
 a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.embedding-model.model-name]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.embedding-model.model-name[quarkus.langchain4j.openai.embedding-model.model-name]`
 
 
@@ -917,6 +934,23 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_LOG
 endif::add-copy-button-to-env-var[]
 --|boolean 
 |`false`
+
+
+a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.chat-model.response-format]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.chat-model.response-format[quarkus.langchain4j.openai."model-name".chat-model.response-format]`
+
+
+[.description]
+--
+The response format the model should use. Some models are not compatible with some response formats, make sure to review OpenAI documentation.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSE_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSE_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|`text`
 
 
 a| [[quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.embedding-model.model-name]]`link:#quarkus-langchain4j-openai_quarkus.langchain4j.openai.-model-name-.embedding-model.model-name[quarkus.langchain4j.openai."model-name".embedding-model.model-name]`

--- a/openai/openai-common/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/jackson/ResponseFormatMixin.java
+++ b/openai/openai-common/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/jackson/ResponseFormatMixin.java
@@ -1,0 +1,11 @@
+package io.quarkiverse.langchain4j.openai.runtime.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+
+import dev.ai4j.openai4j.chat.ResponseFormat;
+import io.quarkus.jackson.JacksonMixin;
+
+@JacksonMixin(ResponseFormat.class)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE)
+public abstract class ResponseFormatMixin {
+}

--- a/openai/openai-common/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/jackson/ResponseFormatTypeMixin.java
+++ b/openai/openai-common/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/jackson/ResponseFormatTypeMixin.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.langchain4j.openai.runtime.jackson;
+
+import dev.ai4j.openai4j.chat.ResponseFormatType;
+import io.quarkus.jackson.JacksonMixin;
+
+@JacksonMixin(ResponseFormatType.class)
+public abstract class ResponseFormatTypeMixin {
+}

--- a/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
+++ b/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
@@ -47,7 +47,7 @@ public class OpenAiRecorder {
                 .topP(chatModelConfig.topP())
                 .presencePenalty(chatModelConfig.presencePenalty())
                 .frequencyPenalty(chatModelConfig.frequencyPenalty())
-                .responseFormat(chatModelConfig.responseFormat());
+                .responseFormat(chatModelConfig.responseFormat().orElse(null));
 
         openAiConfig.organizationId().ifPresent(builder::organizationId);
 
@@ -81,7 +81,7 @@ public class OpenAiRecorder {
                 .topP(chatModelConfig.topP())
                 .presencePenalty(chatModelConfig.presencePenalty())
                 .frequencyPenalty(chatModelConfig.frequencyPenalty())
-                .responseFormat(chatModelConfig.responseFormat());
+                .responseFormat(chatModelConfig.responseFormat().orElse(null));
 
         openAiConfig.organizationId().ifPresent(builder::organizationId);
 

--- a/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
+++ b/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
@@ -46,7 +46,8 @@ public class OpenAiRecorder {
                 .temperature(chatModelConfig.temperature())
                 .topP(chatModelConfig.topP())
                 .presencePenalty(chatModelConfig.presencePenalty())
-                .frequencyPenalty(chatModelConfig.frequencyPenalty());
+                .frequencyPenalty(chatModelConfig.frequencyPenalty())
+                .responseFormat(chatModelConfig.responseFormat());
 
         openAiConfig.organizationId().ifPresent(builder::organizationId);
 
@@ -79,7 +80,8 @@ public class OpenAiRecorder {
                 .temperature(chatModelConfig.temperature())
                 .topP(chatModelConfig.topP())
                 .presencePenalty(chatModelConfig.presencePenalty())
-                .frequencyPenalty(chatModelConfig.frequencyPenalty());
+                .frequencyPenalty(chatModelConfig.frequencyPenalty())
+                .responseFormat(chatModelConfig.responseFormat());
 
         openAiConfig.organizationId().ifPresent(builder::organizationId);
 

--- a/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/ChatModelConfig.java
+++ b/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/ChatModelConfig.java
@@ -68,4 +68,11 @@ public interface ChatModelConfig {
      */
     @ConfigDocDefault("false")
     Optional<Boolean> logResponses();
+
+    /**
+     * The response format the model should use.
+     * Some models are not compatible with some response formats, make sure to review OpenAI documentation.
+     */
+    @WithDefault("text")
+    String responseFormat();
 }

--- a/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/ChatModelConfig.java
+++ b/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/ChatModelConfig.java
@@ -73,6 +73,5 @@ public interface ChatModelConfig {
      * The response format the model should use.
      * Some models are not compatible with some response formats, make sure to review OpenAI documentation.
      */
-    @WithDefault("text")
-    String responseFormat();
+    Optional<String> responseFormat();
 }

--- a/samples/review-triage/src/main/resources/application.properties
+++ b/samples/review-triage/src/main/resources/application.properties
@@ -1,2 +1,7 @@
 quarkus.langchain4j.openai.chat-model.temperature=0.5
 quarkus.langchain4j.openai.timeout=60s
+
+# using a json_object response format requires at least gpt-3.5-turbo-1106 or more recent
+# see https://platform.openai.com/docs/api-reference/chat/create#chat-create-response_format
+quarkus.langchain4j.openai.chat-model.model-name=gpt-3.5-turbo-1106
+quarkus.langchain4j.openai.chat-model.response-format=json_object


### PR DESCRIPTION
- Resolves #274

Not sure about a couple of things:

* tests: I looked into enriching the ITs but didn't find anything meaningful to assert...
* response format type: currently I went with a String. Langchain4J uses an enum `ResponseFormatType`. Not sure if I should surface the langchain4j enum to let langchain4j handle the maintenance :) Or use a new enum for this project? Let me know what you prefer.


