### PR TITLE
Add new parameters to the watsonx.ai chat model

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-watsonx.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-watsonx.adoc
@@ -15,7 +15,7 @@ a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-watsonx_quarkus-lan
 
 [.description]
 --
-Whether the model should be enabled
+Whether the model should be enabled.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_ENABLED+++[]
@@ -32,7 +32,7 @@ a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-watsonx_quarkus-lan
 
 [.description]
 --
-Whether the embedding model should be enabled
+Whether the embedding model should be enabled.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_EMBEDDING_MODEL_ENABLED+++[]
@@ -49,7 +49,7 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-base-url]]`link:#qu
 
 [.description]
 --
-Base URL
+Base URL of the watsonx.ai API.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_BASE_URL+++[]
@@ -66,7 +66,9 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-api-key]]`link:#qua
 
 [.description]
 --
-IBM Cloud API key
+IBM Cloud API key.
+
+To create a new API key, follow this link:https://cloud.ibm.com/iam/apikeys[link].
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_API_KEY+++[]
@@ -83,7 +85,7 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-timeout]]`link:#qua
 
 [.description]
 --
-Timeout for watsonx.ai API calls
+Timeout for watsonx.ai calls.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_TIMEOUT+++[]
@@ -101,7 +103,7 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-version]]`link:#qua
 
 [.description]
 --
-The version date for the API of the form YYYY-MM-DD
+The version date for the API of the form YYYY-MM-DD.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_VERSION+++[]
@@ -118,7 +120,9 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-project-id]]`link:#
 
 [.description]
 --
-Watsonx.ai project id.
+The project that contains the watsonx.ai resource.
+
+To look up your project id, link:https://dataplatform.cloud.ibm.com/projects/?context=wx[click here].
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_PROJECT_ID+++[]
@@ -135,7 +139,7 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-log-requests]]`link
 
 [.description]
 --
-Whether the watsonx.ai client should log requests
+Whether the watsonx.ai client should log requests.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_LOG_REQUESTS+++[]
@@ -152,7 +156,7 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-log-responses]]`lin
 
 [.description]
 --
-Whether the watsonx.ai client should log responses
+Whether the watsonx.ai client should log responses.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_LOG_RESPONSES+++[]
@@ -169,7 +173,7 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-enable-integration]
 
 [.description]
 --
-Whether or not to enable the integration. Defaults to `true`, which means requests are made to the watsonx.ai provider. Set to `false` to disable all requests.
+Whether to enable the integration. Defaults to `true`, which means requests are made to the watsonx.ai provider. Set to `false` to disable all requests.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_ENABLE_INTEGRATION+++[]
@@ -186,7 +190,7 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-iam-base-url]]`link
 
 [.description]
 --
-IAM base URL
+Base URL of the IAM Authentication API.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_IAM_BASE_URL+++[]
@@ -204,7 +208,7 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-iam-timeout]]`link:
 
 [.description]
 --
-Timeout for IAM API calls
+Timeout for IAM authentication calls.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_IAM_TIMEOUT+++[]
@@ -222,7 +226,7 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-iam-grant-type]]`li
 
 [.description]
 --
-IAM grant type
+Grant type for the IAM Authentication API.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_IAM_GRANT_TYPE+++[]
@@ -239,9 +243,9 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-model-id
 
 [.description]
 --
-Model to use.
+Model id to use.
 
-For a complete list of models, visit: `https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models.html?context=wx`
+To view the complete model list, link:https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-api-model-ids.html?context=wx&audience=wdp#model-ids[click here].
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODEL_ID+++[]
@@ -258,9 +262,9 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-decoding
 
 [.description]
 --
-Represents the strategy used for picking the tokens during generation of the output text. Options are greedy and sample. Value defaults to sample if not specified.
+Represents the strategy used for picking the tokens during generation of the output text. During text generation when parameter value is set to `greedy`, each successive token corresponds to the highest probability token given the text that has already been generated. This strategy can lead to repetitive results especially for longer output sequences. The alternative `sample` strategy generates text by picking subsequent tokens based on the probability distribution of possible next tokens defined by (i.e., conditioned on) the already-generated text and the `top_k` and `top_p` parameters.
 
-During text generation when parameter value is set to greedy, each successive token corresponds to the highest probability token given the text that has already been generated. This strategy can lead to repetitive results especially for longer output sequences. The alternative sample strategy generates text by picking subsequent tokens based on the probability distribution of possible next tokens defined by (i.e., conditioned on) the already-generated text and the top_k and top_p parameters described below. See this url for an informative article about text generation.
+*Allowable values:* `++[++sample,greedy++]++`
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_DECODING_METHOD+++[]
@@ -272,46 +276,14 @@ endif::add-copy-button-to-env-var[]
 |`greedy`
 
 
-a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-temperature]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-temperature[quarkus.langchain4j.watsonx.chat-model.temperature]`
-
-
-[.description]
---
-A value used to modify the next-token probabilities in sampling mode. Values less than 1.0 sharpen the probability distribution, resulting in "less random" output. Values greater than 1.0 flatten the probability distribution, resulting in "more random" output. A value of 1.0 has no effect and is the default. The allowed range is 0.0 to 2.0.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_TEMPERATURE+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_TEMPERATURE+++`
-endif::add-copy-button-to-env-var[]
---|double 
-|`1.0`
-
-
-a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-min-new-tokens]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-min-new-tokens[quarkus.langchain4j.watsonx.chat-model.min-new-tokens]`
-
-
-[.description]
---
-If stop sequences are given, they are ignored until minimum tokens are generated. Defaults to 0.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MIN_NEW_TOKENS+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MIN_NEW_TOKENS+++`
-endif::add-copy-button-to-env-var[]
---|int 
-|`0`
-
-
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-max-new-tokens]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-max-new-tokens[quarkus.langchain4j.watsonx.chat-model.max-new-tokens]`
 
 
 [.description]
 --
-The maximum number of new tokens to be generated. The range is 0 to 1024.
+The maximum number of new tokens to be generated. The maximum supported value for this field depends on the model being used. How the "token" is defined depends on the tokenizer and vocabulary size, which in turn depends on the model. Often the tokens are a mix of full words and sub-words. Depending on the users plan, and on the model being used, there may be an enforced maximum number of new tokens.
+
+*Possible values:* `≥ 0`
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MAX_NEW_TOKENS+++[]
@@ -323,12 +295,33 @@ endif::add-copy-button-to-env-var[]
 |`200`
 
 
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-min-new-tokens]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-min-new-tokens[quarkus.langchain4j.watsonx.chat-model.min-new-tokens]`
+
+
+[.description]
+--
+If stop sequences are given, they are ignored until minimum tokens are generated.
+
+*Possible values:* `≥ 0`
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MIN_NEW_TOKENS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MIN_NEW_TOKENS+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|`0`
+
+
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-random-seed]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-random-seed[quarkus.langchain4j.watsonx.chat-model.random-seed]`
 
 
 [.description]
 --
-Random number generator seed to use in sampling mode for experimental repeatability. Must be >= 1.
+Random number generator seed to use in sampling mode for experimental repeatability.
+
+*Possible values:* `≥ 1`
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_RANDOM_SEED+++[]
@@ -345,7 +338,9 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-stop-seq
 
 [.description]
 --
-Stop sequences are one or more strings which will cause the text generation to stop if/when they are produced as part of the output. Stop sequences encountered prior to the minimum number of tokens being generated will be ignored. The list may contain up to 6 strings.
+Stop sequences are one or more strings which will cause the text generation to stop if/when they are produced as part of the output. Stop sequences encountered prior to the minimum number of tokens being generated will be ignored.
+
+*Possible values:* `0 ≤ number of items ≤ 6, contains only unique items`
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_STOP_SEQUENCES+++[]
@@ -357,12 +352,33 @@ endif::add-copy-button-to-env-var[]
 |
 
 
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-temperature]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-temperature[quarkus.langchain4j.watsonx.chat-model.temperature]`
+
+
+[.description]
+--
+A value used to modify the next-token probabilities in `sampling` mode. Values less than `1.0` sharpen the probability distribution, resulting in "less random" output. Values greater than `1.0` flatten the probability distribution, resulting in "more random" output. A value of `1.0` has no effect.
+
+*Possible values:* `0 ≤ value ≤ 2`
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_TEMPERATURE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_TEMPERATURE+++`
+endif::add-copy-button-to-env-var[]
+--|double 
+|`1.0`
+
+
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-top-k]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-top-k[quarkus.langchain4j.watsonx.chat-model.top-k]`
 
 
 [.description]
 --
