### PR TITLE
Putting Generic Authentication flow to the Core

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/BeansProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/BeansProcessor.java
@@ -36,6 +36,7 @@ import io.quarkiverse.langchain4j.deployment.items.SelectedImageModelProviderBui
 import io.quarkiverse.langchain4j.deployment.items.SelectedModerationModelProviderBuildItem;
 import io.quarkiverse.langchain4j.runtime.LangChain4jRecorder;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
+import io.quarkiverse.langchain4j.runtime.auth.ModelAuthProvider;
 import io.quarkus.arc.deployment.BeanDiscoveryFinishedBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.processor.BeanStream;
@@ -353,6 +354,7 @@ public class BeansProcessor {
     @BuildStep
     public void unremoveableBeans(BuildProducer<UnremovableBeanBuildItem> unremoveableProducer) {
         unremoveableProducer.produce(UnremovableBeanBuildItem.beanTypes(ObjectMapper.class));
+        unremoveableProducer.produce(UnremovableBeanBuildItem.beanTypes(ModelAuthProvider.class));
     }
 
 }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/auth/ModelAuthProvider.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/auth/ModelAuthProvider.java
@@ -1,0 +1,42 @@
+package io.quarkiverse.langchain4j.runtime.auth;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
+
+import io.quarkiverse.langchain4j.ModelName;
+
+public interface ModelAuthProvider {
+    String getAuthorization(Input input);
+
+    interface Input {
+        String method();
+
+        URI uri();
+
+        Map<String, List<Object>> headers();
+    }
+
+    static Optional<ModelAuthProvider> resolve(String modelName) {
+        Instance<ModelAuthProvider> beanInstance = modelName == null
+                ? CDI.current().select(ModelAuthProvider.class)
+                : CDI.current().select(ModelAuthProvider.class, ModelName.Literal.of(modelName));
+
+        //get the first one without causing a bean1 resolution exception
+        ModelAuthProvider authorizer = null;
+        for (var handle : beanInstance.handles()) {
+            authorizer = handle.get();
+            break;
+        }
+        return Optional.ofNullable(authorizer);
+    }
+
+    static Optional<ModelAuthProvider> resolve() {
+        return resolve(null);
+    }
+
+}

--- a/docs/modules/ROOT/pages/openai.adoc
+++ b/docs/modules/ROOT/pages/openai.adoc
@@ -183,7 +183,7 @@ public class RequestFilter implements ResteasyReactiveClientRequestFilter {
 ----
 
 ==== Using `AuthProvider`
-One can implement the `AuthProvider` interface and provide the implementation of the `getAuthorization` method.
+One can implement the `ModelAuthProvider` interface and provide the implementation of the `getAuthorization` method.
 
 This is useful when you need to provide different authorization headers for different OpenAI models. The `@Named` annotation can be used to specify the model name in this scenario.
 
@@ -191,12 +191,13 @@ This is useful when you need to provide different authorization headers for diff
 ----
 import io.quarkiverse.langchain4j.ModelName;
 import io.quarkiverse.langchain4j.openai.OpenAiRestApi;
+import io.quarkiverse.langchain4j.runtime.auth.ModelAuthProvider;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 @ApplicationScoped
 @ModelName("my-model-name") //you can omit this if you have only one model or if you want to use the default model
-public class TestClass implements OpenAiRestApi.AuthProvider {
+public class TestClass implements ModelAuthProvider {
     @Inject MyTokenProviderService tokenProviderService;
 
     @Override

--- a/model-providers/openai/openai-common/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/OpenAiCommonProcessor.java
+++ b/model-providers/openai/openai-common/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/OpenAiCommonProcessor.java
@@ -15,8 +15,6 @@ import java.util.zip.ZipEntry;
 
 import com.knuddels.jtokkit.Encodings;
 
-import io.quarkiverse.langchain4j.openai.OpenAiRestApi;
-import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
@@ -27,11 +25,6 @@ public class OpenAiCommonProcessor {
     @BuildStep
     void indexDependencies(BuildProducer<IndexDependencyBuildItem> producer) {
         producer.produce(new IndexDependencyBuildItem("dev.ai4j", "openai4j"));
-    }
-
-    @BuildStep
-    UnremovableBeanBuildItem unremovableBeans() {
-        return UnremovableBeanBuildItem.beanTypes(OpenAiRestApi.AuthProvider.class);
     }
 
     @BuildStep


### PR DESCRIPTION
- Moving the authentication interface from Azure OpenAI introduced in #646 to the Quarkus Langchain Core so that it can be reused across other model providers
- Making Azure OpenAI use this.

Implementation of request mentioned in #626 