### PR TITLE
Fix configuration error in Gemini

### DIFF
--- a/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/VertexAiGeminiRecorder.java
+++ b/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/VertexAiGeminiRecorder.java
@@ -80,7 +80,7 @@ public class VertexAiGeminiRecorder {
 
     private static ConfigValidationException.Problem createConfigProblem(String key, String modelName) {
         return new ConfigValidationException.Problem(
-                "SRCFG00014: The config property quarkus.langchain4j.vertexai%s%s is required but it could not be found in any config source"
+                "SRCFG00014: The config property quarkus.langchain4j.vertexai.gemini%s%s is required but it could not be found in any config source"
                         .formatted(
                                 NamedModelUtil.isDefault(modelName) ? "." : ("." + modelName + "."), key));
     }


### PR DESCRIPTION
The path has to be the same as in `LangChain4jVertexAiGeminiConfig`

- Fixes: https://github.com/quarkiverse/quarkus-langchain4j/issues/555