### PR TITLE
Prevent false positive of javac -parameters

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
@@ -947,7 +947,7 @@ public class AiServicesProcessor {
             templateParams.add(new TemplateParameterInfo(0, "it"));
         }
 
-        if (templateParams.stream().map(TemplateParameterInfo::name).allMatch(Objects::isNull)) {
+        if (!templateParams.isEmpty() && templateParams.stream().map(TemplateParameterInfo::name).allMatch(Objects::isNull)) {
             log.warn(
                     "The application has been compiled without the '-parameters' being set flag on javac. Make sure your build tool is configured to pass this flag to javac, otherwise Quarkus LangChain4j is unlikely to work properly without it.");
         }


### PR DESCRIPTION
This could happen before when there were no template params