### PR TITLE
Refactor jokes jbang bot to be picocli based

### DIFF
--- a/samples/jbang-joke-bot/README.md
+++ b/samples/jbang-joke-bot/README.md
@@ -1,4 +1,4 @@
-# JBang sample aka getting an AI-powered bot in 13 lines of Java
+# JBang sample aka getting an AI-powered bot in 20 lines of Java
 
 To run the sample, you need JBang installed. If you don't have it, choose
 one of the installation options from the [JBang
@@ -16,15 +16,21 @@ Then, run the example with:
 jbang jokes.java
 ```
 
-To have it tell you a joke, call `http://localhost:8080/joke` with a GET
-request.
+or just 
 
-Explanation: The code contains a single method which injects a
-`io.vertx.ext.web.Router`, which is a class from the `quarkus-vertx-http`
-extension responsible for routing requests to appropriate handlers. The
-method is called during application boot thanks to the `@Observes`
-annotation, and it uses the injected `Router` to define a single route on
-the `/joke` path. The route's handler (the lambda expression that accepts a `rc` -
-`RoutingContext` parameter) invokes the model and sets the HTTP response.
-See [Quarkus documentation](https://quarkus.io/guides/reactive-routes#using-the-vert-x-web-router)
-for more information.
+```
+./jokes.java
+```
+
+The result should be something like:
+
+```
+Why couldn't the bicycle find its way home?
+
+Because it lost its bearings!
+
+```
+
+Explanation:  The code contains a simple picocli command-line application.
+The application injects the ChatLanguageModel provided by the Quarkus Langchain4j
+extension and just request a joke by using `tell me a joke` as a prompt.

--- a/samples/jbang-joke-bot/jokes.java
+++ b/samples/jbang-joke-bot/jokes.java
@@ -1,13 +1,20 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.quarkus.platform:quarkus-bom:3.9.4@pom
-//DEPS io.quarkus:quarkus-vertx-http:3.9.4
+//DEPS io.quarkus:quarkus-picocli
 //DEPS io.quarkiverse.langchain4j:quarkus-langchain4j-openai:0.14.0
-
+//Q:CONFIG quarkus.banner.enabled=false
+//Q:CONFIG quarkus.log.level=WARN
 import dev.langchain4j.model.chat.ChatLanguageModel;
-import io.vertx.ext.web.Router;
-import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import picocli.CommandLine.Command;
 
-public class jokes {
-    void route(@Observes Router router, ChatLanguageModel ai) {
-        router.get("/joke").blockingHandler(rc -> rc.end(ai.generate("tell me a joke")));
+@Command
+public class jokes implements Runnable {
+    @Inject
+    private ChatLanguageModel ai;
+
+    @Override
+    public void run() {
+        System.out.println(ai.generate("tell me a joke"));
     }
 }


### PR DESCRIPTION
The pull request changes the jbang jokes bot, to be a cli application  instead of a web application.

The reasoning is that we already have a lot of samples going the web path and it seems to me like a missed opportunity to show case to also demonstrate how it can be done in the CLI.

Now, I understand that the reasoning might be to implement something with the fewer lines of code possible, but I argue that the code is hard to understand.
