### PR TITLE
Properly configure for embedding model

### DIFF
--- a/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
+++ b/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
@@ -139,7 +139,7 @@ public class AzureOpenAiRecorder {
             var builder = AzureOpenAiEmbeddingModel.builder()
                     .endpoint(getEndpoint(azureAiConfig, configName))
                     .apiKey(apiKey)
-                    .adToken(apiKey)
+                    .adToken(adToken)
                     .apiVersion(azureAiConfig.apiVersion())
                     .timeout(azureAiConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .maxRetries(azureAiConfig.maxRetries())


### PR DESCRIPTION
Fixes wrong configuration being passed while initializing Azure Embeddings client.