### PR TITLE
Introduce global logging properties

### DIFF
--- a/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/AnthropicRecorder.java
+++ b/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/AnthropicRecorder.java
@@ -1,7 +1,5 @@
 package io.quarkiverse.langchain4j.anthropic.runtime;
 
-import static io.quarkiverse.langchain4j.runtime.OptionalUtil.firstOrDefault;
-
 import java.util.function.Supplier;
 
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
@@ -35,8 +33,8 @@ public class AnthropicRecorder {
                     .apiKey(apiKey)
                     .version(anthropicConfig.version())
                     .modelName(chatModelConfig.modelName())
-                    .logRequests(firstOrDefault(false, chatModelConfig.logRequests(), anthropicConfig.logRequests()))
-                    .logResponses(firstOrDefault(false, chatModelConfig.logResponses(), anthropicConfig.logResponses()))
+                    .logRequests(chatModelConfig.logRequests().orElse(false))
+                    .logResponses(chatModelConfig.logResponses().orElse(false))
                     .timeout(anthropicConfig.timeout())
                     .topK(chatModelConfig.topK())
                     .maxTokens(chatModelConfig.maxTokens())
@@ -86,8 +84,8 @@ public class AnthropicRecorder {
                     .apiKey(apiKey)
                     .version(anthropicConfig.version())
                     .modelName(chatModelConfig.modelName())
-                    .logRequests(firstOrDefault(false, chatModelConfig.logRequests(), anthropicConfig.logRequests()))
-                    .logResponses(firstOrDefault(false, chatModelConfig.logResponses(), anthropicConfig.logResponses()))
+                    .logRequests(chatModelConfig.logRequests().orElse(false))
+                    .logResponses(chatModelConfig.logResponses().orElse(false))
                     .timeout(anthropicConfig.timeout())
                     .topK(chatModelConfig.topK())
                     .maxTokens(chatModelConfig.maxTokens());

--- a/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/config/ChatModelConfig.java
+++ b/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/config/ChatModelConfig.java
@@ -67,11 +67,13 @@ public interface ChatModelConfig {
      * Whether chat model requests should be logged
      */
     @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.anthropic.log-requests}")
     Optional<Boolean> logRequests();
 
     /**
      * Whether chat model responses should be logged
      */
     @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.anthropic.log-responses}")
     Optional<Boolean> logResponses();
 }

--- a/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/config/LangChain4jAnthropicConfig.java
+++ b/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/config/LangChain4jAnthropicConfig.java
@@ -64,16 +64,18 @@ public interface LangChain4jAnthropicConfig {
          * Whether the Anthropic client should log requests
          */
         @ConfigDocDefault("false")
+        @WithDefault("${quarkus.langchain4j.log-requests}")
         Optional<Boolean> logRequests();
 
         /**
          * Whether the Anthropic client should log responses
          */
         @ConfigDocDefault("false")
+        @WithDefault("${quarkus.langchain4j.log-responses}")
         Optional<Boolean> logResponses();
 
         /**
-         * Whether or not to enable the integration. Defaults to {@code true}, which means requests are made to the Anthropic
+         * Whether to enable the integration. Defaults to {@code true}, which means requests are made to the Anthropic
          * provider.
          * Set to {@code false} to disable all requests.
          */

--- a/bam/deployment/src/test/java/io/quarkiverse/langchain4j/bam/deployment/AllPropertiesTest.java
+++ b/bam/deployment/src/test/java/io/quarkiverse/langchain4j/bam/deployment/AllPropertiesTest.java
@@ -90,8 +90,8 @@ public class AllPropertiesTest {
         assertEquals(WireMockUtil.URL, config.baseUrl().get().toString());
         assertEquals(WireMockUtil.API_KEY, config.apiKey());
         assertEquals(Duration.ofSeconds(60), config.timeout());
-        assertEquals(true, config.logRequests());
-        assertEquals(true, config.logResponses());
+        assertEquals(true, config.logRequests().orElse(false));
+        assertEquals(true, config.logResponses().orElse(false));
         assertEquals("aaaa-mm-dd", config.version());
         assertEquals("my_super_model", config.chatModel().modelId());
         assertEquals("greedy", config.chatModel().decodingMethod());

--- a/bam/deployment/src/test/java/io/quarkiverse/langchain4j/bam/deployment/BamRecordUtil.java
+++ b/bam/deployment/src/test/java/io/quarkiverse/langchain4j/bam/deployment/BamRecordUtil.java
@@ -41,6 +41,16 @@ public class BamRecordUtil {
             public Optional<Float> socialBias() {
                 return Optional.ofNullable(socialBias);
             }
+
+            @Override
+            public Optional<Boolean> logRequests() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> logResponses() {
+                return Optional.empty();
+            }
         });
     }
 
@@ -76,12 +86,12 @@ public class BamRecordUtil {
                     }
 
                     @Override
