### PR TITLE
Fix native compilation issue for csv-chatbot sample

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/DocumentNativeSupportProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/DocumentNativeSupportProcessor.java
@@ -10,6 +10,7 @@ import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 
 import dev.langchain4j.data.document.splitter.DocumentBySentenceSplitter;
+import dev.langchain4j.rag.query.transformer.CompressingQueryTransformer;
 import io.quarkiverse.langchain4j.deployment.items.InProcessEmbeddingBuildItem;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -77,6 +78,7 @@ public class DocumentNativeSupportProcessor {
         for (InProcessEmbeddingBuildItem inProcessEmbeddingBuildItem : inProcessEmbeddingBuildItems) {
             classProducer.produce(new RuntimeInitializedClassBuildItem(inProcessEmbeddingBuildItem.className()));
         }
+        classProducer.produce(new RuntimeInitializedClassBuildItem(CompressingQueryTransformer.class.getName()));
 
         packageProducer.produce(new RuntimeInitializedPackageBuildItem("com.microsoft.schemas.office"));
     }


### PR DESCRIPTION
The original issue was reported [here](https://github.com/quarkiverse/quarkiverse/issues/195#issuecomment-2033751433) and the cause is:

```
2024-04-03T07:24:56.6850640Z Error: Class initialization of dev.langchain4j.rag.query.transformer.CompressingQueryTransformer failed. Use the option 
2024-04-03T07:24:56.6852035Z 
2024-04-03T07:24:56.6853053Z     '--initialize-at-run-time=dev.langchain4j.rag.query.transformer.CompressingQueryTransformer'
2024-04-03T07:24:56.6854029Z 
2024-04-03T07:24:56.6854439Z  to explicitly request initialization of this class at run time.
2024-04-03T07:24:56.6856584Z com.oracle.svm.core.util.UserError$UserException: Class initialization of dev.langchain4j.rag.query.transformer.CompressingQueryTransformer failed. Use the option 
2024-04-03T07:24:56.6858295Z 
2024-04-03T07:24:56.6859215Z     '--initialize-at-run-time=dev.langchain4j.rag.query.transformer.CompressingQueryTransformer'
```