### PR TITLE
Allow the use of the {response_schema} in the prompt

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/PromptProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/PromptProcessor.java
@@ -37,6 +37,7 @@ import org.objectweb.asm.tree.analysis.Interpreter;
 import org.objectweb.asm.tree.analysis.SimpleVerifier;
 
 import dev.langchain4j.model.input.structured.StructuredPromptProcessor;
+import io.quarkiverse.langchain4j.runtime.ResponseSchemaUtil;
 import io.quarkiverse.langchain4j.runtime.StructuredPromptsRecorder;
 import io.quarkiverse.langchain4j.runtime.prompt.Mappable;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -88,6 +89,13 @@ public class PromptProcessor {
             String delimiter = delimiterValue != null ? delimiterValue.asString() : "\n";
             String promptTemplateString = String.join(delimiter, parts);
             ClassInfo annotatedClass = target.asClass();
+
+            // The response schema placeholder is not enabled for the @StructuredPrompt.
+            if (promptTemplateString.contains(ResponseSchemaUtil.placeholder())) {
+                throw new RuntimeException("The %s placeholder is not enabled for the @StructuredPrompt. Found it: %s"
+                        .formatted(ResponseSchemaUtil.placeholder(), annotatedClass));
+            }
+
             boolean hasNestedParams = hasNestedParams(promptTemplateString);
             if (!hasNestedParams) {
                 ClassInfo current = annotatedClass;

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/config/LangChain4jBuildConfig.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/config/LangChain4jBuildConfig.java
@@ -36,6 +36,13 @@ public interface LangChain4jBuildConfig {
      */
     DevServicesConfig devservices();
 
+    /**
+     * Configuration property to enable or disable the use of the {response schema} placeholder in
+     * the @SystemMessage/@UserMessage.
+     */
+    @WithDefault("true")
+    boolean responseSchema();
+
     interface BaseConfig {
         /**
          * Chat model
@@ -61,8 +68,9 @@ public interface LangChain4jBuildConfig {
     @ConfigGroup
     interface DevServicesConfig {
         /**
-         * If DevServices has been explicitly enabled or disabled. DevServices is generally enabled
-         * by default, unless there is an existing configuration present.
+         * If DevServices has been explicitly enabled or disabled. DevServices is generally enabled by default, unless there is
+         * an
+         * existing configuration present.
          * <p>
          * When DevServices is enabled Quarkus will attempt to automatically serve a model if there are any matching ones.
          */

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/ResponseSchemaUtil.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/ResponseSchemaUtil.java
@@ -1,0 +1,19 @@
+package io.quarkiverse.langchain4j.runtime;
+
+public class ResponseSchemaUtil {
+
+    private static final String RESPONSE_SCHEMA = "response_schema";
+    private static final String RESPONSE_SCHEMA_PLACEHOLDER = "%s%s%s".formatted("{", RESPONSE_SCHEMA, "}");
+
+    public static String placeholder() {
+        return RESPONSE_SCHEMA_PLACEHOLDER;
+    }
+
+    public static String templateParam() {
+        return RESPONSE_SCHEMA;
+    }
+
+    public static boolean hasResponseSchema(String templateText) {
+        return templateText.contains(RESPONSE_SCHEMA_PLACEHOLDER);
+    }
+}

--- a/docs/modules/ROOT/pages/ai-services.adoc
+++ b/docs/modules/ROOT/pages/ai-services.adoc
@@ -113,6 +113,14 @@ TriagedReview triage(String review);
 
 In this instance, Quarkus automatically creates an instance of `TriagedReview` from the LLM's JSON response.
 
+To enhance the flexibility of prompt creation, the `\{response_schema\}` placeholder can be used within the prompt. This placeholder is dynamically replaced with the defined schema of the method's return object.
+
+[IMPORTANT]
+====
+By default, if the placeholder `\{response_schema\}` is not present in `@SystemMessage` or `@UserMessage`, it will be added to the end of the prompt.
+To avoid the generation of the schema, the property `quarkus.langchain4j.response-schema` can be set to `false`.
+====
+
 === Receiving User Message as a Parameter
 
 For situations requiring the user message to be passed as a parameter, you can use the `@UserMessage` annotation on a parameter. Exercise caution with this feature, especially when the AI has access to _tools_:

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j.adoc
@@ -63,6 +63,23 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j_quarkus-langchain4j-response-schema]]`link:#quarkus-langchain4j_quarkus-langchain4j-response-schema[quarkus.langchain4j.response-schema]`
+
+
+[.description]
+--
+Configuration property to enable or disable the use of the ++{++response schema++}++ placeholder in the @SystemMessage/@UserMessage.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_RESPONSE_SCHEMA+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_RESPONSE_SCHEMA+++`
+endif::add-copy-button-to-env-var[]
+--|boolean 
+|`true`
+
+
 a| [[quarkus-langchain4j_quarkus-langchain4j-log-requests]]`link:#quarkus-langchain4j_quarkus-langchain4j-log-requests[quarkus.langchain4j.log-requests]`
 
 

--- a/model-providers/bam/deployment/src/test/java/io/quarkiverse/langchain4j/bam/deployment/ResponseSchemaExceptionTest.java
+++ b/model-providers/bam/deployment/src/test/java/io/quarkiverse/langchain4j/bam/deployment/ResponseSchemaExceptionTest.java
@@ -1,0 +1,149 @@
+package io.quarkiverse.langchain4j.bam.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.model.input.structured.StructuredPrompt;
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkus.test.QuarkusUnitTest;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class ResponseSchemaExceptionTest {
+
+    private static final String MESSAGE = "The {response_schema} placeholder cannot be used if the property quarkus.langchain4j.response-schema is set to false. Found in: io.quarkiverse.langchain4j.bam.deployment.ResponseSchemaExceptionTest$";
+
+    @StructuredPrompt("{response_schema} Create a poem about {topic}")
+    static class PoemPrompt {
+
+        private final String topic;
+
+        public PoemPrompt(String topic) {
+            this.topic = topic;
+        }
+
+        public String getTopic() {
+            return topic;
+        }
+    }
+
+    @RegisterAiService
+    @Singleton
+    interface AiServiceSystemMessage {
+
+        @SystemMessage("{response_schema} You are a poet")
+        @UserMessage("Generate a poem about {topic}")
+        String poem(String topic);
+    }
+
+    @RegisterAiService
+    @Singleton
+    interface AiServiceUserMessage {
+
+        @SystemMessage("You are a poet")
+        @UserMessage("{response_schema} Generate a poem about {topic}")
+        String poem(String topic);
+    }
+
+    @RegisterAiService
+    @Singleton
+    @SystemMessage("{response_schema} You are a poet")
+    interface AiServiceSystemMessageOnClass {
+
+        @UserMessage("Generate a poem about {topic}")
+        String poem(String topic);
+    }
+
+    @RegisterAiService
+    @Singleton
+    interface AiServiceStructuredPrompt {
+        String poem(PoemPrompt prompt);
+    }
+
+    @RegisterAiService
+    @Singleton
+    interface AIServiceOnMethod {
+        String poem(@UserMessage String message, @V("topic") String topic);
+    }
+
+    @Nested
+    class ResponseSchemaSystemMessage {
+        @RegisterExtension
+        static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+                .overrideConfigKey("quarkus.langchain4j.response-schema", "false")
+                .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(AiServiceSystemMessage.class))
+                .assertException(t -> {
+                    assertThat(t).isInstanceOf(RuntimeException.class)
+                            .hasMessage(MESSAGE.concat("AiServiceSystemMessage"));
+                });
+
+        @Test
+        void test() {
+            fail("Should not be called");
+        }
+    }
+
+    @Nested
+    class ResponseSchemaUserMessage {
+        @RegisterExtension
+        static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+                .overrideConfigKey("quarkus.langchain4j.response-schema", "false")
+                .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(AiServiceUserMessage.class))
+                .assertException(t -> {
+                    assertThat(t).isInstanceOf(RuntimeException.class)
+                            .hasMessage(MESSAGE.concat("AiServiceUserMessage"));
+                });
+
+        @Test
+        void test() {
+            fail("Should not be called");
+        }
+    }
+
+    @Nested
+    class ResponseSchemaStructuredPrompt {
+        @RegisterExtension
+        static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+                .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(AiServiceStructuredPrompt.class,
+                        PoemPrompt.class))
+                .assertException(t -> {
+                    assertThat(t).isInstanceOf(RuntimeException.class)
+                            .hasMessage(
+                                    "The {response_schema} placeholder is not enabled for the @StructuredPrompt. Found it: io.quarkiverse.langchain4j.bam.deployment.ResponseSchemaExceptionTest$PoemPrompt");
+                });
+
+        @Test
+        void test() {
+            fail("Should not be called");
+        }
+    }
+
+    @Nested
+    class ResponseSchemaSystemMessageOnClass {
+        @RegisterExtension
+        static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+                .overrideConfigKey("quarkus.langchain4j.response-schema", "false")
+                .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(AiServiceSystemMessageOnClass.class))
+                .assertException(t -> {
+                    assertThat(t).isInstanceOf(RuntimeException.class)
+                            .hasMessage(MESSAGE.concat("AiServiceSystemMessageOnClass"));
+                });
+
+        @Test
+        void test() {
+            fail("Should not be called");
+        }
+    }
+}