-The number of highest probability vocabulary tokens to keep for top-k-filtering. Only applies for sampling mode, with range from 1 to 100. When decoding_strategy is set to sample, only the top_k most likely tokens are considered as candidates for the next generated token.
+The number of highest probability vocabulary tokens to keep for top-k-filtering. Only applies for `sampling` mode. When decoding_strategy is set to `sample`, only the `top_k` most likely tokens are considered as candidates for the next generated token.
+
+*Possible values:* `1 ≤ value ≤ 100`
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_TOP_K+++[]
@@ -379,7 +395,9 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-top-p]]`
 
 [.description]
 --
-Similar to top_k except the candidates to generate the next token are the most likely tokens with probabilities that add up to at least top_p. The valid range is 0.0 to 1.0 where 1.0 is equivalent to disabled and is the default. Also known as nucleus sampling.
+Similar to `top_k` except the candidates to generate the next token are the most likely tokens with probabilities that add up to at least `top_p`. Also known as nucleus sampling. A value of `1.0` is equivalent to disabled.
+
+*Possible values:* `0 < value ≤ 1`
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_TOP_P+++[]
@@ -396,7 +414,9 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-repetiti
 
 [.description]
 --
-Represents the penalty for penalizing tokens that have already been generated or belong to the context. The range is 1.0 to 2.0 and defaults to 1.0 (no penalty).
+Represents the penalty for penalizing tokens that have already been generated or belong to the context. The value `1.0` means that there is no penalty.
+
+*Possible values:* `1 ≤ value ≤ 2`
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_REPETITION_PENALTY+++[]
@@ -408,12 +428,82 @@ endif::add-copy-button-to-env-var[]
 |
 
 
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-truncate-input-tokens]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-truncate-input-tokens[quarkus.langchain4j.watsonx.chat-model.truncate-input-tokens]`
+
+
+[.description]
+--
+Represents the maximum number of input tokens accepted. This can be used to avoid requests failing due to input being longer than configured limits. If the text is truncated, then it truncates the start of the input (on the left), so the end of the input will remain the same. If this value exceeds the maximum sequence length (refer to the documentation to find this value for the model) then the call will fail if the total number of tokens exceeds the maximum sequence length. Zero means don't truncate.
+
+*Possible values:* `≥ 0`
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_TRUNCATE_INPUT_TOKENS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_TRUNCATE_INPUT_TOKENS+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|
+
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-include-stop-sequence]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-include-stop-sequence[quarkus.langchain4j.watsonx.chat-model.include-stop-sequence]`
+
+
+[.description]
+--
+Pass `false` to omit matched stop sequences from the end of the output text. The default is `true`, meaning that the output will end with the stop sequence text when matched.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_INCLUDE_STOP_SEQUENCE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_INCLUDE_STOP_SEQUENCE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|
+
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-log-requests]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-log-requests[quarkus.langchain4j.watsonx.chat-model.log-requests]`
+
+
+[.description]
+--
+Whether chat model requests should be logged.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-log-responses]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-log-responses[quarkus.langchain4j.watsonx.chat-model.log-responses]`
+
+
+[.description]
+--
+Whether chat model responses should be logged.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-embedding-model-model-id]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-embedding-model-model-id[quarkus.langchain4j.watsonx.embedding-model.model-id]`
 
 
 [.description]
 --
-Model to use
+Model id to use. To view the complete model list, link:https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models-embed.html?context=wx&audience=wdp[click here].
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_EMBEDDING_MODEL_MODEL_ID+++[]
@@ -423,6 +513,83 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_EMBEDDING_MODEL_MODEL_ID++
 endif::add-copy-button-to-env-var[]
 --|string 
 |`ibm/slate-125m-english-rtrvr`
+
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-embedding-model-log-requests]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-embedding-model-log-requests[quarkus.langchain4j.watsonx.embedding-model.log-requests]`
+
+
+[.description]
+--
+Whether embedding model requests should be logged.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_EMBEDDING_MODEL_LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_EMBEDDING_MODEL_LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-embedding-model-log-responses]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-embedding-model-log-responses[quarkus.langchain4j.watsonx.embedding-model.log-responses]`
+
+
+[.description]
+--
+Whether embedding model responses should be logged.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_EMBEDDING_MODEL_LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_EMBEDDING_MODEL_LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
+h|[[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-length-penalty-it-can-be-used-to-exponentially-increase-the-likelihood-of-the-text-generation-terminating-once-a-specified-number-of-tokens-have-been-generated]]link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-length-penalty-it-can-be-used-to-exponentially-increase-the-likelihood-of-the-text-generation-terminating-once-a-specified-number-of-tokens-have-been-generated[It can be used to exponentially increase the likelihood of the text generation terminating once a specified number of tokens have been generated]
+This configuration section is optional
+h|Type
+h|Default
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-length-penalty-decay-factor]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-length-penalty-decay-factor[quarkus.langchain4j.watsonx.chat-model.length-penalty.decay-factor]`
+
+
+[.description]
+--
+Represents the factor of exponential decay. Larger values correspond to more aggressive decay.
+
+*Possible values:* `> 1`
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_LENGTH_PENALTY_DECAY_FACTOR+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_LENGTH_PENALTY_DECAY_FACTOR+++`
+endif::add-copy-button-to-env-var[]
+--|double 
+|
+
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-length-penalty-start-index]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-length-penalty-start-index[quarkus.langchain4j.watsonx.chat-model.length-penalty.start-index]`
+
+
+[.description]
+--
+A number of generated tokens after which this should take effect.
+
+*Possible values:* `≥ 0`
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_LENGTH_PENALTY_START_INDEX+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_LENGTH_PENALTY_START_INDEX+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|
 
 
 h|[[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-named-config-named-model-config]]link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-named-config-named-model-config[Named model config]
@@ -435,7 +602,7 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-base-url
 
 [.description]
 --
-Base URL
+Base URL of the watsonx.ai API.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__BASE_URL+++[]
@@ -452,7 +619,9 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-api-key]
 
 [.description]
 --
-IBM Cloud API key
+IBM Cloud API key.
+
+To create a new API key, follow this link:https://cloud.ibm.com/iam/apikeys[link].
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__API_KEY+++[]
@@ -469,7 +638,7 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-timeout]
 
 [.description]
 --
-Timeout for watsonx.ai API calls
+Timeout for watsonx.ai calls.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__TIMEOUT+++[]
@@ -487,7 +656,7 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-version]
 
 [.description]
 --
-The version date for the API of the form YYYY-MM-DD
+The version date for the API of the form YYYY-MM-DD.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__VERSION+++[]
@@ -504,7 +673,9 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-project-
 
 [.description]
 --
-Watsonx.ai project id.
+The project that contains the watsonx.ai resource.
+
+To look up your project id, link:https://dataplatform.cloud.ibm.com/projects/?context=wx[click here].
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__PROJECT_ID+++[]
@@ -521,7 +692,7 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-log-requ
 
 [.description]
 --
-Whether the watsonx.ai client should log requests
+Whether the watsonx.ai client should log requests.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__LOG_REQUESTS+++[]
@@ -538,7 +709,7 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-log-resp
 
 [.description]
 --
-Whether the watsonx.ai client should log responses
+Whether the watsonx.ai client should log responses.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__LOG_RESPONSES+++[]
@@ -555,7 +726,7 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-enable-i
 
 [.description]
 --
-Whether or not to enable the integration. Defaults to `true`, which means requests are made to the watsonx.ai provider. Set to `false` to disable all requests.
+Whether to enable the integration. Defaults to `true`, which means requests are made to the watsonx.ai provider. Set to `false` to disable all requests.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__ENABLE_INTEGRATION+++[]
@@ -572,7 +743,7 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-iam-base
 
 [.description]
 --
-IAM base URL
+Base URL of the IAM Authentication API.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__IAM_BASE_URL+++[]
@@ -590,7 +761,7 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-iam-time
 
 [.description]
 --
-Timeout for IAM API calls
+Timeout for IAM authentication calls.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__IAM_TIMEOUT+++[]
@@ -608,7 +779,7 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-iam-gran
 
 [.description]
 --
-IAM grant type
+Grant type for the IAM Authentication API.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__IAM_GRANT_TYPE+++[]
@@ -625,9 +796,9 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-mod
 
 [.description]
 --
-Model to use.
+Model id to use.
 
-For a complete list of models, visit: `https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models.html?context=wx`
+To view the complete model list, link:https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-api-model-ids.html?context=wx&audience=wdp#model-ids[click here].
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODEL_ID+++[]
@@ -644,9 +815,9 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-mod
 
 [.description]
 --
-Represents the strategy used for picking the tokens during generation of the output text. Options are greedy and sample. Value defaults to sample if not specified.
+Represents the strategy used for picking the tokens during generation of the output text. During text generation when parameter value is set to `greedy`, each successive token corresponds to the highest probability token given the text that has already been generated. This strategy can lead to repetitive results especially for longer output sequences. The alternative `sample` strategy generates text by picking subsequent tokens based on the probability distribution of possible next tokens defined by (i.e., conditioned on) the already-generated text and the `top_k` and `top_p` parameters.
 
-During text generation when parameter value is set to greedy, each successive token corresponds to the highest probability token given the text that has already been generated. This strategy can lead to repetitive results especially for longer output sequences. The alternative sample strategy generates text by picking subsequent tokens based on the probability distribution of possible next tokens defined by (i.e., conditioned on) the already-generated text and the top_k and top_p parameters described below. See this url for an informative article about text generation.
+*Allowable values:* `++[++sample,greedy++]++`
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_DECODING_METHOD+++[]
@@ -658,46 +829,14 @@ endif::add-copy-button-to-env-var[]
 |`greedy`
 
 
-a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-temperature]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-temperature[quarkus.langchain4j.watsonx."model-name".chat-model.temperature]`
-
-
-[.description]
---
-A value used to modify the next-token probabilities in sampling mode. Values less than 1.0 sharpen the probability distribution, resulting in "less random" output. Values greater than 1.0 flatten the probability distribution, resulting in "more random" output. A value of 1.0 has no effect and is the default. The allowed range is 0.0 to 2.0.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_TEMPERATURE+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_TEMPERATURE+++`
-endif::add-copy-button-to-env-var[]
---|double 
-|`1.0`
-
-
-a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-min-new-tokens]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-min-new-tokens[quarkus.langchain4j.watsonx."model-name".chat-model.min-new-tokens]`
-
-
-[.description]
---
-If stop sequences are given, they are ignored until minimum tokens are generated. Defaults to 0.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MIN_NEW_TOKENS+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MIN_NEW_TOKENS+++`
-endif::add-copy-button-to-env-var[]
---|int 
-|`0`
-
-
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-max-new-tokens]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-max-new-tokens[quarkus.langchain4j.watsonx."model-name".chat-model.max-new-tokens]`
 
 
 [.description]
 --
