### PR TITLE
Adapt OpenAI Dev UI pages to multiple models

### DIFF
--- a/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/devui/OpenAiDevUIProcessor.java
+++ b/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/devui/OpenAiDevUIProcessor.java
@@ -1,8 +1,14 @@
 package io.quarkiverse.langchain4j.openai.deployment.devui;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import io.quarkiverse.langchain4j.deployment.items.SelectedImageModelProviderBuildItem;
+import io.quarkiverse.langchain4j.deployment.items.SelectedModerationModelProviderBuildItem;
 import io.quarkiverse.langchain4j.openai.deployment.Langchain4jOpenAiBuildConfig;
 import io.quarkiverse.langchain4j.openai.runtime.devui.OpenAiImagesJsonRPCService;
 import io.quarkiverse.langchain4j.openai.runtime.devui.OpenAiModerationModelsJsonRPCService;
+import io.quarkiverse.langchain4j.runtime.NamedModelUtil;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -14,34 +20,66 @@ public class OpenAiDevUIProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
     CardPageBuildItem cardPage(
-            BuildProducer<JsonRPCProvidersBuildItem> producers,
-            Langchain4jOpenAiBuildConfig config) {
+            Langchain4jOpenAiBuildConfig config,
+            List<SelectedImageModelProviderBuildItem> imageModels,
+            List<SelectedModerationModelProviderBuildItem> moderationModels) {
         CardPageBuildItem card = new CardPageBuildItem();
-        addImageModelPage(producers, config, card);
-        addModerationModelPage(producers, config, card);
+        addImageModelPage(config, card, imageModels);
+        addModerationModelPage(config, card, moderationModels);
         return card;
     }
 