-                    public Boolean logRequests() {
+                    public Optional<Boolean> logRequests() {
                         return langchain4jBamConfig.defaultConfig().logRequests();
                     }
 
                     @Override
-                    public Boolean logResponses() {
+                    public Optional<Boolean> logResponses() {
                         return langchain4jBamConfig.defaultConfig().logResponses();
                     }
 

--- a/bam/deployment/src/test/java/io/quarkiverse/langchain4j/bam/deployment/DefaultPropertiesTest.java
+++ b/bam/deployment/src/test/java/io/quarkiverse/langchain4j/bam/deployment/DefaultPropertiesTest.java
@@ -66,8 +66,8 @@ public class DefaultPropertiesTest {
 
         assertEquals(Duration.ofSeconds(10), config.timeout());
         assertEquals(WireMockUtil.VERSION, config.version());
-        assertEquals(false, config.logRequests());
-        assertEquals(false, config.logResponses());
+        assertEquals(false, config.logRequests().orElse(false));
+        assertEquals(false, config.logResponses().orElse(false));
         assertEquals("ibm/granite-13b-chat-v2", config.chatModel().modelId());
         assertEquals("greedy", config.chatModel().decodingMethod());
         assertEquals(1.0, config.chatModel().temperature());

--- a/bam/runtime/src/main/java/io/quarkiverse/langchain4j/bam/runtime/BamRecorder.java
+++ b/bam/runtime/src/main/java/io/quarkiverse/langchain4j/bam/runtime/BamRecorder.java
@@ -43,8 +43,8 @@ public class BamRecorder {
             var builder = BamChatModel.builder()
                     .accessToken(bamConfig.apiKey())
                     .timeout(bamConfig.timeout())
-                    .logRequests(bamConfig.logRequests())
-                    .logResponses(bamConfig.logResponses())
+                    .logRequests(chatModelConfig.logRequests().orElse(false))
+                    .logResponses(chatModelConfig.logResponses().orElse(false))
                     .modelId(chatModelConfig.modelId())
                     .version(bamConfig.version())
                     .decodingMethod(chatModelConfig.decodingMethod())
@@ -96,8 +96,8 @@ public class BamRecorder {
             var builder = BamStreamingChatModel.builder()
                     .accessToken(bamConfig.apiKey())
                     .timeout(bamConfig.timeout())
-                    .logRequests(bamConfig.logRequests())
-                    .logResponses(bamConfig.logResponses())
+                    .logRequests(chatModelConfig.logRequests().orElse(false))
+                    .logResponses(chatModelConfig.logResponses().orElse(false))
                     .modelId(chatModelConfig.modelId())
                     .version(bamConfig.version())
                     .decodingMethod(chatModelConfig.decodingMethod())
@@ -151,8 +151,8 @@ public class BamRecorder {
                     .timeout(bamConfig.timeout())
                     .version(bamConfig.version())
                     .modelId(embeddingModelConfig.modelId())
-                    .logRequests(bamConfig.logRequests())
-                    .logResponses(bamConfig.logResponses());
+                    .logRequests(embeddingModelConfig.logRequests().orElse(false))
+                    .logResponses(embeddingModelConfig.logResponses().orElse(false));
 
             if (bamConfig.baseUrl().isPresent()) {
                 builder.url(bamConfig.baseUrl().get());
@@ -194,8 +194,8 @@ public class BamRecorder {
                     .messagesToModerate(moderationModelConfig.messagesToModerate())
                     .hap(hap)
                     .socialBias(socialBias)
-                    .logRequests(bamConfig.logRequests())
-                    .logResponses(bamConfig.logResponses());
+                    .logRequests(moderationModelConfig.logRequests().orElse(false))
+                    .logResponses(moderationModelConfig.logResponses().orElse(false));
 
             if (bamConfig.baseUrl().isPresent()) {
                 builder.url(bamConfig.baseUrl().get());

--- a/bam/runtime/src/main/java/io/quarkiverse/langchain4j/bam/runtime/config/ChatModelConfig.java
+++ b/bam/runtime/src/main/java/io/quarkiverse/langchain4j/bam/runtime/config/ChatModelConfig.java
@@ -3,6 +3,7 @@ package io.quarkiverse.langchain4j.bam.runtime.config;
 import java.util.List;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
@@ -125,4 +126,18 @@ public interface ChatModelConfig {
      * penalty, and Stop sequences will not be available.
      */
     Optional<Integer> beamWidth();
+
+    /**
+     * Whether the BAM chat model should log requests
+     */
+    @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.bam.log-requests}")
+    Optional<Boolean> logRequests();
+
+    /**
+     * Whether the BAM chat model should log requests
+     */
+    @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.log-responses}")
+    Optional<Boolean> logResponses();
 }

--- a/bam/runtime/src/main/java/io/quarkiverse/langchain4j/bam/runtime/config/EmbeddingModelConfig.java
+++ b/bam/runtime/src/main/java/io/quarkiverse/langchain4j/bam/runtime/config/EmbeddingModelConfig.java
@@ -1,5 +1,8 @@
 package io.quarkiverse.langchain4j.bam.runtime.config;
 
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
@@ -11,4 +14,18 @@ public interface EmbeddingModelConfig {
      */
     @WithDefault("ibm/slate.125m.english.rtrvr")
     String modelId();
+
+    /**
+     * Whether the BAM embedding model should log requests
+     */
+    @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.bam.log-requests}")
+    Optional<Boolean> logRequests();
+
+    /**
+     * Whether the BAM embedding model should log requests
+     */
+    @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.log-responses}")
+    Optional<Boolean> logResponses();
 }

--- a/bam/runtime/src/main/java/io/quarkiverse/langchain4j/bam/runtime/config/LangChain4jBamConfig.java
+++ b/bam/runtime/src/main/java/io/quarkiverse/langchain4j/bam/runtime/config/LangChain4jBamConfig.java
@@ -65,17 +65,19 @@ public interface LangChain4jBamConfig {
         /**
          * Whether the BAM client should log requests
          */
-        @WithDefault("false")
-        Boolean logRequests();
+        @ConfigDocDefault("false")
+        @WithDefault("${quarkus.langchain4j.log-requests}")
+        Optional<Boolean> logRequests();
 
         /**
          * Whether the BAM client should log responses
          */
-        @WithDefault("false")
-        Boolean logResponses();
+        @ConfigDocDefault("false")
+        @WithDefault("${quarkus.langchain4j.log-responses}")
+        Optional<Boolean> logResponses();
 
         /**
-         * Whether or not to enable the integration. Defaults to {@code true}, which means requests are made to the
+         * Whether to enable the integration. Defaults to {@code true}, which means requests are made to the
          * BAM provider.
          * Set to {@code false} to disable all requests.
          */

--- a/bam/runtime/src/main/java/io/quarkiverse/langchain4j/bam/runtime/config/ModerationModelConfig.java
+++ b/bam/runtime/src/main/java/io/quarkiverse/langchain4j/bam/runtime/config/ModerationModelConfig.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import dev.langchain4j.data.message.ChatMessageType;
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
@@ -31,4 +32,18 @@ public interface ModerationModelConfig {
      * The float is a value from 0.1 to 1 that allows you to control when a content must be flagged by the detector.
      */
     Optional<Float> socialBias();
+
+    /**
+     * Whether the BAM moderation model should log requests
+     */
+    @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.bam.log-requests}")
+    Optional<Boolean> logRequests();
+
+    /**
+     * Whether the BAM moderation model should log requests
+     */
+    @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.log-responses}")
+    Optional<Boolean> logResponses();
 }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/config/LangChain4jConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/config/LangChain4jConfig.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.langchain4j.runtime.config;
+
+import static io.quarkus.runtime.annotations.ConfigPhase.RUN_TIME;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigDocDefault;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+
+@ConfigRoot(phase = RUN_TIME)
+@ConfigMapping(prefix = "quarkus.langchain4j")
+public interface LangChain4jConfig {
+
+    /**
+     * Whether clients should log requests
+     */
+    @ConfigDocDefault("false")
+    Optional<Boolean> logRequests();
+
+    /**
+     * Whether clients should log responses
+     */
+    @ConfigDocDefault("false")
+    Optional<Boolean> logResponses();
+}

--- a/hugging-face/runtime/src/main/java/io/quarkiverse/langchain4j/huggingface/runtime/HuggingFaceRecorder.java
+++ b/hugging-face/runtime/src/main/java/io/quarkiverse/langchain4j/huggingface/runtime/HuggingFaceRecorder.java
@@ -1,7 +1,5 @@
 package io.quarkiverse.langchain4j.huggingface.runtime;
 
-import static io.quarkiverse.langchain4j.runtime.OptionalUtil.firstOrDefault;
-
 import java.net.URL;
 import java.util.function.Supplier;
 
@@ -46,8 +44,8 @@ public class HuggingFaceRecorder {
                     .topP(chatModelConfig.topP())
                     .topK(chatModelConfig.topK())
                     .repetitionPenalty(chatModelConfig.repetitionPenalty())
-                    .logRequests(firstOrDefault(false, chatModelConfig.logRequests(), huggingFaceConfig.logRequests()))
-                    .logResponses(firstOrDefault(false, chatModelConfig.logResponses(), huggingFaceConfig.logResponses()));
+                    .logRequests(chatModelConfig.logRequests().orElse(false))
+                    .logResponses(chatModelConfig.logResponses().orElse(false));
 
             if (!DUMMY_KEY.equals(apiKey)) {
                 builder.accessToken(apiKey);

--- a/hugging-face/runtime/src/main/java/io/quarkiverse/langchain4j/huggingface/runtime/config/ChatModelConfig.java
+++ b/hugging-face/runtime/src/main/java/io/quarkiverse/langchain4j/huggingface/runtime/config/ChatModelConfig.java
@@ -80,12 +80,14 @@ public interface ChatModelConfig {
      * Whether chat model requests should be logged
      */
     @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.huggingface.log-requests}")
     Optional<Boolean> logRequests();
 
     /**
      * Whether chat model responses should be logged
      */
     @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.huggingface.log-responses}")
     Optional<Boolean> logResponses();
 
 }

--- a/hugging-face/runtime/src/main/java/io/quarkiverse/langchain4j/huggingface/runtime/config/LangChain4jHuggingFaceConfig.java
+++ b/hugging-face/runtime/src/main/java/io/quarkiverse/langchain4j/huggingface/runtime/config/LangChain4jHuggingFaceConfig.java
@@ -63,12 +63,14 @@ public interface LangChain4jHuggingFaceConfig {
          * Whether the HuggingFace client should log requests
          */
         @ConfigDocDefault("false")
+        @WithDefault("${quarkus.langchain4j.log-requests}")
         Optional<Boolean> logRequests();
 
         /**
          * Whether the HuggingFace client should log responses
          */
         @ConfigDocDefault("false")
+        @WithDefault("${quarkus.langchain4j.log-responses}")
         Optional<Boolean> logResponses();
 
         /**

--- a/mistral/runtime/src/main/java/io/quarkiverse/langchain4j/mistralai/runtime/MistralAiRecorder.java
+++ b/mistral/runtime/src/main/java/io/quarkiverse/langchain4j/mistralai/runtime/MistralAiRecorder.java
@@ -1,7 +1,5 @@
 package io.quarkiverse.langchain4j.mistralai.runtime;
 
-import static io.quarkiverse.langchain4j.runtime.OptionalUtil.firstOrDefault;
-
 import java.util.function.Supplier;
 
 import dev.langchain4j.model.chat.ChatLanguageModel;
@@ -40,8 +38,8 @@ public class MistralAiRecorder {
                     .baseUrl(mistralAiConfig.baseUrl())
                     .apiKey(apiKey)
                     .modelName(chatModelConfig.modelName())
-                    .logRequests(firstOrDefault(false, chatModelConfig.logRequests(), mistralAiConfig.logRequests()))
-                    .logResponses(firstOrDefault(false, chatModelConfig.logResponses(), mistralAiConfig.logResponses()))
+                    .logRequests(chatModelConfig.logRequests().orElse(false))
+                    .logResponses(chatModelConfig.logResponses().orElse(false))
                     .timeout(mistralAiConfig.timeout());
 
             if (chatModelConfig.temperature().isPresent()) {
@@ -92,8 +90,8 @@ public class MistralAiRecorder {
                     .baseUrl(mistralAiConfig.baseUrl())
                     .apiKey(apiKey)
                     .modelName(chatModelConfig.modelName())
-                    .logRequests(firstOrDefault(false, chatModelConfig.logRequests(), mistralAiConfig.logRequests()))
-                    .logResponses(firstOrDefault(false, chatModelConfig.logResponses(), mistralAiConfig.logResponses()))
+                    .logRequests(chatModelConfig.logRequests().orElse(false))
+                    .logResponses(chatModelConfig.logResponses().orElse(false))
                     .timeout(mistralAiConfig.timeout());
 
             if (chatModelConfig.temperature().isPresent()) {
@@ -144,8 +142,8 @@ public class MistralAiRecorder {
                     .baseUrl(mistralAiConfig.baseUrl())
                     .apiKey(apiKey)
                     .modelName(embeddingModelConfig.modelName())
-                    .logRequests(firstOrDefault(false, embeddingModelConfig.logRequests(), mistralAiConfig.logRequests()))
-                    .logResponses(firstOrDefault(false, embeddingModelConfig.logResponses(), mistralAiConfig.logResponses()))
+                    .logRequests(embeddingModelConfig.logRequests().orElse(false))
+                    .logResponses(embeddingModelConfig.logResponses().orElse(false))
                     .timeout(mistralAiConfig.timeout());
 
             return new Supplier<>() {

--- a/mistral/runtime/src/main/java/io/quarkiverse/langchain4j/mistralai/runtime/config/ChatModelConfig.java
+++ b/mistral/runtime/src/main/java/io/quarkiverse/langchain4j/mistralai/runtime/config/ChatModelConfig.java
@@ -56,12 +56,14 @@ public interface ChatModelConfig {
      * Whether chat model requests should be logged
      */
     @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.mistralai.log-requests}")
     Optional<Boolean> logRequests();
 
     /**
      * Whether chat model responses should be logged
      */
     @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.mistralai.log-responses}")
     Optional<Boolean> logResponses();
 
 }

--- a/mistral/runtime/src/main/java/io/quarkiverse/langchain4j/mistralai/runtime/config/EmbeddingModelConfig.java
+++ b/mistral/runtime/src/main/java/io/quarkiverse/langchain4j/mistralai/runtime/config/EmbeddingModelConfig.java
@@ -19,12 +19,14 @@ public interface EmbeddingModelConfig {
      * Whether embedding model requests should be logged
      */
     @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.mistralai.log-requests}")
     Optional<Boolean> logRequests();
 
     /**
      * Whether embedding model responses should be logged
      */
     @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.mistralai.log-responses}")
     Optional<Boolean> logResponses();
 
 }

