### PR TITLE
Fix Azure OpenAI user agent

### DIFF
--- a/openai/azure-openai/deployment/src/test/java/io/quarkiverse/langchain4j/azure/openai/test/AzureOpenAiChatLanguageModelSmokeTest.java
+++ b/openai/azure-openai/deployment/src/test/java/io/quarkiverse/langchain4j/azure/openai/test/AzureOpenAiChatLanguageModelSmokeTest.java
@@ -61,6 +61,6 @@ public class AzureOpenAiChatLanguageModelSmokeTest {
         assertThat(wireMockServer.getAllServeEvents()).hasSize(1);
         ServeEvent serveEvent = wireMockServer.getAllServeEvents().get(0); // this works because we reset requests for Wiremock before each test
         LoggedRequest loggedRequest = serveEvent.getRequest();
-        assertThat(loggedRequest.getHeader("User-Agent")).isEqualTo("langchain4j-azure-openai");
+        assertThat(loggedRequest.getHeader("User-Agent")).isEqualTo("langchain4j-quarkus-azure-openai");
     }
 }

--- a/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/AzureOpenAiImageModel.java
+++ b/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/AzureOpenAiImageModel.java
@@ -3,6 +3,7 @@ package io.quarkiverse.langchain4j.azure.openai;
 import static dev.langchain4j.internal.RetryUtils.withRetry;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.model.openai.OpenAiModelName.DALL_E_2;
+import static io.quarkiverse.langchain4j.azure.openai.Consts.DEFAULT_USER_AGENT;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -65,6 +66,7 @@ public class AzureOpenAiImageModel implements ImageModel {
                 .writeTimeout(timeout)
                 .logRequests(logRequests)
                 .logResponses(logResponses)
+                .userAgent(DEFAULT_USER_AGENT)
                 .build();
     }
 

--- a/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/Consts.java
+++ b/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/Consts.java
@@ -2,7 +2,7 @@ package io.quarkiverse.langchain4j.azure.openai;
 
 final class Consts {
 
-    static final String DEFAULT_USER_AGENT = "langchain4j-azure-openai";
+    static final String DEFAULT_USER_AGENT = "langchain4j-quarkus-azure-openai";
 
     private Consts() {
     }


### PR DESCRIPTION

- Add the user agent to `AzureOpenAiImageModel.java` as it was missing
- Create a specific user agent for Quarkus-LangChain4J : the issue with the currently used one is that it's the same as the LangChain4J Azure OpenAI project, which underneath uses the official Azure SDK. I'm trying to separate both, as for reporting I want to know who uses our SDK and who doesn't, so we know where we need to put the effort.