### PR TITLE
fix: 🐛 fix NPE if chunk is null for Mistral AI

### DIFF
--- a/mistral/runtime/src/main/java/io/quarkiverse/langchain4j/mistralai/QuarkusMistralAiClient.java
+++ b/mistral/runtime/src/main/java/io/quarkiverse/langchain4j/mistralai/QuarkusMistralAiClient.java
@@ -79,7 +79,10 @@ public class QuarkusMistralAiClient extends MistralAiClient {
                 MistralAiChatCompletionChoice choice = response.getChoices().get(0);
                 String chunk = choice.getDelta().getContent();
                 contentBuilder.get().append(chunk);
-                handler.onNext(chunk);
+
+                if (chunk != null) {
+                    handler.onNext(chunk);
+                }
 
                 MistralAiUsage usageInfo = response.getUsage();
                 if (usageInfo != null) {


### PR DESCRIPTION
fix #489 

@geoand as discuss, the PR to fix the NPE in case of no data in `content` field in Mistral response.

I didn't find tests in Mistral package but I tested on my project and it fixes the bug.

Let me know if I need to write a test somewhere 😉