--- a/mistral/runtime/src/main/java/io/quarkiverse/langchain4j/mistralai/runtime/config/LangChain4jMistralAiConfig.java
+++ b/mistral/runtime/src/main/java/io/quarkiverse/langchain4j/mistralai/runtime/config/LangChain4jMistralAiConfig.java
@@ -69,16 +69,18 @@ public interface LangChain4jMistralAiConfig {
          * Whether the Mistral client should log requests
          */
         @ConfigDocDefault("false")
+        @WithDefault("${quarkus.langchain4j.log-requests}")
         Optional<Boolean> logRequests();
 
         /**
          * Whether the Mistral client should log responses
          */
         @ConfigDocDefault("false")
+        @WithDefault("${quarkus.langchain4j.log-responses}")
         Optional<Boolean> logResponses();
 
         /**
-         * Whether or not to enable the integration. Defaults to {@code true}, which means requests are made to the Mistral AI
+         * Whether to enable the integration. Defaults to {@code true}, which means requests are made to the Mistral AI
          * provider.
          * Set to {@code false} to disable all requests.
          */

--- a/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/OllamaRecorder.java
+++ b/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/OllamaRecorder.java
@@ -39,8 +39,8 @@ public class OllamaRecorder {
             var builder = OllamaChatLanguageModel.builder()
                     .baseUrl(ollamaConfig.baseUrl())
                     .timeout(ollamaConfig.timeout())
-                    .logRequests(ollamaConfig.logRequests())
-                    .logResponses(ollamaConfig.logResponses())
+                    .logRequests(chatModelConfig.logRequests().orElse(false))
+                    .logResponses(chatModelConfig.logResponses().orElse(false))
                     .model(chatModelConfig.modelId())
                     .options(optionsBuilder.build());
 
@@ -78,7 +78,9 @@ public class OllamaRecorder {
             var builder = OllamaEmbeddingModel.builder()
                     .baseUrl(ollamaConfig.baseUrl())
                     .timeout(ollamaConfig.timeout())
-                    .model(embeddingModelConfig.modelId());
+                    .model(embeddingModelConfig.modelId())
+                    .logRequests(embeddingModelConfig.logRequests().orElse(false))
+                    .logResponses(embeddingModelConfig.logResponses().orElse(false));
 
             return new Supplier<>() {
                 @Override

--- a/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/config/ChatModelConfig.java
+++ b/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/config/ChatModelConfig.java
@@ -2,6 +2,7 @@ package io.quarkiverse.langchain4j.ollama.runtime.config;
 
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
@@ -51,8 +52,27 @@ public interface ChatModelConfig {
     /**
      * With a static number the result is always the same. With a random number the result varies
      * Example:
+     *
+     * <pre>
+     * {@code
      * Random random = new Random();
      * int x = random.nextInt(Integer.MAX_VALUE);
+     * }
+     * </pre>
      */
     Optional<Integer> seed();
+
+    /**
+     * Whether chat model requests should be logged
+     */
+    @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.ollama.log-requests}")
+    Optional<Boolean> logRequests();
+
+    /**
+     * Whether chat model responses should be logged
+     */
+    @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.ollama.log-responses}")
+    Optional<Boolean> logResponses();
 }

--- a/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/config/EmbeddingModelConfig.java
+++ b/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/config/EmbeddingModelConfig.java
@@ -2,6 +2,7 @@ package io.quarkiverse.langchain4j.ollama.runtime.config;
 
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
@@ -49,4 +50,18 @@ public interface EmbeddingModelConfig {
      */
     @WithDefault("40")
     Integer topK();
+
+    /**
+     * Whether embedding model requests should be logged
+     */
+    @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.ollama.log-requests}")
+    Optional<Boolean> logRequests();
+
+    /**
+     * Whether embedding model responses should be logged
+     */
+    @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.ollama.log-responses}")
+    Optional<Boolean> logResponses();
 }

