### PR TITLE
Add `prompt-joiner` property for watsonx provider

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-watsonx.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-watsonx.adoc
@@ -498,6 +498,23 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-prompt-joiner]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-prompt-joiner[quarkus.langchain4j.watsonx.chat-model.prompt-joiner]`
+
+
+[.description]
+--
+Delimiter used to concatenate the ChatMessage elements into a single string. By setting this property, you can define your preferred way of concatenating messages to ensure that the prompt is structured in the correct way.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_PROMPT_JOINER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_PROMPT_JOINER+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-embedding-model-model-id]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-embedding-model-model-id[quarkus.langchain4j.watsonx.embedding-model.model-id]`
 
 
@@ -1049,6 +1066,23 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_LO
 endif::add-copy-button-to-env-var[]
 --|boolean 
 |`false`
+
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-prompt-joiner]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-prompt-joiner[quarkus.langchain4j.watsonx."model-name".chat-model.prompt-joiner]`
+
+
+[.description]
+--
+Delimiter used to concatenate the ChatMessage elements into a single string. By setting this property, you can define your preferred way of concatenating messages to ensure that the prompt is structured in the correct way.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_PROMPT_JOINER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_PROMPT_JOINER+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
 
 
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-embedding-model-model-id]]`link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-embedding-model-model-id[quarkus.langchain4j.watsonx."model-name".embedding-model.model-id]`

--- a/docs/modules/ROOT/pages/watsonx.adoc
+++ b/docs/modules/ROOT/pages/watsonx.adoc
@@ -62,13 +62,11 @@ quarkus.langchain4j.watsonx.api-key=hG-...
 
 NOTE: To determine the API key, go to https://cloud.ibm.com/iam/apikeys and generate it.
 
-==== All configuration properties
+==== Writing prompts
 
-include::includes/quarkus-langchain4j-watsonx.adoc[leveloffset=+1,opts=optional]
+When creating prompts using watsonx.ai, it's important to follow the guidelines of the model you choose. Depending on the model, some special instructions may be required to ensure the desired output. For best results, always refer to the documentation provided for each model to maximize the effectiveness of your prompts.
 
-== Example
-
-An example usage is the following:
+For example, if you choose to use `ibm/granite-13b-chat-v2`, you can use the `<|system|>`, `<|user|>`, and `<|assistant|>` instructions:
 
 [source,properties,subs=attributes+]
 ----
@@ -79,21 +77,21 @@ quarkus.langchain4j.watsonx.chat-model.model-id=ibm/granite-13b-chat-v2
 
 [source,java]
 ----
-public record Result(Integer result) {}
-----
-
-[source,java]
-----
 @RegisterAiService
 public interface LLMService {
-    
-    @SystemMessage("You are a calculator")
+
+    public record Result(Integer result) {}
+
+    @SystemMessage("""
+        <|system|>
+        You are a calculator and you must perform the mathematical operation
+        {response_schema}
+        """)
     @UserMessage("""
-        You must perform the mathematical operation delimited by ---
-        ---
+        <|user|>
         {firstNumber} + {secondNumber}
-        ---
-    """)
+        <|assistant|>
+        """)
     public Result calculator(int firstNumber, int secondNumber);
 }
 ----
@@ -108,6 +106,7 @@ public class LLMResource {
 
     @GET
     @Path("/calculator")
+    @Produces(MediaType.APPLICATION_JSON)
     public Result calculator() {
         return llmService.calculator(2, 2);
     }
@@ -120,4 +119,10 @@ public class LLMResource {
 {"result":4}
 ----
 
+IMPORTANT: The `@SystemMessage` and `@UserMessage` are joined by default without spaces or new lines, if you want to change this behavior use the property `quarkus.langchain4j.watsonx.chat-model.prompt-joiner=<value>`. By adjusting this property, you can define your preferred way of joining messages and ensure that the prompt structure meets your specific needs.
+
 NOTE: Sometimes it may be useful to use the `quarkus.langchain4j.watsonx.chat-model.stop-sequences` property to prevent the LLM model from returning more results than desired.
+
+==== All configuration properties
+
+include::includes/quarkus-langchain4j-watsonx.adoc[leveloffset=+1,opts=optional]

--- a/model-providers/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/AiChatServiceTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/AiChatServiceTest.java
@@ -74,7 +74,7 @@ public class AiChatServiceTest {
     @Singleton
     interface NewAIService {
 
-        @SystemMessage("This is a systemMessage")
+        @SystemMessage("This is a systemMessage\n")
         @UserMessage("This is a userMessage {text}")
         String chat(String text);
     }
@@ -91,9 +91,8 @@ public class AiChatServiceTest {
         String projectId = watsonConfig.projectId();
         String input = new StringBuilder()
                 .append("This is a systemMessage")
-                .append("\n\n")
-                .append("This is a userMessage Hello")
                 .append("\n")
+                .append("This is a userMessage Hello")
                 .toString();
         Parameters parameters = Parameters.builder()
                 .decodingMethod(chatModelConfig.decodingMethod())

--- a/model-providers/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/DefaultPropertiesTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/DefaultPropertiesTest.java
@@ -81,6 +81,8 @@ public class DefaultPropertiesTest {
         assertEquals(false, config.chatModel().randomSeed().isPresent());
         assertEquals(false, config.chatModel().stopSequences().isPresent());
         assertEquals(1.0, config.chatModel().temperature());
+        assertEquals("", config.chatModel().promptJoiner().orElse(""));
+
         assertTrue(config.chatModel().topK().isEmpty());
         assertTrue(config.chatModel().topP().isEmpty());
         assertTrue(config.chatModel().repetitionPenalty().isEmpty());
@@ -92,7 +94,6 @@ public class DefaultPropertiesTest {
 
         String modelId = config.chatModel().modelId();
         String projectId = config.projectId();
-        String input = "TEST";
         Parameters parameters = Parameters.builder()
                 .decodingMethod(config.chatModel().decodingMethod())
                 .temperature(config.chatModel().temperature())
@@ -100,7 +101,7 @@ public class DefaultPropertiesTest {
                 .maxNewTokens(config.chatModel().maxNewTokens())
                 .build();
 
-        TextGenerationRequest body = new TextGenerationRequest(modelId, projectId, input + "\n", parameters);
+        TextGenerationRequest body = new TextGenerationRequest(modelId, projectId, "SystemMessageUserMessage", parameters);
 
         mockServers.mockIAMBuilder(200)
                 .response("token", new Date())
@@ -126,6 +127,7 @@ public class DefaultPropertiesTest {
                         """)
                 .build();
 
-        assertEquals("Response!", model.generate(input));
+        assertEquals("Response!", model.generate(dev.langchain4j.data.message.SystemMessage.from("SystemMessage"),
+                dev.langchain4j.data.message.UserMessage.from("UserMessage")).content().text());
     }
 }

--- a/model-providers/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/TokenCountEstimatorTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/TokenCountEstimatorTest.java
@@ -126,7 +126,7 @@ public class TokenCountEstimatorTest {
     void token_count_estimator_list() throws Exception {
         mockServer();
         assertEquals(11, tokenization.estimateTokenCount(
-                List.of(SystemMessage.from("Write a tagline for an alumni"), UserMessage.from("association: Together we"))));
+                List.of(SystemMessage.from("Write a tagline for an alumni "), UserMessage.from("association: Together we"))));
     }
 
     private String mockServer() throws Exception {

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxChatModel.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxChatModel.java
@@ -1,7 +1,5 @@
 package io.quarkiverse.langchain4j.watsonx;
 
-import static java.util.stream.Collectors.joining;
-
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
@@ -71,11 +69,8 @@ public class WatsonxChatModel extends WatsonxModel implements ChatLanguageModel,
 
     @Override
     public int estimateTokenCount(List<ChatMessage> messages) {
-        var input = messages
-                .stream()
-                .map(ChatMessage::text)
-                .collect(joining(" "));
 
+        var input = toInput(messages);
         var request = new TokenizationRequest(modelId, input, projectId);
 
         return retryOn(new Callable<Integer>() {

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxStreamingChatModel.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxStreamingChatModel.java
@@ -1,7 +1,5 @@
 package io.quarkiverse.langchain4j.watsonx;
 
-import static java.util.stream.Collectors.joining;
-
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -134,11 +132,7 @@ public class WatsonxStreamingChatModel extends WatsonxModel implements Streaming
     @Override
     public int estimateTokenCount(List<ChatMessage> messages) {
 
-        var input = messages
-                .stream()
-                .map(ChatMessage::text)
-                .collect(joining(" "));
-
+        var input = toInput(messages);
         var request = new TokenizationRequest(modelId, input, projectId);
         return retryOn(new Callable<Integer>() {
             @Override

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/WatsonxRecorder.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/WatsonxRecorder.java
@@ -177,6 +177,7 @@ public class WatsonxRecorder {
         }
 
         return WatsonxChatModel.builder()
+                .promptJoiner(chatModelConfig.promptJoiner().orElse(""))
                 .tokenGenerator(tokenGenerator)
                 .url(url)
                 .timeout(watsonConfig.timeout().orElse(Duration.ofSeconds(10)))

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/ChatModelConfig.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/ChatModelConfig.java
@@ -156,6 +156,13 @@ public interface ChatModelConfig {
     @WithDefault("${quarkus.langchain4j.watsonx.log-responses}")
     Optional<Boolean> logResponses();
 
+    /**
+     * Delimiter used to concatenate the ChatMessage elements into a single string. By setting this property, you can define
+     * your
+     * preferred way of concatenating messages to ensure that the prompt is structured in the correct way.
+     */
+    Optional<String> promptJoiner();
+
     @ConfigGroup
     public interface LengthPenaltyConfig {
 


### PR DESCRIPTION
Before these changes, all `ChatMessage`(s) were joined using the delimiter `\n` or `\n\n`.
The idea is to give the choice to the developer by using the `quarkus.langchain4j.watsonx.chat-model.prompt-joiner` property.

This way the developer can choose the preferred way of concatenating messages to ensure the prompt is structured correctly.