### PR TITLE
Fix issue with Azure OpenAI and metrics usage

### DIFF
--- a/integration-tests/multiple-providers/src/test/java/org/acme/example/multiple/MultipleTokenCountEstimatorProvidersTest.java
+++ b/integration-tests/multiple-providers/src/test/java/org/acme/example/multiple/MultipleTokenCountEstimatorProvidersTest.java
@@ -1,7 +1,6 @@
 package org.acme.example.multiple;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import jakarta.inject.Inject;
 
@@ -47,20 +46,17 @@ public class MultipleTokenCountEstimatorProvidersTest {
     void azureOpenAiTest() {
         assertThat(ClientProxy.unwrap(azureChat)).isInstanceOf(AzureOpenAiChatModel.class);
         assertThat(ClientProxy.unwrap(azureTokenizer)).isInstanceOf(AzureOpenAiChatModel.class);
-        assertEquals(ClientProxy.unwrap(azureChat), ClientProxy.unwrap(azureTokenizer));
     }
 
     @Test
     void bamTest() {
         assertThat(ClientProxy.unwrap(bamChat)).isInstanceOf(BamChatModel.class);
         assertThat(ClientProxy.unwrap(bamTokenizer)).isInstanceOf(BamChatModel.class);
-        assertEquals(ClientProxy.unwrap(bamChat), ClientProxy.unwrap(bamTokenizer));
     }
 
     @Test
     void watsonxTest() {
         assertThat(ClientProxy.unwrap(watsonxChat)).isInstanceOf(WatsonxChatModel.class);
         assertThat(ClientProxy.unwrap(watsonxTokenizer)).isInstanceOf(WatsonxChatModel.class);
-        assertEquals(ClientProxy.unwrap(watsonxChat), ClientProxy.unwrap(watsonxTokenizer));
     }
 }

--- a/model-providers/bam/runtime/src/main/java/io/quarkiverse/langchain4j/bam/runtime/BamRecorder.java
+++ b/model-providers/bam/runtime/src/main/java/io/quarkiverse/langchain4j/bam/runtime/BamRecorder.java
@@ -67,12 +67,10 @@ public class BamRecorder {
                 builder.url(bamConfig.baseUrl().get());
             }
 
-            var result = builder.build(BamChatModel.class);
-
             return new Supplier<>() {
                 @Override
                 public ChatLanguageModel get() {
-                    return result;
+                    return builder.build(BamChatModel.class);
                 }
             };
 

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
@@ -68,12 +68,10 @@ public class AzureOpenAiRecorder {
                 builder.maxTokens(chatModelConfig.maxTokens().get());
             }
 
-            var chatModel = builder.build();
-
             return new Supplier<>() {
                 @Override
                 public ChatLanguageModel get() {
-                    return chatModel;
+                    return builder.build();
                 }
             };
         } else {

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/WatsonxRecorder.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/WatsonxRecorder.java
@@ -45,12 +45,12 @@ public class WatsonxRecorder {
 
         if (watsonConfig.enableIntegration()) {
 
-            var chatModel = generateChatBuilder(watsonConfig, configName).build(WatsonxChatModel.class);
+            var builder = generateChatBuilder(watsonConfig, configName);
 
             return new Supplier<>() {
                 @Override
                 public ChatLanguageModel get() {
-                    return chatModel;
+                    return builder.build(WatsonxChatModel.class);
                 }
             };
 


### PR DESCRIPTION
Essentially the ChatLanguageModel was being
built too early thus messing up the construction
order of the dependencies

- Fixes: #731