--- a/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/config/LangChain4jOllamaConfig.java
+++ b/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/config/LangChain4jOllamaConfig.java
@@ -4,7 +4,9 @@ import static io.quarkus.runtime.annotations.ConfigPhase.RUN_TIME;
 
 import java.time.Duration;
 import java.util.Map;
+import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -48,17 +50,19 @@ public interface LangChain4jOllamaConfig {
         /**
          * Whether the Ollama client should log requests
          */
-        @WithDefault("false")
-        Boolean logRequests();
+        @ConfigDocDefault("false")
+        @WithDefault("${quarkus.langchain4j.log-requests}")
+        Optional<Boolean> logRequests();
 
         /**
          * Whether the Ollama client should log responses
          */
-        @WithDefault("false")
-        Boolean logResponses();
+        @ConfigDocDefault("false")
+        @WithDefault("${quarkus.langchain4j.log-responses}")
+        Optional<Boolean> logResponses();
 
         /**
-         * Whether or not to enable the integration. Defaults to {@code true}, which means requests are made to the OpenAI
+         * Whether to enable the integration. Defaults to {@code true}, which means requests are made to the OpenAI
          * provider.
          * Set to {@code false} to disable all requests.
          */

--- a/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
+++ b/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
@@ -1,7 +1,5 @@
 package io.quarkiverse.langchain4j.azure.openai.runtime;
 
-import static io.quarkiverse.langchain4j.runtime.OptionalUtil.firstOrDefault;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -54,8 +52,8 @@ public class AzureOpenAiRecorder {
                     .apiVersion(azureAiConfig.apiVersion())
                     .timeout(azureAiConfig.timeout())
                     .maxRetries(azureAiConfig.maxRetries())
-                    .logRequests(firstOrDefault(false, chatModelConfig.logRequests(), azureAiConfig.logRequests()))
-                    .logResponses(firstOrDefault(false, chatModelConfig.logResponses(), azureAiConfig.logResponses()))
+                    .logRequests(chatModelConfig.logRequests().orElse(false))
+                    .logResponses(chatModelConfig.logResponses().orElse(false))
                     .temperature(chatModelConfig.temperature())
                     .topP(chatModelConfig.topP())
                     .presencePenalty(chatModelConfig.presencePenalty())
@@ -99,8 +97,8 @@ public class AzureOpenAiRecorder {
                     .adToken(adToken)
                     .apiVersion(azureAiConfig.apiVersion())
                     .timeout(azureAiConfig.timeout())
-                    .logRequests(firstOrDefault(false, chatModelConfig.logRequests(), azureAiConfig.logRequests()))
-                    .logResponses(firstOrDefault(false, chatModelConfig.logResponses(), azureAiConfig.logResponses()))
+                    .logRequests(chatModelConfig.logRequests().orElse(false))
+                    .logResponses(chatModelConfig.logResponses().orElse(false))
                     .temperature(chatModelConfig.temperature())
                     .topP(chatModelConfig.topP())
                     .presencePenalty(chatModelConfig.presencePenalty())
@@ -144,8 +142,8 @@ public class AzureOpenAiRecorder {
                     .apiVersion(azureAiConfig.apiVersion())
                     .timeout(azureAiConfig.timeout())
                     .maxRetries(azureAiConfig.maxRetries())
-                    .logRequests(firstOrDefault(false, embeddingModelConfig.logRequests(), azureAiConfig.logRequests()))
-                    .logResponses(firstOrDefault(false, embeddingModelConfig.logResponses(), azureAiConfig.logResponses()));
+                    .logRequests(embeddingModelConfig.logRequests().orElse(false))
+                    .logResponses(embeddingModelConfig.logResponses().orElse(false));
 
             return new Supplier<>() {
                 @Override
@@ -179,8 +177,8 @@ public class AzureOpenAiRecorder {
                     .apiVersion(azureAiConfig.apiVersion())
                     .timeout(azureAiConfig.timeout())
                     .maxRetries(azureAiConfig.maxRetries())
-                    .logRequests(firstOrDefault(false, imageModelConfig.logRequests(), azureAiConfig.logRequests()))
-                    .logResponses(firstOrDefault(false, imageModelConfig.logResponses(), azureAiConfig.logResponses()))
+                    .logRequests(imageModelConfig.logRequests().orElse(false))
+                    .logResponses(imageModelConfig.logResponses().orElse(false))
                     .modelName(imageModelConfig.modelName())
                     .size(imageModelConfig.size())
                     .quality(imageModelConfig.quality())

--- a/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/ChatModelConfig.java
+++ b/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/ChatModelConfig.java
@@ -55,12 +55,14 @@ public interface ChatModelConfig {
      * Whether chat model requests should be logged
      */
     @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.azure-openai.log-requests}")
     Optional<Boolean> logRequests();
 
     /**
      * Whether chat model responses should be logged
      */
     @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.azure-openai.log-responses}")
     Optional<Boolean> logResponses();
 
     /**

--- a/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/EmbeddingModelConfig.java
+++ b/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/EmbeddingModelConfig.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
 
 @ConfigGroup
 public interface EmbeddingModelConfig {
@@ -12,11 +13,13 @@ public interface EmbeddingModelConfig {
      * Whether embedding model requests should be logged
      */
     @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.azure-openai.log-requests}")
     Optional<Boolean> logRequests();
 
     /**
      * Whether embedding model responses should be logged
      */
     @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.azure-openai.log-responses}")
     Optional<Boolean> logResponses();
 }

--- a/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/ImageModelConfig.java
+++ b/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/ImageModelConfig.java
@@ -89,11 +89,13 @@ public interface ImageModelConfig {
      * Whether image model requests should be logged
      */
     @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.azure-openai.log-requests}")
     Optional<Boolean> logRequests();
 
     /**
      * Whether image model responses should be logged
      */
     @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.azure-openai.log-responses}")
     Optional<Boolean> logResponses();
 }

