### PR TITLE
Set a smaller segment-size for the easy-rag sample

### DIFF
--- a/samples/chatbot-easy-rag/src/main/resources/application.properties
+++ b/samples/chatbot-easy-rag/src/main/resources/application.properties
@@ -1,2 +1,6 @@
 quarkus.langchain4j.openai.timeout=60s
 quarkus.langchain4j.easy-rag.path=src/main/resources/catalog
+
+quarkus.langchain4j.easy-rag.max-segment-size=100
+quarkus.langchain4j.easy-rag.max-overlap-size=25
+quarkus.langchain4j.easy-rag.max-results=4


### PR DESCRIPTION
With the default settings, documents get mapped 1:1 into segments, so it doesn't demonstrate the capabilities very well