### PR TITLE
Set `false` as default value for fullText in hugging face config

### DIFF
--- a/model-providers/hugging-face/runtime/src/main/java/io/quarkiverse/langchain4j/huggingface/runtime/HuggingFaceRecorder.java
+++ b/model-providers/hugging-face/runtime/src/main/java/io/quarkiverse/langchain4j/huggingface/runtime/HuggingFaceRecorder.java
@@ -46,13 +46,11 @@ public class HuggingFaceRecorder {
                     .topK(chatModelConfig.topK())
                     .repetitionPenalty(chatModelConfig.repetitionPenalty())
                     .logRequests(chatModelConfig.logRequests().orElse(false))
-                    .logResponses(chatModelConfig.logResponses().orElse(false));
+                    .logResponses(chatModelConfig.logResponses().orElse(false))
+                    .returnFullText(chatModelConfig.returnFullText());
 
             if (!DUMMY_KEY.equals(apiKey)) {
                 builder.accessToken(apiKey);
-            }
-            if (chatModelConfig.returnFullText().isPresent()) {
-                builder.returnFullText(chatModelConfig.returnFullText().get());
             }
 
             if (chatModelConfig.maxNewTokens().isPresent()) {

--- a/model-providers/hugging-face/runtime/src/main/java/io/quarkiverse/langchain4j/huggingface/runtime/config/ChatModelConfig.java
+++ b/model-providers/hugging-face/runtime/src/main/java/io/quarkiverse/langchain4j/huggingface/runtime/config/ChatModelConfig.java
@@ -45,7 +45,7 @@ public interface ChatModelConfig {
      * If set to {@code false}, the return results will not contain the original query making it easier for prompting
      */
     @WithDefault("false")
-    Optional<Boolean> returnFullText();
+    Boolean returnFullText();
 
     /**
      * If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your

--- a/model-providers/hugging-face/runtime/src/main/java/io/quarkiverse/langchain4j/huggingface/runtime/config/ChatModelConfig.java
+++ b/model-providers/hugging-face/runtime/src/main/java/io/quarkiverse/langchain4j/huggingface/runtime/config/ChatModelConfig.java
@@ -44,6 +44,7 @@ public interface ChatModelConfig {
     /**
      * If set to {@code false}, the return results will not contain the original query making it easier for prompting
      */
+    @WithDefault("false")
     Optional<Boolean> returnFullText();
 
     /**


### PR DESCRIPTION
Fixed issue returning the full text by default for hugging face