### PR TITLE
Use top-level timeout property in samples

### DIFF
--- a/samples/chatbot-easy-rag/src/main/resources/application.properties
+++ b/samples/chatbot-easy-rag/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.langchain4j.openai.timeout=60s
+quarkus.langchain4j.timeout=60s
 quarkus.langchain4j.easy-rag.path=src/main/resources/catalog
 
 quarkus.langchain4j.easy-rag.max-segment-size=100

--- a/samples/chatbot/src/main/resources/application.properties
+++ b/samples/chatbot/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 quarkus.langchain4j.redis.dimension=1536
-quarkus.langchain4j.openai.timeout=60s
+quarkus.langchain4j.timeout=60s

--- a/samples/cli-translator/src/main/resources/application.properties
+++ b/samples/cli-translator/src/main/resources/application.properties
@@ -1,5 +1,5 @@
+quarkus.langchain4j.timeout=60s
 quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 quarkus.langchain4j.openai.chat-model.temperature=0
-quarkus.langchain4j.openai.timeout=60s
 quarkus.banner.enabled=false
 quarkus.log.level=WARN

--- a/samples/review-triage/src/main/resources/application.properties
+++ b/samples/review-triage/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 quarkus.langchain4j.openai.chat-model.temperature=0.5
-quarkus.langchain4j.openai.timeout=60s
+quarkus.langchain4j.timeout=60s
 
 # using a json_object response format requires at least gpt-3.5-turbo-1106 or more recent
 # see https://platform.openai.com/docs/api-reference/chat/create#chat-create-response_format

--- a/samples/sql-chatbot/src/main/resources/application.properties
+++ b/samples/sql-chatbot/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.langchain4j.openai.timeout=60s
+quarkus.langchain4j.timeout=60s
 csv.file=src/main/resources/data/movies.csv
 
 quarkus.hibernate-orm.database.generation=drop-and-create


### PR DESCRIPTION
This make it easier when switching from one
model provider to another