### PR TITLE
Bringing domain-name on par with the rest of the optional configurations

### DIFF
--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/Consts.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/Consts.java
@@ -3,6 +3,7 @@ package io.quarkiverse.langchain4j.azure.openai;
 final class Consts {
 
     static final String DEFAULT_USER_AGENT = "langchain4j-quarkus-azure-openai";
+    static final String DUMMY_VALUE = "<dummy>";
 
     private Consts() {
     }

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
@@ -243,10 +243,10 @@ public class AzureOpenAiRecorder {
             String configName,
             EndpointType type) {
         var resourceName = azureAiConfig.resourceNameFor(type);
-        var domainName = azureAiConfig.domainName();
+        var domainName = azureAiConfig.domainNameFor(type);
         var deploymentName = azureAiConfig.deploymentNameFor(type);
 
-        if (resourceName.isEmpty() || deploymentName.isEmpty()) {
+        if (resourceName.isEmpty() || deploymentName.isEmpty() || domainName.isEmpty()) {
             List<Problem> configProblems = new ArrayList<>();
 
             if (resourceName.isEmpty()) {
@@ -255,6 +255,10 @@ public class AzureOpenAiRecorder {
 
             if (deploymentName.isEmpty()) {
                 configProblems.add(createConfigProblem("deployment-name", configName));
+            }
+
+            if (domainName.isEmpty()) {
+                configProblems.add(createConfigProblem("domain-name", configName));
             }
 
             throw new ConfigValidationException(configProblems.toArray(EMPTY_PROBLEMS));

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/ChatModelConfig.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/ChatModelConfig.java
@@ -12,25 +12,28 @@ public interface ChatModelConfig {
      * This property will override the {@code quarkus.langchain4j.azure-openai.resource-name}
      * specifically for chat models if it is set.
      */
+    @WithDefault(ConfigConstants.DUMMY_VALUE)
     Optional<String> resourceName();
 
     /**
      * This property will override the {@code quarkus.langchain4j.azure-openai.domain-name}
      * specifically for chat models if it is set.
      */
-    @WithDefault("openai.azure.com")
+    @WithDefault(ConfigConstants.DUMMY_VALUE)
     Optional<String> domainName();
 
     /**
      * This property will override the {@code quarkus.langchain4j.azure-openai.deployment-name}
      * specifically for chat models if it is set.
      */
+    @WithDefault(ConfigConstants.DUMMY_VALUE)
     Optional<String> deploymentName();
 
     /**
      * This property will override the {@code quarkus.langchain4j.azure-openai.endpoint}
      * specifically for chat models if it is set.
      */
+    @WithDefault(ConfigConstants.DUMMY_VALUE)
     Optional<String> endpoint();
 
     /**

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/ConfigConstants.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/ConfigConstants.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.langchain4j.azure.openai.runtime.config;
+
+final class ConfigConstants {
+    static final String DUMMY_VALUE = "<dummy>";
+
+    private ConfigConstants() {
+    }
+}

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/EmbeddingModelConfig.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/EmbeddingModelConfig.java
@@ -18,7 +18,6 @@ public interface EmbeddingModelConfig {
      * This property will override the {@code quarkus.langchain4j.azure-openai.domain-name}
      * specifically for embedding models if it is set.
      */
-    @WithDefault("openai.azure.com")
     Optional<String> domainName();
 
     /**

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/ImageModelConfig.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/ImageModelConfig.java
@@ -19,7 +19,6 @@ public interface ImageModelConfig {
      * This property will override the {@code quarkus.langchain4j.azure-openai.domain-name}
      * specifically for image models if it is set.
      */
-    @WithDefault("openai.azure.com")
     Optional<String> domainName();
 
     /**

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/LangChain4jAzureOpenAiConfig.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/LangChain4jAzureOpenAiConfig.java
@@ -150,18 +150,36 @@ public interface LangChain4jAzureOpenAiConfig {
          */
         ImageModelConfig imageModel();
 
+        default Optional<String> domainNameFor(EndpointType type) {
+            var deepDomainName = switch (type) {
+                case CHAT -> chatModel().domainName();
+                case EMBEDDING -> embeddingModel().domainName();
+                case IMAGE -> imageModel().domainName();
+            };
+            return deepDomainName
+                    .filter(v -> !ConfigConstants.DUMMY_VALUE.equals(v))
+                    .or(new Supplier<Optional<String>>() {
+                        @Override
+                        public Optional<String> get() {
+                            return domainName();
+                        }
+                    });
+        }
+
         default Optional<String> endPointFor(EndpointType type) {
             var deepEndpoint = switch (type) {
                 case CHAT -> chatModel().endpoint();
                 case EMBEDDING -> embeddingModel().endpoint();
                 case IMAGE -> imageModel().endpoint();
             };
-            return deepEndpoint.or(new Supplier<Optional<String>>() {
-                @Override
-                public Optional<String> get() {
-                    return endpoint();
-                }
-            });
+            return deepEndpoint
+                    .filter(v -> !ConfigConstants.DUMMY_VALUE.equals(v))
+                    .or(new Supplier<Optional<String>>() {
+                        @Override
+                        public Optional<String> get() {
+                            return endpoint();
+                        }
+                    });
         }
 
         default Optional<String> resourceNameFor(EndpointType type) {
@@ -170,12 +188,14 @@ public interface LangChain4jAzureOpenAiConfig {
                 case EMBEDDING -> embeddingModel().resourceName();
                 case IMAGE -> imageModel().resourceName();
             };
-            return deepResourceName.or(new Supplier<Optional<String>>() {
-                @Override
-                public Optional<String> get() {
-                    return resourceName();
-                }
-            });
+            return deepResourceName
+                    .filter(v -> !ConfigConstants.DUMMY_VALUE.equals(v))
+                    .or(new Supplier<Optional<String>>() {
+                        @Override
+                        public Optional<String> get() {
+                            return resourceName();
+                        }
+                    });
         }
 
         default Optional<String> deploymentNameFor(EndpointType type) {
@@ -184,12 +204,14 @@ public interface LangChain4jAzureOpenAiConfig {
                 case EMBEDDING -> embeddingModel().deploymentName();
                 case IMAGE -> imageModel().deploymentName();
             };
-            return deepDeploymentName.or(new Supplier<Optional<String>>() {
-                @Override
-                public Optional<String> get() {
-                    return deploymentName();
-                }
-            });
+            return deepDeploymentName
+                    .filter(v -> !ConfigConstants.DUMMY_VALUE.equals(v))
+                    .or(new Supplier<Optional<String>>() {
+                        @Override
+                        public Optional<String> get() {
+                            return deploymentName();
+                        }
+                    });
         }
 
         enum EndpointType {


### PR DESCRIPTION
Addition to #698, this brings the `domainName()` configuration property to feature parity with similar properties, like deploymentName. 