### PR TITLE
Allow multi-deployment configuration for Azure OpenAI

### DIFF
--- a/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/ChatModelConfig.java
+++ b/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/ChatModelConfig.java
@@ -8,6 +8,23 @@ import io.smallrye.config.WithDefault;
 
 @ConfigGroup
 public interface ChatModelConfig {
+    /**
+     * This property will override the {@code quarkus.langchain4j.azure-openai.resource-name}
+     * specifically for chat models if it is set.
+     */
+    Optional<String> resourceName();
+
+    /**
+     * This property will override the {@code quarkus.langchain4j.azure-openai.deployment-name}
+     * specifically for chat models if it is set.
+     */
+    Optional<String> deploymentName();
+
+    /**
+     * This property will override the {@code quarkus.langchain4j.azure-openai.endpoint}
+     * specifically for chat models if it is set.
+     */
+    Optional<String> endpoint();
 
     /**
      * What sampling temperature to use, with values between 0 and 2.

--- a/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/EmbeddingModelConfig.java
+++ b/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/EmbeddingModelConfig.java
@@ -8,6 +8,23 @@ import io.smallrye.config.WithDefault;
 
 @ConfigGroup
 public interface EmbeddingModelConfig {
+    /**
+     * This property will override the {@code quarkus.langchain4j.azure-openai.resource-name}
+     * specifically for embedding models if it is set.
+     */
+    Optional<String> resourceName();
+
+    /**
+     * This property will override the {@code quarkus.langchain4j.azure-openai.deployment-name}
+     * specifically for embedding models if it is set.
+     */
+    Optional<String> deploymentName();
+
+    /**
+     * This property will override the {@code quarkus.langchain4j.azure-openai.endpoint}
+     * specifically for embedding models if it is set.
+     */
+    Optional<String> endpoint();
 
     /**
      * Whether embedding model requests should be logged

--- a/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/ImageModelConfig.java
+++ b/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/ImageModelConfig.java
@@ -9,6 +9,23 @@ import io.smallrye.config.WithDefault;
 
 @ConfigGroup
 public interface ImageModelConfig {
+    /**
+     * This property will override the {@code quarkus.langchain4j.azure-openai.resource-name}
+     * specifically for image models if it is set.
+     */
+    Optional<String> resourceName();
+
+    /**
+     * This property will override the {@code quarkus.langchain4j.azure-openai.deployment-name}
+     * specifically for image models if it is set.
+     */
+    Optional<String> deploymentName();
+
+    /**
+     * This property will override the {@code quarkus.langchain4j.azure-openai.endpoint}
+     * specifically for image models if it is set.
+     */
+    Optional<String> endpoint();
 
     /**
      * Model name to use

--- a/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/LangChain4jAzureOpenAiConfig.java
+++ b/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/LangChain4jAzureOpenAiConfig.java
@@ -5,6 +5,7 @@ import static io.quarkus.runtime.annotations.ConfigPhase.RUN_TIME;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
@@ -137,5 +138,53 @@ public interface LangChain4jAzureOpenAiConfig {
          * Image model related settings
          */
         ImageModelConfig imageModel();
+
+        default Optional<String> endPointFor(EndpointType type) {
+            var deepEndpoint = switch (type) {
+                case CHAT -> chatModel().endpoint();
+                case EMBEDDING -> embeddingModel().endpoint();
+                case IMAGE -> imageModel().endpoint();
+            };
+            return deepEndpoint.or(new Supplier<Optional<String>>() {
+                @Override
+                public Optional<String> get() {
+                    return endpoint();
+                }
+            });
+        }
+
+        default Optional<String> resourceNameFor(EndpointType type) {
+            var deepResourceName = switch (type) {
+                case CHAT -> chatModel().resourceName();
+                case EMBEDDING -> embeddingModel().resourceName();
+                case IMAGE -> imageModel().resourceName();
+            };
+            return deepResourceName.or(new Supplier<Optional<String>>() {
+                @Override
+                public Optional<String> get() {
+                    return resourceName();
+                }
+            });
+        }
+
+        default Optional<String> deploymentNameFor(EndpointType type) {
+            var deepDeploymentName = switch (type) {
+                case CHAT -> chatModel().deploymentName();
+                case EMBEDDING -> embeddingModel().deploymentName();
+                case IMAGE -> imageModel().deploymentName();
+            };
+            return deepDeploymentName.or(new Supplier<Optional<String>>() {
+                @Override
+                public Optional<String> get() {
+                    return deploymentName();
+                }
+            });
+        }
+
+        enum EndpointType {
+            CHAT,
+            EMBEDDING,
+            IMAGE
+        }
     }
 }

