### PR TITLE
Allow ollama devservices to run with docker gpus

### DIFF
--- a/model-providers/ollama/devservices/src/main/java/io/quarkiverse/langchain4j/ollama/devservices/OllamaConfig.java
+++ b/model-providers/ollama/devservices/src/main/java/io/quarkiverse/langchain4j/ollama/devservices/OllamaConfig.java
@@ -38,4 +38,10 @@ public interface OllamaConfig {
     @WithDefault(ORCA_MINI_MODEL)
     String model();
 
+    /**
+     * If the ollama container requests all available gpus.
+     */
+    @WithDefault("false")
+    boolean requestGpu();
+
 }


### PR DESCRIPTION
This adds a configuration to the ollama devservices to allow the started container to request gpus.