### PR TITLE
Include instruction for docker users in email-me-a-poem readme

### DIFF
--- a/samples/email-a-poem/README.md
+++ b/samples/email-a-poem/README.md
@@ -12,8 +12,13 @@ A prerequisite to running this example is to provide your OpenAI API key.
 export QUARKUS_LANGCHAIN4J_OPENAI_API_KEY=<your-openai-api-key>
 ```
 
-To allow the application to send emails, start a mock SMTP server (replace
-Podman with your own container runtime):
+To allow the application to send emails, start a mock SMTP server container:
+
+```
+docker run -p 8025:8025 -p 1025:1025 docker.io/mailhog/mailhog
+```
+
+Alternatively, for podman users can use the following command:
 
 ```
 podman run -p 8025:8025 -p 1025:1025 docker.io/mailhog/mailhog


### PR DESCRIPTION
A lot of people that will go through the email me a poem read me, won't even know what `podman` is.
So, this pull request uses `docker` first and then includes instructions for `podman` users.