-The maximum number of new tokens to be generated. The range is 0 to 1024.
+The maximum number of new tokens to be generated. The maximum supported value for this field depends on the model being used. How the "token" is defined depends on the tokenizer and vocabulary size, which in turn depends on the model. Often the tokens are a mix of full words and sub-words. Depending on the users plan, and on the model being used, there may be an enforced maximum number of new tokens.
+
+*Possible values:* `≥ 0`
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MAX_NEW_TOKENS+++[]
@@ -709,12 +848,33 @@ endif::add-copy-button-to-env-var[]
 |`200`
 
 
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-min-new-tokens]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-min-new-tokens[quarkus.langchain4j.watsonx."model-name".chat-model.min-new-tokens]`
+
+
+[.description]
+--
+If stop sequences are given, they are ignored until minimum tokens are generated.
+
+*Possible values:* `≥ 0`
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MIN_NEW_TOKENS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MIN_NEW_TOKENS+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|`0`
+
+
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-random-seed]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-random-seed[quarkus.langchain4j.watsonx."model-name".chat-model.random-seed]`
 
 
 [.description]
 --
-Random number generator seed to use in sampling mode for experimental repeatability. Must be >= 1.
+Random number generator seed to use in sampling mode for experimental repeatability.
+
+*Possible values:* `≥ 1`
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_RANDOM_SEED+++[]
@@ -731,7 +891,9 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-mod
 
 [.description]
 --
-Stop sequences are one or more strings which will cause the text generation to stop if/when they are produced as part of the output. Stop sequences encountered prior to the minimum number of tokens being generated will be ignored. The list may contain up to 6 strings.
+Stop sequences are one or more strings which will cause the text generation to stop if/when they are produced as part of the output. Stop sequences encountered prior to the minimum number of tokens being generated will be ignored.
+
+*Possible values:* `0 ≤ number of items ≤ 6, contains only unique items`
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_STOP_SEQUENCES+++[]
@@ -743,12 +905,33 @@ endif::add-copy-button-to-env-var[]
 |
 
 
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-temperature]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-temperature[quarkus.langchain4j.watsonx."model-name".chat-model.temperature]`
+
+
+[.description]
+--
+A value used to modify the next-token probabilities in `sampling` mode. Values less than `1.0` sharpen the probability distribution, resulting in "less random" output. Values greater than `1.0` flatten the probability distribution, resulting in "more random" output. A value of `1.0` has no effect.
+
+*Possible values:* `0 ≤ value ≤ 2`
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_TEMPERATURE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_TEMPERATURE+++`
+endif::add-copy-button-to-env-var[]
+--|double 
+|`1.0`
+
+
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-top-k]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-top-k[quarkus.langchain4j.watsonx."model-name".chat-model.top-k]`
 
 
 [.description]
 --
-The number of highest probability vocabulary tokens to keep for top-k-filtering. Only applies for sampling mode, with range from 1 to 100. When decoding_strategy is set to sample, only the top_k most likely tokens are considered as candidates for the next generated token.
+The number of highest probability vocabulary tokens to keep for top-k-filtering. Only applies for `sampling` mode. When decoding_strategy is set to `sample`, only the `top_k` most likely tokens are considered as candidates for the next generated token.
+
+*Possible values:* `1 ≤ value ≤ 100`
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_TOP_K+++[]
@@ -765,7 +948,9 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-mod
 
 [.description]
 --
-Similar to top_k except the candidates to generate the next token are the most likely tokens with probabilities that add up to at least top_p. The valid range is 0.0 to 1.0 where 1.0 is equivalent to disabled and is the default. Also known as nucleus sampling.
+Similar to `top_k` except the candidates to generate the next token are the most likely tokens with probabilities that add up to at least `top_p`. Also known as nucleus sampling. A value of `1.0` is equivalent to disabled.
+
+*Possible values:* `0 < value ≤ 1`
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_TOP_P+++[]
@@ -782,7 +967,9 @@ a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-mod
 
 [.description]
 --
-Represents the penalty for penalizing tokens that have already been generated or belong to the context. The range is 1.0 to 2.0 and defaults to 1.0 (no penalty).
+Represents the penalty for penalizing tokens that have already been generated or belong to the context. The value `1.0` means that there is no penalty.
+
+*Possible values:* `1 ≤ value ≤ 2`
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_REPETITION_PENALTY+++[]
@@ -794,12 +981,82 @@ endif::add-copy-button-to-env-var[]
 |
 
 
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-truncate-input-tokens]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-truncate-input-tokens[quarkus.langchain4j.watsonx."model-name".chat-model.truncate-input-tokens]`
+
+
+[.description]
+--
+Represents the maximum number of input tokens accepted. This can be used to avoid requests failing due to input being longer than configured limits. If the text is truncated, then it truncates the start of the input (on the left), so the end of the input will remain the same. If this value exceeds the maximum sequence length (refer to the documentation to find this value for the model) then the call will fail if the total number of tokens exceeds the maximum sequence length. Zero means don't truncate.
+
+*Possible values:* `≥ 0`
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_TRUNCATE_INPUT_TOKENS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_TRUNCATE_INPUT_TOKENS+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|
+
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-include-stop-sequence]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-include-stop-sequence[quarkus.langchain4j.watsonx."model-name".chat-model.include-stop-sequence]`
+
+
+[.description]
+--
+Pass `false` to omit matched stop sequences from the end of the output text. The default is `true`, meaning that the output will end with the stop sequence text when matched.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_INCLUDE_STOP_SEQUENCE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_INCLUDE_STOP_SEQUENCE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|
+
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-log-requests]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-log-requests[quarkus.langchain4j.watsonx."model-name".chat-model.log-requests]`
+
+
+[.description]
+--
+Whether chat model requests should be logged.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-log-responses]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-log-responses[quarkus.langchain4j.watsonx."model-name".chat-model.log-responses]`
+
+
+[.description]
+--
+Whether chat model responses should be logged.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-embedding-model-model-id]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-embedding-model-model-id[quarkus.langchain4j.watsonx."model-name".embedding-model.model-id]`
 
 
 [.description]
 --