--- a/model-providers/bam/deployment/src/test/java/io/quarkiverse/langchain4j/bam/deployment/ResponseSchemaOffTest.java
+++ b/model-providers/bam/deployment/src/test/java/io/quarkiverse/langchain4j/bam/deployment/ResponseSchemaOffTest.java
@@ -1,0 +1,50 @@
+package io.quarkiverse.langchain4j.bam.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.bam.runtime.config.LangChain4jBamConfig;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ResponseSchemaOffTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bam.base-url", WireMockUtil.URL)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bam.api-key", WireMockUtil.API_KEY)
+            .overrideConfigKey("quarkus.langchain4j.response-schema", "false")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
+
+    @RegisterAiService
+    @Singleton
+    interface OnMethodAIService {
+        String poem(@UserMessage String message, @V("topic") String topic);
+    }
+
+    @Inject
+    OnMethodAIService onMethodAIService;
+
+    @Inject
+    LangChain4jBamConfig langchain4jBamConfig;
+
+    @Test
+    void on_method_ai_service() throws Exception {
+        var ex = assertThrows(RuntimeException.class,
+                () -> onMethodAIService.poem("{response_schema} Generate a poem about {topic}", "dog"));
+        assertEquals(
+                "The {response_schema} placeholder cannot be used if the property quarkus.langchain4j.response-schema is set to false. Found in: io.quarkiverse.langchain4j.bam.deployment.ResponseSchemaOffTest$OnMethodAIService",
+                ex.getMessage());
+    }
+
+}

