### PR TITLE
add stop sequence config for openAI chat config model

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai.adoc
@@ -368,6 +368,23 @@ endif::add-copy-button-to-env-var[]
 |
 
 
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-stop]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-stop[quarkus.langchain4j.openai.chat-model.stop]`
+
+
+[.description]
+--
+The list of stop words to use.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_STOP+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_STOP+++`
+endif::add-copy-button-to-env-var[]
+--|list of string 
+|
+
+
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-embedding-model-model-name]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-embedding-model-model-name[quarkus.langchain4j.openai.embedding-model.model-name]`
 
 
@@ -984,6 +1001,23 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSE_FORMAT+++`
 endif::add-copy-button-to-env-var[]
 --|string 
+|
+
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-stop]]`link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-stop[quarkus.langchain4j.openai."model-name".chat-model.stop]`
+
+
+[.description]
+--
+The list of stop words to use.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_STOP+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_STOP+++`
+endif::add-copy-button-to-env-var[]
+--|list of string 
 |
 
 

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
@@ -104,7 +104,8 @@ public class OpenAiRecorder {
                     .topP(chatModelConfig.topP())
                     .presencePenalty(chatModelConfig.presencePenalty())
                     .frequencyPenalty(chatModelConfig.frequencyPenalty())
-                    .responseFormat(chatModelConfig.responseFormat().orElse(null));
+                    .responseFormat(chatModelConfig.responseFormat().orElse(null))
+                    .stop(chatModelConfig.stop().orElse(null));
 
             openAiConfig.organizationId().ifPresent(builder::organizationId);
 

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
@@ -59,7 +59,8 @@ public class OpenAiRecorder {
                     .topP(chatModelConfig.topP())
                     .presencePenalty(chatModelConfig.presencePenalty())
                     .frequencyPenalty(chatModelConfig.frequencyPenalty())
-                    .responseFormat(chatModelConfig.responseFormat().orElse(null));
+                    .responseFormat(chatModelConfig.responseFormat().orElse(null))
+                    .stop(chatModelConfig.stop().orElse(null));
 
             openAiConfig.organizationId().ifPresent(builder::organizationId);
 

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/ChatModelConfig.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/ChatModelConfig.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.langchain4j.openai.runtime.config;
 
+import java.util.List;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigDocDefault;
@@ -76,4 +77,11 @@ public interface ChatModelConfig {
      * Some models are not compatible with some response formats, make sure to review OpenAI documentation.
      */
     Optional<String> responseFormat();
+
+    /**
+     * The list of stop words to use.
+     *
+     * @return
+     */
+    Optional<List<String>> stop();
 }


### PR DESCRIPTION
As specified [here](https://platform.openai.com/docs/api-reference/chat/create#chat-create-stop) in a chat completion request we should be able to pass a `stop` parameter containing a string or list of strings.
It's implemented in upstream `langchain4j` , this PR just add it to the config and the recorder.

