### PR TITLE
Allow creating and launching an OpenWebUI container via Dev UI 

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/devui/AdditionalDevUiCardBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/devui/AdditionalDevUiCardBuildItem.java
@@ -1,0 +1,41 @@
+package io.quarkiverse.langchain4j.deployment.devui;
+
+import java.util.Collections;
+import java.util.Map;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class AdditionalDevUiCardBuildItem extends MultiBuildItem {
+
+    private final String title;
+    private final String icon;
+    private final String componentLink;
+    private final Map<String, Object> buildTimeData;
+
+    public AdditionalDevUiCardBuildItem(String title, String icon, String componentLink) {
+        this(title, icon, componentLink, Collections.emptyMap());
+    }
+
+    public AdditionalDevUiCardBuildItem(String title, String icon, String componentLink, Map<String, Object> buildTimeData) {
+        this.title = title;
+        this.icon = icon;
+        this.componentLink = componentLink;
+        this.buildTimeData = buildTimeData;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getIcon() {
+        return icon;
+    }
+
+    public String getComponentLink() {
+        return componentLink;
+    }
+
+    public Map<String, Object> getBuildTimeData() {
+        return buildTimeData;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/devui/LangChain4jDevUIProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/devui/LangChain4jDevUIProcessor.java
@@ -33,7 +33,8 @@ public class LangChain4jDevUIProcessor {
             List<InProcessEmbeddingBuildItem> inProcessEmbeddingModelBuildItems,
             List<EmbeddingStoreBuildItem> embeddingStoreBuildItem,
             List<SelectedChatModelProviderBuildItem> chatModelProviders,
-            Optional<InMemoryEmbeddingStoreBuildItem> inMemoryEmbeddingStoreBuildItem) {
+            Optional<InMemoryEmbeddingStoreBuildItem> inMemoryEmbeddingStoreBuildItem,
+            List<AdditionalDevUiCardBuildItem> additionalDevUiCardBuildItems) {
         CardPageBuildItem card = new CardPageBuildItem();
         addAiServicesPage(card, aiServices);
         if (toolsMetadataBuildItem != null) {
@@ -49,6 +50,15 @@ public class LangChain4jDevUIProcessor {
         }
         if (!chatModelProviders.isEmpty()) {
             addChatPage(card, aiServices);
+        }
+
+        for (AdditionalDevUiCardBuildItem additionalDevUiCardBuildItem : additionalDevUiCardBuildItems) {
+            card.addPage(Page.webComponentPageBuilder()
+                    .title(additionalDevUiCardBuildItem.getTitle())
+                    .icon(additionalDevUiCardBuildItem.getIcon())
+                    .componentLink(additionalDevUiCardBuildItem.getComponentLink()));
+
+            additionalDevUiCardBuildItem.getBuildTimeData().forEach((k, v) -> card.addBuildTimeData(k, v));
         }
         return card;
     }

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/devui/OpenWebUIDevUIProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/devui/OpenWebUIDevUIProcessor.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.langchain4j.deployment.devui;
+
+import io.quarkiverse.langchain4j.runtime.devui.OpenWebUIJsonRPCService;
+import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
+import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
+
+public final class OpenWebUIDevUIProcessor {
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    void registerOpenWebUiCard(BuildProducer<JsonRPCProvidersBuildItem> jsonRPCProviders,
+            CuratedApplicationShutdownBuildItem closeBuildItem) {
+        jsonRPCProviders.produce(new JsonRPCProvidersBuildItem(OpenWebUIJsonRPCService.class));
+        closeBuildItem.addCloseTask(OpenWebUIJsonRPCService.CLOSE_TASK, true);
+    }
+}

--- a/core/deployment/src/main/resources/dev-ui/qwc-open-webui.js
+++ b/core/deployment/src/main/resources/dev-ui/qwc-open-webui.js
@@ -1,0 +1,379 @@
+import { LitElement, html, css } from 'lit';
+import { JsonRpc } from 'jsonrpc';
+import '@vaadin/checkbox';
+import '@vaadin/progress-bar';
+import { envVarMappings } from 'build-time-data';
+
+class OpenWebUI extends LitElement {
+
+  jsonRpc = new JsonRpc(this);
+
+  static styles = css`
+  :host {
+    margin: 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: left;
+    justify-content: center;
+    font-family: Arial, sans-serif;
+  }
+  div {
+    background-color: #f9f9f9;
+    padding: 20px;
+    border-radius: 5px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.1);
+  }
+  label {
+    font-weight: bold;
+  }
+  .large-input {
+    width: 500px;
+  }
+  button {
+    padding: 10px 20px;
+    border: none;
+    border-radius: 5px;
+    background-color: #007BFF;
+    color: white;
+    cursor: pointer;
+  }
+  button:hover {
+    background-color: #0056b3;
+  }
+  button:disabled {
+    background-color: #cccccc;
+    cursor: not-allowed;
+  }
+  
+  button:disabled:hover {
+    background-color: #cccccc;
+  }
+  h2 {
+    color: #333;
+  }
+  a {
+    color: #007BFF;
+    text-decoration: none;
+  }
+  a:hover {
+    text-decoration: underline;
+  }
+  .hide {
+      visibility: hidden;
+  }
+  .show {
+      visibility: visible;
+  }    
+  `;
+
+   static properties = {
+       container: {state: true},
+       image: {state: true},
+       requestGpu: {state: true},
+       portBindings: {state: true},
+       envVars: {state: true},
+       envVarMappings: {state: true},
+       volumes: {state: true},
+       url: {state: true},
+       signedUp: {state: true},
+       autoSingup: {state: true},
+       username: {state: true},
+       email: {state: true},
+       password: {state: true},
+       _progressBarClass: {state: true},
+   }
+
+   constructor() {
+    super();
+    this.image = "ghcr.io/open-webui/open-webui:main";
+    this.requestGpu = false;
+    this.portBindings = {3000 : 8080};
+    this.envVars = {};
+    this.envVarMappings = envVarMappings;
+    this.volumes = {"open-webui": "/app/backend/data"};
+    this.signedUp = false;
+    this.autoSignup = true;
+    this.username = "quarkus";
+    this.email = "quarkus@quarkus.io";
+    this.password = "quarkus";
+    Object.entries(this.envVarMappings).forEach(([envVarKey, quarkusConfigPropertyKey]) => {
+      this.jsonRpc.getConfigValue({key: quarkusConfigPropertyKey}).then((resp) => {
+        const envVarValue = resp.result;
+        if (envVarValue) {
+          this.envVars[envVarKey] = envVarValue;
+        }
+      });
+    });
+    this._hideProgressBar();
+    this._refresh();
+    }
+
+
+  render() {
+    return html`<div>
+      <p>
+      ${this._renderContainerInfo()}
+      </p>
+      ${this._renderCreateOptions()}
+      <vaadin-progress-bar class="${this._progressBarClass}" indeterminate></vaadin-progress-bar>
+      <div>
+        <button @click="${this._startOpenWebUI}" ?disabled="${this.container}">Start</button>
+        <button @click="${this._stopOpenWebUI}" ?disabled="${!this.container}">Stop</button>
+      </div>
+    </div>`;
+  }
+
+
+  _renderCreateOptions() {
+    return html`
+      <div>
+        <div>
+          <label>Image:</label>
+          <input type="text" class="large-input" .value="${this.image}" @input="${e => this.image = e.target.value}">
+        </div>
+        <div>
+          <label>Request GPU:</label>
+          <vaadin-checkbox .checked="${this.requestGpu}" @change="${(event) => {
+                                      this.requestGpu = event.target.checked;
+                                      this.requestUpdate();
+                                  }}"></vaadin-checkbox>
+        </div>
+        <details>
+          <summary>Auto Signup</summary>
+           <label>Enabled:</label>
+           <vaadin-checkbox .checked="${this.autoSignup} @change="${(event) => {
+                                      this.autoSignup = event.target.checked;
+                                      this.requestUpdate();
+                                  }}"></vaadin-checkbox>
+
+           <p> 
+             <label>Name:</label>
+             <input type="text" .value="${this.username}" @input="${e => this.username = e.target.value}">
+           </p>
+           <p>
+             <label>Email:</label>
+             <input type="text" .value="${this.email}" @input="${e => this.email = e.target.value}">
+           </p>
+           <p>
+             <label>Password:</label>
+             <input type="text" .value="${this.password}" @input="${e => this.password = e.target.value}">
+           </p>
+        </details>
+        <details title="Define container port bindings">
+          <summary>Port Bindings</summary>
+            ${Object.entries(this.portBindings).map(([key, value], index) => html`
+              <div>
+                <input type="text" .value="${key}" @blur="${e => this._changePortBindingKey(index, e.target.value)}">
+                <input type="text" class="large-input" .value="${value}" @input="${e => this._changePortBindingValue(index, e.target.value)}">
+                <button @click="${() => this._removePortBinding(key)}">-</button>
+              </div>
+            `)}
+            <button @click="${this._addPortBinding}">+</button>
+        </details>
+        <details title="Define container volume bindings">
+          <summary>Volumes</summary>
+            ${Object.entries(this.volumes).map(([key, value], index) => html`
+              <div>
+                <input type="text" .value="${key}" @blur="${e => this._changeVolumeKey(index, e.target.value)}">
+                <input type="text" class="large-input" .value="${value}" @input="${e => this._changeVolumeValue(index, e.target.value)}">
+                <button @click="${() => this._removeVolume(key)}">-</button>
+              </div>
+            `)}
+            <button @click="${this._addVolume}">+</button>
+        </details>
+        <details title="Specify environment variables as key/value pairs">
+          <summary>Environment Variables</summary>
+            ${Object.entries(this.envVars).map(([key, value], index) => html`
+              <div>
+                <input type="text" .value="${key}" @input="${e => this._changeEnvVarKey(index, e.target.value)}">
+                <input type="text" class="large-input" .value="${value}" @input="${e => this._changeEnvVarValue(index, e.target.value)}">
+                <button @click="${() => this._removeEnvVar(key)}">-</button>
+              </div>
+            `)}
+            <button @click="${this._addEnvVar}">+</button>
+        </details>
+      </div>
+    </div>`;
+  }
+
+  _refresh() {
+      this.jsonRpc.inspectOpenWebUIContainer().then((resp) => {
+      this.container = resp.result;
+      this.requestUpdate();
+    });
+
+    this.jsonRpc.getOpenWebUIUrl().then((resp) => {
+      this.url = resp.result;
+      this.requestUpdate();
+    });
+
+  }
+   
+  _renderContainerInfo() {
+      if (this.container) {
+        return html`
+          <div>
+            <h2>Open WebUI container</h2>
+            <p><label>ID:</label> ${this.container.id}</p>
+            <p><label>Name:</label> ${this.container.name}</p>
+            <p><label>Image:</label> ${this.container.config.image}</p>
+            <p><label>Command:</label> ${this.container.config.cmd.join(" ")}</p>
+            <p><label>Link:</label><a href="${this.url}" target="_blank">${this.url}</a></p>
+          </div>
+        `;
+    }
+    return html``;
+  }
+
+
+  _startOpenWebUI() {
+    this._showProgressBar();
+    this.jsonRpc.startOpenWebUI({image: this.image, requestGpu: this.requestGpu, portBindings: this.portBindings, envVars: this.envVars, volumes: this.volumes}).then(() => {  
+      this._hideProgressBar();
+      this._refresh();
+      if (this.autoSignup) {
+        // Ensure that we do have a URL before trying to sign up
+        this.jsonRpc.getOpenWebUIUrl().then(() => {
+          this._openWebUISignup().then(() => {
+            this.signUp = true;
+          });
+        });
+      }
+    }).catch(() => {
+      this._hideProgressBar();
+    });
+  }
+
+  _stopOpenWebUI() {
+    this._showProgressBar();
+    this.jsonRpc.stopOpenWebUI().then(() => {
+      this._hideProgressBar();
+      this._refresh();
+    }).catch(() => {
+      this._hideProgressBar();
+    });
+  }
+
+   _openWebUISignup(timeout=10000, interval=1000) {
+    const signupUrl = this.url + "/api/v1/auths/signup";
+    const payload = { name: this.username,  email: this.email, password: this.password };
+    return new Promise((resolve, reject) => {
+        const startTime = Date.now();
+        function attemptFetch() {
+          fetch(signupUrl, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(payload)
+          }).then(response => {
+              if (response.ok) {  
+                  resolve('OpenWebUI ready');
+              } else {
+                  throw new Error('OpenWebUI not ready');
+              }
+          }).catch(error => {
+              const currentTime = Date.now();
+              if (currentTime - startTime >= timeout) {
+                  reject('Timed out waiting for OpenWebUI to be ready');
+              } else {
+                  setTimeout(attemptFetch, interval); 
+              }
+          });
+        }
+        attemptFetch();
+      }); 
+    }
+
+  // Port Bindings
+  _changePortBindingKey(index, newKey) {
+    const oldKey = Object.keys(this.portBindings)[index];
+    const value = this.portBindings[oldKey];
+    delete this.portBindings[oldKey];
+    this.portBindings[newKey] = value;
+    this.requestUpdate();
+  }
+  
+  _changePortBindingValue(index, newValue) {
+    const key = Object.keys(this.portBindings)[index];
+    this.portBindings[key] = newValue;
+    this.requestUpdate();
+  }
+  
+  _removePortBinding(key) {
+    delete this.portBindings[key];
+    this.requestUpdate();
+  }
+
+  _addPortBinding() {
+    const max = Object.keys(this.portBindings).reduce((a, b) => Math.max(a, b), 0);
+    const next = max + 1;
+    this.portBindings[next] = "";
+    this.requestUpdate();
+  }
+
+
+  // Env Vars 
+  _changeEnvVarKey(index, newKey) {
+    const oldKey = Object.keys(this.envVars)[index];
+    const value = this.envVars[oldKey];
+    delete this.envVars[oldKey];
+    this.envVars[newKey] = value;
+    this.requestUpdate();
+  }
+  
+  _changeEnvVarValue(index, newValue) {
+    const key = Object.keys(this.envVars)[index];
+    this.envVars[key] = newValue;
+    this.requestUpdate();
+  }
+  
+  _removeEnvVar(key) {
+    delete this.envVars[key];
+    this.requestUpdate();
+  }
+
+  _addEnvVar() {
+    this.envVars[""] = "";
+    this.requestUpdate();
+  }
+
+  // Volumes
+  _changeVolumeKey(index, newKey) {
+    const oldKey = Object.keys(this.volumes)[index];
+    const value = this.volumes[oldKey];
+    delete this.volumes[oldKey];
+    this.volumes[newKey] = value;
+    this.requestUpdate();
+  }
+  
+  _changeVolumeValue(index, newValue) {
+      const key = Object.keys(this.volumes)[index];
+      this.volumes[key] = newValue;
+      this.requestUpdate();
+  }
+  
+  _removeVolume(key) {
+    delete this.volumes[key];
+    this.requestUpdate();
+  }
+  
+  _addVolume() {
+      this.volumes[""] = "";
+      this.requestUpdate();
+  }
+
+  _hideProgressBar(){
+    this._progressBarClass = "hide";
+  }
+
+   _showProgressBar(){
+     this._progressBarClass = "show";
+   }
+}
+customElements.define('qwc-open-webui', OpenWebUI);
+
+
+
+
+

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -27,6 +27,13 @@
         </dependency>
 
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices-common</artifactId>
+            <scope>compile</scope>
+            <version>${quarkus.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.quarkiverse.langchain4j</groupId>
             <artifactId>quarkus-langchain4j-core-runtime-spi</artifactId>
             <version>${project.version}</version>

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/devui/OpenWebUIJsonRPCService.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/devui/OpenWebUIJsonRPCService.java
@@ -1,0 +1,148 @@
+package io.quarkiverse.langchain4j.runtime.devui;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.testcontainers.DockerClientFactory;
+
+import com.github.dockerjava.api.command.CreateContainerResponse;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.api.model.Bind;
+import com.github.dockerjava.api.model.Container;
+import com.github.dockerjava.api.model.DeviceRequest;
+import com.github.dockerjava.api.model.HostConfig;
+import com.github.dockerjava.api.model.PortBinding;
+import com.github.dockerjava.api.model.Volume;
+
+@ActivateRequestContext
+public class OpenWebUIJsonRPCService {
+
+    public static final Runnable CLOSE_TASK = () -> {
+        OpenWebUIJsonRPCService service = new OpenWebUIJsonRPCService();
+        service.stopOpenWebUI();
+    };
+
+    private static final String CONTAINER_NAME_PREFIX = "quarkus-open-webui-";
+
+    public boolean isOpenWebUIRunning() {
+        var container = inspectOpenWebUIContainer();
+        return container != null && container.getState().getRunning();
+    }
+
+    public String getOpenWebUIUrl() {
+        var container = inspectOpenWebUIContainer();
+        if (container != null) {
+            return container.getNetworkSettings().getPorts().getBindings().values().stream().flatMap(Arrays::stream)
+                    .map(p -> "http://localhost" + ":" + p.getHostPortSpec())
+                    .findFirst()
+                    .orElse(null);
+        }
+        return null;
+    }
+
+    public InspectContainerResponse inspectOpenWebUIContainer() {
+        return DockerClientFactory.lazyClient().listContainersCmd().exec()
+                .stream()
+                .filter(OpenWebUIJsonRPCService::isOpenWebUIContainer)
+                .findFirst()
+                .map(c -> c.getId())
+                .map(id -> DockerClientFactory.lazyClient().inspectContainerCmd(id).exec())
+                .orElse(null);
+    }
+
+    public CreateContainerResponse startOpenWebUI(String image,
+            boolean requestGpu,
+            Map<Integer, Integer> portBindings,
+            Map<String, String> envVars,
+            Map<String, String> volumes) {
+        if (!isOpenWebUIRunning()) {
+
+            List<PortBinding> allPortBindings = new ArrayList<>();
+            List<String> allEnvVars = new ArrayList<>();
+            List<Bind> allBinds = new ArrayList<>();
+            List<Volume> allVolumes = new ArrayList<>();
+            List<DeviceRequest> allDeviceRequests = new ArrayList<>();
+
+            try {
+                var images = DockerClientFactory.lazyClient().listImagesCmd().exec();
+                if (images.stream().filter(i -> i.getRepoTags() != null)
+                        .noneMatch(i -> Arrays.asList(i.getRepoTags()).contains(image))) {
+                    DockerClientFactory.lazyClient().pullImageCmd(image).start().awaitCompletion();
+                }
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+
+            for (var e : portBindings.entrySet()) {
+                allPortBindings.add(PortBinding.parse(e.getKey() + ":" + e.getValue()));
+            }
+
+            for (var e : envVars.entrySet()) {
+                allEnvVars.add(e.getKey() + "=" + e.getValue());
+            }
+
+            for (var e : volumes.entrySet()) {
+                String path = e.getKey();
+                Volume volume = new Volume(e.getValue());
+                allBinds.add(new Bind(path, volume));
+                allVolumes.add(volume);
+                try {
+                    DockerClientFactory.lazyClient().inspectVolumeCmd(path).exec();
+                } catch (NotFoundException nfe) {
+                    DockerClientFactory.lazyClient().createVolumeCmd().withName(path).exec();
+                }
+            }
+
+            if (requestGpu) {
+                DeviceRequest gpu = new DeviceRequest().withCount(-1).withCapabilities(List.of(List.of("gpu")));
+                allDeviceRequests.add(gpu);
+            }
+
+            HostConfig hostConfig = new HostConfig()
+                    .withBinds(allBinds)
+                    .withPortBindings(allPortBindings)
+                    .withExtraHosts("host.docker.internal:host-gateway")
+                    .withDeviceRequests(allDeviceRequests);
+
+            CreateContainerResponse container = DockerClientFactory.lazyClient()
+                    .createContainerCmd(image)
+                    .withEnv(allEnvVars)
+                    .withVolumes(allVolumes)
+                    .withName(CONTAINER_NAME_PREFIX + System.currentTimeMillis())
+                    .withHostConfig(hostConfig)
+                    .exec();
+
+            DockerClientFactory.lazyClient().startContainerCmd(container.getId()).exec();
+            return container;
+        }
+        return null;
+    }
+
+    public boolean stopOpenWebUI() {
+        InspectContainerResponse container = inspectOpenWebUIContainer();
+        if (container != null) {
+            DockerClientFactory.lazyClient().stopContainerCmd(container.getId()).exec();
+            DockerClientFactory.lazyClient().removeContainerCmd(container.getId()).exec();
+            return true;
+        }
+        return false;
+    }
+
+    public String getConfigValue(String key) {
+        try {
+            return ConfigProvider.getConfig().getValue(key, String.class);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static boolean isOpenWebUIContainer(Container c) {
+        return Arrays.stream(c.getNames()).anyMatch(n -> n.startsWith("/" + CONTAINER_NAME_PREFIX));
+    }
+}

--- a/model-providers/ollama/deployment/src/main/java/io/quarkiverse/langchain4j/ollama/deployment/devui/OllamaDevUiProcessor.java
+++ b/model-providers/ollama/deployment/src/main/java/io/quarkiverse/langchain4j/ollama/deployment/devui/OllamaDevUiProcessor.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.langchain4j.ollama.deployment.devui;
+
+import java.util.Map;
+
+import io.quarkiverse.langchain4j.deployment.devui.AdditionalDevUiCardBuildItem;
+import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+
+public final class OllamaDevUiProcessor {
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    void registerOpenWebUiCard(BuildProducer<AdditionalDevUiCardBuildItem> producer) {
+        producer.produce(new AdditionalDevUiCardBuildItem("Open WebUI", "font-awesome-solid:globe", "qwc-open-webui.js",
+                Map.of("envVarMappings",
+                        Map.of("OLLAMA_BASE_URL", "quarkus.langchain4j.ollama.base-url"))));
+    }
+}

--- a/model-providers/openai/openai-common/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/devui/OpenAiDevUIProcessor.java
+++ b/model-providers/openai/openai-common/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/devui/OpenAiDevUIProcessor.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.langchain4j.openai.deployment.devui;
+
+import java.util.Map;
+
+import io.quarkiverse.langchain4j.deployment.devui.AdditionalDevUiCardBuildItem;
+import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+
+public final class OpenAiDevUIProcessor {
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    void registerOpenWebUiCard(BuildProducer<AdditionalDevUiCardBuildItem> producer) {
+        producer.produce(new AdditionalDevUiCardBuildItem("Open WebUI", "font-awesome-solid:globe", "qwc-open-webui.js",
+                Map.of("envVarMappings",
+                        Map.of("OPENAI_API_KEY", "quarkus.langchain4j.openai.api-key"))));
+    }
+}


### PR DESCRIPTION
Resolves: #581 

The pull request introduces the following:

- A new Open WebUI card under langchain4j extension (when using OpenAI or Ollama).
- The Open WebUI card allows starting, stoping or launching Open WebUI.
- OpenAI api key is automatically passed to the container (for OpenAI)
- Ollama base url is automatically passed to the container (for Ollama)
- Options for custom env variables, env variable mapping and port bindings are provided. 
- Added support for automatically signing up