--- a/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/LangChain4jAzureOpenAiConfig.java
+++ b/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/LangChain4jAzureOpenAiConfig.java
@@ -105,17 +105,18 @@ public interface LangChain4jAzureOpenAiConfig {
          * Whether the OpenAI client should log requests
          */
         @ConfigDocDefault("false")
+        @WithDefault("${quarkus.langchain4j.log-requests}")
         Optional<Boolean> logRequests();
 
         /**
          * Whether the OpenAI client should log responses
          */
         @ConfigDocDefault("false")
+        @WithDefault("${quarkus.langchain4j.log-responses}")
         Optional<Boolean> logResponses();
 
         /**
-         * Whether or not to enable the integration. Defaults to {@code true}, which means requests are made to the OpenAI
-         * provider.
+         * Whether to enable the integration. Defaults to {@code true}, which means requests are made to the OpenAI provider.
          * Set to {@code false} to disable all requests.
          */
         @WithDefault("true")

--- a/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
+++ b/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
@@ -1,7 +1,5 @@
 package io.quarkiverse.langchain4j.openai.runtime;
 
-import static io.quarkiverse.langchain4j.runtime.OptionalUtil.firstOrDefault;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
@@ -53,8 +51,8 @@ public class OpenAiRecorder {
                     .apiKey(apiKey)
                     .timeout(openAiConfig.timeout())
                     .maxRetries(openAiConfig.maxRetries())
-                    .logRequests(firstOrDefault(false, chatModelConfig.logRequests(), openAiConfig.logRequests()))
-                    .logResponses(firstOrDefault(false, chatModelConfig.logResponses(), openAiConfig.logResponses()))
+                    .logRequests(chatModelConfig.logRequests().orElse(false))
+                    .logResponses(chatModelConfig.logResponses().orElse(false))
                     .modelName(chatModelConfig.modelName())
                     .temperature(chatModelConfig.temperature())
                     .topP(chatModelConfig.topP())
@@ -97,8 +95,8 @@ public class OpenAiRecorder {
                     .baseUrl(openAiConfig.baseUrl())
                     .apiKey(apiKey)
                     .timeout(openAiConfig.timeout())
-                    .logRequests(firstOrDefault(false, chatModelConfig.logRequests(), openAiConfig.logRequests()))
-                    .logResponses(firstOrDefault(false, chatModelConfig.logResponses(), openAiConfig.logResponses()))
+                    .logRequests(chatModelConfig.logRequests().orElse(false))
+                    .logResponses(chatModelConfig.logResponses().orElse(false))
                     .modelName(chatModelConfig.modelName())
                     .temperature(chatModelConfig.temperature())
                     .topP(chatModelConfig.topP())
@@ -142,8 +140,8 @@ public class OpenAiRecorder {
                     .apiKey(apiKey)
                     .timeout(openAiConfig.timeout())
                     .maxRetries(openAiConfig.maxRetries())
-                    .logRequests(firstOrDefault(false, embeddingModelConfig.logRequests(), openAiConfig.logRequests()))
-                    .logResponses(firstOrDefault(false, embeddingModelConfig.logResponses(), openAiConfig.logResponses()))
+                    .logRequests(embeddingModelConfig.logRequests().orElse(false))
+                    .logResponses(embeddingModelConfig.logResponses().orElse(false))
                     .modelName(embeddingModelConfig.modelName());
 
             if (embeddingModelConfig.user().isPresent()) {
@@ -182,8 +180,8 @@ public class OpenAiRecorder {
                     .apiKey(apiKey)
                     .timeout(openAiConfig.timeout())
                     .maxRetries(openAiConfig.maxRetries())
-                    .logRequests(firstOrDefault(false, moderationModelConfig.logRequests(), openAiConfig.logRequests()))
-                    .logResponses(firstOrDefault(false, moderationModelConfig.logResponses(), openAiConfig.logResponses()))
+                    .logRequests(moderationModelConfig.logRequests().orElse(false))
+                    .logResponses(moderationModelConfig.logResponses().orElse(false))
                     .modelName(moderationModelConfig.modelName());
 
             openAiConfig.organizationId().ifPresent(builder::organizationId);
@@ -218,8 +216,8 @@ public class OpenAiRecorder {
                     .apiKey(apiKey)
                     .timeout(openAiConfig.timeout())
                     .maxRetries(openAiConfig.maxRetries())
-                    .logRequests(firstOrDefault(false, imageModelConfig.logRequests(), openAiConfig.logRequests()))
-                    .logResponses(firstOrDefault(false, imageModelConfig.logResponses(), openAiConfig.logResponses()))
+                    .logRequests(imageModelConfig.logRequests().orElse(false))
+                    .logResponses(imageModelConfig.logResponses().orElse(false))
                     .modelName(imageModelConfig.modelName())
                     .size(imageModelConfig.size())
                     .quality(imageModelConfig.quality())

--- a/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/ChatModelConfig.java
+++ b/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/ChatModelConfig.java
@@ -61,12 +61,14 @@ public interface ChatModelConfig {
      * Whether chat model requests should be logged
      */
     @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.openai.log-requests}")
     Optional<Boolean> logRequests();
 
     /**
      * Whether chat model responses should be logged
      */
     @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.openai.log-responses}")
     Optional<Boolean> logResponses();
 
     /**

--- a/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/EmbeddingModelConfig.java
+++ b/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/EmbeddingModelConfig.java
@@ -19,12 +19,14 @@ public interface EmbeddingModelConfig {
      * Whether embedding model requests should be logged
      */
     @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.openai.log-requests}")
     Optional<Boolean> logRequests();
 
     /**
      * Whether embedding model responses should be logged
      */
     @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.openai.log-responses}")
     Optional<Boolean> logResponses();
 
     /**

--- a/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/ImageModelConfig.java
+++ b/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/ImageModelConfig.java
@@ -89,11 +89,13 @@ public interface ImageModelConfig {
      * Whether image model requests should be logged
      */
     @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.openai.log-requests}")
     Optional<Boolean> logRequests();
 
     /**
      * Whether image model responses should be logged
      */
     @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.openai.log-responses}")
     Optional<Boolean> logResponses();
 }

--- a/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/LangChain4jOpenAiConfig.java
+++ b/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/LangChain4jOpenAiConfig.java
@@ -74,16 +74,18 @@ public interface LangChain4jOpenAiConfig {
          * Whether the OpenAI client should log requests
          */
         @ConfigDocDefault("false")
+        @WithDefault("${quarkus.langchain4j.log-requests}")
         Optional<Boolean> logRequests();
 
         /**
          * Whether the OpenAI client should log responses
          */
         @ConfigDocDefault("false")
+        @WithDefault("${quarkus.langchain4j.log-responses}")
         Optional<Boolean> logResponses();
 
         /**
-         * Whether or not to enable the integration. Defaults to {@code true}, which means requests are made to the OpenAI
+         * Whether to enable the integration. Defaults to {@code true}, which means requests are made to the OpenAI
          * provider.
          * Set to {@code false} to disable all requests.
          */

--- a/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/ModerationModelConfig.java
+++ b/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/ModerationModelConfig.java
@@ -19,11 +19,13 @@ public interface ModerationModelConfig {
      * Whether moderation model requests should be logged
      */
     @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.openai.log-requests}")
     Optional<Boolean> logRequests();
 
     /**
      * Whether moderation model responses should be logged
      */
     @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.openai.log-responses}")
     Optional<Boolean> logResponses();
 }

