### PR TITLE
Turn off built-in fault tolerance by default

### DIFF
--- a/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/config/ChatModelConfig.java
+++ b/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/config/ChatModelConfig.java
@@ -50,9 +50,12 @@ public interface ChatModelConfig {
     Integer topK();
 
     /**
-     * The maximum number of retries for API requests.
+     * The maximum number of times to retry. 1 means exactly one attempt, with retrying disabled.
+     *
+     * @deprecated Using the fault tolerance mechanisms built in Langchain4j is not recommended. If possible,
+     *             use MicroProfile Fault Tolerance instead.
      */
-    @WithDefault("3")
+    @WithDefault("1")
     Integer maxRetries();
 
     /**

--- a/cohere/runtime/src/main/java/io/quarkiverse/langchain4j/cohere/runtime/QuarkusCohereScoringModel.java
+++ b/cohere/runtime/src/main/java/io/quarkiverse/langchain4j/cohere/runtime/QuarkusCohereScoringModel.java
@@ -40,6 +40,9 @@ public class QuarkusCohereScoringModel implements ScoringModel {
             Integer maxRetries) {
         this.model = model;
         this.maxRetries = maxRetries;
+        if (this.maxRetries < 1) {
+            throw new IllegalArgumentException("max-retries must be at least 1");
+        }
         ClientHeadersFactory factory = new ClientHeadersFactory() {
             @Override
             public MultivaluedMap<String, String> update(MultivaluedMap<String, String> incomingHeaders,

--- a/cohere/runtime/src/main/java/io/quarkiverse/langchain4j/cohere/runtime/config/CohereScoringModelConfig.java
+++ b/cohere/runtime/src/main/java/io/quarkiverse/langchain4j/cohere/runtime/config/CohereScoringModelConfig.java
@@ -20,9 +20,12 @@ public interface CohereScoringModelConfig {
     Duration timeout();
 
     /**
-     * Maximum number of retries for Cohere API invocations.
+     * The maximum number of times to retry. 1 means exactly one attempt, with retrying disabled.
+     *
+     * @deprecated Using the fault tolerance mechanisms built in Langchain4j is not recommended. If possible,
+     *             use MicroProfile Fault Tolerance instead.
      */
-    @WithDefault("3")
+    @WithDefault("1")
     Integer maxRetries();
 
 }

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-anthropic.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-anthropic.adoc
@@ -243,7 +243,7 @@ a| [[quarkus-langchain4j-anthropic_quarkus-langchain4j-anthropic-chat-model-max-
 
 [.description]
 --
-The maximum number of retries for API requests.
+The maximum number of times to retry. 1 means exactly one attempt, with retrying disabled.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_ANTHROPIC_CHAT_MODEL_MAX_RETRIES+++[]
@@ -252,7 +252,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_ANTHROPIC_CHAT_MODEL_MAX_RETRIES+++`
 endif::add-copy-button-to-env-var[]
 --|int 
-|`3`
+|`1`
 
 
 a| [[quarkus-langchain4j-anthropic_quarkus-langchain4j-anthropic-chat-model-stop-sequences]]`link:#quarkus-langchain4j-anthropic_quarkus-langchain4j-anthropic-chat-model-stop-sequences[quarkus.langchain4j.anthropic.chat-model.stop-sequences]`
@@ -527,7 +527,7 @@ a| [[quarkus-langchain4j-anthropic_quarkus-langchain4j-anthropic-model-name-chat
 
 [.description]
 --
-The maximum number of retries for API requests.
+The maximum number of times to retry. 1 means exactly one attempt, with retrying disabled.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_ANTHROPIC__MODEL_NAME__CHAT_MODEL_MAX_RETRIES+++[]
@@ -536,7 +536,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_ANTHROPIC__MODEL_NAME__CHAT_MODEL_MAX_RETRIES+++`
 endif::add-copy-button-to-env-var[]
 --|int 
-|`3`
+|`1`
 
 
 a| [[quarkus-langchain4j-anthropic_quarkus-langchain4j-anthropic-model-name-chat-model-stop-sequences]]`link:#quarkus-langchain4j-anthropic_quarkus-langchain4j-anthropic-model-name-chat-model-stop-sequences[quarkus.langchain4j.anthropic."model-name".chat-model.stop-sequences]`

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-cohere.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-cohere.adoc
@@ -84,7 +84,7 @@ a| [[quarkus-langchain4j-cohere_quarkus-langchain4j-cohere-scoring-model-max-ret
 
 [.description]
 --
-Maximum number of retries for Cohere API invocations.
+The maximum number of times to retry. 1 means exactly one attempt, with retrying disabled.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_COHERE_SCORING_MODEL_MAX_RETRIES+++[]
@@ -93,7 +93,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_COHERE_SCORING_MODEL_MAX_RETRIES+++`
 endif::add-copy-button-to-env-var[]
 --|int 
-|`3`
+|`1`
 
 |===
 ifndef::no-duration-note[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai.adoc
@@ -152,7 +152,7 @@ a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-max-retries]]`link:#q
 
 [.description]
 --
-The maximum number of times to retry
+The maximum number of times to retry. 1 means exactly one attempt, with retrying disabled.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_MAX_RETRIES+++[]
@@ -161,7 +161,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_MAX_RETRIES+++`
 endif::add-copy-button-to-env-var[]
 --|int 
-|`3`
+|`1`
 
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-log-requests]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-log-requests[quarkus.langchain4j.openai.log-requests]`
@@ -771,7 +771,7 @@ a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-max-retrie
 
 [.description]
 --
-The maximum number of times to retry
+The maximum number of times to retry. 1 means exactly one attempt, with retrying disabled.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__MAX_RETRIES+++[]
@@ -780,7 +780,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__MAX_RETRIES+++`
 endif::add-copy-button-to-env-var[]
 --|int 
-|`3`
+|`1`
 
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-log-requests]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-log-requests[quarkus.langchain4j.openai."model-name".log-requests]`

--- a/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/AzureOpenAiChatModel.java
+++ b/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/AzureOpenAiChatModel.java
@@ -93,7 +93,10 @@ public class AzureOpenAiChatModel implements ChatLanguageModel, TokenCountEstima
         this.maxTokens = maxTokens;
         this.presencePenalty = presencePenalty;
         this.frequencyPenalty = frequencyPenalty;
-        this.maxRetries = getOrDefault(maxRetries, 3);
+        this.maxRetries = getOrDefault(maxRetries, 1);
+        if (this.maxRetries < 1) {
+            throw new IllegalArgumentException("max-retries must be at least 1");
+        }
         this.tokenizer = tokenizer;
         this.responseFormat = responseFormat;
     }

--- a/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/AzureOpenAiEmbeddingModel.java
+++ b/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/AzureOpenAiEmbeddingModel.java
@@ -61,6 +61,9 @@ public class AzureOpenAiEmbeddingModel implements EmbeddingModel, TokenCountEsti
             Boolean logResponses) {
 
         timeout = getOrDefault(timeout, ofSeconds(60));
+        if (maxRetries < 1) {
+            throw new IllegalArgumentException("max-retries must be at least 1");
+        }
 
         this.client = ((QuarkusOpenAiClient.Builder) OpenAiClient.builder()
                 .baseUrl(ensureNotBlank(endpoint, "endpoint"))

--- a/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/LangChain4jAzureOpenAiConfig.java
+++ b/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/LangChain4jAzureOpenAiConfig.java
@@ -93,9 +93,12 @@ public interface LangChain4jAzureOpenAiConfig {
         Duration timeout();
 
         /**
-         * The maximum number of times to retry
+         * The maximum number of times to retry. 1 means exactly one attempt, with retrying disabled.
+         *
+         * @deprecated Using the fault tolerance mechanisms built in Langchain4j is not recommended. If possible,
+         *             use MicroProfile Fault Tolerance instead.
          */
-        @WithDefault("3")
+        @WithDefault("1")
         Integer maxRetries();
 
         /**

--- a/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/QuarkusOpenAiImageModel.java
+++ b/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/QuarkusOpenAiImageModel.java
@@ -49,6 +49,9 @@ public class QuarkusOpenAiImageModel implements ImageModel {
         this.user = user;
         this.responseFormat = responseFormat;
         this.maxRetries = maxRetries;
+        if (this.maxRetries < 1) {
+            throw new IllegalArgumentException("max-retries must be at least 1");
+        }
         this.persistDirectory = persistDirectory;
 
         this.client = QuarkusOpenAiClient.builder()

--- a/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/LangChain4jOpenAiConfig.java
+++ b/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/LangChain4jOpenAiConfig.java
@@ -62,9 +62,12 @@ public interface LangChain4jOpenAiConfig {
         Duration timeout();
 
         /**
-         * The maximum number of times to retry
+         * The maximum number of times to retry. 1 means exactly one attempt, with retrying disabled.
+         *
+         * @deprecated Using the built-in fault tolerance mechanisms is not recommended. If possible,
+         *             use MicroProfile Fault Tolerance instead.
          */
-        @WithDefault("3")
+        @WithDefault("1")
         Integer maxRetries();
 
         /**


### PR DESCRIPTION
I've also added some basic validation checks where possible (models that are implemented on our side), but I'm not completely sure about this. We could potentially do that in the recorders, making it more like validating the configuration?!