### PR TITLE
Add a warning about missing -parameters flag for javac

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -944,6 +945,11 @@ public class AiServicesProcessor {
         if ((templateParams.size() == 1) && (params.size() == 1)) {
             // the special 'it' param is supported when the method only has one parameter
             templateParams.add(new TemplateParameterInfo(0, "it"));
+        }
+
+        if (templateParams.stream().map(TemplateParameterInfo::name).allMatch(Objects::isNull)) {
+            log.warn(
+                    "The application has been compiled without the '-parameters' being set flag on javac. Make sure your build tool is configured to pass this flag to javac, otherwise Quarkus LangChain4j is unlikely to work properly without it.");
         }
 
         return templateParams;


### PR DESCRIPTION
Without this warning, users can end up with only an
error complaining about a duplicate null key

This was prompted by https://stackoverflow.com/q/78695273/2504224, but it's 
far from the first time I've seen the same issue.