--- a/openshift-ai/runtime/src/main/java/io/quarkiverse/langchain4j/openshiftai/runtime/OpenshiftAiRecorder.java
+++ b/openshift-ai/runtime/src/main/java/io/quarkiverse/langchain4j/openshiftai/runtime/OpenshiftAiRecorder.java
@@ -47,8 +47,8 @@ public class OpenshiftAiRecorder {
             var builder = OpenshiftAiChatModel.builder()
                     .url(baseUrl)
                     .timeout(openshiftAiConfig.timeout())
-                    .logRequests(openshiftAiConfig.logRequests())
-                    .logResponses(openshiftAiConfig.logResponses())
+                    .logRequests(chatModelConfig.logRequests().orElse(false))
+                    .logResponses(chatModelConfig.logResponses().orElse(false))
                     .modelId(modelId);
 
             return new Supplier<>() {

--- a/openshift-ai/runtime/src/main/java/io/quarkiverse/langchain4j/openshiftai/runtime/config/ChatModelConfig.java
+++ b/openshift-ai/runtime/src/main/java/io/quarkiverse/langchain4j/openshiftai/runtime/config/ChatModelConfig.java
@@ -1,5 +1,8 @@
 package io.quarkiverse.langchain4j.openshiftai.runtime.config;
 
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
@@ -11,4 +14,18 @@ public interface ChatModelConfig {
      */
     @WithDefault("dummy") // TODO: this is set to a dummy value because otherwise Smallrye Config cannot give a proper error for named models
     String modelId();
+
+    /**
+     * Whether chat model requests should be logged
+     */
+    @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.openshift-ai.log-requests}")
+    Optional<Boolean> logRequests();
+
+    /**
+     * Whether chat model responses should be logged
+     */
+    @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.openshift-ai.log-responses}")
+    Optional<Boolean> logResponses();
 }