-Model to use
+Model id to use. To view the complete model list, link:https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models-embed.html?context=wx&audience=wdp[click here].
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__EMBEDDING_MODEL_MODEL_ID+++[]
@@ -809,6 +1066,83 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__EMBEDDING_MOD
 endif::add-copy-button-to-env-var[]
 --|string 
 |`ibm/slate-125m-english-rtrvr`
+
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-embedding-model-log-requests]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-embedding-model-log-requests[quarkus.langchain4j.watsonx."model-name".embedding-model.log-requests]`
+
+
+[.description]
+--
+Whether embedding model requests should be logged.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__EMBEDDING_MODEL_LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__EMBEDDING_MODEL_LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-embedding-model-log-responses]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-embedding-model-log-responses[quarkus.langchain4j.watsonx."model-name".embedding-model.log-responses]`
+
+
+[.description]
+--
+Whether embedding model responses should be logged.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__EMBEDDING_MODEL_LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__EMBEDDING_MODEL_LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`false`
+
+
+h|[[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-length-penalty-it-can-be-used-to-exponentially-increase-the-likelihood-of-the-text-generation-terminating-once-a-specified-number-of-tokens-have-been-generated]]link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-length-penalty-it-can-be-used-to-exponentially-increase-the-likelihood-of-the-text-generation-terminating-once-a-specified-number-of-tokens-have-been-generated[It can be used to exponentially increase the likelihood of the text generation terminating once a specified number of tokens have been generated]
+This configuration section is optional
+h|Type
+h|Default
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-length-penalty-decay-factor]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-length-penalty-decay-factor[quarkus.langchain4j.watsonx."model-name".chat-model.length-penalty.decay-factor]`
+
+
+[.description]
+--
+Represents the factor of exponential decay. Larger values correspond to more aggressive decay.
+
+*Possible values:* `> 1`
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_LENGTH_PENALTY_DECAY_FACTOR+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_LENGTH_PENALTY_DECAY_FACTOR+++`
+endif::add-copy-button-to-env-var[]
+--|double 
+|
+
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-length-penalty-start-index]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-length-penalty-start-index[quarkus.langchain4j.watsonx."model-name".chat-model.length-penalty.start-index]`
+
+
+[.description]
+--
+A number of generated tokens after which this should take effect.
+
+*Possible values:* `≥ 0`
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_LENGTH_PENALTY_START_INDEX+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_LENGTH_PENALTY_START_INDEX+++`
+endif::add-copy-button-to-env-var[]
+--|int 
+|
 
 |===
 ifndef::no-duration-note[]

--- a/docs/modules/ROOT/pages/watsonx.adoc
+++ b/docs/modules/ROOT/pages/watsonx.adoc
@@ -30,6 +30,7 @@ The `base-url` property depends on the region of the provided service instance, 
 * Dallas: https://us-south.ml.cloud.ibm.com
 * Frankfurt: https://eu-de.ml.cloud.ibm.com
 * Tokyo: https://jp-tok.ml.cloud.ibm.com
+* London: https://eu-gb.ml.cloud.ibm.com
 
 [source,properties,subs=attributes+]
 ----
@@ -44,6 +45,8 @@ To get the ID of a project, complete the following steps:
 1. Open the project, and then click the Manage tab.
 2. Copy the project ID from the Details section of the General page.
 
+NOTE: To view the list of projects, go to https://dataplatform.cloud.ibm.com/projects/?context=wx.
+
 [source,properties,subs=attributes+]
 ----
 quarkus.langchain4j.watsonx.project-id=23d...
@@ -57,7 +60,7 @@ To prompt foundation models in IBM watsonx.ai programmatically, you need an IBM 
 quarkus.langchain4j.watsonx.api-key=hG-...
 ----
 
-IMPORTANT: To determine the API key, go to https://cloud.ibm.com/iam/apikeys and generate it.
+NOTE: To determine the API key, go to https://cloud.ibm.com/iam/apikeys and generate it.
 
 ==== All configuration properties
 

--- a/watsonx/deployment/src/main/java/io/quarkiverse/langchain4j/watsonx/deployment/ChatModelBuildConfig.java
+++ b/watsonx/deployment/src/main/java/io/quarkiverse/langchain4j/watsonx/deployment/ChatModelBuildConfig.java
@@ -9,7 +9,7 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 public interface ChatModelBuildConfig {
 
     /**
-     * Whether the model should be enabled
+     * Whether the model should be enabled.
      */
     @ConfigDocDefault("true")
     Optional<Boolean> enabled();

--- a/watsonx/deployment/src/main/java/io/quarkiverse/langchain4j/watsonx/deployment/EmbeddingModelBuildConfig.java
+++ b/watsonx/deployment/src/main/java/io/quarkiverse/langchain4j/watsonx/deployment/EmbeddingModelBuildConfig.java
@@ -9,7 +9,7 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 public interface EmbeddingModelBuildConfig {
 
     /**
-     * Whether the embedding model should be enabled
+     * Whether the embedding model should be enabled.
      */
     @ConfigDocDefault("true")
     Optional<Boolean> enabled();

--- a/watsonx/deployment/src/main/java/io/quarkiverse/langchain4j/watsonx/deployment/LangChain4jWatsonBuildConfig.java
+++ b/watsonx/deployment/src/main/java/io/quarkiverse/langchain4j/watsonx/deployment/LangChain4jWatsonBuildConfig.java
@@ -10,12 +10,12 @@ import io.smallrye.config.ConfigMapping;
 public interface LangChain4jWatsonBuildConfig {
 
     /**
-     * Chat model related settings
+     * Chat model related settings.
      */
     ChatModelBuildConfig chatModel();
 
     /**
-     * Embedding model related settings
+     * Embedding model related settings.
      */
     EmbeddingModelBuildConfig embeddingModel();
 }

--- a/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/AllPropertiesTest.java
+++ b/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/AllPropertiesTest.java
@@ -1,13 +1,18 @@
 package com.ibm.langchain4j.watsonx.deployment;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.Duration;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import jakarta.inject.Inject;
+import jakarta.ws.rs.core.MediaType;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -19,8 +24,14 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
 
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.StreamingResponseHandler;
 import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.Response;
 import io.quarkiverse.langchain4j.watsonx.bean.Parameters;
+import io.quarkiverse.langchain4j.watsonx.bean.Parameters.LengthPenalty;
 import io.quarkiverse.langchain4j.watsonx.bean.TextGenerationRequest;
 import io.quarkiverse.langchain4j.watsonx.client.WatsonxRestApi;
 import io.quarkiverse.langchain4j.watsonx.runtime.config.LangChain4jWatsonxConfig;
@@ -36,7 +47,13 @@ public class AllPropertiesTest {
     LangChain4jWatsonxConfig langchain4jWatsonConfig;
 
     @Inject
-    ChatLanguageModel model;
+    ChatLanguageModel chatModel;
+
+    @Inject
+    StreamingChatLanguageModel streamingChatModel;
+
+    @Inject
+    EmbeddingModel embeddingModel;
 
     static WireMockUtil mockServers;
 
@@ -54,6 +71,8 @@ public class AllPropertiesTest {
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.grant-type", "grantME")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.model-id", "my_super_model")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.decoding-method", "greedy")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.length-penalty.decay-factor", "1.1")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.length-penalty.start-index", "0")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.max-new-tokens", "200")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.min-new-tokens", "10")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.random-seed", "2")
@@ -62,6 +81,8 @@ public class AllPropertiesTest {
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.top-k", "90")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.top-p", "0.5")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.repetition-penalty", "2.0")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.truncate-input-tokens", "0")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.include-stop-sequence", "false")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
 
     @BeforeAll
@@ -84,7 +105,7 @@ public class AllPropertiesTest {
     }
 
     @Test
