### PR TITLE
Update pgvector-store.adoc - remove reference to Redis

### DIFF
--- a/docs/modules/ROOT/pages/pgvector-store.adoc
+++ b/docs/modules/ROOT/pages/pgvector-store.adoc
@@ -6,7 +6,7 @@ When implementing Retrieval Augmented Generation (RAG), a capable document store
 
 == Leveraging the pgvector Document Store
 
-To utilize the Redis document store, you'll need to include the following dependency:
+To utilize the PostgreSQL pgVector document store, you'll need to include the following dependency:
 
 [source,xml,subs=attributes+]
 ----


### PR DESCRIPTION
Line 7 - replace reference to "Redis" with reference to "PostgreSQL pgVector" as this page deals with Postgres and pgVector.