### PR TITLE
Allow ollama devservice container to create an image with any configured model

### DIFF
--- a/model-providers/ollama/devservices/src/main/java/io/quarkiverse/langchain4j/ollama/devservices/OllamaContainer.java
+++ b/model-providers/ollama/devservices/src/main/java/io/quarkiverse/langchain4j/ollama/devservices/OllamaContainer.java
@@ -51,18 +51,19 @@ public class OllamaContainer extends GenericContainer<OllamaContainer> {
 
     private String runtimeModelId;
 
-    OllamaContainer(OllamaConfig config, String localOllamaImage, boolean useSharedNetwork, LazyFuture<DockerImageName> image) {
+    OllamaContainer(OllamaConfig config, String localOllamaImage, boolean useSharedNetwork, LazyFuture<DockerImageName> image,
+            String runtimeModelId) {
         super(image.get());
         this.config = config;
         this.dockerImageName = image.get();
         this.localOllamaImage = localOllamaImage;
         this.useSharedNetwork = useSharedNetwork;
-        this.runtimeModelId = getModelId(config);
+        this.runtimeModelId = runtimeModelId;
         super.withLabel(OllamaProcessor.DEV_SERVICE_LABEL, OllamaProcessor.FEATURE);
         super.withNetwork(Network.SHARED);
 
         super.addFixedExposedPort(PORT_OLLAMA, PORT_OLLAMA);
-        super.withImagePullPolicy(dockerImageName -> !dockerImageName.getVersionPart().endsWith(this.runtimeModelId));
+        super.withImagePullPolicy(dockerImageName -> !dockerImageName.asCanonicalNameString().equals(localOllamaImage));
     }
 
     @Override

--- a/model-providers/ollama/devservices/src/main/java/io/quarkiverse/langchain4j/ollama/devservices/OllamaProcessor.java
+++ b/model-providers/ollama/devservices/src/main/java/io/quarkiverse/langchain4j/ollama/devservices/OllamaProcessor.java
@@ -129,10 +129,12 @@ public class OllamaProcessor {
             return null;
         }
 
-        String localOllamaImage = String.format("tc-%s-orca-mini", ollamaConfig.imageName());
-
+        String runtimeModel = OllamaContainer.getModelId(ollamaConfig);
+        String filteredModelName = filterModelTag(runtimeModel);
+        String localOllamaImage = String.format("tc-%s-%s", ollamaConfig.imageName(), filteredModelName);
         final OllamaImage ollamaImage = new OllamaImage(ollamaConfig.imageName(), localOllamaImage);
-        OllamaContainer ollama = new OllamaContainer(ollamaConfig, localOllamaImage, useSharedNetwork, ollamaImage);
+        OllamaContainer ollama = new OllamaContainer(ollamaConfig, localOllamaImage, useSharedNetwork, ollamaImage,
+                runtimeModel);
         ollama.start();
         createImage(ollama, localOllamaImage);
 
@@ -141,6 +143,10 @@ public class OllamaProcessor {
                 ollama::close,
                 ollama.getExposedConfig());
 
+    }
+
+    static String filterModelTag(String runtimeModel) {
+        return runtimeModel.replace(':', '_');
     }
 
     static void createImage(GenericContainer<?> container, String localImageName) {


### PR DESCRIPTION
Allows ollama devservice container to create an image with any configured model.

This renames model tags replacing the `:` by `_` so that the created image has a correctly named tag.