### PR TITLE
Unify on using EmbeddingStoreIT as test base for embedding stores

### DIFF
--- a/chroma/deployment/pom.xml
+++ b/chroma/deployment/pom.xml
@@ -36,6 +36,14 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <version>${langchain4j.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>

--- a/chroma/deployment/src/test/java/io/quarkiverse/langchain4j/chroma/deployment/ChromaEmbeddingStoreTest.java
+++ b/chroma/deployment/src/test/java/io/quarkiverse/langchain4j/chroma/deployment/ChromaEmbeddingStoreTest.java
@@ -1,31 +1,20 @@
 package io.quarkiverse.langchain4j.chroma.deployment;
 
 import static dev.langchain4j.internal.Utils.randomUUID;
-import static java.util.Arrays.asList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.data.Percentage.withPercentage;
-
-import java.util.List;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import dev.langchain4j.data.document.Metadata;
-import dev.langchain4j.data.embedding.Embedding;
-import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.AllMiniLmL6V2QuantizedEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
-import dev.langchain4j.store.embedding.CosineSimilarity;
-import dev.langchain4j.store.embedding.EmbeddingMatch;
-import dev.langchain4j.store.embedding.EmbeddingStore;
-import dev.langchain4j.store.embedding.RelevanceScore;
+import dev.langchain4j.store.embedding.EmbeddingStoreIT;
 import io.quarkiverse.langchain4j.chroma.ChromaEmbeddingStore;
+import io.quarkus.logging.Log;
 import io.quarkus.test.QuarkusUnitTest;
 
-class ChromaEmbeddingStoreTest {
+class ChromaEmbeddingStoreTest extends EmbeddingStoreIT {
 
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
@@ -34,211 +23,33 @@ class ChromaEmbeddingStoreTest {
     @ConfigProperty(name = "quarkus.langchain4j.chroma.url")
     String chromaUrl;
 
-    private EmbeddingStore<TextSegment> embeddingStore() {
-        return ChromaEmbeddingStore.builder()
-                .baseUrl(chromaUrl)
-                .collectionName(randomUUID())
-                .build();
-    }
+    private ChromaEmbeddingStore embeddingStore;
 
     private final EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
 
-    @Test
-    void should_add_embedding() {
-        EmbeddingStore<TextSegment> embeddingStore = embeddingStore();
-
-        Embedding embedding = embeddingModel.embed(randomUUID()).content();
-
-        String id = embeddingStore.add(embedding);
-        assertThat(id).isNotNull();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(1, withPercentage(1));
-        assertThat(match.embeddingId()).isEqualTo(id);
-        assertThat(match.embedding()).isEqualTo(embedding);
-        assertThat(match.embedded()).isNull();
+    @Override
+    protected ChromaEmbeddingStore embeddingStore() {
+        if (embeddingStore == null) {
+            embeddingStore = ChromaEmbeddingStore.builder()
+                    .baseUrl(chromaUrl)
+                    .collectionName(randomUUID())
+                    .build();
+        }
+        return embeddingStore;
     }
 
-    @Test
-    void should_add_embedding_with_id() {
-        EmbeddingStore<TextSegment> embeddingStore = embeddingStore();
-
-        String id = randomUUID();
-        Embedding embedding = embeddingModel.embed(randomUUID()).content();
-
-        embeddingStore.add(id, embedding);
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(1, withPercentage(1));
-        assertThat(match.embeddingId()).isEqualTo(id);
-        assertThat(match.embedding()).isEqualTo(embedding);
-        assertThat(match.embedded()).isNull();
+    @Override
+    protected EmbeddingModel embeddingModel() {
+        return embeddingModel;
     }
 
-    @Test
-    void should_add_embedding_with_segment() {
-        EmbeddingStore<TextSegment> embeddingStore = embeddingStore();
-
-        TextSegment segment = TextSegment.from(randomUUID());
-        Embedding embedding = embeddingModel.embed(segment.text()).content();
-
-        String id = embeddingStore.add(embedding, segment);
-        assertThat(id).isNotNull();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(1, withPercentage(1));
-        assertThat(match.embeddingId()).isEqualTo(id);
-        assertThat(match.embedding()).isEqualTo(embedding);
-        assertThat(match.embedded()).isEqualTo(segment);
+    @Override
+    protected void clearStore() {
+        try {
+            embeddingStore().deleteAll(384);
+        } catch (Exception e) {
+            Log.warn(e);
+        }
     }
 
-    @Test
-    void should_add_embedding_with_segment_with_metadata() {
-        EmbeddingStore<TextSegment> embeddingStore = embeddingStore();
-
-        TextSegment segment = TextSegment.from(randomUUID(), Metadata.from("test-key", "test-value"));
-        Embedding embedding = embeddingModel.embed(segment.text()).content();
-
-        String id = embeddingStore.add(embedding, segment);
-        assertThat(id).isNotNull();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(1, withPercentage(1));
-        assertThat(match.embeddingId()).isEqualTo(id);
-        assertThat(match.embedding()).isEqualTo(embedding);
-        assertThat(match.embedded()).isEqualTo(segment);
-    }
-
-    @Test
-    void should_add_multiple_embeddings() {
-        EmbeddingStore<TextSegment> embeddingStore = embeddingStore();
-
-        Embedding firstEmbedding = embeddingModel.embed(randomUUID()).content();
-        Embedding secondEmbedding = embeddingModel.embed(randomUUID()).content();
-
-        List<String> ids = embeddingStore.addAll(asList(firstEmbedding, secondEmbedding));
-        assertThat(ids).hasSize(2);
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(firstEmbedding, 10);
-        assertThat(relevant).hasSize(2);
-
-        EmbeddingMatch<TextSegment> firstMatch = relevant.get(0);
-        assertThat(firstMatch.score()).isCloseTo(1, withPercentage(1));
-        assertThat(firstMatch.embeddingId()).isEqualTo(ids.get(0));
-        assertThat(firstMatch.embedding()).isEqualTo(firstEmbedding);
-        assertThat(firstMatch.embedded()).isNull();
-
-        EmbeddingMatch<TextSegment> secondMatch = relevant.get(1);
-        assertThat(secondMatch.score()).isBetween(0d, 1d);
-        assertThat(secondMatch.embeddingId()).isEqualTo(ids.get(1));
-        assertThat(secondMatch.embedding()).isEqualTo(secondEmbedding);
-        assertThat(secondMatch.embedded()).isNull();
-    }
-
-    @Test
-    void should_add_multiple_embeddings_with_segments() {
-        EmbeddingStore<TextSegment> embeddingStore = embeddingStore();
-
-        TextSegment firstSegment = TextSegment.from(randomUUID());
-        Embedding firstEmbedding = embeddingModel.embed(firstSegment.text()).content();
-        TextSegment secondSegment = TextSegment.from(randomUUID());
-        Embedding secondEmbedding = embeddingModel.embed(secondSegment.text()).content();
-
-        List<String> ids = embeddingStore.addAll(
-                asList(firstEmbedding, secondEmbedding),
-                asList(firstSegment, secondSegment));
-        assertThat(ids).hasSize(2);
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(firstEmbedding, 10);
-        assertThat(relevant).hasSize(2);
-
-        EmbeddingMatch<TextSegment> firstMatch = relevant.get(0);
-        assertThat(firstMatch.score()).isCloseTo(1, withPercentage(1));
-        assertThat(firstMatch.embeddingId()).isEqualTo(ids.get(0));
-        assertThat(firstMatch.embedding()).isEqualTo(firstEmbedding);
-        assertThat(firstMatch.embedded()).isEqualTo(firstSegment);
-
-        EmbeddingMatch<TextSegment> secondMatch = relevant.get(1);
-        assertThat(secondMatch.score()).isBetween(0d, 1d);
-        assertThat(secondMatch.embeddingId()).isEqualTo(ids.get(1));
-        assertThat(secondMatch.embedding()).isEqualTo(secondEmbedding);
-        assertThat(secondMatch.embedded()).isEqualTo(secondSegment);
-    }
-
-    @Test
-    void should_find_with_min_score() {
-        EmbeddingStore<TextSegment> embeddingStore = embeddingStore();
-
-        String firstId = randomUUID();
-        Embedding firstEmbedding = embeddingModel.embed(randomUUID()).content();
-        embeddingStore.add(firstId, firstEmbedding);
-
-        String secondId = randomUUID();
-        Embedding secondEmbedding = embeddingModel.embed(randomUUID()).content();
-        embeddingStore.add(secondId, secondEmbedding);
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(firstEmbedding, 10);
-        assertThat(relevant).hasSize(2);
-        EmbeddingMatch<TextSegment> firstMatch = relevant.get(0);
-        assertThat(firstMatch.score()).isCloseTo(1, withPercentage(1));
-        assertThat(firstMatch.embeddingId()).isEqualTo(firstId);
-        EmbeddingMatch<TextSegment> secondMatch = relevant.get(1);
-        assertThat(secondMatch.score()).isBetween(0d, 1d);
-        assertThat(secondMatch.embeddingId()).isEqualTo(secondId);
-
-        List<EmbeddingMatch<TextSegment>> relevant2 = embeddingStore.findRelevant(
-                firstEmbedding,
-                10,
-                secondMatch.score() - 0.01);
-        assertThat(relevant2).hasSize(2);
-        assertThat(relevant2.get(0).embeddingId()).isEqualTo(firstId);
-        assertThat(relevant2.get(1).embeddingId()).isEqualTo(secondId);
-
-        List<EmbeddingMatch<TextSegment>> relevant3 = embeddingStore.findRelevant(
-                firstEmbedding,
-                10,
-                secondMatch.score());
-        assertThat(relevant3).hasSize(2);
-        assertThat(relevant3.get(0).embeddingId()).isEqualTo(firstId);
-        assertThat(relevant3.get(1).embeddingId()).isEqualTo(secondId);
-
-        List<EmbeddingMatch<TextSegment>> relevant4 = embeddingStore.findRelevant(
-                firstEmbedding,
-                10,
-                secondMatch.score() + 0.01);
-        assertThat(relevant4).hasSize(1);
-        assertThat(relevant4.get(0).embeddingId()).isEqualTo(firstId);
-    }
-
-    @Test
-    void should_return_correct_score() {
-        EmbeddingStore<TextSegment> embeddingStore = embeddingStore();
-
-        Embedding embedding = embeddingModel.embed("hello").content();
-
-        String id = embeddingStore.add(embedding);
-        assertThat(id).isNotNull();
-
-        Embedding referenceEmbedding = embeddingModel.embed("hi").content();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(referenceEmbedding, 1);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(
-                RelevanceScore.fromCosineSimilarity(CosineSimilarity.between(embedding, referenceEmbedding)),
-                withPercentage(1));
-    }
 }

--- a/chroma/runtime/src/main/java/io/quarkiverse/langchain4j/chroma/runtime/ChromaCollectionsRestApi.java
+++ b/chroma/runtime/src/main/java/io/quarkiverse/langchain4j/chroma/runtime/ChromaCollectionsRestApi.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.langchain4j.chroma.runtime;
 
+import java.util.List;
+
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
@@ -31,6 +33,10 @@ public interface ChromaCollectionsRestApi {
     @Path("{collectionId}/query")
     @POST
     QueryResponse queryCollection(String collectionId, QueryRequest queryRequest);
+
+    @Path("{collectionId}/delete")
+    @POST
+    List<String> deleteEmbeddings(String collectionId, DeleteEmbeddingsRequest queryRequest);
 
     @ClientObjectMapper
     static ObjectMapper objectMapper(ObjectMapper defaultObjectMapper) {

--- a/chroma/runtime/src/main/java/io/quarkiverse/langchain4j/chroma/runtime/DeleteEmbeddingsRequest.java
+++ b/chroma/runtime/src/main/java/io/quarkiverse/langchain4j/chroma/runtime/DeleteEmbeddingsRequest.java
@@ -1,0 +1,20 @@
+package io.quarkiverse.langchain4j.chroma.runtime;
+
+import java.util.List;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class DeleteEmbeddingsRequest {
+
+    private List<String> ids;
+
+    public DeleteEmbeddingsRequest(List<String> ids) {
+        this.ids = ids;
+    }
+
+    public List<String> getIds() {
+        return ids;
+    }
+
+}

--- a/infinispan/deployment/pom.xml
+++ b/infinispan/deployment/pom.xml
@@ -54,6 +54,14 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <version>${langchain4j.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>

--- a/infinispan/deployment/src/test/java/io/quarkiverse/langchain4j/infinispan/deployment/InfinispanEmbeddingStoreTest.java
+++ b/infinispan/deployment/src/test/java/io/quarkiverse/langchain4j/infinispan/deployment/InfinispanEmbeddingStoreTest.java
@@ -1,227 +1,36 @@
 package io.quarkiverse.langchain4j.infinispan.deployment;
 
-import static dev.langchain4j.internal.Utils.randomUUID;
-import static java.util.Arrays.asList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.data.Percentage.withPercentage;
-
-import java.util.List;
-
 import jakarta.inject.Inject;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
-
-import dev.langchain4j.data.document.Metadata;
-import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.AllMiniLmL6V2QuantizedEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
-import dev.langchain4j.store.embedding.CosineSimilarity;
-import dev.langchain4j.store.embedding.EmbeddingMatch;
 import dev.langchain4j.store.embedding.EmbeddingStore;
-import dev.langchain4j.store.embedding.RelevanceScore;
+import dev.langchain4j.store.embedding.EmbeddingStoreIT;
 import io.quarkiverse.langchain4j.infinispan.InfinispanEmbeddingStore;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-public class InfinispanEmbeddingStoreTest {
+public class InfinispanEmbeddingStoreTest extends EmbeddingStoreIT {
 
     @Inject
-    EmbeddingStore embeddingStore;
-
-    @Inject
-    InfinispanEmbeddingStore infinispanEmbeddingStore;
+    InfinispanEmbeddingStore embeddingStore;
 
     private final EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
 
-    @AfterEach
-    public void cleanup() {
-        infinispanEmbeddingStore.deleteAll();
+    @Override
+    protected void clearStore() {
+        embeddingStore.deleteAll();
     }
 
-    @Test
-    void should_add_embedding() {
-        assertThat(embeddingStore).isSameAs(infinispanEmbeddingStore);
-
-        Embedding embedding = embeddingModel.embed(randomUUID()).content();
-
-        String id = embeddingStore.add(embedding);
-        assertThat(id).isNotNull();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(1, withPercentage(1));
-        assertThat(match.embeddingId()).isEqualTo(id);
-        assertThat(match.embedding()).isEqualTo(embedding);
-        assertThat(match.embedded()).isNull();
+    @Override
+    protected EmbeddingStore<TextSegment> embeddingStore() {
+        return embeddingStore;
     }
 
-    @Test
-    void should_add_embedding_with_id() {
-        String id = randomUUID();
-        Embedding embedding = embeddingModel.embed(randomUUID()).content();
-
-        embeddingStore.add(id, embedding);
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(1, withPercentage(1));
-        assertThat(match.embeddingId()).isEqualTo(id);
-        assertThat(match.embedding()).isEqualTo(embedding);
-        assertThat(match.embedded()).isNull();
+    @Override
+    protected EmbeddingModel embeddingModel() {
+        return embeddingModel;
     }
 
-    @Test
-    void should_add_embedding_with_segment() {
-        TextSegment segment = TextSegment.from(randomUUID());
-        Embedding embedding = embeddingModel.embed(segment.text()).content();
-
-        String id = embeddingStore.add(embedding, segment);
-        assertThat(id).isNotNull();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(1, withPercentage(1));
-        assertThat(match.embeddingId()).isEqualTo(id);
-        assertThat(match.embedding()).isEqualTo(embedding);
-        assertThat(match.embedded()).isEqualTo(segment);
-    }
-
-    @Test
-    void should_add_embedding_with_segment_with_metadata() {
-        TextSegment segment = TextSegment.from(randomUUID(), Metadata.from("test-key", "test-value"));
-        Embedding embedding = embeddingModel.embed(segment.text()).content();
-
-        String id = embeddingStore.add(embedding, segment);
-        assertThat(id).isNotNull();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(1, withPercentage(1));
-        assertThat(match.embeddingId()).isEqualTo(id);
-        assertThat(match.embedding()).isEqualTo(embedding);
-        assertThat(match.embedded()).isEqualTo(segment);
-    }
-
-    @Test
-    void should_add_multiple_embeddings() {
-        Embedding firstEmbedding = embeddingModel.embed(randomUUID()).content();
-        Embedding secondEmbedding = embeddingModel.embed(randomUUID()).content();
-
-        List<String> ids = embeddingStore.addAll(asList(firstEmbedding, secondEmbedding));
-        assertThat(ids).hasSize(2);
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(firstEmbedding, 10);
-        assertThat(relevant).hasSize(2);
-
-        EmbeddingMatch<TextSegment> firstMatch = relevant.get(0);
-        assertThat(firstMatch.score()).isCloseTo(1, withPercentage(1));
-        assertThat(firstMatch.embeddingId()).isEqualTo(ids.get(0));
-        assertThat(firstMatch.embedding()).isEqualTo(firstEmbedding);
-        assertThat(firstMatch.embedded()).isNull();
-
-        EmbeddingMatch<TextSegment> secondMatch = relevant.get(1);
-        assertThat(secondMatch.score()).isBetween(0d, 1d);
-        assertThat(secondMatch.embeddingId()).isEqualTo(ids.get(1));
-        assertThat(secondMatch.embedding()).isEqualTo(secondEmbedding);
-        assertThat(secondMatch.embedded()).isNull();
-    }
-
-    @Test
-    void should_add_multiple_embeddings_with_segments() {
-        TextSegment firstSegment = TextSegment.from(randomUUID());
-        Embedding firstEmbedding = embeddingModel.embed(firstSegment.text()).content();
-        TextSegment secondSegment = TextSegment.from(randomUUID());
-        Embedding secondEmbedding = embeddingModel.embed(secondSegment.text()).content();
-
-        List<String> ids = embeddingStore.addAll(
-                asList(firstEmbedding, secondEmbedding),
-                asList(firstSegment, secondSegment));
-        assertThat(ids).hasSize(2);
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(firstEmbedding, 10);
-        assertThat(relevant).hasSize(2);
-
-        EmbeddingMatch<TextSegment> firstMatch = relevant.get(0);
-        assertThat(firstMatch.score()).isCloseTo(1, withPercentage(1));
-        assertThat(firstMatch.embeddingId()).isEqualTo(ids.get(0));
-        assertThat(firstMatch.embedding()).isEqualTo(firstEmbedding);
-        assertThat(firstMatch.embedded()).isEqualTo(firstSegment);
-
-        EmbeddingMatch<TextSegment> secondMatch = relevant.get(1);
-        assertThat(secondMatch.score()).isBetween(0d, 1d);
-        assertThat(secondMatch.embeddingId()).isEqualTo(ids.get(1));
-        assertThat(secondMatch.embedding()).isEqualTo(secondEmbedding);
-        assertThat(secondMatch.embedded()).isEqualTo(secondSegment);
-    }
-
-    @Test
-    void should_find_with_min_score() {
-        String firstId = randomUUID();
-        Embedding firstEmbedding = embeddingModel.embed(randomUUID()).content();
-        embeddingStore.add(firstId, firstEmbedding);
-
-        String secondId = randomUUID();
-        Embedding secondEmbedding = embeddingModel.embed(randomUUID()).content();
-        embeddingStore.add(secondId, secondEmbedding);
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(firstEmbedding, 10);
-        assertThat(relevant).hasSize(2);
-        EmbeddingMatch<TextSegment> firstMatch = relevant.get(0);
-        assertThat(firstMatch.score()).isCloseTo(1, withPercentage(1));
-        assertThat(firstMatch.embeddingId()).isEqualTo(firstId);
-        EmbeddingMatch<TextSegment> secondMatch = relevant.get(1);
-        assertThat(secondMatch.score()).isBetween(0d, 1d);
-        assertThat(secondMatch.embeddingId()).isEqualTo(secondId);
-
-        List<EmbeddingMatch<TextSegment>> relevant2 = embeddingStore.findRelevant(
-                firstEmbedding,
-                10,
-                secondMatch.score() - 0.01);
-        assertThat(relevant2).hasSize(2);
-        assertThat(relevant2.get(0).embeddingId()).isEqualTo(firstId);
-        assertThat(relevant2.get(1).embeddingId()).isEqualTo(secondId);
-
-        List<EmbeddingMatch<TextSegment>> relevant3 = embeddingStore.findRelevant(
-                firstEmbedding,
-                10,
-                secondMatch.score());
-        assertThat(relevant3).hasSize(2);
-        assertThat(relevant3.get(0).embeddingId()).isEqualTo(firstId);
-        assertThat(relevant3.get(1).embeddingId()).isEqualTo(secondId);
-
-        List<EmbeddingMatch<TextSegment>> relevant4 = embeddingStore.findRelevant(
-                firstEmbedding,
-                10,
-                secondMatch.score() + 0.01);
-        assertThat(relevant4).hasSize(1);
-        assertThat(relevant4.get(0).embeddingId()).isEqualTo(firstId);
-    }
-
-    @Test
-    void should_return_correct_score() {
-        Embedding embedding = embeddingModel.embed("hello").content();
-
-        String id = embeddingStore.add(embedding);
-        assertThat(id).isNotNull();
-
-        Embedding referenceEmbedding = embeddingModel.embed("hi").content();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(referenceEmbedding, 1);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(
-                RelevanceScore.fromCosineSimilarity(CosineSimilarity.between(embedding, referenceEmbedding)),
-                withPercentage(1));
-    }
 }

--- a/milvus/deployment/pom.xml
+++ b/milvus/deployment/pom.xml
@@ -32,6 +32,14 @@
             <artifactId>quarkus-devservices-deployment</artifactId>
         </dependency>
         <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <version>${langchain4j.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>

--- a/milvus/deployment/src/test/java/io/quarkiverse/langchain4j/milvus/deployment/MilvusEmbeddingStoreTest.java
+++ b/milvus/deployment/src/test/java/io/quarkiverse/langchain4j/milvus/deployment/MilvusEmbeddingStoreTest.java
@@ -1,31 +1,20 @@
 package io.quarkiverse.langchain4j.milvus.deployment;
 
-import static dev.langchain4j.internal.Utils.randomUUID;
-import static java.util.Arrays.asList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.data.Percentage.withPercentage;
-
-import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import jakarta.inject.Inject;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import dev.langchain4j.data.document.Metadata;
-import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.AllMiniLmL6V2QuantizedEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
-import dev.langchain4j.store.embedding.CosineSimilarity;
-import dev.langchain4j.store.embedding.EmbeddingMatch;
 import dev.langchain4j.store.embedding.EmbeddingStore;
-import dev.langchain4j.store.embedding.RelevanceScore;
+import dev.langchain4j.store.embedding.EmbeddingStoreWithoutMetadataIT;
+import dev.langchain4j.store.embedding.milvus.MilvusEmbeddingStore;
 import io.milvus.client.MilvusClient;
 import io.milvus.client.MilvusServiceClient;
 import io.milvus.grpc.MutationResult;
@@ -36,7 +25,7 @@ import io.milvus.param.dml.DeleteParam;
 import io.quarkus.logging.Log;
 import io.quarkus.test.QuarkusUnitTest;
 
-public class MilvusEmbeddingStoreTest {
+public class MilvusEmbeddingStoreTest extends EmbeddingStoreWithoutMetadataIT {
 
     public static final String COLLECTION_NAME = "test_embeddings";
 
@@ -50,212 +39,46 @@ public class MilvusEmbeddingStoreTest {
                             "application.properties"));
 
     @Inject
-    EmbeddingStore<TextSegment> embeddingStore;
+    MilvusEmbeddingStore embeddingStore;
+
     private final EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
 
-    /**
-     * Delete all embeddings from the collection before each test.
-     */
-    @AfterEach
-    public void cleanup() {
+    @Override
+    protected void clearStore() {
+        // make sure the bean is initialized, so the collection is created
+        embeddingStore.toString();
         ConnectParam connectParam = ConnectParam.newBuilder()
                 .withHost("localhost")
                 .withPort(19530)
                 .build();
         MilvusClient client = new MilvusServiceClient(connectParam);
-        client.loadCollection(LoadCollectionParam.newBuilder().withCollectionName(COLLECTION_NAME).build());
-        R<MutationResult> deleteResult = client.delete(DeleteParam.newBuilder()
-                .withCollectionName(COLLECTION_NAME)
-                // seems we can't just say "delete all entries", but
-                // can provide a predicate that is always false
-                .withExpr("id != 'BLABLA'")
-                .build());
-        Log.info("Deleted: " + deleteResult.getData().getDeleteCnt());
-        client.close();
+        try {
+            client.loadCollection(LoadCollectionParam.newBuilder().withCollectionName(COLLECTION_NAME).build());
+            R<MutationResult> deleteResult = client.delete(DeleteParam.newBuilder()
+                    .withCollectionName(COLLECTION_NAME)
+                    // seems we can't just say "delete all entries", but
+                    // can provide a predicate that is always false
+                    .withExpr("id != 'BLABLA'")
+                    .build());
+            Log.info("Deleted: " + deleteResult.getData().getDeleteCnt());
+            try {
+                TimeUnit.SECONDS.sleep(2);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        } finally {
+            client.close();
+        }
     }
 
-    @Test
-    void should_add_embedding() {
-        Embedding embedding = embeddingModel.embed(randomUUID()).content();
-
-        String id = embeddingStore.add(embedding);
-        assertThat(id).isNotNull();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(1, withPercentage(1));
-        assertThat(match.embeddingId()).isEqualTo(id);
-        assertThat(match.embedding()).isEqualTo(embedding);
-        assertThat(match.embedded()).isNull();
+    @Override
+    protected EmbeddingStore<TextSegment> embeddingStore() {
+        return embeddingStore;
     }
 
-    @Test
-    void should_add_embedding_with_id() {
-        String id = randomUUID();
-        Embedding embedding = embeddingModel.embed(randomUUID()).content();
-
-        embeddingStore.add(id, embedding);
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(1, withPercentage(1));
-        assertThat(match.embeddingId()).isEqualTo(id);
-        assertThat(match.embedding()).isEqualTo(embedding);
-        assertThat(match.embedded()).isNull();
+    @Override
+    protected EmbeddingModel embeddingModel() {
+        return embeddingModel;
     }
 
-    @Test
-    void should_add_embedding_with_segment() {
-        TextSegment segment = TextSegment.from(randomUUID());
-        Embedding embedding = embeddingModel.embed(segment.text()).content();
-
-        String id = embeddingStore.add(embedding, segment);
-        assertThat(id).isNotNull();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(1, withPercentage(1));
-        assertThat(match.embeddingId()).isEqualTo(id);
-        assertThat(match.embedding()).isEqualTo(embedding);
-        assertThat(match.embedded()).isEqualTo(segment);
-    }
-
-    @Disabled("Milvus store doesn't support storing metadata yet")
-    @Test
-    void should_add_embedding_with_segment_with_metadata() {
-        TextSegment segment = TextSegment.from(randomUUID(), Metadata.from("test-key", "test-value"));
-        Embedding embedding = embeddingModel.embed(segment.text()).content();
-
-        String id = embeddingStore.add(embedding, segment);
-
-        assertThat(id).isNotNull();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(1, withPercentage(1));
-        assertThat(match.embeddingId()).isEqualTo(id);
-        assertThat(match.embedding()).isEqualTo(embedding);
-        assertThat(match.embedded()).isEqualTo(segment);
-    }
-
-    @Test
-    void should_add_multiple_embeddings() {
-        Embedding firstEmbedding = embeddingModel.embed(randomUUID()).content();
-        Embedding secondEmbedding = embeddingModel.embed(randomUUID()).content();
-
-        List<String> ids = embeddingStore.addAll(asList(firstEmbedding, secondEmbedding));
-        assertThat(ids).hasSize(2);
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(firstEmbedding, 10);
-        assertThat(relevant).hasSize(2);
-
-        EmbeddingMatch<TextSegment> firstMatch = relevant.get(0);
-        assertThat(firstMatch.score()).isCloseTo(1, withPercentage(1));
-        assertThat(firstMatch.embeddingId()).isEqualTo(ids.get(0));
-        assertThat(firstMatch.embedding()).isEqualTo(firstEmbedding);
-        assertThat(firstMatch.embedded()).isNull();
-
-        EmbeddingMatch<TextSegment> secondMatch = relevant.get(1);
-        assertThat(secondMatch.score()).isBetween(0d, 1d);
-        assertThat(secondMatch.embeddingId()).isEqualTo(ids.get(1));
-        assertThat(secondMatch.embedding()).isEqualTo(secondEmbedding);
-        assertThat(secondMatch.embedded()).isNull();
-    }
-
-    @Test
-    void should_add_multiple_embeddings_with_segments() {
-        TextSegment firstSegment = TextSegment.from(randomUUID());
-        Embedding firstEmbedding = embeddingModel.embed(firstSegment.text()).content();
-        TextSegment secondSegment = TextSegment.from(randomUUID());
-        Embedding secondEmbedding = embeddingModel.embed(secondSegment.text()).content();
-
-        List<String> ids = embeddingStore.addAll(
-                asList(firstEmbedding, secondEmbedding),
-                asList(firstSegment, secondSegment));
-        assertThat(ids).hasSize(2);
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(firstEmbedding, 10);
-        assertThat(relevant).hasSize(2);
-
-        EmbeddingMatch<TextSegment> firstMatch = relevant.get(0);
-        assertThat(firstMatch.score()).isCloseTo(1, withPercentage(1));
-        assertThat(firstMatch.embeddingId()).isEqualTo(ids.get(0));
-        assertThat(firstMatch.embedding()).isEqualTo(firstEmbedding);
-        assertThat(firstMatch.embedded()).isEqualTo(firstSegment);
-
-        EmbeddingMatch<TextSegment> secondMatch = relevant.get(1);
-        assertThat(secondMatch.score()).isBetween(0d, 1d);
-        assertThat(secondMatch.embeddingId()).isEqualTo(ids.get(1));
-        assertThat(secondMatch.embedding()).isEqualTo(secondEmbedding);
-        assertThat(secondMatch.embedded()).isEqualTo(secondSegment);
-    }
-
-    @Test
-    void should_find_with_min_score() {
-        String firstId = randomUUID();
-        Embedding firstEmbedding = embeddingModel.embed(randomUUID()).content();
-        embeddingStore.add(firstId, firstEmbedding);
-
-        String secondId = randomUUID();
-        Embedding secondEmbedding = embeddingModel.embed(randomUUID()).content();
-        embeddingStore.add(secondId, secondEmbedding);
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(firstEmbedding, 10);
-        assertThat(relevant).hasSize(2);
-        EmbeddingMatch<TextSegment> firstMatch = relevant.get(0);
-        assertThat(firstMatch.score()).isCloseTo(1, withPercentage(1));
-        assertThat(firstMatch.embeddingId()).isEqualTo(firstId);
-        EmbeddingMatch<TextSegment> secondMatch = relevant.get(1);
-        assertThat(secondMatch.score()).isBetween(0d, 1d);
-        assertThat(secondMatch.embeddingId()).isEqualTo(secondId);
-
-        List<EmbeddingMatch<TextSegment>> relevant2 = embeddingStore.findRelevant(
-                firstEmbedding,
-                10,
-                secondMatch.score() - 0.01);
-        assertThat(relevant2).hasSize(2);
-        assertThat(relevant2.get(0).embeddingId()).isEqualTo(firstId);
-        assertThat(relevant2.get(1).embeddingId()).isEqualTo(secondId);
-
-        List<EmbeddingMatch<TextSegment>> relevant3 = embeddingStore.findRelevant(
-                firstEmbedding,
-                10,
-                secondMatch.score());
-        assertThat(relevant3).hasSize(2);
-        assertThat(relevant3.get(0).embeddingId()).isEqualTo(firstId);
-        assertThat(relevant3.get(1).embeddingId()).isEqualTo(secondId);
-
-        List<EmbeddingMatch<TextSegment>> relevant4 = embeddingStore.findRelevant(
-                firstEmbedding,
-                10,
-                secondMatch.score() + 0.01);
-        assertThat(relevant4).hasSize(1);
-        assertThat(relevant4.get(0).embeddingId()).isEqualTo(firstId);
-    }
-
-    @Test
-    void should_return_correct_score() {
-        Embedding embedding = embeddingModel.embed("hello").content();
-
-        String id = embeddingStore.add(embedding);
-        assertThat(id).isNotNull();
-
-        Embedding referenceEmbedding = embeddingModel.embed("hi").content();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(referenceEmbedding, 1);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(
-                RelevanceScore.fromCosineSimilarity(CosineSimilarity.between(embedding, referenceEmbedding)),
-                withPercentage(1));
-    }
 }

--- a/pgvector/deployment/pom.xml
+++ b/pgvector/deployment/pom.xml
@@ -36,6 +36,14 @@
         <version>${project.version}</version>
     </dependency>
     <dependency>
+          <groupId>dev.langchain4j</groupId>
+          <artifactId>langchain4j-core</artifactId>
+          <classifier>tests</classifier>
+          <type>test-jar</type>
+          <scope>test</scope>
+          <version>${langchain4j.version}</version>
+    </dependency>
+    <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit5-internal</artifactId>
         <scope>test</scope>

--- a/pgvector/deployment/src/test/java/io/quarkiverse/langchain4j/pgvector/test/Langchain4jPgvectorTest.java
+++ b/pgvector/deployment/src/test/java/io/quarkiverse/langchain4j/pgvector/test/Langchain4jPgvectorTest.java
@@ -1,35 +1,23 @@
 package io.quarkiverse.langchain4j.pgvector.test;
 
-import static dev.langchain4j.internal.Utils.randomUUID;
-import static java.util.Arrays.asList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.data.Percentage.withPercentage;
-
 import java.sql.SQLException;
-import java.util.List;
 
 import jakarta.inject.Inject;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import dev.langchain4j.data.document.Metadata;
-import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.AllMiniLmL6V2QuantizedEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
-import dev.langchain4j.store.embedding.CosineSimilarity;
-import dev.langchain4j.store.embedding.EmbeddingMatch;
 import dev.langchain4j.store.embedding.EmbeddingStore;
-import dev.langchain4j.store.embedding.RelevanceScore;
+import dev.langchain4j.store.embedding.EmbeddingStoreIT;
 import io.quarkiverse.langchain4j.pgvector.PgVectorEmbeddingStore;
 import io.quarkus.test.QuarkusUnitTest;
 
-public class Langchain4jPgvectorTest {
+public class Langchain4jPgvectorTest extends EmbeddingStoreIT {
 
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
@@ -39,201 +27,27 @@ public class Langchain4jPgvectorTest {
                             "application.properties"));
 
     @Inject
-    EmbeddingStore embeddingStore;
-
-    @Inject
     PgVectorEmbeddingStore pgvectorEmbeddingStore;
 
     private final EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
 
-    @AfterEach
-    public void cleanup() throws SQLException {
-        pgvectorEmbeddingStore.deleteAll();
+    @Override
+    protected void clearStore() {
+        try {
+            pgvectorEmbeddingStore.deleteAll();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
     }
 
-    @Test
-    void should_add_embedding() {
-        assertThat(embeddingStore).isSameAs(pgvectorEmbeddingStore);
-
-        Embedding embedding = embeddingModel.embed(randomUUID()).content();
-
-        String id = embeddingStore.add(embedding);
-        assertThat(id).isNotNull();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(1, withPercentage(1));
-        assertThat(match.embeddingId()).isEqualTo(id);
-        assertThat(match.embedding()).isEqualTo(embedding);
-        assertThat(match.embedded()).isNull();
+    @Override
+    protected EmbeddingStore<TextSegment> embeddingStore() {
+        return pgvectorEmbeddingStore;
     }
 
-    @Test
-    void should_add_embedding_with_id() {
-        String id = randomUUID();
-        Embedding embedding = embeddingModel.embed(randomUUID()).content();
-
-        embeddingStore.add(id, embedding);
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(1, withPercentage(1));
-        assertThat(match.embeddingId()).isEqualTo(id);
-        assertThat(match.embedding()).isEqualTo(embedding);
-        assertThat(match.embedded()).isNull();
-    }
-
-    @Test
-    void should_add_embedding_with_segment() {
-        TextSegment segment = TextSegment.from(randomUUID());
-        Embedding embedding = embeddingModel.embed(segment.text()).content();
-
-        String id = embeddingStore.add(embedding, segment);
-        assertThat(id).isNotNull();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(1, withPercentage(1));
-        assertThat(match.embeddingId()).isEqualTo(id);
-        assertThat(match.embedding()).isEqualTo(embedding);
-        assertThat(match.embedded()).isEqualTo(segment);
-    }
-
-    @Test
-    void should_add_embedding_with_segment_with_metadata() {
-        TextSegment segment = TextSegment.from(randomUUID(), Metadata.from("test-key", "test-value"));
-        Embedding embedding = embeddingModel.embed(segment.text()).content();
-
-        String id = embeddingStore.add(embedding, segment);
-        assertThat(id).isNotNull();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(1, withPercentage(1));
-        assertThat(match.embeddingId()).isEqualTo(id);
-        assertThat(match.embedding()).isEqualTo(embedding);
-        assertThat(match.embedded()).isEqualTo(segment);
-    }
-
-    @Test
-    void should_add_multiple_embeddings() {
-        Embedding firstEmbedding = embeddingModel.embed(randomUUID()).content();
-        Embedding secondEmbedding = embeddingModel.embed(randomUUID()).content();
-
-        List<String> ids = embeddingStore.addAll(asList(firstEmbedding, secondEmbedding));
-        assertThat(ids).hasSize(2);
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(firstEmbedding, 10);
-        assertThat(relevant).hasSize(2);
-
-        EmbeddingMatch<TextSegment> firstMatch = relevant.get(0);
-        assertThat(firstMatch.score()).isCloseTo(1, withPercentage(1));
-        assertThat(firstMatch.embeddingId()).isEqualTo(ids.get(0));
-        assertThat(firstMatch.embedding()).isEqualTo(firstEmbedding);
-        assertThat(firstMatch.embedded()).isNull();
-
-        EmbeddingMatch<TextSegment> secondMatch = relevant.get(1);
-        assertThat(secondMatch.score()).isBetween(0d, 1d);
-        assertThat(secondMatch.embeddingId()).isEqualTo(ids.get(1));
-        assertThat(secondMatch.embedding()).isEqualTo(secondEmbedding);
-        assertThat(secondMatch.embedded()).isNull();
-    }
-
-    @Test
-    void should_add_multiple_embeddings_with_segments() {
-        TextSegment firstSegment = TextSegment.from(randomUUID());
-        Embedding firstEmbedding = embeddingModel.embed(firstSegment.text()).content();
-        TextSegment secondSegment = TextSegment.from(randomUUID());
-        Embedding secondEmbedding = embeddingModel.embed(secondSegment.text()).content();
-
-        List<String> ids = embeddingStore.addAll(
-                asList(firstEmbedding, secondEmbedding),
-                asList(firstSegment, secondSegment));
-        assertThat(ids).hasSize(2);
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(firstEmbedding, 10);
-        assertThat(relevant).hasSize(2);
-
-        EmbeddingMatch<TextSegment> firstMatch = relevant.get(0);
-        assertThat(firstMatch.score()).isCloseTo(1, withPercentage(1));
-        assertThat(firstMatch.embeddingId()).isEqualTo(ids.get(0));
-        assertThat(firstMatch.embedding()).isEqualTo(firstEmbedding);
-        assertThat(firstMatch.embedded()).isEqualTo(firstSegment);
-
-        EmbeddingMatch<TextSegment> secondMatch = relevant.get(1);
-        assertThat(secondMatch.score()).isBetween(0d, 1d);
-        assertThat(secondMatch.embeddingId()).isEqualTo(ids.get(1));
-        assertThat(secondMatch.embedding()).isEqualTo(secondEmbedding);
-        assertThat(secondMatch.embedded()).isEqualTo(secondSegment);
-    }
-
-    @Test
-    void should_find_with_min_score() {
-        String firstId = randomUUID();
-        Embedding firstEmbedding = embeddingModel.embed(randomUUID()).content();
-        embeddingStore.add(firstId, firstEmbedding);
-
-        String secondId = randomUUID();
-        Embedding secondEmbedding = embeddingModel.embed(randomUUID()).content();
-        embeddingStore.add(secondId, secondEmbedding);
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(firstEmbedding, 10);
-        assertThat(relevant).hasSize(2);
-        EmbeddingMatch<TextSegment> firstMatch = relevant.get(0);
-        assertThat(firstMatch.score()).isCloseTo(1, withPercentage(1));
-        assertThat(firstMatch.embeddingId()).isEqualTo(firstId);
-        EmbeddingMatch<TextSegment> secondMatch = relevant.get(1);
-        assertThat(secondMatch.score()).isBetween(0d, 1d);
-        assertThat(secondMatch.embeddingId()).isEqualTo(secondId);
-
-        List<EmbeddingMatch<TextSegment>> relevant2 = embeddingStore.findRelevant(
-                firstEmbedding,
-                10,
-                secondMatch.score() - 0.01);
-        assertThat(relevant2).hasSize(2);
-        assertThat(relevant2.get(0).embeddingId()).isEqualTo(firstId);
-        assertThat(relevant2.get(1).embeddingId()).isEqualTo(secondId);
-
-        List<EmbeddingMatch<TextSegment>> relevant3 = embeddingStore.findRelevant(
-                firstEmbedding,
-                10,
-                secondMatch.score());
-        assertThat(relevant3).hasSize(2);
-        assertThat(relevant3.get(0).embeddingId()).isEqualTo(firstId);
-        assertThat(relevant3.get(1).embeddingId()).isEqualTo(secondId);
-
-        List<EmbeddingMatch<TextSegment>> relevant4 = embeddingStore.findRelevant(
-                firstEmbedding,
-                10,
-                secondMatch.score() + 0.01);
-        assertThat(relevant4).hasSize(1);
-        assertThat(relevant4.get(0).embeddingId()).isEqualTo(firstId);
-    }
-
-    @Test
-    void should_return_correct_score() {
-        Embedding embedding = embeddingModel.embed("hello").content();
-
-        String id = embeddingStore.add(embedding);
-        assertThat(id).isNotNull();
-
-        Embedding referenceEmbedding = embeddingModel.embed("hi").content();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(referenceEmbedding, 1);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(
-                RelevanceScore.fromCosineSimilarity(CosineSimilarity.between(embedding, referenceEmbedding)),
-                withPercentage(1));
+    @Override
+    protected EmbeddingModel embeddingModel() {
+        return embeddingModel;
     }
 
 }

--- a/pinecone/deployment/pom.xml
+++ b/pinecone/deployment/pom.xml
@@ -28,6 +28,14 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <version>${langchain4j.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>

--- a/pinecone/deployment/src/test/java/io/quarkiverse/langchain4j/pinecone/deployment/PineconeEmbeddingStoreTest.java
+++ b/pinecone/deployment/src/test/java/io/quarkiverse/langchain4j/pinecone/deployment/PineconeEmbeddingStoreTest.java
@@ -1,10 +1,5 @@
 package io.quarkiverse.langchain4j.pinecone.deployment;
 
-import static dev.langchain4j.internal.Utils.randomUUID;
-import static java.util.Arrays.asList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.data.Percentage.withPercentage;
-
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -13,19 +8,14 @@ import jakarta.inject.Inject;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import dev.langchain4j.data.document.Metadata;
-import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.AllMiniLmL6V2QuantizedEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
-import dev.langchain4j.store.embedding.CosineSimilarity;
-import dev.langchain4j.store.embedding.EmbeddingMatch;
-import dev.langchain4j.store.embedding.RelevanceScore;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.EmbeddingStoreIT;
 import io.quarkiverse.langchain4j.pinecone.PineconeEmbeddingStore;
 import io.quarkiverse.langchain4j.pinecone.runtime.DeleteRequest;
 import io.quarkiverse.langchain4j.pinecone.runtime.PineconeVectorOperationsApi;
@@ -54,7 +44,7 @@ import io.quarkus.test.QuarkusUnitTest;
  *
  */
 @EnabledIfEnvironmentVariable(named = "PINECONE_API_KEY", matches = ".+")
-public class PineconeEmbeddingStoreTest {
+public class PineconeEmbeddingStoreTest extends EmbeddingStoreIT {
 
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
@@ -75,11 +65,23 @@ public class PineconeEmbeddingStoreTest {
 
     private final EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
 
-    @BeforeEach
-    public void cleanup() {
-        // Normally we would use deleteAll=true for deleting all vectors,
-        // but that doesn't work in the gcp-starter environment,
-        // so make it a two-step process instead by querying for all vectors, and then removing them.
+    @Override
+    protected EmbeddingStore<TextSegment> embeddingStore() {
+        return embeddingStore;
+    }
+
+    @Override
+    protected EmbeddingModel embeddingModel() {
+        return embeddingModel;
+    }
+
+    @Override
+    protected void awaitUntilPersisted() {
+        delay();
+    }
+
+    @Override
+    protected void clearStore() {
         Log.info("About to delete all embeddings");
         PineconeVectorOperationsApi client = embeddingStore.getUnderlyingClient();
         float[] vector = new float[384];
@@ -89,16 +91,16 @@ public class PineconeEmbeddingStoreTest {
             Log.info("Deleting " + existingEntries.size() + " embeddings: " + existingEntries);
             client.delete(new DeleteRequest(existingEntries, false, null, null));
         }
-
+        delay();
     }
 
     /**
-     * Seems we have to add some delay after each insert operation before Pinecone
-     * processes the vector and makes it available for querying.
+     * Seems we have to add some delay after each insert/delete operation
+     * before Pinecone fully processes the operation.
      */
     private static void delay() {
         try {
-            int timeout = 30;
+            int timeout = 20;
             Log.info("Waiting " + timeout + " seconds to allow Pinecone time to process deletions");
             TimeUnit.SECONDS.sleep(timeout);
         } catch (InterruptedException e) {
@@ -106,196 +108,4 @@ public class PineconeEmbeddingStoreTest {
         }
     }
 
-    @Test
-    void should_add_embedding() {
-        Embedding embedding = embeddingModel.embed(randomUUID()).content();
-
-        String id = embeddingStore.add(embedding);
-        assertThat(id).isNotNull();
-
-        delay();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(1, withPercentage(1));
-        assertThat(match.embeddingId()).isEqualTo(id);
-        assertThat(match.embedding()).isEqualTo(embedding);
-        assertThat(match.embedded()).isNull();
-    }
-
-    @Test
-    void should_add_embedding_with_id() {
-        String id = randomUUID();
-        Embedding embedding = embeddingModel.embed(randomUUID()).content();
-
-        embeddingStore.add(id, embedding);
-        delay();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(1, withPercentage(1));
-        assertThat(match.embeddingId()).isEqualTo(id);
-        assertThat(match.embedding()).isEqualTo(embedding);
-        assertThat(match.embedded()).isNull();
-    }
-
-    @Test
-    void should_add_embedding_with_segment() {
-        TextSegment segment = TextSegment.from(randomUUID());
-        Embedding embedding = embeddingModel.embed(segment.text()).content();
-
-        String id = embeddingStore.add(embedding, segment);
-        delay();
-        assertThat(id).isNotNull();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(1, withPercentage(1));
-        assertThat(match.embeddingId()).isEqualTo(id);
-        assertThat(match.embedding()).isEqualTo(embedding);
-        assertThat(match.embedded()).isEqualTo(segment);
-    }
-
-    @Test
-    void should_add_embedding_with_segment_with_metadata() {
-        TextSegment segment = TextSegment.from(randomUUID(), Metadata.from("test-key", "test-value"));
-        Embedding embedding = embeddingModel.embed(segment.text()).content();
-
-        String id = embeddingStore.add(embedding, segment);
-
-        assertThat(id).isNotNull();
-
-        delay();
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(1, withPercentage(1));
-        assertThat(match.embeddingId()).isEqualTo(id);
-        assertThat(match.embedding()).isEqualTo(embedding);
-        assertThat(match.embedded()).isEqualTo(segment);
-    }
-
-    @Test
-    void should_add_multiple_embeddings() {
-        Embedding firstEmbedding = embeddingModel.embed(randomUUID()).content();
-        Embedding secondEmbedding = embeddingModel.embed(randomUUID()).content();
-
-        List<String> ids = embeddingStore.addAll(asList(firstEmbedding, secondEmbedding));
-        assertThat(ids).hasSize(2);
-        delay();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(firstEmbedding, 10);
-        assertThat(relevant).hasSize(2);
-
-        EmbeddingMatch<TextSegment> firstMatch = relevant.get(0);
-        assertThat(firstMatch.score()).isCloseTo(1, withPercentage(1));
-        assertThat(firstMatch.embeddingId()).isEqualTo(ids.get(0));
-        assertThat(firstMatch.embedding()).isEqualTo(firstEmbedding);
-        assertThat(firstMatch.embedded()).isNull();
-
-        EmbeddingMatch<TextSegment> secondMatch = relevant.get(1);
-        assertThat(secondMatch.score()).isBetween(0d, 1d);
-        assertThat(secondMatch.embeddingId()).isEqualTo(ids.get(1));
-        assertThat(secondMatch.embedding()).isEqualTo(secondEmbedding);
-        assertThat(secondMatch.embedded()).isNull();
-    }
-
-    @Test
-    void should_add_multiple_embeddings_with_segments() {
-        TextSegment firstSegment = TextSegment.from(randomUUID());
-        Embedding firstEmbedding = embeddingModel.embed(firstSegment.text()).content();
-        TextSegment secondSegment = TextSegment.from(randomUUID());
-        Embedding secondEmbedding = embeddingModel.embed(secondSegment.text()).content();
-
-        List<String> ids = embeddingStore.addAll(
-                asList(firstEmbedding, secondEmbedding),
-                asList(firstSegment, secondSegment));
-        assertThat(ids).hasSize(2);
-        delay();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(firstEmbedding, 10);
-        assertThat(relevant).hasSize(2);
-
-        EmbeddingMatch<TextSegment> firstMatch = relevant.get(0);
-        assertThat(firstMatch.score()).isCloseTo(1, withPercentage(1));
-        assertThat(firstMatch.embeddingId()).isEqualTo(ids.get(0));
-        assertThat(firstMatch.embedding()).isEqualTo(firstEmbedding);
-        assertThat(firstMatch.embedded()).isEqualTo(firstSegment);
-
-        EmbeddingMatch<TextSegment> secondMatch = relevant.get(1);
-        assertThat(secondMatch.score()).isBetween(0d, 1d);
-        assertThat(secondMatch.embeddingId()).isEqualTo(ids.get(1));
-        assertThat(secondMatch.embedding()).isEqualTo(secondEmbedding);
-        assertThat(secondMatch.embedded()).isEqualTo(secondSegment);
-    }
-
-    @Test
-    void should_find_with_min_score() {
-        String firstId = randomUUID();
-        Embedding firstEmbedding = embeddingModel.embed(randomUUID()).content();
-        embeddingStore.add(firstId, firstEmbedding);
-
-        String secondId = randomUUID();
-        Embedding secondEmbedding = embeddingModel.embed(randomUUID()).content();
-        embeddingStore.add(secondId, secondEmbedding);
-
-        delay();
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(firstEmbedding, 10);
-        assertThat(relevant).hasSize(2);
-        EmbeddingMatch<TextSegment> firstMatch = relevant.get(0);
-        assertThat(firstMatch.score()).isCloseTo(1, withPercentage(1));
-        assertThat(firstMatch.embeddingId()).isEqualTo(firstId);
-        EmbeddingMatch<TextSegment> secondMatch = relevant.get(1);
-        assertThat(secondMatch.score()).isBetween(0d, 1d);
-        assertThat(secondMatch.embeddingId()).isEqualTo(secondId);
-
-        List<EmbeddingMatch<TextSegment>> relevant2 = embeddingStore.findRelevant(
-                firstEmbedding,
-                10,
-                secondMatch.score() - 0.01);
-        assertThat(relevant2).hasSize(2);
-        assertThat(relevant2.get(0).embeddingId()).isEqualTo(firstId);
-        assertThat(relevant2.get(1).embeddingId()).isEqualTo(secondId);
-
-        List<EmbeddingMatch<TextSegment>> relevant3 = embeddingStore.findRelevant(
-                firstEmbedding,
-                10,
-                secondMatch.score());
-        assertThat(relevant3).hasSize(2);
-        assertThat(relevant3.get(0).embeddingId()).isEqualTo(firstId);
-        assertThat(relevant3.get(1).embeddingId()).isEqualTo(secondId);
-
-        List<EmbeddingMatch<TextSegment>> relevant4 = embeddingStore.findRelevant(
-                firstEmbedding,
-                10,
-                secondMatch.score() + 0.01);
-        assertThat(relevant4).hasSize(1);
-        assertThat(relevant4.get(0).embeddingId()).isEqualTo(firstId);
-    }
-
-    @Test
-    void should_return_correct_score() {
-        Embedding embedding = embeddingModel.embed("hello").content();
-
-        String id = embeddingStore.add(embedding);
-        assertThat(id).isNotNull();
-
-        Embedding referenceEmbedding = embeddingModel.embed("hi").content();
-
-        delay();
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(referenceEmbedding, 1);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(
-                RelevanceScore.fromCosineSimilarity(CosineSimilarity.between(embedding, referenceEmbedding)),
-                withPercentage(1));
-    }
 }

--- a/redis/deployment/pom.xml
+++ b/redis/deployment/pom.xml
@@ -32,6 +32,14 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <version>${langchain4j.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>

--- a/redis/deployment/src/test/java/io/quarkiverse/langchain4j/redis/deployment/RedisEmbeddingStoreTest.java
+++ b/redis/deployment/src/test/java/io/quarkiverse/langchain4j/redis/deployment/RedisEmbeddingStoreTest.java
@@ -1,34 +1,21 @@
 package io.quarkiverse.langchain4j.redis.deployment;
 
-import static dev.langchain4j.internal.Utils.randomUUID;
-import static java.util.Arrays.asList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.data.Percentage.withPercentage;
-
-import java.util.List;
-
 import jakarta.inject.Inject;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import dev.langchain4j.data.document.Metadata;
-import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.AllMiniLmL6V2QuantizedEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
-import dev.langchain4j.store.embedding.CosineSimilarity;
-import dev.langchain4j.store.embedding.EmbeddingMatch;
 import dev.langchain4j.store.embedding.EmbeddingStore;
-import dev.langchain4j.store.embedding.RelevanceScore;
+import dev.langchain4j.store.embedding.EmbeddingStoreIT;
 import io.quarkiverse.langchain4j.redis.RedisEmbeddingStore;
 import io.quarkus.test.QuarkusUnitTest;
 
-public class RedisEmbeddingStoreTest {
+public class RedisEmbeddingStoreTest extends EmbeddingStoreIT {
 
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
@@ -39,199 +26,22 @@ public class RedisEmbeddingStoreTest {
                             "application.properties"));
 
     @Inject
-    EmbeddingStore embeddingStore;
-    @Inject
-    RedisEmbeddingStore redisEmbeddingStore;
+    RedisEmbeddingStore embeddingStore;
 
     private final EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
 
-    @AfterEach
-    public void cleanup() {
-        redisEmbeddingStore.deleteAll();
+    @Override
+    protected void clearStore() {
+        embeddingStore.deleteAll();
     }
 
-    @Test
-    void should_add_embedding() {
-        assertThat(embeddingStore).isSameAs(redisEmbeddingStore);
-
-        Embedding embedding = embeddingModel.embed(randomUUID()).content();
-
-        String id = embeddingStore.add(embedding);
-        assertThat(id).isNotNull();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(1, withPercentage(1));
-        assertThat(match.embeddingId()).isEqualTo(id);
-        assertThat(match.embedding()).isEqualTo(embedding);
-        assertThat(match.embedded()).isNull();
+    @Override
+    protected EmbeddingStore<TextSegment> embeddingStore() {
+        return embeddingStore;
     }
 
-    @Test
-    void should_add_embedding_with_id() {
-        String id = randomUUID();
-        Embedding embedding = embeddingModel.embed(randomUUID()).content();
-
-        embeddingStore.add(id, embedding);
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(1, withPercentage(1));
-        assertThat(match.embeddingId()).isEqualTo(id);
-        assertThat(match.embedding()).isEqualTo(embedding);
-        assertThat(match.embedded()).isNull();
-    }
-
-    @Test
-    void should_add_embedding_with_segment() {
-        TextSegment segment = TextSegment.from(randomUUID());
-        Embedding embedding = embeddingModel.embed(segment.text()).content();
-
-        String id = embeddingStore.add(embedding, segment);
-        assertThat(id).isNotNull();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(1, withPercentage(1));
-        assertThat(match.embeddingId()).isEqualTo(id);
-        assertThat(match.embedding()).isEqualTo(embedding);
-        assertThat(match.embedded()).isEqualTo(segment);
-    }
-
-    @Test
-    void should_add_embedding_with_segment_with_metadata() {
-        TextSegment segment = TextSegment.from(randomUUID(), Metadata.from("test-key", "test-value"));
-        Embedding embedding = embeddingModel.embed(segment.text()).content();
-
-        String id = embeddingStore.add(embedding, segment);
-        assertThat(id).isNotNull();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(1, withPercentage(1));
-        assertThat(match.embeddingId()).isEqualTo(id);
-        assertThat(match.embedding()).isEqualTo(embedding);
-        assertThat(match.embedded()).isEqualTo(segment);
-    }
-
-    @Test
-    void should_add_multiple_embeddings() {
-        Embedding firstEmbedding = embeddingModel.embed(randomUUID()).content();
-        Embedding secondEmbedding = embeddingModel.embed(randomUUID()).content();
-
-        List<String> ids = embeddingStore.addAll(asList(firstEmbedding, secondEmbedding));
-        assertThat(ids).hasSize(2);
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(firstEmbedding, 10);
-        assertThat(relevant).hasSize(2);
-
-        EmbeddingMatch<TextSegment> firstMatch = relevant.get(0);
-        assertThat(firstMatch.score()).isCloseTo(1, withPercentage(1));
-        assertThat(firstMatch.embeddingId()).isEqualTo(ids.get(0));
-        assertThat(firstMatch.embedding()).isEqualTo(firstEmbedding);
-        assertThat(firstMatch.embedded()).isNull();
-
-        EmbeddingMatch<TextSegment> secondMatch = relevant.get(1);
-        assertThat(secondMatch.score()).isBetween(0d, 1d);
-        assertThat(secondMatch.embeddingId()).isEqualTo(ids.get(1));
-        assertThat(secondMatch.embedding()).isEqualTo(secondEmbedding);
-        assertThat(secondMatch.embedded()).isNull();
-    }
-
-    @Test
-    void should_add_multiple_embeddings_with_segments() {
-        TextSegment firstSegment = TextSegment.from(randomUUID());
-        Embedding firstEmbedding = embeddingModel.embed(firstSegment.text()).content();
-        TextSegment secondSegment = TextSegment.from(randomUUID());
-        Embedding secondEmbedding = embeddingModel.embed(secondSegment.text()).content();
-
-        List<String> ids = embeddingStore.addAll(
-                asList(firstEmbedding, secondEmbedding),
-                asList(firstSegment, secondSegment));
-        assertThat(ids).hasSize(2);
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(firstEmbedding, 10);
-        assertThat(relevant).hasSize(2);
-
-        EmbeddingMatch<TextSegment> firstMatch = relevant.get(0);
-        assertThat(firstMatch.score()).isCloseTo(1, withPercentage(1));
-        assertThat(firstMatch.embeddingId()).isEqualTo(ids.get(0));
-        assertThat(firstMatch.embedding()).isEqualTo(firstEmbedding);
-        assertThat(firstMatch.embedded()).isEqualTo(firstSegment);
-
-        EmbeddingMatch<TextSegment> secondMatch = relevant.get(1);
-        assertThat(secondMatch.score()).isBetween(0d, 1d);
-        assertThat(secondMatch.embeddingId()).isEqualTo(ids.get(1));
-        assertThat(secondMatch.embedding()).isEqualTo(secondEmbedding);
-        assertThat(secondMatch.embedded()).isEqualTo(secondSegment);
-    }
-
-    @Test
-    void should_find_with_min_score() {
-        String firstId = randomUUID();
-        Embedding firstEmbedding = embeddingModel.embed(randomUUID()).content();
-        embeddingStore.add(firstId, firstEmbedding);
-
-        String secondId = randomUUID();
-        Embedding secondEmbedding = embeddingModel.embed(randomUUID()).content();
-        embeddingStore.add(secondId, secondEmbedding);
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(firstEmbedding, 10);
-        assertThat(relevant).hasSize(2);
-        EmbeddingMatch<TextSegment> firstMatch = relevant.get(0);
-        assertThat(firstMatch.score()).isCloseTo(1, withPercentage(1));
-        assertThat(firstMatch.embeddingId()).isEqualTo(firstId);
-        EmbeddingMatch<TextSegment> secondMatch = relevant.get(1);
-        assertThat(secondMatch.score()).isBetween(0d, 1d);
-        assertThat(secondMatch.embeddingId()).isEqualTo(secondId);
-
-        List<EmbeddingMatch<TextSegment>> relevant2 = embeddingStore.findRelevant(
-                firstEmbedding,
-                10,
-                secondMatch.score() - 0.01);
-        assertThat(relevant2).hasSize(2);
-        assertThat(relevant2.get(0).embeddingId()).isEqualTo(firstId);
-        assertThat(relevant2.get(1).embeddingId()).isEqualTo(secondId);
-
-        List<EmbeddingMatch<TextSegment>> relevant3 = embeddingStore.findRelevant(
-                firstEmbedding,
-                10,
-                secondMatch.score());
-        assertThat(relevant3).hasSize(2);
-        assertThat(relevant3.get(0).embeddingId()).isEqualTo(firstId);
-        assertThat(relevant3.get(1).embeddingId()).isEqualTo(secondId);
-
-        List<EmbeddingMatch<TextSegment>> relevant4 = embeddingStore.findRelevant(
-                firstEmbedding,
-                10,
-                secondMatch.score() + 0.01);
-        assertThat(relevant4).hasSize(1);
-        assertThat(relevant4.get(0).embeddingId()).isEqualTo(firstId);
-    }
-
-    @Test
-    void should_return_correct_score() {
-        Embedding embedding = embeddingModel.embed("hello").content();
-
-        String id = embeddingStore.add(embedding);
-        assertThat(id).isNotNull();
-
-        Embedding referenceEmbedding = embeddingModel.embed("hi").content();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(referenceEmbedding, 1);
-        assertThat(relevant).hasSize(1);
-
-        EmbeddingMatch<TextSegment> match = relevant.get(0);
-        assertThat(match.score()).isCloseTo(
-                RelevanceScore.fromCosineSimilarity(CosineSimilarity.between(embedding, referenceEmbedding)),
-                withPercentage(1));
+    @Override
+    protected EmbeddingModel embeddingModel() {
+        return embeddingModel;
     }
 }

--- a/samples/fraud-detection/src/main/resources/application.properties
+++ b/samples/fraud-detection/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 quarkus.langchain4j.openai.timeout=60s
 quarkus.langchain4j.openai.chat-model.temperature=0
-quarkus.langchain4j.openai.chat-model.model-name=gpt-4-1106-preview
+#quarkus.langchain4j.openai.chat-model.model-name=gpt-4-1106-preview
 
 #quarkus.langchain4j.openai.log-requests=true
 #quarkus.langchain4j.openai.log-responses=true


### PR DESCRIPTION
Reuse the `EmbeddingStoreIT` class that kinda serves as a TCK for embedding stores.
This removes a lot of code duplication and brings us a bit closer to the upstream langchain4j project.

I also had to add the `deleteAll` functionality for the Chroma store, because the testcase requires that each test starts with a clean store.