### PR TITLE
make vertexai.gemini timeout configurable

### DIFF
--- a/model-providers/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/VertexAiGeminiRecorder.java
+++ b/model-providers/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/VertexAiGeminiRecorder.java
@@ -48,6 +48,9 @@ public class VertexAiGeminiRecorder {
             if (chatModelConfig.topP().isPresent()) {
                 builder.topP(chatModelConfig.topP().getAsDouble());
             }
+            if (chatModelConfig.timeout().isPresent()) {
+                builder.timeout(chatModelConfig.timeout().get());
+            }
 
             // TODO: add the rest of the properties
 

--- a/model-providers/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/config/ChatModelConfig.java
+++ b/model-providers/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/config/ChatModelConfig.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.langchain4j.vertexai.runtime.gemini.config;
 
+import java.time.Duration;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
@@ -91,4 +92,12 @@ public interface ChatModelConfig {
     @ConfigDocDefault("false")
     @WithDefault("${quarkus.langchain4j.vertexai.gemini.log-responses}")
     Optional<Boolean> logResponses();
+
+    /**
+     * Global timeout for requests to gemini APIs
+     */
+    @ConfigDocDefault("10s")
+    @WithDefault("${quarkus.langchain4j.vertexai.gemini.timeout}")
+    Optional<Duration> timeout();
+
 }

--- a/model-providers/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/config/LangChain4jVertexAiGeminiConfig.java
+++ b/model-providers/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/config/LangChain4jVertexAiGeminiConfig.java
@@ -2,6 +2,7 @@ package io.quarkiverse.langchain4j.vertexai.runtime.gemini.config;
 
 import static io.quarkus.runtime.annotations.ConfigPhase.RUN_TIME;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 
@@ -80,6 +81,12 @@ public interface LangChain4jVertexAiGeminiConfig {
         @ConfigDocDefault("false")
         @WithDefault("${quarkus.langchain4j.log-responses}")
         Optional<Boolean> logResponses();
+
+        /**
+         * Timeout for requests to gemini APIs
+         */
+        @WithDefault("${quarkus.langchain4j.timeout}")
+        Optional<Duration> timeout();
 
         /**
          * Chat model related settings


### PR DESCRIPTION
and inherit the default from quarkus.langchain4j.timeout

- Closes:  https://github.com/quarkiverse/quarkus-langchain4j/issues/638