### PR TITLE
disable antora until having proper working solution

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -76,11 +76,13 @@
             <artifactId>quarkus-langchain4j-watsonx</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
+        <!-- remove as does not work on podman machine 
+            <dependency>
             <groupId>io.quarkiverse.antora</groupId>
             <artifactId>quarkus-antora</artifactId>
             <version>${quarkus-antora.version}</version>
         </dependency>
+        -->
 
         <!-- Test dependencies -->
         <dependency>

--- a/docs/src/test/java/io/quarkiverse/langchain4j/docs/it/AntoraTest.java
+++ b/docs/src/test/java/io/quarkiverse/langchain4j/docs/it/AntoraTest.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
 import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -14,6 +15,7 @@ import io.restassured.http.ContentType;
 public class AntoraTest {
 
     @Test
+    @Disabled("Antora is not enabled by default as its broken on podman machine")
     public void antoraSite() throws TimeoutException, IOException, InterruptedException {
         RestAssured
                 .given()


### PR DESCRIPTION
fixing https://github.com/quarkiverse/quarkus-langchain4j/issues/493 and what is [related failures](https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/langchain4j.20build.20troubles) like missing classes in test and conflicting 8081 ports.

by removing antora all builds works again on OSX/podman.

My theory is that the antora devservice is assuming volume mounts/permissions can be adjusted from inside container in a portable way - it can't (unfortunately).

Thus it fails somewhat silently - causing the AntoraTest to not shutdown, causing 8081 failures ...why it then result in devui not being able to find classes is beyond me - but that error goes away with this code commented out.