### PR TITLE
change the success message as some opensource models like empower-fun…

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/ToolProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/ToolProcessor.java
@@ -292,7 +292,7 @@ public class ToolProcessor {
 
             boolean toolReturnsVoid = methodInfo.returnType().kind() == Type.Kind.VOID;
             if (toolReturnsVoid) {
-                invokeMc.returnValue(invokeMc.load("Success"));
+                invokeMc.returnValue(invokeMc.load("\\\"Success\\\""));
             } else {
                 invokeMc.returnValue(result);
             }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/QuarkusToolExecutor.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/QuarkusToolExecutor.java
@@ -61,7 +61,7 @@ public class QuarkusToolExecutor implements ToolExecutor {
 
     private static String handleResult(ToolInvoker invokerInstance, Object invocationResult) {
         if (invokerInstance.methodMetadata().isReturnsVoid()) {
-            return "Success";
+            return "\\\"Success\\\"";
         }
         return Json.toJson(invocationResult);
     }


### PR DESCRIPTION

change the success message as some opensource models like empower-functions-medium (can be tested with baseUrl: https://app.empower.dev/api/v1/functions/) accepts Tool Message as Json only