--- a/openai/azure-openai/runtime/src/test/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorderEndpointTests.java
+++ b/openai/azure-openai/runtime/src/test/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorderEndpointTests.java
@@ -26,7 +26,7 @@ class AzureOpenAiRecorderEndpointTests {
     @Test
     void noEndpointConfigSet() {
         var configValidationException = catchThrowableOfType(() -> AzureOpenAiRecorder.getEndpoint(this.config,
-                NamedConfigUtil.DEFAULT_NAME),
+                NamedConfigUtil.DEFAULT_NAME, LangChain4jAzureOpenAiConfig.AzureAiConfig.EndpointType.CHAT),
                 ConfigValidationException.class);
 
         assertThat(configValidationException.getProblemCount())
@@ -50,7 +50,7 @@ class AzureOpenAiRecorderEndpointTests {
                 .resourceName();
 
         var configValidationException = catchThrowableOfType(() -> AzureOpenAiRecorder.getEndpoint(this.config,
-                NamedConfigUtil.DEFAULT_NAME),
+                NamedConfigUtil.DEFAULT_NAME, LangChain4jAzureOpenAiConfig.AzureAiConfig.EndpointType.CHAT),
                 ConfigValidationException.class);
 
         assertThat(configValidationException.getProblemCount())
@@ -69,7 +69,7 @@ class AzureOpenAiRecorderEndpointTests {
                 .deploymentName();
 
         var configValidationException = catchThrowableOfType(() -> AzureOpenAiRecorder.getEndpoint(this.config,
-                NamedConfigUtil.DEFAULT_NAME),
+                NamedConfigUtil.DEFAULT_NAME, LangChain4jAzureOpenAiConfig.AzureAiConfig.EndpointType.CHAT),
                 ConfigValidationException.class);
 
         assertThat(configValidationException.getProblemCount())
@@ -87,7 +87,8 @@ class AzureOpenAiRecorderEndpointTests {
                 .when(this.config)
                 .endpoint();
 
-        assertThat(AzureOpenAiRecorder.getEndpoint(this.config, NamedConfigUtil.DEFAULT_NAME))
+        assertThat(AzureOpenAiRecorder.getEndpoint(this.config, NamedConfigUtil.DEFAULT_NAME,
+                LangChain4jAzureOpenAiConfig.AzureAiConfig.EndpointType.CHAT))
                 .isNotNull()
                 .isEqualTo("https://somewhere.com");
     }
@@ -102,7 +103,8 @@ class AzureOpenAiRecorderEndpointTests {
                 .when(this.config)
                 .deploymentName();
 
-        assertThat(AzureOpenAiRecorder.getEndpoint(this.config, NamedConfigUtil.DEFAULT_NAME))
+        assertThat(AzureOpenAiRecorder.getEndpoint(this.config, NamedConfigUtil.DEFAULT_NAME,
+                LangChain4jAzureOpenAiConfig.AzureAiConfig.EndpointType.CHAT))
                 .isNotNull()
                 .isEqualTo(String.format(AzureOpenAiRecorder.AZURE_ENDPOINT_URL_PATTERN, "resourceName", "deploymentName"));
     }
@@ -186,6 +188,21 @@ class AzureOpenAiRecorderEndpointTests {
         public ChatModelConfig chatModel() {
             return new ChatModelConfig() {
                 @Override
+                public Optional<String> resourceName() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> deploymentName() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> endpoint() {
+                    return Optional.empty();
+                }
+
+                @Override
                 public Double temperature() {
                     return null;
                 }
@@ -232,6 +249,21 @@ class AzureOpenAiRecorderEndpointTests {
         public EmbeddingModelConfig embeddingModel() {
             return new EmbeddingModelConfig() {
                 @Override
+                public Optional<String> resourceName() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> deploymentName() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> endpoint() {
+                    return Optional.empty();
+                }
+
+                @Override
                 public Optional<Boolean> logRequests() {
                     return Optional.empty();
                 }
@@ -246,6 +278,21 @@ class AzureOpenAiRecorderEndpointTests {
         @Override
         public ImageModelConfig imageModel() {
             return new ImageModelConfig() {
+                @Override
+                public Optional<String> resourceName() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> deploymentName() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> endpoint() {
+                    return Optional.empty();
+                }
+
                 @Override
                 public String modelName() {
                     return null;


### PR DESCRIPTION
Relevant to #237, this will allow overriding the following properties per model in the Azure OpenAI configuration

- `endpoint`
- `resource-name`
- `deployment-name`

Example configuration that is now possible:

```properties
quarkus.langchain4j.azure-openai.ad-token=token
quarkus.langchain4j.azure-openai.api-version=2023-07-01-preview
quarkus.langchain4j.azure-openai.chat-model.enabled=true
quarkus.langchain4j.azure-openai.deployment-name=my-deployment-name
quarkus.langchain4j.azure-openai.embedding-model.enabled=true
quarkus.langchain4j.azure-openai.resource-name=name
quarkus.langchain4j.azure-openai.embedding-model.deployment-name=another-deployment-name
```

In ht e above example, all models in the parent configuration will have the `my-deployment-name`, but the Embedding model will have the `another-deployment-name` specifically as a name. 