-    private void addImageModelPage(
-            BuildProducer<JsonRPCProvidersBuildItem> producers,
-            Langchain4jOpenAiBuildConfig config,
-            CardPageBuildItem card) {
+    @BuildStep(onlyIf = IsDevelopment.class)
+    void jsonRpcProviders(BuildProducer<JsonRPCProvidersBuildItem> rpcProviders,
+            Langchain4jOpenAiBuildConfig config) {
         if (config.imageModel().enabled().orElse(true)) {
-            card.addPage(Page.webComponentPageBuilder().title("Images")
-                    .componentLink("qwc-images.js")
-                    .icon("font-awesome-solid:palette"));
-            producers.produce(new JsonRPCProvidersBuildItem(OpenAiImagesJsonRPCService.class));
+            rpcProviders.produce(new JsonRPCProvidersBuildItem(OpenAiImagesJsonRPCService.class));
+        }
+        if (config.moderationModel().enabled().orElse(true)) {
+            rpcProviders.produce(new JsonRPCProvidersBuildItem(OpenAiModerationModelsJsonRPCService.class));
         }
     }
 
-    private void addModerationModelPage(BuildProducer<JsonRPCProvidersBuildItem> producers,
+    private void addImageModelPage(
             Langchain4jOpenAiBuildConfig config,
-            CardPageBuildItem card) {
+            CardPageBuildItem card,
+            List<SelectedImageModelProviderBuildItem> imageModels) {
+        List<String> configurations = new ArrayList<>();
+        for (SelectedImageModelProviderBuildItem imageModel : imageModels) {
+            configurations.add(imageModel.getModelName());
+        }
+        if (configurations.isEmpty()) {
+            // Even if the default OpenAI config instance is not injected
+            // anywhere, let the image page know about it so users can play
+            // around with images out of the box (even with an empty
+            // application). If the API key isn't configured, don't fail the
+            // startup - the image page will show an error.
+            configurations.add(NamedModelUtil.DEFAULT_NAME);
+        }
+        if (config.imageModel().enabled().orElse(true)) {
+            card.addBuildTimeData("imageModelConfigurations", configurations);
+            card.addPage(Page.webComponentPageBuilder().title("Images")
+                    .componentLink("qwc-images.js")
+                    .icon("font-awesome-solid:palette"));
+        }
+    }
+
+    private void addModerationModelPage(
+            Langchain4jOpenAiBuildConfig config,
+            CardPageBuildItem card,
+            List<SelectedModerationModelProviderBuildItem> moderationModels) {
+        List<String> configurations = new ArrayList<>();
+        for (SelectedModerationModelProviderBuildItem imageModel : moderationModels) {
+            configurations.add(imageModel.getModelName());
+        }
+        if (configurations.isEmpty()) {
+            configurations.add(NamedModelUtil.DEFAULT_NAME);
+        }
         if (config.moderationModel().enabled().orElse(true)) {
+            card.addBuildTimeData("moderationModelConfigurations", configurations);
             card.addPage(Page.webComponentPageBuilder().title("Moderation model")
                     .componentLink("qwc-moderation.js")
                     .icon("font-awesome-solid:triangle-exclamation"));
-            producers.produce(new JsonRPCProvidersBuildItem(OpenAiModerationModelsJsonRPCService.class));
         }
     }
 

--- a/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/devui/OpenAiModerationModelsJsonRPCService.java
+++ b/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/devui/OpenAiModerationModelsJsonRPCService.java
@@ -1,12 +1,6 @@
 package io.quarkiverse.langchain4j.openai.runtime.devui;
 
-import java.time.Duration;
-
-import jakarta.annotation.PostConstruct;
-import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
-
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import dev.ai4j.openai4j.OpenAiClient;
 import dev.ai4j.openai4j.moderation.Categories;
@@ -15,61 +9,49 @@ import dev.ai4j.openai4j.moderation.ModerationRequest;
 import dev.ai4j.openai4j.moderation.ModerationResponse;
 import dev.ai4j.openai4j.moderation.ModerationResult;
 import dev.langchain4j.internal.RetryUtils;
+import io.quarkiverse.langchain4j.openai.runtime.config.Langchain4jOpenAiConfig;
+import io.quarkiverse.langchain4j.runtime.NamedModelUtil;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public class OpenAiModerationModelsJsonRPCService {
 
     @Inject
-    @ConfigProperty(name = "quarkus.langchain4j.openai.base-url")
-    String baseUrl;
+    Langchain4jOpenAiConfig config;
 
-    @Inject
-    @ConfigProperty(name = "quarkus.langchain4j.openai.api-key")
-    String apiKey;
-
-    @Inject
-    @ConfigProperty(name = "quarkus.langchain4j.openai.timeout")
-    Duration timeout;
-
-    @Inject
-    @ConfigProperty(name = "quarkus.langchain4j.openai.max-retries")
-    Integer maxRetries;
-
-    OpenAiClient client;
-
-    @PostConstruct
-    public void init() {
-        client = OpenAiClient.builder().openAiApiKey(apiKey).baseUrl(baseUrl)
-                .callTimeout(timeout).connectTimeout(timeout)
-                .readTimeout(timeout).writeTimeout(timeout).build();
-    }
-
-    @PreDestroy
-    public void cleanup() {
-        if (client != null) {
+    public JsonObject moderate(String configuration, String modelName, String prompt) {
+        if (NamedModelUtil.isDefault(configuration) && config.defaultConfig().apiKey().equals("dummy")) {
+            // for non-default configurations, we assume that Quarkus has verified by now that the api key is set
+            throw new RuntimeException("OpenAI API key is not configured. " +
+                    "Please specify the key in the `quarkus.langchain4j.openai.api-key` configuration property.");
+        }
+        Langchain4jOpenAiConfig.OpenAiConfig clientConfig = NamedModelUtil.isDefault(configuration) ? config.defaultConfig()
+                : config.namedConfig().get(configuration);
+        OpenAiClient client = OpenAiClient.builder().openAiApiKey(clientConfig.apiKey()).baseUrl(clientConfig.baseUrl())
+                .callTimeout(clientConfig.timeout()).connectTimeout(clientConfig.timeout())
+                .readTimeout(clientConfig.timeout()).writeTimeout(clientConfig.timeout()).build();
+        try {
+            ModerationRequest request = ModerationRequest.builder().model(modelName).input(prompt).build();
+            ModerationResponse response = RetryUtils.withRetry(() -> client.moderation(request).execute(),
+                    clientConfig.maxRetries());
+            ModerationResult moderationResult = response.results().get(0);
+            CategoryScores categoryScores = moderationResult.categoryScores();
+            Categories categoryFlags = moderationResult.categories();
+            JsonObject result = new JsonObject();
+            result.put("flagged", moderationResult.isFlagged());
+            JsonArray categories = new JsonArray();
+            addCategoryScore(categories, "sexual", categoryScores.sexual(), categoryFlags.sexual());
+            addCategoryScore(categories, "hate", categoryScores.hate(), categoryFlags.hate());
+            addCategoryScore(categories, "hate-threatening", categoryScores.hateThreatening(), categoryFlags.hateThreatening());
+            addCategoryScore(categories, "self-harm", categoryScores.selfHarm(), categoryFlags.selfHarm());
+            addCategoryScore(categories, "violence", categoryScores.violence(), categoryFlags.violence());
+            addCategoryScore(categories, "violence-graphic", categoryScores.violenceGraphic(), categoryFlags.violenceGraphic());
+            addCategoryScore(categories, "sexual-minors", categoryScores.sexualMinors(), categoryFlags.sexualMinors());
+            result.put("categories", categories);
+            return result;
+        } finally {
             client.shutdown();
         }
-    }
-
-    public JsonObject moderate(String modelName, String prompt) {
-        ModerationRequest request = ModerationRequest.builder().model(modelName).input(prompt).build();
-        ModerationResponse response = RetryUtils.withRetry(() -> client.moderation(request).execute(), this.maxRetries);
-        ModerationResult moderationResult = response.results().get(0);
-        CategoryScores categoryScores = moderationResult.categoryScores();
-        Categories categoryFlags = moderationResult.categories();
-        JsonObject result = new JsonObject();
-        result.put("flagged", moderationResult.isFlagged());
-        JsonArray categories = new JsonArray();
-        addCategoryScore(categories, "sexual", categoryScores.sexual(), categoryFlags.sexual());
-        addCategoryScore(categories, "hate", categoryScores.hate(), categoryFlags.hate());
-        addCategoryScore(categories, "hate-threatening", categoryScores.hateThreatening(), categoryFlags.hateThreatening());
-        addCategoryScore(categories, "self-harm", categoryScores.selfHarm(), categoryFlags.selfHarm());
-        addCategoryScore(categories, "violence", categoryScores.violence(), categoryFlags.violence());
-        addCategoryScore(categories, "violence-graphic", categoryScores.violenceGraphic(), categoryFlags.violenceGraphic());
-        addCategoryScore(categories, "sexual-minors", categoryScores.sexualMinors(), categoryFlags.sexualMinors());
-        result.put("categories", categories);
-        return result;
     }
 
     private void addCategoryScore(JsonArray categories, String name, Double score, Boolean flagged) {


### PR DESCRIPTION
- Fixes https://github.com/quarkiverse/quarkus-langchain4j/issues/322 : for the moderation and image pages, when using the default model and the API key is missing, we show a nicer error now. For other pages, it's not necessary because they inject the model directly from CDI and thus if the API key is missing, it will have failed earlier anyway.
- Moderation and image pages now support selecting the named OpenAI model configuration, which will serve as the "base", on top of which you can override parameters using dropdowns
- I'd like to extend the embedding store and chat pages to support multiple models too, but haven't figured out yet how to do it nicely, will revisit

CC @gastaldi 