### PR TITLE
Update extension metadata to use name consistent with LangChain4j

### DIFF
--- a/.github/workflows/build-against-langchain4j.yml
+++ b/.github/workflows/build-against-langchain4j.yml
@@ -1,4 +1,4 @@
-name: Build against Langchain4j main
+name: Build against LangChain4j main
 
 on:
   schedule:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Check out the [samples](https://github.com/quarkiverse/quarkus-langchain4j/tree/
 
 ## Getting Started
 
-To incorporate Quarkus Langchain4j into your Quarkus project, add the following Maven dependency:
+To incorporate Quarkus LangChain4j into your Quarkus project, add the following Maven dependency:
 
 ```xml
 <dependency>

--- a/bam/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/bam/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
-name: Quarkus Langchain4j BAM
+name: Quarkus LangChain4j BAM
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-description: Provides integration of Quarkus Langchain4j with the IBM BAM API
+description: Provides integration of Quarkus LangChain4j with the IBM BAM API
 metadata:
    keywords:
     - ai

--- a/chroma/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/chroma/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
-name: Langchain4j Chroma
+name: LangChain4j Chroma
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-description: Provides integration of Quarkus Langchain4j with the Chroma vector database
+description: Provides integration of Quarkus LangChain4j with the Chroma vector database
 metadata:
   keywords:
     - ai

--- a/core/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/core/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
-name: Langchain4j
+name: LangChain4j
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-description: Provides the basic integration with Langchain4j
+description: Provides the basic integration with LangChain4j
 metadata:
   keywords:
     - ai

--- a/hugging-face/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/hugging-face/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
-name: Langchain4j Hugging Face
+name: LangChain4j Hugging Face
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-description: Provides integration of Quarkus Langchain4j with the Hugging Face API
+description: Provides integration of Quarkus LangChain4j with the Hugging Face API
 metadata:
   keywords:
     - ai

--- a/infinispan/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/infinispan/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
-name: Langchain4j Infinispan embedding store
+name: LangChain4j Infinispan embedding store
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-description: Provides the Infinispan Embedding store for Langchain4j
+description: Provides the Infinispan Embedding store for LangChain4j
 metadata:
   keywords:
     - ai

--- a/milvus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/milvus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
-name: Langchain4j Milvus embedding store
+name: LangChain4j Milvus embedding store
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-description: Provides the Milvus Embedding store for Langchain4j
+description: Provides the Milvus Embedding store for LangChain4j
 metadata:
   keywords:
     - ai

--- a/ollama/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/ollama/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
-name: Langchain4j Ollama
+name: LangChain4j Ollama
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-description: Provides the basic integration of Ollama with Langchain4j
+description: Provides the basic integration of Ollama with LangChain4j
 metadata:
   keywords:
     - ai

--- a/openai/azure-openai/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/openai/azure-openai/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
-name: Langchain4j Azure OpenAI
+name: LangChain4j Azure OpenAI
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-description: Provides the basic integration of Azure OpenAi with Langchain4j
+description: Provides the basic integration of Azure OpenAi with LangChain4j
 metadata:
   keywords:
     - ai

--- a/openai/openai-common/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/openai/openai-common/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,4 +1,4 @@
-name: Langchain4j OpenAI Common
+name: LangChain4j OpenAI Common
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
   unlisted: true

--- a/openai/openai-vanilla/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/openai/openai-vanilla/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
-name: Langchain4j OpenAI
+name: LangChain4j OpenAI
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-description: Provides the basic integration with Langchain4j
+description: Provides the basic integration with LangChain4j
 metadata:
   keywords:
     - ai

--- a/openshift-ai/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/openshift-ai/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
-name: Quarkus Langchain4j OpenShift AI
+name: Quarkus LangChain4j OpenShift AI
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-description: Provides integration of Quarkus Langchain4j with the OpenShift AI
+description: Provides integration of Quarkus LangChain4j with the OpenShift AI
 metadata:
    keywords:
     - ai

--- a/pgvector/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/pgvector/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
-name: Quarkus Langchain4j pgvector embedding store
+name: Quarkus LangChain4j pgvector embedding store
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-description: Provides the pgvector Embedding store for Quarkus Langchain4j
+description: Provides the pgvector Embedding store for Quarkus LangChain4j
 metadata:
    keywords:
     - ai

--- a/pinecone/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/pinecone/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
-name: Langchain4j Pinecone embedding store
+name: LangChain4j Pinecone embedding store
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-description: Provides the Pinecone Embedding store for Langchain4j
+description: Provides the Pinecone Embedding store for LangChain4j
 metadata:
   keywords:
     - ai

--- a/redis/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/redis/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
-name: Langchain4j Redis embedding store
+name: LangChain4j Redis embedding store
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-description: Provides the Redis Embedding store for Langchain4j
+description: Provides the Redis Embedding store for LangChain4j
 metadata:
   keywords:
     - ai

--- a/watsonx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/watsonx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
-name: Quarkus Langchain4j Watsonx
+name: Quarkus LangChain4j Watsonx
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-description: Provides integration of Quarkus Langchain4j with the IBM Watsonx API
+description: Provides integration of Quarkus LangChain4j with the IBM Watsonx API
 metadata:
    keywords:
     - ai


### PR DESCRIPTION
I notice that https://quarkus.io/extensions/io.quarkiverse.langchain4j/quarkus-langchain4j-azure-openai/ (and others) refers to 'Langchain4j' but https://github.com/langchain4j/langchain4j calls it 'LangChain4j'. 

We should probably be consistent, so I've updated the metadata. Our `pom.xml`s already use 'LangChain4j', so I didn't need to change those. 

All of the Java code uses `Langchain4j`, but changing that is more invasive, and could affect external APIs, so I've left it alone for now. 