-    void generate() throws Exception {
+    void check_config() throws Exception {
         var config = langchain4jWatsonConfig.defaultConfig();
         assertEquals(WireMockUtil.URL_WATSONX_SERVER, config.baseUrl().toString());
         assertEquals(WireMockUtil.URL_IAM_SERVER, config.iam().baseUrl().toString());
@@ -98,6 +119,8 @@ public class AllPropertiesTest {
         assertEquals("aaaa-mm-dd", config.version());
         assertEquals("my_super_model", config.chatModel().modelId());
         assertEquals("greedy", config.chatModel().decodingMethod());
+        assertEquals(1.1, config.chatModel().lengthPenalty().get().decayFactor().get());
+        assertEquals(0, config.chatModel().lengthPenalty().get().startIndex().get());
         assertEquals(200, config.chatModel().maxNewTokens());
         assertEquals(10, config.chatModel().minNewTokens());
         assertEquals(2, config.chatModel().randomSeed().get());
@@ -106,7 +129,13 @@ public class AllPropertiesTest {
         assertEquals(90, config.chatModel().topK().get());
         assertEquals(0.5, config.chatModel().topP().get());
         assertEquals(2.0, config.chatModel().repetitionPenalty().get());
+        assertEquals(0, config.chatModel().truncateInputTokens().get());
+        assertEquals(false, config.chatModel().includeStopSequence().get());
+    }
 
+    @Test
+    void check_chat_model_config() throws Exception {
+        var config = langchain4jWatsonConfig.defaultConfig();
         String modelId = config.chatModel().modelId();
         String projectId = config.projectId();
         String input = "TEST";
@@ -114,12 +143,15 @@ public class AllPropertiesTest {
                 .minNewTokens(10)
                 .maxNewTokens(200)
                 .decodingMethod("greedy")
+                .lengthPenalty(new LengthPenalty(1.1, 0))
                 .randomSeed(2)
                 .stopSequences(List.of("\n", "\n\n"))
                 .temperature(1.5)
                 .topK(90)
                 .topP(0.5)
                 .repetitionPenalty(2.0)
+                .truncateInputTokens(0)
+                .includeStopSequence(false)
                 .build();
 
         TextGenerationRequest body = new TextGenerationRequest(modelId, projectId, input + "\n", parameters);
@@ -148,6 +180,94 @@ public class AllPropertiesTest {
                         """)
                 .build();
 
-        assertEquals("Response!", model.generate(input));
+        assertEquals("Response!", chatModel.generate(input));
+    }
+
+    @Test
+    void check_chat_streaming_model_config() throws Exception {
+        var config = langchain4jWatsonConfig.defaultConfig();
+        String modelId = config.chatModel().modelId();
+        String projectId = config.projectId();
+        String input = "TEST";
+        var parameters = Parameters.builder()
+                .minNewTokens(10)
+                .maxNewTokens(200)
+                .decodingMethod("greedy")
+                .lengthPenalty(new LengthPenalty(1.1, 0))
+                .randomSeed(2)
+                .stopSequences(List.of("\n", "\n\n"))
+                .temperature(1.5)
+                .topK(90)
+                .topP(0.5)
+                .repetitionPenalty(2.0)
+                .truncateInputTokens(0)
+                .includeStopSequence(false)
+                .build();
+
+        TextGenerationRequest body = new TextGenerationRequest(modelId, projectId, input + "\n", parameters);
+
+        mockServers.mockIAMBuilder(200)
+                .grantType(config.iam().grantType())
+                .response(WireMockUtil.BEARER_TOKEN, new Date())
+                .build();
+
+        String eventStreamResponse = """
+                id: 1
+                event: message
+                data: {"model_id":"ibm/granite-13b-chat-v2","model_version":"2.1.0","created_at":"2024-05-04T14:29:19.162Z","results":[{"generated_text":"","generated_token_count":0,"input_token_count":2,"stop_reason":"not_finished"}]}
+
+                id: 2
+                event: message
+                data: {"model_id":"ibm/granite-13b-chat-v2","model_version":"2.1.0","created_at":"2024-05-04T14:29:19.203Z","results":[{"generated_text":". ","generated_token_count":2,"input_token_count":0,"stop_reason":"not_finished"}]}
+
+                id: 3
+                event: message
+                data: {"model_id":"ibm/granite-13b-chat-v2","model_version":"2.1.0","created_at":"2024-05-04T14:29:19.223Z","results":[{"generated_text":"I'","generated_token_count":3,"input_token_count":0,"stop_reason":"not_finished"}]}
+
+                id: 4
+                event: message
+                data: {"model_id":"ibm/granite-13b-chat-v2","model_version":"2.1.0","created_at":"2024-05-04T14:29:19.243Z","results":[{"generated_text":"m ","generated_token_count":4,"input_token_count":0,"stop_reason":"not_finished"}]}
+
+                id: 5
+                event: message
+                data: {"model_id":"ibm/granite-13b-chat-v2","model_version":"2.1.0","created_at":"2024-05-04T14:29:19.262Z","results":[{"generated_text":"a beginner","generated_token_count":5,"input_token_count":0,"stop_reason":"max_tokens"}]}
+
+                id: 5
+                event: close
+                data: {}}
+                """;
+
+        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_CHAT_STREAMING_API, 200, "aaaa-mm-dd")
+                .body(mapper.writeValueAsString(body))
+                .responseMediaType(MediaType.SERVER_SENT_EVENTS)
+                .response(eventStreamResponse)
+                .build();
+
+        var streamingResponse = new AtomicReference<AiMessage>();
+        streamingChatModel.generate(input, new StreamingResponseHandler<>() {
+            @Override
+            public void onNext(String token) {
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                fail("Streaming failed: %s".formatted(error.getMessage()), error);
+            }
+
+            @Override
+            public void onComplete(Response<AiMessage> response) {
+                System.out.println(response);
+                streamingResponse.set(response.content());
+            }
+        });
+
+        await()
+                .atMost(Duration.ofMinutes(1))
+                .pollInterval(Duration.ofSeconds(2))
+                .until(() -> streamingResponse.get() != null);
+
+        assertThat(streamingResponse.get().text())
+                .isNotNull()
+                .isEqualTo(". I'm a beginner");
     }
 }

--- a/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/DefaultPropertiesTest.java
+++ b/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/DefaultPropertiesTest.java
@@ -2,6 +2,7 @@ package com.ibm.langchain4j.watsonx.deployment;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.util.Date;
@@ -75,10 +76,16 @@ public class DefaultPropertiesTest {
         assertEquals(false, config.logResponses().orElse(false));
         assertEquals(WireMockUtil.DEFAULT_CHAT_MODEL, config.chatModel().modelId());
         assertEquals("greedy", config.chatModel().decodingMethod());
-        assertEquals(1.0, config.chatModel().temperature());
-        assertEquals(0, config.chatModel().minNewTokens());
         assertEquals(200, config.chatModel().maxNewTokens());
+        assertEquals(0, config.chatModel().minNewTokens());
+        assertEquals(false, config.chatModel().randomSeed().isPresent());
+        assertEquals(false, config.chatModel().stopSequences().isPresent());
         assertEquals(1.0, config.chatModel().temperature());
+        assertTrue(config.chatModel().topK().isEmpty());
+        assertTrue(config.chatModel().topP().isEmpty());
+        assertTrue(config.chatModel().repetitionPenalty().isEmpty());
+        assertTrue(config.chatModel().truncateInputTokens().isEmpty());
+        assertTrue(config.chatModel().includeStopSequence().isEmpty());
         assertEquals(Duration.ofSeconds(10), config.iam().timeout());
         assertEquals("urn:ibm:params:oauth:grant-type:apikey", config.iam().grantType());
         assertEquals(WireMockUtil.DEFAULT_EMBEDDING_MODEL, config.embeddingModel().modelId());
@@ -118,7 +125,6 @@ public class DefaultPropertiesTest {
                             }
                         """)
                 .build();
-        ;
 
         assertEquals("Response!", model.generate(input));
     }

--- a/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/WireMockUtil.java
+++ b/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/WireMockUtil.java
@@ -20,6 +20,7 @@ public class WireMockUtil {
     public static final int PORT_WATSONX_SERVER = 8089;
     public static final String URL_WATSONX_SERVER = "http://localhost:8089";
     public static final String URL_WATSONX_CHAT_API = "/ml/v1/text/generation?version=%s";
+    public static final String URL_WATSONX_CHAT_STREAMING_API = "/ml/v1/text/generation_stream?version=%s";
     public static final String URL_WATSONX_EMBEDDING_API = "/ml/v1/text/embeddings?version=%s";
 
     public static final int PORT_IAM_SERVER = 8090;

--- a/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxChatModel.java
+++ b/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxChatModel.java
@@ -4,6 +4,7 @@ import static java.util.stream.Collectors.joining;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 
 import dev.langchain4j.data.message.AiMessage;
@@ -13,6 +14,7 @@ import dev.langchain4j.model.chat.TokenCountEstimator;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
 import io.quarkiverse.langchain4j.watsonx.bean.Parameters;
+import io.quarkiverse.langchain4j.watsonx.bean.Parameters.LengthPenalty;
 import io.quarkiverse.langchain4j.watsonx.bean.TextGenerationRequest;
 import io.quarkiverse.langchain4j.watsonx.bean.TextGenerationResponse;
 import io.quarkiverse.langchain4j.watsonx.bean.TextGenerationResponse.Result;
@@ -27,8 +29,14 @@ public class WatsonxChatModel extends WatsonxModel implements ChatLanguageModel,
     @Override
     public Response<AiMessage> generate(List<ChatMessage> messages) {
 
+        LengthPenalty lengthPenalty = null;
+        if (Objects.nonNull(decayFactor) || Objects.nonNull(startIndex)) {
+            lengthPenalty = new LengthPenalty(decayFactor, startIndex);
+        }
+
         Parameters parameters = Parameters.builder()
                 .decodingMethod(decodingMethod)
+                .lengthPenalty(lengthPenalty)
                 .minNewTokens(minNewTokens)
                 .maxNewTokens(maxNewTokens)
                 .randomSeed(randomSeed)
@@ -37,6 +45,8 @@ public class WatsonxChatModel extends WatsonxModel implements ChatLanguageModel,
                 .topP(topP)
                 .topK(topK)
                 .repetitionPenalty(repetitionPenalty)
+                .truncateInputTokens(truncateInputTokens)
+                .includeStopSequence(includeStopSequence)
                 .build();
 
         TextGenerationRequest request = new TextGenerationRequest(modelId, projectId, toInput(messages), parameters);

--- a/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxModel.java
+++ b/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxModel.java
@@ -26,14 +26,18 @@ public abstract class WatsonxModel {
     final String version;
     final String projectId;
     final String decodingMethod;
-    final Integer minNewTokens;
+    final Double decayFactor;
+    final Integer startIndex;
     final Integer maxNewTokens;
+    final Integer minNewTokens;
     final Integer randomSeed;
     final List<String> stopSequences;
     final Double temperature;
     final Double topP;
     final Integer topK;
     final Double repetitionPenalty;
+    final Integer truncateInputTokens;
+    final Boolean includeStopSequence;
     final WatsonxRestApi client;
 
     public WatsonxModel(Builder config) {
@@ -55,14 +59,18 @@ public abstract class WatsonxModel {
         this.version = config.version;
         this.projectId = config.projectId;
         this.decodingMethod = config.decodingMethod;
-        this.minNewTokens = config.minNewTokens;
+        this.decayFactor = config.decayFactor;
+        this.startIndex = config.startIndex;
         this.maxNewTokens = config.maxNewTokens;
+        this.minNewTokens = config.minNewTokens;
         this.randomSeed = config.randomSeed;
         this.stopSequences = config.stopSequences;
         this.temperature = config.temperature;
         this.topP = config.topP;
         this.topK = config.topK;
         this.repetitionPenalty = config.repetitionPenalty;
+        this.truncateInputTokens = config.truncateInputTokens;
+        this.includeStopSequence = config.includeStopSequence;
         this.tokenGenerator = config.tokenGenerator;
     }
 
@@ -143,15 +151,19 @@ public abstract class WatsonxModel {
         private String projectId;
         private Duration timeout;
         private String decodingMethod;
-        private Integer minNewTokens;
+        private Double decayFactor;
+        private Integer startIndex;
         private Integer maxNewTokens;
+        private Integer minNewTokens;
         private Integer randomSeed;
         private List<String> stopSequences;
         private Double temperature;
-        private URL url;
         private Integer topK;
         private Double topP;
         private Double repetitionPenalty;
+        private Integer truncateInputTokens;
+        private Boolean includeStopSequence;
+        private URL url;
         public boolean logResponses;
         public boolean logRequests;
         private TokenGenerator tokenGenerator;
@@ -186,6 +198,16 @@ public abstract class WatsonxModel {
             return this;
         }
 
+        public Builder decayFactor(Double decayFactor) {
+            this.decayFactor = decayFactor;
+            return this;
+        }
+
+        public Builder startIndex(Integer startIndex) {
+            this.startIndex = startIndex;
+            return this;
+        }
+
         public Builder minNewTokens(Integer minNewTokens) {
             this.minNewTokens = minNewTokens;
             return this;
@@ -211,11 +233,6 @@ public abstract class WatsonxModel {
             return this;
         }
 
-        public Builder decondingMethod(String decodingMethod) {
-            this.decodingMethod = decodingMethod;
-            return this;
-        }
-
         public Builder randomSeed(Integer randomSeed) {
             this.randomSeed = randomSeed;
             return this;
@@ -228,6 +245,16 @@ public abstract class WatsonxModel {
 
         public Builder stopSequences(List<String> stopSequences) {
             this.stopSequences = stopSequences;
+            return this;
+        }
+
+        public Builder truncateInputTokens(Integer truncateInputTokens) {
+            this.truncateInputTokens = truncateInputTokens;
+            return this;
+        }
+
+        public Builder includeStopSequence(Boolean includeStopSequence) {
+            this.includeStopSequence = includeStopSequence;
             return this;
         }
 

--- a/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxStreamingChatModel.java
+++ b/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxStreamingChatModel.java
@@ -5,6 +5,7 @@ import static java.util.stream.Collectors.joining;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Flow.Publisher;
 import java.util.function.Consumer;
@@ -22,6 +23,7 @@ import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
 import io.quarkiverse.langchain4j.QuarkusJsonCodecFactory;
 import io.quarkiverse.langchain4j.watsonx.bean.Parameters;
+import io.quarkiverse.langchain4j.watsonx.bean.Parameters.LengthPenalty;
 import io.quarkiverse.langchain4j.watsonx.bean.TextGenerationRequest;
 import io.quarkiverse.langchain4j.watsonx.bean.TextGenerationResponse;
 import io.quarkiverse.langchain4j.watsonx.bean.TokenizationRequest;
@@ -38,9 +40,14 @@ public class WatsonxStreamingChatModel extends WatsonxModel implements Streaming
     @Override
     public void generate(List<ChatMessage> messages, StreamingResponseHandler<AiMessage> handler) {
 
+        LengthPenalty lengthPenalty = null;
+        if (Objects.nonNull(decayFactor) || Objects.nonNull(startIndex)) {
+            lengthPenalty = new LengthPenalty(decayFactor, startIndex);
+        }
+
         Parameters parameters = Parameters.builder()
                 .decodingMethod(decodingMethod)
-                .stopSequences(stopSequences)
+                .lengthPenalty(lengthPenalty)
                 .minNewTokens(minNewTokens)
                 .maxNewTokens(maxNewTokens)
                 .randomSeed(randomSeed)
@@ -49,6 +56,8 @@ public class WatsonxStreamingChatModel extends WatsonxModel implements Streaming
                 .topP(topP)
                 .topK(topK)
                 .repetitionPenalty(repetitionPenalty)
+                .truncateInputTokens(truncateInputTokens)
+                .includeStopSequence(includeStopSequence)
                 .build();
 
         TextGenerationRequest request = new TextGenerationRequest(modelId, projectId, toInput(messages), parameters);

--- a/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/bean/Parameters.java
+++ b/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/bean/Parameters.java
@@ -4,18 +4,25 @@ import java.util.List;
 
 public class Parameters {
 
+    public record LengthPenalty(Double decayFactor, Integer startIndex) {
+    };
+
     private final String decodingMethod;
-    private final Integer minNewTokens;
+    private final LengthPenalty lengthPenalty;
     private final Integer maxNewTokens;
+    private final Integer minNewTokens;
     private final Integer randomSeed;
     private final List<String> stopSequences;
     private final Double temperature;
     private final Integer topK;
     private final Double topP;
     private final Double repetitionPenalty;
+    private final Integer truncateInputTokens;
+    private final Boolean includeStopSequence;
 
     private Parameters(Builder builder) {
         this.decodingMethod = builder.decodingMethod;
+        this.lengthPenalty = builder.lengthPenalty;
         this.minNewTokens = builder.minNewTokens;
         this.maxNewTokens = builder.maxNewTokens;
         this.randomSeed = builder.randomSeed;
@@ -24,6 +31,8 @@ public class Parameters {
         this.topK = builder.topK;
         this.topP = builder.topP;
         this.repetitionPenalty = builder.repetitionPenalty;
+        this.truncateInputTokens = builder.truncateInputTokens;
+        this.includeStopSequence = builder.includeStopSequence;
     }
 
     public static Builder builder() {
@@ -32,6 +41,10 @@ public class Parameters {
 
     public String getDecodingMethod() {
         return decodingMethod;
+    }
+
+    public LengthPenalty getLengthPenalty() {
+        return lengthPenalty;
     }
 
     public Integer getMinNewTokens() {
@@ -66,9 +79,18 @@ public class Parameters {
         return repetitionPenalty;
     }
 
+    public Integer getTruncateInputTokens() {
+        return truncateInputTokens;
+    }
+
+    public Boolean getIncludeStopSequence() {
+        return includeStopSequence;
+    }
+
     public static class Builder {
 
         private String decodingMethod;
+        private LengthPenalty lengthPenalty;
         private Integer minNewTokens;
         private Integer maxNewTokens;
         private Integer randomSeed;
@@ -77,9 +99,16 @@ public class Parameters {
         private Integer topK;
         private Double topP;
         private Double repetitionPenalty;
+        private Integer truncateInputTokens;
+        private Boolean includeStopSequence;
 
         public Builder decodingMethod(String decodingMethod) {
             this.decodingMethod = decodingMethod;
+            return this;
+        }
+
+        public Builder lengthPenalty(LengthPenalty lengthPenalty) {
+            this.lengthPenalty = lengthPenalty;
             return this;
         }
 
@@ -95,11 +124,6 @@ public class Parameters {
 
         public Builder temperature(Double temperature) {
             this.temperature = temperature;
-            return this;
-        }
-
-        public Builder decondingMethod(String decodingMethod) {
-            this.decodingMethod = decodingMethod;
             return this;
         }
 
@@ -125,6 +149,16 @@ public class Parameters {
 
         public Builder stopSequences(List<String> stopSequences) {
             this.stopSequences = stopSequences;
+            return this;
+        }
+
+        public Builder truncateInputTokens(Integer truncateInputTokens) {
+            this.truncateInputTokens = truncateInputTokens;
+            return this;
+        }
+
+        public Builder includeStopSequence(Boolean includeStopSequence) {
+            this.includeStopSequence = includeStopSequence;
             return this;
         }
 

--- a/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/ChatModelConfig.java
+++ b/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/ChatModelConfig.java
@@ -11,99 +11,166 @@ import io.smallrye.config.WithDefault;
 public interface ChatModelConfig {
 
     /**
-     * Model to use.
+     * Model id to use.
      * <p>
-     * For a complete list of models, visit:
-     * {@link https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models.html?context=wx}
+     * To view the complete model list, <a href=
+     * "https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-api-model-ids.html?context=wx&audience=wdp#model-ids">click
+     * here</a>.
      */
     @WithDefault("ibm/granite-20b-multilingual")
     String modelId();
 
     /**
-     * Represents the strategy used for picking the tokens during generation of the output text. Options are greedy and sample.
-     * Value defaults to sample if not specified.
+     * Represents the strategy used for picking the tokens during generation of the output text. During text generation when
+     * parameter
+     * value is set to <code>greedy</code>, each successive token corresponds to the highest probability token given the text
+     * that has
+     * already been generated. This strategy can lead to repetitive results especially for longer output sequences. The
+     * alternative
+     * <code>sample</code> strategy generates text by picking subsequent tokens based on the probability distribution of
+     * possible next
+     * tokens defined by (i.e., conditioned on) the already-generated text and the <code>top_k</code> and <code>top_p</code>
+     * parameters.
      * <p>
-     * During text generation when parameter value is set to greedy, each successive token corresponds to the highest
-     * probability token given the text that has already been generated.
-     * This strategy can lead to repetitive results especially for longer output sequences.
-     * The alternative sample strategy generates text by picking subsequent tokens based on the probability distribution of
-     * possible next tokens defined by (i.e., conditioned on)
-     * the already-generated text and the top_k and top_p parameters described below. See this url for an informative article
-     * about text generation.
+     * <strong>Allowable values:</strong> <code>[sample,greedy]</code>
      */
     @WithDefault("greedy")
     String decodingMethod();
 
     /**
-     * A value used to modify the next-token probabilities in sampling mode.
-     * Values less than 1.0 sharpen the probability distribution, resulting in "less random" output.
-     * Values greater than 1.0 flatten the probability distribution, resulting in "more random" output. A value of 1.0 has no
-     * effect and is the default.
-     * The allowed range is 0.0 to 2.0.
+     * It can be used to exponentially increase the likelihood of the text generation terminating once a specified number of
+     * tokens
+     * have been generated.
      */
-    @WithDefault("1.0")
-    Double temperature();
+    Optional<LengthPenaltyConfig> lengthPenalty();
 
     /**
-     * If stop sequences are given, they are ignored until minimum tokens are generated. Defaults to 0.
-     */
-    @WithDefault("0")
-    Integer minNewTokens();
-
-    /**
-     * The maximum number of new tokens to be generated. The range is 0 to 1024.
+     * The maximum number of new tokens to be generated. The maximum supported value for this field depends on the model being
+     * used.
+     * How the "token" is defined depends on the tokenizer and vocabulary size, which in turn depends on the model. Often the
+     * tokens
+     * are a mix of full words and sub-words. Depending on the users plan, and on the model being used, there may be an enforced
+     * maximum number of new tokens.
+     * <p>
+     * <strong>Possible values:</strong> <code>≥ 0</code>
      */
     @WithDefault("200")
     Integer maxNewTokens();
 
     /**
-     * Random number generator seed to use in sampling mode for experimental
-     * repeatability. Must be >= 1.
+     * If stop sequences are given, they are ignored until minimum tokens are generated.
+     * <p>
+     * <strong>Possible values:</strong> <code>≥ 0</code>
+     */
+    @WithDefault("0")
+    Integer minNewTokens();
+
+    /**
+     * Random number generator seed to use in sampling mode for experimental repeatability.
+     * <p>
+     * <strong>Possible values:</strong> <code>≥ 1</code>
      */
     Optional<Integer> randomSeed();
 
     /**
-     * Stop sequences are one or more strings which will cause the text generation
-     * to stop if/when they are produced as part of the output. Stop sequences
-     * encountered prior to the minimum number of tokens being generated will be
-     * ignored. The list may contain up to 6 strings.
+     * Stop sequences are one or more strings which will cause the text generation to stop if/when they are produced as part of
+     * the
+     * output. Stop sequences encountered prior to the minimum number of tokens being generated will be ignored.
+     * <p>
+     * <strong>Possible values:</strong> <code>0 ≤ number of items ≤ 6, contains only unique items</code>
      */
     Optional<List<String>> stopSequences();
 
     /**
-     * The number of highest probability vocabulary tokens to keep for
-     * top-k-filtering. Only applies for sampling mode, with range from 1 to 100.
-     * When decoding_strategy is set to sample, only the top_k most likely tokens
-     * are considered as candidates for the next generated token.
+     * A value used to modify the next-token probabilities in <code>sampling</code> mode. Values less than <code>1.0</code>
+     * sharpen
+     * the probability distribution, resulting in "less random" output. Values greater than <code>1.0</code> flatten the
+     * probability
+     * distribution, resulting in "more random" output. A value of <code>1.0</code> has no effect.
+     * <p>
+     * <strong>Possible values:</strong> <code>0 ≤ value ≤ 2</code>
+     */
+    @WithDefault("1.0")
+    Double temperature();
+
+    /**
+     * The number of highest probability vocabulary tokens to keep for top-k-filtering. Only applies for <code>sampling</code>
+     * mode.
+     * When decoding_strategy is set to <code>sample</code>, only the <code>top_k</code> most likely tokens are considered as
+     * candidates for the next generated token.
+     * <p>
+     * <strong>Possible values:</strong> <code>1 ≤ value ≤ 100</code>
      */
     Optional<Integer> topK();
 
     /**
-     * Similar to top_k except the candidates to generate the next token are the
-     * most likely tokens with probabilities that add up to at least top_p. The
-     * valid range is 0.0 to 1.0 where 1.0 is equivalent to disabled and is the
-     * default. Also known as nucleus sampling.
+     * Similar to <code>top_k</code> except the candidates to generate the next token are the most likely tokens with
+     * probabilities
+     * that add up to at least <code>top_p</code>. Also known as nucleus sampling. A value of <code>1.0</code> is equivalent to
+     * disabled.
+     * <p>
+     * <strong>Possible values:</strong> <code>0 < value ≤ 1</code>
      */
     Optional<Double> topP();
 
     /**
-     * Represents the penalty for penalizing tokens that have already been generated
-     * or belong to the context. The range is 1.0 to 2.0 and defaults to 1.0 (no
-     * penalty).
+     * Represents the penalty for penalizing tokens that have already been generated or belong to the context. The value
+     * <code>1.0</code> means that there is no penalty.
+     * <p>
+     * <strong>Possible values:</strong> <code>1 ≤ value ≤ 2</code>
      */
     Optional<Double> repetitionPenalty();
 
     /**
-     * Whether chat model requests should be logged
+     * Represents the maximum number of input tokens accepted. This can be used to avoid requests failing due to input being
+     * longer
+     * than configured limits. If the text is truncated, then it truncates the start of the input (on the left), so the end of
+     * the
+     * input will remain the same. If this value exceeds the maximum sequence length (refer to the documentation to find this
+     * value
+     * for the model) then the call will fail if the total number of tokens exceeds the maximum sequence length. Zero means
+     * don't
+     * truncate.
+     * <p>
+     * <strong>Possible values:</strong> <code>≥ 0</code>
+     */
+    Optional<Integer> truncateInputTokens();
+
+    /**
+     * Pass <code>false</code> to omit matched stop sequences from the end of the output text. The default is <code>true</code>,
+     * meaning that the output will end with the stop sequence text when matched.
+     */
+    Optional<Boolean> includeStopSequence();
+
+    /**
+     * Whether chat model requests should be logged.
      */
     @ConfigDocDefault("false")
     @WithDefault("${quarkus.langchain4j.watsonx.log-requests}")
     Optional<Boolean> logRequests();
 
     /**
-     * Whether chat model responses should be logged
+     * Whether chat model responses should be logged.
      */
     @ConfigDocDefault("false")
     @WithDefault("${quarkus.langchain4j.watsonx.log-responses}")
     Optional<Boolean> logResponses();
+
+    @ConfigGroup
+    public interface LengthPenaltyConfig {
+
+        /**
+         * Represents the factor of exponential decay. Larger values correspond to more aggressive decay.
+         * <p>
+         * <strong>Possible values:</strong> <code>> 1</code>
+         */
+        Optional<Double> decayFactor();
+
+        /**
+         * A number of generated tokens after which this should take effect.
+         * <p>
+         * <strong>Possible values:</strong> <code>≥ 0</code>
+         */
+        Optional<Integer> startIndex();
+    }
 }

--- a/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/EmbeddingModelConfig.java
+++ b/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/EmbeddingModelConfig.java
@@ -10,20 +10,24 @@ import io.smallrye.config.WithDefault;
 public interface EmbeddingModelConfig {
 
     /**
-     * Model to use
+     * Model id to use.
+     *
+     * To view the complete model list, <a href=
+     * "https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models-embed.html?context=wx&audience=wdp">click
+     * here</a>.
      */
     @WithDefault("ibm/slate-125m-english-rtrvr")
     String modelId();
 
     /**
-     * Whether embedding model requests should be logged
+     * Whether embedding model requests should be logged.
      */
     @ConfigDocDefault("false")
     @WithDefault("${quarkus.langchain4j.watsonx.log-requests}")
     Optional<Boolean> logRequests();
 
     /**
-     * Whether embedding model responses should be logged
+     * Whether embedding model responses should be logged.
      */
     @ConfigDocDefault("false")
     @WithDefault("${quarkus.langchain4j.watsonx.log-responses}")

--- a/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/IAMConfig.java
+++ b/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/IAMConfig.java
@@ -10,19 +10,19 @@ import io.smallrye.config.WithDefault;
 public interface IAMConfig {
 
     /**
-     * IAM base URL
+     * Base URL of the IAM Authentication API.
      */
     @WithDefault("https://iam.cloud.ibm.com")
     URL baseUrl();
 
     /**
-     * Timeout for IAM API calls
+     * Timeout for IAM authentication calls.
      */
     @WithDefault("10s")
     Duration timeout();
 
     /**
-     * IAM grant type
+     * Grant type for the IAM Authentication API.
      */
     @WithDefault("urn:ibm:params:oauth:grant-type:apikey")
     String grantType();

--- a/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/LangChain4jWatsonxConfig.java
+++ b/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/LangChain4jWatsonxConfig.java
@@ -38,44 +38,48 @@ public interface LangChain4jWatsonxConfig {
     @ConfigGroup
     interface WatsonConfig {
         /**
-         * Base URL
+         * Base URL of the watsonx.ai API.
          */
         @WithDefault("https://dummy.ai/api")
         String baseUrl();
 
         /**
-         * IBM Cloud API key
+         * IBM Cloud API key.
+         * <p>
+         * To create a new API key, follow this <a href="https://cloud.ibm.com/iam/apikeys">link</a>.
          */
         @WithDefault("dummy")
         String apiKey();
 
         /**
-         * Timeout for watsonx.ai API calls
+         * Timeout for watsonx.ai calls.
          */
         @WithDefault("10s")
         Duration timeout();
 
         /**
-         * The version date for the API of the form YYYY-MM-DD
+         * The version date for the API of the form YYYY-MM-DD.
          */
         @WithDefault("2024-03-14")
         String version();
 
         /**
-         * Watsonx.ai project id.
+         * The project that contains the watsonx.ai resource.
+         * <p>
+         * To look up your project id, <a href="https://dataplatform.cloud.ibm.com/projects/?context=wx">click here</a>.
          */
         @WithDefault("dummy")
         String projectId();
 
         /**
-         * Whether the watsonx.ai client should log requests
+         * Whether the watsonx.ai client should log requests.
          */
         @ConfigDocDefault("false")
         @WithDefault("${quarkus.langchain4j.log-requests}")
         Optional<Boolean> logRequests();
 
         /**
-         * Whether the watsonx.ai client should log responses
+         * Whether the watsonx.ai client should log responses.
          */
         @ConfigDocDefault("false")
         @WithDefault("${quarkus.langchain4j.log-requests}")
@@ -83,24 +87,24 @@ public interface LangChain4jWatsonxConfig {
 
         /**
          * Whether to enable the integration. Defaults to {@code true}, which means requests are made to the watsonx.ai
-         * provider.
-         * Set to {@code false} to disable all requests.
+         * provider. Set to
+         * {@code false} to disable all requests.
          */
         @WithDefault("true")
         Boolean enableIntegration();
 
         /**
-         * Chat model related settings
+         * IAM authentication related settings.
          */
         IAMConfig iam();
 
         /**
-         * Chat model related settings
+         * Chat model related settings.
          */
         ChatModelConfig chatModel();
 
         /**
-         * Embedding model related settings
+         * Embedding model related settings.
          */
         EmbeddingModelConfig embeddingModel();
     }


### PR DESCRIPTION
The following parameters have been added to the `ChatLanguageModel` and `StreamingChatLanguageModel`:
- `quarkus.langchain4j.watsonx.chat-model.length-penalty.decay-factor`
- `quarkus.langchain4j.watsonx.chat-model.length-penalty.start-index`
- `quarkus.langchain4j.watsonx.chat-model.include-stop-sequence`
- `quarkus.langchain4j.watsonx.chat-model.truncate-input-tokens`

I also used this PR to add some links to the watsonx.ai documentation.