--- a/openshift-ai/runtime/src/main/java/io/quarkiverse/langchain4j/openshiftai/runtime/config/LangChain4jOpenshiftAiConfig.java
+++ b/openshift-ai/runtime/src/main/java/io/quarkiverse/langchain4j/openshiftai/runtime/config/LangChain4jOpenshiftAiConfig.java
@@ -5,7 +5,9 @@ import static io.quarkus.runtime.annotations.ConfigPhase.RUN_TIME;
 import java.net.URL;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
@@ -52,17 +54,19 @@ public interface LangChain4jOpenshiftAiConfig {
         /**
          * Whether the OpenShift AI client should log requests
          */
-        @WithDefault("false")
-        Boolean logRequests();
+        @ConfigDocDefault("false")
+        @WithDefault("${quarkus.langchain4j.log-requests}")
+        Optional<Boolean> logRequests();
 
         /**
          * Whether the OpenShift AI client should log responses
          */
-        @WithDefault("false")
-        Boolean logResponses();
+        @ConfigDocDefault("false")
+        @WithDefault("${quarkus.langchain4j.log-responses}")
+        Optional<Boolean> logResponses();
 
         /**
-         * Whether or not to enable the integration. Defaults to {@code true}, which means requests are made to the OpenAI
+         * Whether to enable the integration. Defaults to {@code true}, which means requests are made to the OpenAI
          * provider.
          * Set to {@code false} to disable all requests.
          */

--- a/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/VertexAiGeminiRecorder.java
+++ b/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/VertexAiGeminiRecorder.java
@@ -1,7 +1,5 @@
 package io.quarkiverse.langchain4j.vertexai.runtime.gemini;
 
-import static io.quarkiverse.langchain4j.runtime.OptionalUtil.firstOrDefault;
-
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -38,8 +36,8 @@ public class VertexAiGeminiRecorder {
                     .publisher(vertexAiConfig.publisher())
                     .modelId(chatModelConfig.modelId())
                     .maxOutputTokens(chatModelConfig.maxOutputTokens())
-                    .logRequests(firstOrDefault(false, chatModelConfig.logRequests(), vertexAiConfig.logRequests()))
-                    .logResponses(firstOrDefault(false, chatModelConfig.logResponses(), vertexAiConfig.logResponses()));
+                    .logRequests(chatModelConfig.logRequests().orElse(false))
+                    .logResponses(chatModelConfig.logResponses().orElse(false));
 
             if (chatModelConfig.temperature().isEmpty()) {
                 builder.temperature(chatModelConfig.temperature().getAsDouble());

--- a/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/config/ChatModelConfig.java
+++ b/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/config/ChatModelConfig.java
@@ -82,11 +82,13 @@ public interface ChatModelConfig {
      * Whether chat model requests should be logged
      */
     @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.vertexai.gemini.log-requests}")
     Optional<Boolean> logRequests();
 
     /**
      * Whether chat model responses should be logged
      */
     @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.vertexai.gemini.log-responses}")
     Optional<Boolean> logResponses();
 }

--- a/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/config/LangChain4jVertexAiGeminiConfig.java
+++ b/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/config/LangChain4jVertexAiGeminiConfig.java
@@ -71,12 +71,14 @@ public interface LangChain4jVertexAiGeminiConfig {
          * Whether the Vertex AI client should log requests
          */
         @ConfigDocDefault("false")
+        @WithDefault("${quarkus.langchain4j.log-requests}")
         Optional<Boolean> logRequests();
 
         /**
          * Whether the Vertex AI client should log responses
          */
         @ConfigDocDefault("false")
+        @WithDefault("${quarkus.langchain4j.log-responses}")
         Optional<Boolean> logResponses();
 
         /**

--- a/vertex-ai/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/VertexAiRecorder.java
+++ b/vertex-ai/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/VertexAiRecorder.java
@@ -1,7 +1,5 @@
 package io.quarkiverse.langchain4j.vertexai.runtime;
 
-import static io.quarkiverse.langchain4j.runtime.OptionalUtil.firstOrDefault;
-
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -41,8 +39,8 @@ public class VertexAiRecorder {
                     .temperature(chatModelConfig.temperature())
                     .topK(chatModelConfig.topK())
                     .topP(chatModelConfig.topP())
-                    .logRequests(firstOrDefault(false, chatModelConfig.logRequests(), vertexAiConfig.logRequests()))
-                    .logResponses(firstOrDefault(false, chatModelConfig.logResponses(), vertexAiConfig.logResponses()));
+                    .logRequests(chatModelConfig.logRequests().orElse(false))
+                    .logResponses(chatModelConfig.logResponses().orElse(false));
 
             // TODO: add the rest of the properties
 

--- a/vertex-ai/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/config/ChatModelConfig.java
+++ b/vertex-ai/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/config/ChatModelConfig.java
@@ -65,11 +65,13 @@ public interface ChatModelConfig {
      * Whether chat model requests should be logged
      */
     @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.vertexai.log-requests}")
     Optional<Boolean> logRequests();
 
     /**
      * Whether chat model responses should be logged
      */
     @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.vertexai.log-responses}")
     Optional<Boolean> logResponses();
 }