--- a/model-providers/bam/deployment/src/test/java/io/quarkiverse/langchain4j/bam/deployment/ResponseSchemaOnTest.java
+++ b/model-providers/bam/deployment/src/test/java/io/quarkiverse/langchain4j/bam/deployment/ResponseSchemaOnTest.java
@@ -1,0 +1,293 @@
+package io.quarkiverse.langchain4j.bam.deployment;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.bam.BamRestApi;
+import io.quarkiverse.langchain4j.bam.Message;
+import io.quarkiverse.langchain4j.bam.Parameters;
+import io.quarkiverse.langchain4j.bam.TextGenerationRequest;
+import io.quarkiverse.langchain4j.bam.runtime.config.LangChain4jBamConfig;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ResponseSchemaOnTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bam.base-url", WireMockUtil.URL)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bam.api-key", WireMockUtil.API_KEY)
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
+
+    static WireMockServer wireMockServer;
+    static ObjectMapper mapper;
+    static WireMockUtil mockServers;
+    static String SCHEMA = "\nYou must answer strictly in the following JSON format: {\n\"text\": (type: string)\n}";
+    static String RESPONSE = """
+            {
+                "results": [
+                    {
+                        "generated_token_count": 20,
+                        "input_token_count": 146,
+                        "stop_reason": "max_tokens",
+                        "seed": 40268626,
+                        "generated_text": "{\\n\\\"text\\\": \\\"Beautiful dog\\\"\\n}"
+                    }
+                ]
+            }
+            """;
+
+    public record Poem(String text) {
+    }
+
+    //@StructuredPrompt("{response_schema} Create a poem about {topic}")
+    static class PoemPrompt {
+
+        private final String topic;
+
+        public PoemPrompt(String topic) {
+            this.topic = topic;
+        }
+
+        public String getTopic() {
+            return topic;
+        }
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        wireMockServer = new WireMockServer(options().port(WireMockUtil.PORT));
+        wireMockServer.start();
+        mapper = BamRestApi.objectMapper(new ObjectMapper());
+        mockServers = new WireMockUtil(wireMockServer);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        wireMockServer.stop();
+    }
+
+    @RegisterAiService(chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
+    @Singleton
+    interface NoBeanAIService {
+
+        @SystemMessage("You are a poet")
+        @UserMessage("Generate a poem about {topic}")
+        String poem(String topic);
+    }
+
+    @RegisterAiService(chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
+    @Singleton
+    interface BeanAIService {
+
+        @SystemMessage("You are a poet")
+        @UserMessage("Generate a poem about {topic}")
+        Poem poem(String topic);
+    }
+
+    @RegisterAiService(chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
+    @Singleton
+    interface SchemaAIService {
+
+        @SystemMessage("{response_schema} You are a poet")
+        @UserMessage("Generate a poem about {topic} {response_schema}")
+        Poem poem(String topic);
+    }
+
+    @RegisterAiService(chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
+    @Singleton
+    interface SystemMessageAIService {
+
+        @SystemMessage("{response_schema} You are a poet")
+        @UserMessage("Generate a poem about {topic}")
+        Poem poem(String topic);
+    }
+
+    @RegisterAiService(chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
+    @Singleton
+    interface OnMethodAIService {
+        Poem poem(@UserMessage String message, @V("topic") String topic);
+    }
+
+    @RegisterAiService(chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
+    @Singleton
+    interface StructuredPromptAIService {
+        Poem poem(PoemPrompt prompt);
+    }
+
+    @RegisterAiService(chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
+    @Singleton
+    @SystemMessage("{response_schema} You are a poet")
+    interface SysteMessageOnClassAIService {
+        @UserMessage("Generate a poem about {topic}")
+        Poem poem(String topic);
+    }
+
+    @Inject
+    NoBeanAIService noBeanAIService;
+
+    @Inject
+    BeanAIService beanAIService;
+
+    @Inject
+    SchemaAIService schemaAIService;
+
+    @Inject
+    SystemMessageAIService systemMessageAIService;
+
+    @Inject
+    OnMethodAIService onMethodAIService;
+
+    @Inject
+    StructuredPromptAIService structuredPromptAIService;
+
+    @Inject
+    SysteMessageOnClassAIService systeMessageOnClassAIService;
+
+    @Inject
+    LangChain4jBamConfig langchain4jBamConfig;
+
+    @Test
+    void no_bean_ai_service() throws Exception {
+
+        List<Message> messages = List.of(
+                new Message("system", "You are a poet"),
+                new Message("user", "Generate a poem about dog"));
+
+        mockServers
+                .mockBuilder(WireMockUtil.URL_CHAT_API, 200)
+                .body(mapper.writeValueAsString(from(messages)))
+                .response(RESPONSE)
+                .build();
+
+        assertEquals("{\n\"text\": \"Beautiful dog\"\n}", noBeanAIService.poem("dog"));
+    }
+
+    @Test
+    void bean_ai_service() throws Exception {
+
+        List<Message> messages = List.of(
+                new Message("system", "You are a poet"),
+                new Message("user", "Generate a poem about dog".concat(SCHEMA)));
+
+        mockServers
+                .mockBuilder(WireMockUtil.URL_CHAT_API, 200)
+                .body(mapper.writeValueAsString(from(messages)))
+                .response(RESPONSE)
+                .build();
+
+        assertEquals(new Poem("Beautiful dog"), beanAIService.poem("dog"));
+    }
+
+    @Test
+    void schema_ai_service() throws Exception {
+
+        List<Message> messages = List.of(
+                new Message("system", SCHEMA.concat(" You are a poet")),
+                new Message("user", "Generate a poem about dog ".concat(SCHEMA)));
+
+        mockServers
+                .mockBuilder(WireMockUtil.URL_CHAT_API, 200)
+                .body(mapper.writeValueAsString(from(messages)))
+                .response(RESPONSE)
+                .build();
+
+        assertEquals(new Poem("Beautiful dog"), schemaAIService.poem("dog"));
+    }
+
+    @Test
+    void schema_system_message_ai_service() throws Exception {
+
+        List<Message> messages = List.of(
+                new Message("system", SCHEMA.concat(" You are a poet")),
+                new Message("user", "Generate a poem about dog"));
+
+        mockServers
+                .mockBuilder(WireMockUtil.URL_CHAT_API, 200)
+                .body(mapper.writeValueAsString(from(messages)))
+                .response(RESPONSE)
+                .build();
+
+        assertEquals(new Poem("Beautiful dog"), systemMessageAIService.poem("dog"));
+    }
+
+    @Test
+    void on_method_ai_service() throws Exception {
+
+        List<Message> messages = List.of(
+                new Message("user", SCHEMA.concat(" Generate a poem about dog")));
+
+        mockServers
+                .mockBuilder(WireMockUtil.URL_CHAT_API, 200)
+                .body(mapper.writeValueAsString(from(messages)))
+                .response(RESPONSE)
+                .build();
+
+        assertEquals(new Poem("Beautiful dog"),
+                onMethodAIService.poem("{response_schema} Generate a poem about {topic}", "dog"));
+    }
+
+    @Test
+    @Disabled("The response schema placeholder doesn't work with the @StructuredPrompt")
+    void structured_prompt_ai_service() throws Exception {
+
+        List<Message> messages = List.of(
+                new Message("user", SCHEMA.concat("Generate a poem about dog")));
+
+        mockServers
+                .mockBuilder(WireMockUtil.URL_CHAT_API, 200)
+                .body(mapper.writeValueAsString(from(messages)))
+                .response(RESPONSE)
+                .build();
+
+        assertEquals(new Poem("Beautiful dog"), structuredPromptAIService.poem(new PoemPrompt("dog")));
+    }
+
+    @Test
+    void system_message_on_class_ai_service() throws Exception {
+
+        List<Message> messages = List.of(
+                new Message("system", SCHEMA.concat(" You are a poet")),
+                new Message("user", "Generate a poem about dog"));
+
+        mockServers
+                .mockBuilder(WireMockUtil.URL_CHAT_API, 200)
+                .body(mapper.writeValueAsString(from(messages)))
+                .response(RESPONSE)
+                .build();
+
+        assertEquals(new Poem("Beautiful dog"), systeMessageOnClassAIService.poem("dog"));
+    }
+
+    private TextGenerationRequest from(List<Message> messages) {
+        var config = langchain4jBamConfig.defaultConfig();
+
+        var parameters = Parameters.builder()
+                .decodingMethod(config.chatModel().decodingMethod())
+                .temperature(config.chatModel().temperature())
+                .minNewTokens(config.chatModel().minNewTokens())
+                .maxNewTokens(config.chatModel().maxNewTokens())
+                .build();
+
+        return new TextGenerationRequest(config.chatModel().modelId(), messages, parameters);
+    }
+}


### PR DESCRIPTION
As mentioned in #679, the idea of this PR is to increase the flexibility of prompt creation with the use of the `{response_schema}` placeholder.

This new placeholder allows the developer to choose where to place the schema in the prompt.

```java
@RegisterAiService
public interface LLMExtractor {


    @UserMessage("""
    <|begin_of_text|><|start_header_id|>system<|end_header_id|>

     # IDENTITY and PURPOSE

     You are a entity extractor. You take input and output a JSON.
     Your goal is to:

    * Extract the entities from the text: ["firstname", "lastname", "email", "city"];
    * Respond only with the entities extracted from the text;
    * Capitalize the first letter of the firstname, lastname, and city entities;
    * {response_schema};

    <|eot_id|>
    <|start_header_id|>user<|end_header_id|>

     # INPUT

     INPUT: {text}

    <|eot_id|><|start_header_id|>assistant<|end_header_id|>
     """)
    public User user(String text);
}

```

If there is no `{response_schema}` placeholder in the `@SystemMessage` or `@UserMessage`, the current default behavior is executed (the schema is added at the end of the prompt).

If necessary, the developer can disable the schema generation using the `quarkus.langchain4j.response-schema` property to `false`.

The new placeholder works with all possible AIService interactions except `@StructuredPrompt`.