### PR TITLE
Introduce global timeout configuration

### DIFF
--- a/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/AnthropicRecorder.java
+++ b/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/AnthropicRecorder.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.langchain4j.anthropic.runtime;
 
+import java.time.Duration;
 import java.util.function.Supplier;
 
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
@@ -35,7 +36,7 @@ public class AnthropicRecorder {
                     .modelName(chatModelConfig.modelName())
                     .logRequests(chatModelConfig.logRequests().orElse(false))
                     .logResponses(chatModelConfig.logResponses().orElse(false))
-                    .timeout(anthropicConfig.timeout())
+                    .timeout(anthropicConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .topK(chatModelConfig.topK())
                     .maxTokens(chatModelConfig.maxTokens())
                     .maxRetries(chatModelConfig.maxRetries());
@@ -87,7 +88,7 @@ public class AnthropicRecorder {
                     .modelName(chatModelConfig.modelName())
                     .logRequests(chatModelConfig.logRequests().orElse(false))
                     .logResponses(chatModelConfig.logResponses().orElse(false))
-                    .timeout(anthropicConfig.timeout())
+                    .timeout(anthropicConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .topK(chatModelConfig.topK())
                     .maxTokens(chatModelConfig.maxTokens());
 

--- a/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/config/LangChain4jAnthropicConfig.java
+++ b/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/config/LangChain4jAnthropicConfig.java
@@ -57,8 +57,9 @@ public interface LangChain4jAnthropicConfig {
         /**
          * Timeout for Anthropic calls
          */
-        @WithDefault("10s")
-        Duration timeout();
+        @ConfigDocDefault("10s")
+        @WithDefault("${quarkus.langchain4j.timeout}")
+        Optional<Duration> timeout();
 
         /**
          * Whether the Anthropic client should log requests

--- a/bam/deployment/src/test/java/io/quarkiverse/langchain4j/bam/deployment/AllPropertiesTest.java
+++ b/bam/deployment/src/test/java/io/quarkiverse/langchain4j/bam/deployment/AllPropertiesTest.java
@@ -38,7 +38,7 @@ public class AllPropertiesTest {
     static QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .overrideRuntimeConfigKey("quarkus.langchain4j.bam.base-url", WireMockUtil.URL)
             .overrideRuntimeConfigKey("quarkus.langchain4j.bam.api-key", WireMockUtil.API_KEY)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.bam.timeout", "60s")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.timeout", "60s")
             .overrideRuntimeConfigKey("quarkus.langchain4j.bam.log-requests", "true")
             .overrideRuntimeConfigKey("quarkus.langchain4j.bam.log-responses", "true")
             .overrideRuntimeConfigKey("quarkus.langchain4j.bam.timeout", "60s")
@@ -89,7 +89,7 @@ public class AllPropertiesTest {
 
         assertEquals(WireMockUtil.URL, config.baseUrl().get().toString());
         assertEquals(WireMockUtil.API_KEY, config.apiKey());
-        assertEquals(Duration.ofSeconds(60), config.timeout());
+        assertEquals(Duration.ofSeconds(60), config.timeout().get());
         assertEquals(true, config.logRequests().orElse(false));
         assertEquals(true, config.logResponses().orElse(false));
         assertEquals("aaaa-mm-dd", config.version());

--- a/bam/deployment/src/test/java/io/quarkiverse/langchain4j/bam/deployment/BamRecordUtil.java
+++ b/bam/deployment/src/test/java/io/quarkiverse/langchain4j/bam/deployment/BamRecordUtil.java
@@ -76,7 +76,7 @@ public class BamRecordUtil {
                     }
 
                     @Override
-                    public Duration timeout() {
+                    public Optional<Duration> timeout() {
                         return langchain4jBamConfig.defaultConfig().timeout();
                     }
 

--- a/bam/deployment/src/test/java/io/quarkiverse/langchain4j/bam/deployment/DefaultPropertiesTest.java
+++ b/bam/deployment/src/test/java/io/quarkiverse/langchain4j/bam/deployment/DefaultPropertiesTest.java
@@ -5,8 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 
 import jakarta.inject.Inject;
 
@@ -64,7 +64,7 @@ public class DefaultPropertiesTest {
     void generate() throws Exception {
         var config = langchain4jBamConfig.defaultConfig();
 
-        assertEquals(Duration.ofSeconds(10), config.timeout());
+        assertEquals(Optional.empty(), config.timeout());
         assertEquals(WireMockUtil.VERSION, config.version());
         assertEquals(false, config.logRequests().orElse(false));
         assertEquals(false, config.logResponses().orElse(false));

--- a/bam/runtime/src/main/java/io/quarkiverse/langchain4j/bam/runtime/BamRecorder.java
+++ b/bam/runtime/src/main/java/io/quarkiverse/langchain4j/bam/runtime/BamRecorder.java
@@ -2,6 +2,7 @@ package io.quarkiverse.langchain4j.bam.runtime;
 
 import static io.quarkiverse.langchain4j.runtime.OptionalUtil.firstOrDefault;
 
+import java.time.Duration;
 import java.util.function.Supplier;
 
 import dev.langchain4j.model.chat.ChatLanguageModel;
@@ -42,7 +43,7 @@ public class BamRecorder {
 
             var builder = BamChatModel.builder()
                     .accessToken(bamConfig.apiKey())
-                    .timeout(bamConfig.timeout())
+                    .timeout(bamConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .logRequests(chatModelConfig.logRequests().orElse(false))
                     .logResponses(chatModelConfig.logResponses().orElse(false))
                     .modelId(chatModelConfig.modelId())
@@ -95,7 +96,7 @@ public class BamRecorder {
 
             var builder = BamStreamingChatModel.builder()
                     .accessToken(bamConfig.apiKey())
-                    .timeout(bamConfig.timeout())
+                    .timeout(bamConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .logRequests(chatModelConfig.logRequests().orElse(false))
                     .logResponses(chatModelConfig.logResponses().orElse(false))
                     .modelId(chatModelConfig.modelId())
@@ -148,7 +149,7 @@ public class BamRecorder {
 
             var builder = BamModel.builder()
                     .accessToken(bamConfig.apiKey())
-                    .timeout(bamConfig.timeout())
+                    .timeout(bamConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .version(bamConfig.version())
                     .modelId(embeddingModelConfig.modelId())
                     .logRequests(embeddingModelConfig.logRequests().orElse(false))
@@ -189,7 +190,7 @@ public class BamRecorder {
 
             var builder = BamModel.builder()
                     .accessToken(bamConfig.apiKey())
-                    .timeout(bamConfig.timeout())
+                    .timeout(bamConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .version(bamConfig.version())
                     .messagesToModerate(moderationModelConfig.messagesToModerate())
                     .hap(hap)

--- a/bam/runtime/src/main/java/io/quarkiverse/langchain4j/bam/runtime/config/LangChain4jBamConfig.java
+++ b/bam/runtime/src/main/java/io/quarkiverse/langchain4j/bam/runtime/config/LangChain4jBamConfig.java
@@ -53,8 +53,9 @@ public interface LangChain4jBamConfig {
         /**
          * Timeout for BAM calls
          */
-        @WithDefault("10s")
-        Duration timeout();
+        @ConfigDocDefault("10s")
+        @WithDefault("${quarkus.langchain4j.timeout}")
+        Optional<Duration> timeout();
 
         /**
          * Version to use

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/config/LangChain4jConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/config/LangChain4jConfig.java
@@ -2,6 +2,7 @@ package io.quarkiverse.langchain4j.runtime.config;
 
 import static io.quarkus.runtime.annotations.ConfigPhase.RUN_TIME;
 
+import java.time.Duration;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigDocDefault;
@@ -23,4 +24,10 @@ public interface LangChain4jConfig {
      */
     @ConfigDocDefault("false")
     Optional<Boolean> logResponses();
+
+    /**
+     * Global timeout for requests to LLM APIs
+     */
+    @ConfigDocDefault("10s")
+    Optional<Duration> timeout();
 }

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-anthropic.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-anthropic.adoc
@@ -93,7 +93,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_ANTHROPIC_TIMEOUT+++`
 endif::add-copy-button-to-env-var[]
 --|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
   link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
-|`10S`
+|`10s`
 
 
 a| [[quarkus-langchain4j-anthropic_quarkus-langchain4j-anthropic-log-requests]]`link:#quarkus-langchain4j-anthropic_quarkus-langchain4j-anthropic-log-requests[quarkus.langchain4j.anthropic.log-requests]`
@@ -377,7 +377,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_ANTHROPIC__MODEL_NAME__TIMEOUT+++`
 endif::add-copy-button-to-env-var[]
 --|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
   link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
-|`10S`
+|`10s`
 
 
 a| [[quarkus-langchain4j-anthropic_quarkus-langchain4j-anthropic-model-name-log-requests]]`link:#quarkus-langchain4j-anthropic_quarkus-langchain4j-anthropic-model-name-log-requests[quarkus.langchain4j.anthropic."model-name".log-requests]`

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-bam.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-bam.adoc
@@ -111,7 +111,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_BAM_TIMEOUT+++`
 endif::add-copy-button-to-env-var[]
 --|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
   link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
-|`10S`
+|`10s`
 
 
 a| [[quarkus-langchain4j-bam_quarkus-langchain4j-bam-version]]`link:#quarkus-langchain4j-bam_quarkus-langchain4j-bam-version[quarkus.langchain4j.bam.version]`
@@ -669,7 +669,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_BAM__MODEL_NAME__TIMEOUT+++`
 endif::add-copy-button-to-env-var[]
 --|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
   link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
-|`10S`
+|`10s`
 
 
 a| [[quarkus-langchain4j-bam_quarkus-langchain4j-bam-model-name-version]]`link:#quarkus-langchain4j-bam_quarkus-langchain4j-bam-model-name-version[quarkus.langchain4j.bam."model-name".version]`

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-huggingface.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-huggingface.adoc
@@ -93,7 +93,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_HUGGINGFACE_TIMEOUT+++`
 endif::add-copy-button-to-env-var[]
 --|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
   link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
-|`10S`
+|`10s`
 
 
 a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-chat-model-inference-endpoint-url]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-chat-model-inference-endpoint-url[quarkus.langchain4j.huggingface.chat-model.inference-endpoint-url]`
@@ -415,7 +415,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_HUGGINGFACE__MODEL_NAME__TIMEOUT++
 endif::add-copy-button-to-env-var[]
 --|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
   link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
-|`10S`
+|`10s`
 
 
 a| [[quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-chat-model-inference-endpoint-url]]`link:#quarkus-langchain4j-huggingface_quarkus-langchain4j-huggingface-model-name-chat-model-inference-endpoint-url[quarkus.langchain4j.huggingface."model-name".chat-model.inference-endpoint-url]`

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-mistralai.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-mistralai.adoc
@@ -93,7 +93,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_MISTRALAI_TIMEOUT+++`
 endif::add-copy-button-to-env-var[]
 --|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
   link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
-|`10S`
+|`10s`
 
 
 a| [[quarkus-langchain4j-mistralai_quarkus-langchain4j-mistralai-chat-model-model-name]]`link:#quarkus-langchain4j-mistralai_quarkus-langchain4j-mistralai-chat-model-model-name[quarkus.langchain4j.mistralai.chat-model.model-name]`
@@ -394,7 +394,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_MISTRALAI__MODEL_NAME__TIMEOUT+++`
 endif::add-copy-button-to-env-var[]
 --|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
   link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
-|`10S`
+|`10s`
 
 
 a| [[quarkus-langchain4j-mistralai_quarkus-langchain4j-mistralai-model-name-chat-model-model-name]]`link:#quarkus-langchain4j-mistralai_quarkus-langchain4j-mistralai-model-name-chat-model-model-name[quarkus.langchain4j.mistralai."model-name".chat-model.model-name]`

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-ollama.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-ollama.adoc
@@ -110,7 +110,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA_TIMEOUT+++`
 endif::add-copy-button-to-env-var[]
 --|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
   link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
-|`10S`
+|`10s`
 
 
 a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-log-requests]]`link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-log-requests[quarkus.langchain4j.ollama.log-requests]`
@@ -513,7 +513,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__TIMEOUT+++`
 endif::add-copy-button-to-env-var[]
 --|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
   link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
-|`10S`
+|`10s`
 
 
 a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-log-requests]]`link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-log-requests[quarkus.langchain4j.ollama."model-name".log-requests]`

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai.adoc
@@ -144,7 +144,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_TIMEOUT+++`
 endif::add-copy-button-to-env-var[]
 --|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
   link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
-|`10S`
+|`10s`
 
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-max-retries]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-max-retries[quarkus.langchain4j.openai.max-retries]`
@@ -763,7 +763,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__TIMEOUT+++`
 endif::add-copy-button-to-env-var[]
 --|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
   link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
-|`10S`
+|`10s`
 
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-max-retries]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-max-retries[quarkus.langchain4j.openai."model-name".max-retries]`

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-watsonx.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-watsonx.adoc
@@ -95,7 +95,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_TIMEOUT+++`
 endif::add-copy-button-to-env-var[]
 --|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
   link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
-|`10S`
+|`10s`
 
 
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-version]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-version[quarkus.langchain4j.watsonx.version]`
@@ -218,7 +218,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_IAM_TIMEOUT+++`
 endif::add-copy-button-to-env-var[]
 --|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
   link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
-|`10S`
+|`10s`
 
 
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-iam-grant-type]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-iam-grant-type[quarkus.langchain4j.watsonx.iam.grant-type]`
@@ -648,7 +648,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__TIMEOUT+++`
 endif::add-copy-button-to-env-var[]
 --|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
   link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
-|`10S`
+|`10s`
 
 
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-version]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-version[quarkus.langchain4j.watsonx."model-name".version]`
@@ -771,7 +771,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__IAM_TIMEOUT++
 endif::add-copy-button-to-env-var[]
 --|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
   link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
-|`10S`
+|`10s`
 
 
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-iam-grant-type]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-iam-grant-type[quarkus.langchain4j.watsonx."model-name".iam.grant-type]`

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j.adoc
@@ -97,6 +97,24 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
+a| [[quarkus-langchain4j_quarkus-langchain4j-timeout]]`link:#quarkus-langchain4j_quarkus-langchain4j-timeout[quarkus.langchain4j.timeout]`
+
+
+[.description]
+--
+Global timeout for requests to LLM APIs
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_TIMEOUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_TIMEOUT+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
+|`10s`
+
+
 h|[[quarkus-langchain4j_quarkus-langchain4j-default-config-default-model-config]]link:#quarkus-langchain4j_quarkus-langchain4j-default-config-default-model-config[Default model config]
 
 h|Type
@@ -243,3 +261,22 @@ endif::add-copy-button-to-env-var[]
 |
 
 |===
+ifndef::no-duration-note[]
+[NOTE]
+[id='duration-note-anchor-{summaryTableId}']
+.About the Duration format
+====
+To write duration values, use the standard `java.time.Duration` format.
+See the link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html#parse(java.lang.CharSequence)[Duration#parse() Java API documentation] for more information.
+
+You can also use a simplified format, starting with a number:
+
+* If the value is only a number, it represents time in seconds.
+* If the value is a number followed by `ms`, it represents time in milliseconds.
+
+In other cases, the simplified format is translated to the `java.time.Duration` format for parsing:
+
+* If the value is a number followed by `h`, `m`, or `s`, it is prefixed with `PT`.
+* If the value is a number followed by `d`, it is prefixed with `P`.
+====
+endif::no-duration-note[]

--- a/hugging-face/runtime/src/main/java/io/quarkiverse/langchain4j/huggingface/runtime/HuggingFaceRecorder.java
+++ b/hugging-face/runtime/src/main/java/io/quarkiverse/langchain4j/huggingface/runtime/HuggingFaceRecorder.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.langchain4j.huggingface.runtime;
 
 import java.net.URL;
+import java.time.Duration;
 import java.util.function.Supplier;
 
 import dev.langchain4j.model.chat.ChatLanguageModel;
@@ -37,7 +38,7 @@ public class HuggingFaceRecorder {
 
             var builder = QuarkusHuggingFaceChatModel.builder()
                     .url(url)
-                    .timeout(huggingFaceConfig.timeout())
+                    .timeout(huggingFaceConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .temperature(chatModelConfig.temperature())
                     .waitForModel(chatModelConfig.waitForModel())
                     .doSample(chatModelConfig.doSample())
@@ -89,7 +90,7 @@ public class HuggingFaceRecorder {
 
             var builder = QuarkusHuggingFaceEmbeddingModel.builder()
                     .url(url)
-                    .timeout(huggingFaceConfig.timeout())
+                    .timeout(huggingFaceConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .waitForModel(embeddingModelConfig.waitForModel());
 
             if (!DUMMY_KEY.equals(apiKey)) {

--- a/hugging-face/runtime/src/main/java/io/quarkiverse/langchain4j/huggingface/runtime/config/LangChain4jHuggingFaceConfig.java
+++ b/hugging-face/runtime/src/main/java/io/quarkiverse/langchain4j/huggingface/runtime/config/LangChain4jHuggingFaceConfig.java
@@ -46,8 +46,9 @@ public interface LangChain4jHuggingFaceConfig {
         /**
          * Timeout for HuggingFace calls
          */
-        @WithDefault("10s")
-        Duration timeout();
+        @ConfigDocDefault("10s")
+        @WithDefault("${quarkus.langchain4j.timeout}")
+        Optional<Duration> timeout();
 
         /**
          * Chat model related settings

--- a/integration-tests/ollama/src/main/resources/application.properties
+++ b/integration-tests/ollama/src/main/resources/application.properties
@@ -1,2 +1,2 @@
-quarkus.langchain4j.ollama.timeout=60s
+quarkus.langchain4j.timeout=60s
 quarkus.langchain4j.log-requests=true

--- a/integration-tests/openai/src/main/resources/application.properties
+++ b/integration-tests/openai/src/main/resources/application.properties
@@ -3,7 +3,7 @@ openai.key=ADD_A_TOKEN
 %test.quarkus.langchain4j.openai.base-url= https://mockgpt.wiremockapi.cloud/v1
 
 quarkus.langchain4j.openai.api-key=${openai.key}
-quarkus.langchain4j.openai.timeout=60s
+quarkus.langchain4j.timeout=60s
 quarkus.langchain4j.openai.log-requests=true
 %test.quarkus.langchain4j.openai.log-requests=false
 quarkus.langchain4j.openai.log-responses=true

--- a/mistral/runtime/src/main/java/io/quarkiverse/langchain4j/mistralai/runtime/MistralAiRecorder.java
+++ b/mistral/runtime/src/main/java/io/quarkiverse/langchain4j/mistralai/runtime/MistralAiRecorder.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.langchain4j.mistralai.runtime;
 
+import java.time.Duration;
 import java.util.function.Supplier;
 
 import dev.langchain4j.model.chat.ChatLanguageModel;
@@ -40,7 +41,7 @@ public class MistralAiRecorder {
                     .modelName(chatModelConfig.modelName())
                     .logRequests(chatModelConfig.logRequests().orElse(false))
                     .logResponses(chatModelConfig.logResponses().orElse(false))
-                    .timeout(mistralAiConfig.timeout());
+                    .timeout(mistralAiConfig.timeout().orElse(Duration.ofSeconds(10)));
 
             if (chatModelConfig.temperature().isPresent()) {
                 builder.temperature(chatModelConfig.temperature().getAsDouble());
@@ -93,7 +94,7 @@ public class MistralAiRecorder {
                     .modelName(chatModelConfig.modelName())
                     .logRequests(chatModelConfig.logRequests().orElse(false))
                     .logResponses(chatModelConfig.logResponses().orElse(false))
-                    .timeout(mistralAiConfig.timeout());
+                    .timeout(mistralAiConfig.timeout().orElse(Duration.ofSeconds(10)));
 
             if (chatModelConfig.temperature().isPresent()) {
                 builder.temperature(chatModelConfig.temperature().getAsDouble());
@@ -145,7 +146,7 @@ public class MistralAiRecorder {
                     .modelName(embeddingModelConfig.modelName())
                     .logRequests(embeddingModelConfig.logRequests().orElse(false))
                     .logResponses(embeddingModelConfig.logResponses().orElse(false))
-                    .timeout(mistralAiConfig.timeout());
+                    .timeout(mistralAiConfig.timeout().orElse(Duration.ofSeconds(10)));
 
             return new Supplier<>() {
                 @Override

--- a/mistral/runtime/src/main/java/io/quarkiverse/langchain4j/mistralai/runtime/config/LangChain4jMistralAiConfig.java
+++ b/mistral/runtime/src/main/java/io/quarkiverse/langchain4j/mistralai/runtime/config/LangChain4jMistralAiConfig.java
@@ -52,8 +52,9 @@ public interface LangChain4jMistralAiConfig {
         /**
          * Timeout for Mistral calls
          */
-        @WithDefault("10s")
-        Duration timeout();
+        @ConfigDocDefault("10s")
+        @WithDefault("${quarkus.langchain4j.timeout}")
+        Optional<Duration> timeout();
 
         /**
          * Chat model related settings

--- a/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/OllamaRecorder.java
+++ b/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/OllamaRecorder.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.langchain4j.ollama.runtime;
 
+import java.time.Duration;
 import java.util.function.Supplier;
 
 import dev.langchain4j.model.chat.ChatLanguageModel;
@@ -49,7 +50,7 @@ public class OllamaRecorder {
             }
             var builder = OllamaChatLanguageModel.builder()
                     .baseUrl(ollamaConfig.baseUrl().orElse(DEFAULT_BASE_URL))
-                    .timeout(ollamaConfig.timeout())
+                    .timeout(ollamaConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .logRequests(chatModelConfig.logRequests().orElse(false))
                     .logResponses(chatModelConfig.logResponses().orElse(false))
                     .model(ollamaFixedConfig.chatModel().modelId())
@@ -92,7 +93,7 @@ public class OllamaRecorder {
 
             var builder = OllamaEmbeddingModel.builder()
                     .baseUrl(ollamaConfig.baseUrl().orElse(DEFAULT_BASE_URL))
-                    .timeout(ollamaConfig.timeout())
+                    .timeout(ollamaConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .model(ollamaFixedConfig.embeddingModel().modelId())
                     .logRequests(embeddingModelConfig.logRequests().orElse(false))
                     .logResponses(embeddingModelConfig.logResponses().orElse(false));
@@ -138,7 +139,7 @@ public class OllamaRecorder {
             }
             var builder = OllamaStreamingChatLanguageModel.builder()
                     .baseUrl(ollamaConfig.baseUrl().orElse(DEFAULT_BASE_URL))
-                    .timeout(ollamaConfig.timeout())
+                    .timeout(ollamaConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .logRequests(ollamaConfig.logRequests().orElse(false))
                     .logResponses(ollamaConfig.logResponses().orElse(false))
                     .model(ollamaFixedConfig.chatModel().modelId())

--- a/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/config/LangChain4jOllamaConfig.java
+++ b/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/config/LangChain4jOllamaConfig.java
@@ -43,8 +43,9 @@ public interface LangChain4jOllamaConfig {
         /**
          * Timeout for Ollama calls
          */
-        @WithDefault("10s")
-        Duration timeout();
+        @ConfigDocDefault("10s")
+        @WithDefault("${quarkus.langchain4j.timeout}")
+        Optional<Duration> timeout();
 
         /**
          * Whether the Ollama client should log requests

--- a/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
+++ b/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
@@ -2,6 +2,7 @@ package io.quarkiverse.langchain4j.azure.openai.runtime;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -50,7 +51,7 @@ public class AzureOpenAiRecorder {
                     .apiKey(apiKey)
                     .adToken(adToken)
                     .apiVersion(azureAiConfig.apiVersion())
-                    .timeout(azureAiConfig.timeout())
+                    .timeout(azureAiConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .maxRetries(azureAiConfig.maxRetries())
                     .logRequests(chatModelConfig.logRequests().orElse(false))
                     .logResponses(chatModelConfig.logResponses().orElse(false))
@@ -96,7 +97,7 @@ public class AzureOpenAiRecorder {
                     .apiKey(apiKey)
                     .adToken(adToken)
                     .apiVersion(azureAiConfig.apiVersion())
-                    .timeout(azureAiConfig.timeout())
+                    .timeout(azureAiConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .logRequests(chatModelConfig.logRequests().orElse(false))
                     .logResponses(chatModelConfig.logResponses().orElse(false))
                     .temperature(chatModelConfig.temperature())
@@ -140,7 +141,7 @@ public class AzureOpenAiRecorder {
                     .apiKey(apiKey)
                     .adToken(apiKey)
                     .apiVersion(azureAiConfig.apiVersion())
-                    .timeout(azureAiConfig.timeout())
+                    .timeout(azureAiConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .maxRetries(azureAiConfig.maxRetries())
                     .logRequests(embeddingModelConfig.logRequests().orElse(false))
                     .logResponses(embeddingModelConfig.logResponses().orElse(false));
@@ -175,7 +176,7 @@ public class AzureOpenAiRecorder {
                     .apiKey(apiKey)
                     .adToken(adToken)
                     .apiVersion(azureAiConfig.apiVersion())
-                    .timeout(azureAiConfig.timeout())
+                    .timeout(azureAiConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .maxRetries(azureAiConfig.maxRetries())
                     .logRequests(imageModelConfig.logRequests().orElse(false))
                     .logResponses(imageModelConfig.logResponses().orElse(false))

--- a/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/LangChain4jAzureOpenAiConfig.java
+++ b/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/LangChain4jAzureOpenAiConfig.java
@@ -89,8 +89,9 @@ public interface LangChain4jAzureOpenAiConfig {
         /**
          * Timeout for OpenAI calls
          */
-        @WithDefault("10s")
-        Duration timeout();
+        @ConfigDocDefault("10s")
+        @WithDefault("${quarkus.langchain4j.timeout}")
+        Optional<Duration> timeout();
 
         /**
          * The maximum number of times to retry. 1 means exactly one attempt, with retrying disabled.

--- a/openai/azure-openai/runtime/src/test/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorderEndpointTests.java
+++ b/openai/azure-openai/runtime/src/test/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorderEndpointTests.java
@@ -158,8 +158,8 @@ class AzureOpenAiRecorderEndpointTests {
         }
 
         @Override
-        public Duration timeout() {
-            return null;
+        public Optional<Duration> timeout() {
+            return Optional.empty();
         }
 
         @Override

--- a/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
+++ b/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
@@ -2,6 +2,7 @@ package io.quarkiverse.langchain4j.openai.runtime;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -49,7 +50,7 @@ public class OpenAiRecorder {
             var builder = OpenAiChatModel.builder()
                     .baseUrl(openAiConfig.baseUrl())
                     .apiKey(apiKey)
-                    .timeout(openAiConfig.timeout())
+                    .timeout(openAiConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .maxRetries(openAiConfig.maxRetries())
                     .logRequests(chatModelConfig.logRequests().orElse(false))
                     .logResponses(chatModelConfig.logResponses().orElse(false))
@@ -94,7 +95,7 @@ public class OpenAiRecorder {
             var builder = OpenAiStreamingChatModel.builder()
                     .baseUrl(openAiConfig.baseUrl())
                     .apiKey(apiKey)
-                    .timeout(openAiConfig.timeout())
+                    .timeout(openAiConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .logRequests(chatModelConfig.logRequests().orElse(false))
                     .logResponses(chatModelConfig.logResponses().orElse(false))
                     .modelName(chatModelConfig.modelName())
@@ -138,7 +139,7 @@ public class OpenAiRecorder {
             var builder = OpenAiEmbeddingModel.builder()
                     .baseUrl(openAiConfig.baseUrl())
                     .apiKey(apiKey)
-                    .timeout(openAiConfig.timeout())
+                    .timeout(openAiConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .maxRetries(openAiConfig.maxRetries())
                     .logRequests(embeddingModelConfig.logRequests().orElse(false))
                     .logResponses(embeddingModelConfig.logResponses().orElse(false))
@@ -178,7 +179,7 @@ public class OpenAiRecorder {
             var builder = OpenAiModerationModel.builder()
                     .baseUrl(openAiConfig.baseUrl())
                     .apiKey(apiKey)
-                    .timeout(openAiConfig.timeout())
+                    .timeout(openAiConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .maxRetries(openAiConfig.maxRetries())
                     .logRequests(moderationModelConfig.logRequests().orElse(false))
                     .logResponses(moderationModelConfig.logResponses().orElse(false))
@@ -214,7 +215,7 @@ public class OpenAiRecorder {
             var builder = QuarkusOpenAiImageModel.builder()
                     .baseUrl(openAiConfig.baseUrl())
                     .apiKey(apiKey)
-                    .timeout(openAiConfig.timeout())
+                    .timeout(openAiConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .maxRetries(openAiConfig.maxRetries())
                     .logRequests(imageModelConfig.logRequests().orElse(false))
                     .logResponses(imageModelConfig.logResponses().orElse(false))

--- a/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/LangChain4jOpenAiConfig.java
+++ b/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/LangChain4jOpenAiConfig.java
@@ -58,8 +58,9 @@ public interface LangChain4jOpenAiConfig {
         /**
          * Timeout for OpenAI calls
          */
-        @WithDefault("10s")
-        Duration timeout();
+        @ConfigDocDefault("10s")
+        @WithDefault("${quarkus.langchain4j.timeout}")
+        Optional<Duration> timeout();
 
         /**
          * The maximum number of times to retry. 1 means exactly one attempt, with retrying disabled.

--- a/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/devui/OpenAiImagesJsonRPCService.java
+++ b/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/devui/OpenAiImagesJsonRPCService.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.langchain4j.openai.runtime.devui;
 
+import java.time.Duration;
 import java.util.Optional;
 
 import jakarta.inject.Inject;
@@ -27,7 +28,7 @@ public class OpenAiImagesJsonRPCService {
         ImageModel model = QuarkusOpenAiImageModel.builder()
                 .baseUrl(clientConfig.baseUrl())
                 .apiKey(clientConfig.apiKey())
-                .timeout(clientConfig.timeout())
+                .timeout(clientConfig.timeout().orElse(Duration.ofSeconds(10)))
                 .user(clientConfig.imageModel().user())
                 .maxRetries(clientConfig.maxRetries())
                 .persistDirectory(Optional.empty())

--- a/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/devui/OpenAiModerationModelsJsonRPCService.java
+++ b/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/devui/OpenAiModerationModelsJsonRPCService.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.langchain4j.openai.runtime.devui;
 
+import java.time.Duration;
+
 import jakarta.inject.Inject;
 
 import dev.ai4j.openai4j.OpenAiClient;
@@ -28,8 +30,10 @@ public class OpenAiModerationModelsJsonRPCService {
         LangChain4jOpenAiConfig.OpenAiConfig clientConfig = NamedConfigUtil.isDefault(configuration) ? config.defaultConfig()
                 : config.namedConfig().get(configuration);
         OpenAiClient client = OpenAiClient.builder().openAiApiKey(clientConfig.apiKey()).baseUrl(clientConfig.baseUrl())
-                .callTimeout(clientConfig.timeout()).connectTimeout(clientConfig.timeout())
-                .readTimeout(clientConfig.timeout()).writeTimeout(clientConfig.timeout()).build();
+                .callTimeout(clientConfig.timeout().orElse(Duration.ofSeconds(10)))
+                .connectTimeout(clientConfig.timeout().orElse(Duration.ofSeconds(10)))
+                .readTimeout(clientConfig.timeout().orElse(Duration.ofSeconds(10)))
+                .writeTimeout(clientConfig.timeout().orElse(Duration.ofSeconds(10))).build();
         try {
             ModerationRequest request = ModerationRequest.builder().model(modelName).input(prompt).build();
             ModerationResponse response = RetryUtils.withRetry(() -> client.moderation(request).execute(),

--- a/openshift-ai/runtime/src/main/java/io/quarkiverse/langchain4j/openshiftai/runtime/OpenshiftAiRecorder.java
+++ b/openshift-ai/runtime/src/main/java/io/quarkiverse/langchain4j/openshiftai/runtime/OpenshiftAiRecorder.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.langchain4j.openshiftai.runtime;
 
 import java.net.URL;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
@@ -46,7 +47,7 @@ public class OpenshiftAiRecorder {
 
             var builder = OpenshiftAiChatModel.builder()
                     .url(baseUrl)
-                    .timeout(openshiftAiConfig.timeout())
+                    .timeout(openshiftAiConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .logRequests(chatModelConfig.logRequests().orElse(false))
                     .logResponses(chatModelConfig.logResponses().orElse(false))
                     .modelId(modelId);

--- a/openshift-ai/runtime/src/main/java/io/quarkiverse/langchain4j/openshiftai/runtime/config/LangChain4jOpenshiftAiConfig.java
+++ b/openshift-ai/runtime/src/main/java/io/quarkiverse/langchain4j/openshiftai/runtime/config/LangChain4jOpenshiftAiConfig.java
@@ -48,8 +48,9 @@ public interface LangChain4jOpenshiftAiConfig {
         /**
          * Timeout for OpenShift AI calls
          */
-        @WithDefault("10s")
-        Duration timeout();
+        @ConfigDocDefault("10s")
+        @WithDefault("${quarkus.langchain4j.timeout}")
+        Optional<Duration> timeout();
 
         /**
          * Whether the OpenShift AI client should log requests

--- a/samples/email-a-poem/src/main/resources/application.properties
+++ b/samples/email-a-poem/src/main/resources/application.properties
@@ -1,6 +1,6 @@
-quarkus.langchain4j.openai.timeout=60s
-quarkus.langchain4j.openai.log-requests=true
-quarkus.langchain4j.openai.log-responses=true
+quarkus.langchain4j.timeout=60s
+quarkus.langchain4j.log-requests=true
+quarkus.langchain4j.log-responses=true
 
 quarkus.mailer.from=acme@acme.org
 quarkus.mailer.port=1025

--- a/samples/fraud-detection/src/main/resources/application.properties
+++ b/samples/fraud-detection/src/main/resources/application.properties
@@ -2,7 +2,7 @@ quarkus.langchain4j.openai.chat-model.temperature=0
 
 # For distance fraud detection ChatGPT 3.5 does not work, so we use GPT-4
 # Also we need to increase the timeout to 120s
-quarkus.langchain4j.openai.timeout=120s
+quarkus.langchain4j.timeout=120s
 quarkus.langchain4j.openai.chat-model.model-name=gpt-4o
 
 #quarkus.langchain4j.openai.log-requests=true

--- a/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/AllPropertiesTest.java
+++ b/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/AllPropertiesTest.java
@@ -111,8 +111,8 @@ public class AllPropertiesTest {
         assertEquals(WireMockUtil.URL_IAM_SERVER, config.iam().baseUrl().toString());
         assertEquals(WireMockUtil.API_KEY, config.apiKey());
         assertEquals(WireMockUtil.PROJECT_ID, config.projectId());
-        assertEquals(Duration.ofSeconds(60), config.timeout());
-        assertEquals(Duration.ofSeconds(60), config.iam().timeout());
+        assertEquals(Duration.ofSeconds(60), config.timeout().get());
+        assertEquals(Duration.ofSeconds(60), config.iam().timeout().get());
         assertEquals("grantME", config.iam().grantType());
         assertEquals(true, config.logRequests().orElse(false));
         assertEquals(true, config.logResponses().orElse(false));

--- a/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/DefaultPropertiesTest.java
+++ b/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/DefaultPropertiesTest.java
@@ -4,8 +4,8 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.time.Duration;
 import java.util.Date;
+import java.util.Optional;
 
 import jakarta.inject.Inject;
 
@@ -70,7 +70,7 @@ public class DefaultPropertiesTest {
     @Test
     void generate() throws Exception {
         var config = langchain4jWatsonConfig.defaultConfig();
-        assertEquals(Duration.ofSeconds(10), config.timeout());
+        assertEquals(Optional.empty(), config.timeout());
         assertEquals(WireMockUtil.VERSION, config.version());
         assertEquals(false, config.logRequests().orElse(false));
         assertEquals(false, config.logResponses().orElse(false));
@@ -86,7 +86,7 @@ public class DefaultPropertiesTest {
         assertTrue(config.chatModel().repetitionPenalty().isEmpty());
         assertTrue(config.chatModel().truncateInputTokens().isEmpty());
         assertTrue(config.chatModel().includeStopSequence().isEmpty());
-        assertEquals(Duration.ofSeconds(10), config.iam().timeout());
+        assertEquals(Optional.empty(), config.iam().timeout());
         assertEquals("urn:ibm:params:oauth:grant-type:apikey", config.iam().grantType());
         assertEquals(WireMockUtil.DEFAULT_EMBEDDING_MODEL, config.embeddingModel().modelId());
 

--- a/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/WatsonxRecorder.java
+++ b/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/WatsonxRecorder.java
@@ -3,6 +3,7 @@ package io.quarkiverse.langchain4j.watsonx.runtime;
 import static io.quarkiverse.langchain4j.runtime.OptionalUtil.firstOrDefault;
 
 import java.net.URL;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -112,7 +113,7 @@ public class WatsonxRecorder {
             var builder = WatsonxEmbeddingModel.builder()
                     .tokenGenerator(tokenGenerator)
                     .url(url)
-                    .timeout(watsonConfig.timeout())
+                    .timeout(watsonConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .logRequests(embeddingModelConfig.logRequests().orElse(false))
                     .logResponses(embeddingModelConfig.logResponses().orElse(false))
                     .version(watsonConfig.version())
@@ -141,7 +142,8 @@ public class WatsonxRecorder {
 
             @Override
             public TokenGenerator apply(String iamUrl) {
-                return new TokenGenerator(iamConfig.baseUrl(), iamConfig.timeout(), iamConfig.grantType(), apiKey);
+                return new TokenGenerator(iamConfig.baseUrl(), iamConfig.timeout().orElse(Duration.ofSeconds(10)),
+                        iamConfig.grantType(), apiKey);
             }
         };
     }
@@ -177,7 +179,7 @@ public class WatsonxRecorder {
         return WatsonxChatModel.builder()
                 .tokenGenerator(tokenGenerator)
                 .url(url)
-                .timeout(watsonConfig.timeout())
+                .timeout(watsonConfig.timeout().orElse(Duration.ofSeconds(10)))
                 .logRequests(chatModelConfig.logRequests().orElse(false))
                 .logResponses(chatModelConfig.logResponses().orElse(false))
                 .version(watsonConfig.version())

--- a/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/IAMConfig.java
+++ b/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/IAMConfig.java
@@ -2,7 +2,9 @@ package io.quarkiverse.langchain4j.watsonx.runtime.config;
 
 import java.net.URL;
 import java.time.Duration;
+import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
@@ -18,8 +20,9 @@ public interface IAMConfig {
     /**
      * Timeout for IAM authentication calls.
      */
-    @WithDefault("10s")
-    Duration timeout();
+    @ConfigDocDefault("10s")
+    @WithDefault("${quarkus.langchain4j.timeout}")
+    Optional<Duration> timeout();
 
     /**
      * Grant type for the IAM Authentication API.

--- a/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/LangChain4jWatsonxConfig.java
+++ b/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/LangChain4jWatsonxConfig.java
@@ -54,8 +54,9 @@ public interface LangChain4jWatsonxConfig {
         /**
          * Timeout for watsonx.ai calls.
          */
-        @WithDefault("10s")
-        Duration timeout();
+        @ConfigDocDefault("10s")
+        @WithDefault("${quarkus.langchain4j.timeout}")
+        Optional<Duration> timeout();
 
         /**
          * The version date for the API of the form YYYY-MM-DD.


### PR DESCRIPTION
This is useful so users don't have to change to
provider specific configuration (in the same way
we've already done for logging requests / responses)