--- a/vertex-ai/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/config/LangChain4jVertexAiConfig.java
+++ b/vertex-ai/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/config/LangChain4jVertexAiConfig.java
@@ -71,12 +71,14 @@ public interface LangChain4jVertexAiConfig {
          * Whether the Vertex AI client should log requests
          */
         @ConfigDocDefault("false")
+        @WithDefault("${quarkus.langchain4j.log-requests}")
         Optional<Boolean> logRequests();
 
         /**
          * Whether the Vertex AI client should log responses
          */
         @ConfigDocDefault("false")
+        @WithDefault("${quarkus.langchain4j.log-responses}")
         Optional<Boolean> logResponses();
 
         /**

--- a/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/AllPropertiesTest.java
+++ b/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/AllPropertiesTest.java
@@ -93,8 +93,8 @@ public class AllPropertiesTest {
         assertEquals(Duration.ofSeconds(60), config.timeout());
         assertEquals(Duration.ofSeconds(60), config.iam().timeout());
         assertEquals("grantME", config.iam().grantType());
-        assertEquals(true, config.logRequests());
-        assertEquals(true, config.logResponses());
+        assertEquals(true, config.logRequests().orElse(false));
+        assertEquals(true, config.logResponses().orElse(false));
         assertEquals("aaaa-mm-dd", config.version());
         assertEquals("my_super_model", config.chatModel().modelId());
         assertEquals("greedy", config.chatModel().decodingMethod());

--- a/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/DefaultPropertiesTest.java
+++ b/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/DefaultPropertiesTest.java
@@ -71,8 +71,8 @@ public class DefaultPropertiesTest {
         var config = langchain4jWatsonConfig.defaultConfig();
         assertEquals(Duration.ofSeconds(10), config.timeout());
         assertEquals(WireMockUtil.VERSION, config.version());
-        assertEquals(false, config.logRequests());
-        assertEquals(false, config.logResponses());
+        assertEquals(false, config.logRequests().orElse(false));
+        assertEquals(false, config.logResponses().orElse(false));
         assertEquals(WireMockUtil.DEFAULT_CHAT_MODEL, config.chatModel().modelId());
         assertEquals("greedy", config.chatModel().decodingMethod());
         assertEquals(1.0, config.chatModel().temperature());

--- a/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/WatsonxRecorder.java
+++ b/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/WatsonxRecorder.java
@@ -22,6 +22,7 @@ import io.quarkiverse.langchain4j.watsonx.WatsonxChatModel;
 import io.quarkiverse.langchain4j.watsonx.WatsonxEmbeddingModel;
 import io.quarkiverse.langchain4j.watsonx.WatsonxStreamingChatModel;
 import io.quarkiverse.langchain4j.watsonx.runtime.config.ChatModelConfig;
+import io.quarkiverse.langchain4j.watsonx.runtime.config.EmbeddingModelConfig;
 import io.quarkiverse.langchain4j.watsonx.runtime.config.IAMConfig;
 import io.quarkiverse.langchain4j.watsonx.runtime.config.LangChain4jWatsonxConfig;
 import io.quarkus.runtime.annotations.Recorder;
@@ -62,8 +63,8 @@ public class WatsonxRecorder {
                     .tokenGenerator(tokenGenerator)
                     .url(url)
                     .timeout(watsonConfig.timeout())
-                    .logRequests(watsonConfig.logRequests())
-                    .logResponses(watsonConfig.logResponses())
+                    .logRequests(chatModelConfig.logRequests().orElse(false))
+                    .logResponses(chatModelConfig.logResponses().orElse(false))
                     .version(watsonConfig.version())
                     .projectId(watsonConfig.projectId())
                     .modelId(chatModelConfig.modelId())
@@ -120,8 +121,8 @@ public class WatsonxRecorder {
                     .tokenGenerator(tokenGenerator)
                     .url(url)
                     .timeout(watsonConfig.timeout())
-                    .logRequests(watsonConfig.logRequests())
-                    .logResponses(watsonConfig.logResponses())
+                    .logRequests(chatModelConfig.logRequests().orElse(false))
+                    .logResponses(chatModelConfig.logResponses().orElse(false))
                     .version(watsonConfig.version())
                     .projectId(watsonConfig.projectId())
                     .modelId(chatModelConfig.modelId())
@@ -173,15 +174,16 @@ public class WatsonxRecorder {
                 throw new RuntimeException(e);
             }
 
+            EmbeddingModelConfig embeddingModelConfig = watsonConfig.embeddingModel();
             var builder = WatsonxEmbeddingModel.builder()
                     .tokenGenerator(tokenGenerator)
                     .url(url)
                     .timeout(watsonConfig.timeout())
-                    .logRequests(watsonConfig.logRequests())
-                    .logResponses(watsonConfig.logResponses())
+                    .logRequests(embeddingModelConfig.logRequests().orElse(false))
+                    .logResponses(embeddingModelConfig.logResponses().orElse(false))
                     .version(watsonConfig.version())
                     .projectId(watsonConfig.projectId())
-                    .modelId(watsonConfig.embeddingModel().modelId());
+                    .modelId(embeddingModelConfig.modelId());
 
             return new Supplier<>() {
                 @Override

--- a/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/ChatModelConfig.java
+++ b/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/ChatModelConfig.java
@@ -3,6 +3,7 @@ package io.quarkiverse.langchain4j.watsonx.runtime.config;
 import java.util.List;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
@@ -91,4 +92,18 @@ public interface ChatModelConfig {
      * penalty).
      */
     Optional<Double> repetitionPenalty();
+
+    /**
+     * Whether chat model requests should be logged
+     */
+    @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.watsonx.log-requests}")
+    Optional<Boolean> logRequests();
+
+    /**
+     * Whether chat model responses should be logged
+     */
+    @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.watsonx.log-responses}")
+    Optional<Boolean> logResponses();
 }

--- a/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/EmbeddingModelConfig.java
+++ b/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/EmbeddingModelConfig.java
@@ -1,5 +1,8 @@
 package io.quarkiverse.langchain4j.watsonx.runtime.config;
 
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
@@ -11,4 +14,18 @@ public interface EmbeddingModelConfig {
      */
     @WithDefault("ibm/slate-125m-english-rtrvr")
     String modelId();
+
+    /**
+     * Whether embedding model requests should be logged
+     */
+    @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.watsonx.log-requests}")
+    Optional<Boolean> logRequests();
+
+    /**
+     * Whether embedding model responses should be logged
+     */
+    @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.watsonx.log-responses}")
+    Optional<Boolean> logResponses();
 }

--- a/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/LangChain4jWatsonxConfig.java
+++ b/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/LangChain4jWatsonxConfig.java
@@ -4,7 +4,9 @@ import static io.quarkus.runtime.annotations.ConfigPhase.RUN_TIME;
 
 import java.time.Duration;
 import java.util.Map;
+import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
@@ -68,17 +70,19 @@ public interface LangChain4jWatsonxConfig {
         /**
          * Whether the watsonx.ai client should log requests
          */
-        @WithDefault("false")
-        Boolean logRequests();
+        @ConfigDocDefault("false")
+        @WithDefault("${quarkus.langchain4j.log-requests}")
+        Optional<Boolean> logRequests();
 
         /**
          * Whether the watsonx.ai client should log responses
          */
-        @WithDefault("false")
-        Boolean logResponses();
+        @ConfigDocDefault("false")
+        @WithDefault("${quarkus.langchain4j.log-requests}")
+        Optional<Boolean> logResponses();
 
         /**
-         * Whether or not to enable the integration. Defaults to {@code true}, which means requests are made to the watsonx.ai
+         * Whether to enable the integration. Defaults to {@code true}, which means requests are made to the watsonx.ai
          * provider.
          * Set to {@code false} to disable all requests.
          */


### PR DESCRIPTION
This allows us to use quarkus.langchain4j.log-requests=true instead of specifying needing to specify the provider as well