### PR TITLE
Segregate memory of concurrent requests to different AI services

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
@@ -346,7 +346,8 @@ public class AiServiceMethodImplementationSupport {
             for (DefaultMemoryIdProvider provider : DEFAULT_MEMORY_ID_PROVIDERS) {
                 Object memoryId = provider.getMemoryId();
                 if (memoryId != null) {
-                    return memoryId;
+                    String perServiceSuffix = "#" + createInfo.getInterfaceName() + "." + createInfo.getMethodName();
+                    return memoryId + perServiceSuffix;
                 }
             }
         }

--- a/websockets-next/tests/src/test/java/io/quarkiverse/langchain4j/websockets/next/tests/WebSocketsNextTest.java
+++ b/websockets-next/tests/src/test/java/io/quarkiverse/langchain4j/websockets/next/tests/WebSocketsNextTest.java
@@ -32,7 +32,6 @@ import dev.langchain4j.store.memory.chat.InMemoryChatMemoryStore;
 import io.quarkiverse.langchain4j.RegisterAiService;
 import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
 import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
-import io.quarkus.arc.InjectableContext;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.websockets.next.OnOpen;
@@ -77,7 +76,7 @@ public class WebSocketsNextTest extends OpenAiBaseTest {
                 .statusCode(200);
 
         assertThat(chatMemoryStore.idsFromGetMessages).hasSize(1)
-                .hasOnlyElementsOfType(InjectableContext.ContextState.class);
+                .hasOnlyElementsOfType(String.class);
         assertThat(chatMemoryStore.idsFromGetMessages).hasSameElementsAs(chatMemoryStore.idsFromDeleteMessaged);
 
         when()
@@ -86,7 +85,7 @@ public class WebSocketsNextTest extends OpenAiBaseTest {
                 .statusCode(200);
 
         assertThat(chatMemoryStore.idsFromGetMessages).hasSize(2)
-                .hasOnlyElementsOfType(InjectableContext.ContextState.class);
+                .hasOnlyElementsOfType(String.class);
         assertThat(chatMemoryStore.idsFromGetMessages).hasSameElementsAs(chatMemoryStore.idsFromDeleteMessaged);
     }
 


### PR DESCRIPTION
This is done by adding the name of the interface and method to the name given by the provider