### PR TITLE
Ensure that @Retry works properly with chat memory

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/CommittableChatMemory.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/CommittableChatMemory.java
@@ -1,0 +1,15 @@
+package io.quarkiverse.langchain4j.runtime.aiservice;
+
+import dev.langchain4j.memory.ChatMemory;
+
+/**
+ * This is needed in order to make it possible defer updating {@link ChatMemory} until the implementation has completed
+ * successfully.
+ */
+interface CommittableChatMemory extends ChatMemory {
+
+    /**
+     * Should be called to actually update the chat memory
+     */
+    void commit();
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/DefaultCommittableChatMemory.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/DefaultCommittableChatMemory.java
@@ -1,0 +1,68 @@
+package io.quarkiverse.langchain4j.runtime.aiservice;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.memory.ChatMemory;
+
+class DefaultCommittableChatMemory implements CommittableChatMemory {
+
+    private final ChatMemory delegate;
+    private final List<ChatMessage> newMessages;
+
+    public DefaultCommittableChatMemory(ChatMemory delegate) {
+        this.delegate = delegate;
+        this.newMessages = new ArrayList<>(delegate.messages());
+    }
+
+    @Override
+    public Object id() {
+        return delegate.id();
+    }
+
+    @Override
+    public void add(ChatMessage message) {
+        if (message instanceof SystemMessage) {
+            Optional<SystemMessage> systemMessage = findSystemMessage(newMessages);
+            if (systemMessage.isPresent()) {
+                if (systemMessage.get().equals(message)) {
+                    return; // do not add the same system message
+                } else {
+                    newMessages.remove(systemMessage.get()); // need to replace existing system message
+                }
+            }
+        }
+        newMessages.add(message);
+    }
+
+    private static Optional<SystemMessage> findSystemMessage(List<ChatMessage> messages) {
+        return messages.stream()
+                .filter(message -> message instanceof SystemMessage)
+                .map(message -> (SystemMessage) message)
+                .findAny();
+    }
+
+    @Override
+    public List<ChatMessage> messages() {
+        return new ArrayList<>(newMessages);
+    }
+
+    // the following operations are terminal
+
+    @Override
+    public void clear() {
+        newMessages.clear();
+        delegate.clear();
+    }
+
+    @Override
+    public void commit() {
+        delegate.clear(); // remove the original messages as this class keeps the entire state
+        for (ChatMessage newMessage : newMessages) {
+            delegate.add(newMessage);
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/NoopChatMemory.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/NoopChatMemory.java
@@ -1,0 +1,38 @@
+package io.quarkiverse.langchain4j.runtime.aiservice;
+
+import java.util.Collections;
+import java.util.List;
+
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.memory.ChatMemory;
+
+/**
+ * An implementation of {@link ChatMemory} that does nothing.
+ * This is useful for simplifying the AiService code.
+ */
+class NoopChatMemory implements CommittableChatMemory {
+    @Override
+    public Object id() {
+        return "default";
+    }
+
+    @Override
+    public void add(ChatMessage message) {
+
+    }
+
+    @Override
+    public List<ChatMessage> messages() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void clear() {
+
+    }
+
+    @Override
+    public void commit() {
+
+    }
+}

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/org/acme/examples/aiservices/CustomChatMemoryStoreTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/org/acme/examples/aiservices/CustomChatMemoryStoreTest.java
@@ -181,8 +181,7 @@ public class CustomChatMemoryStoreTest extends OpenAiBaseTest {
         assertThat(CustomChatMemoryStore.GET_MESSAGES_COUNT).hasPositiveValue();
         assertThat(CustomChatMemoryStore.UPDATE_MESSAGES_COUNT).hasPositiveValue();
 
-        // assert delete has not been called because the tool is singleton
-        assertThat(CustomChatMemoryStore.DELETE_MESSAGES_COUNT).hasValue(0);
+        int deleteCount = CustomChatMemoryStore.DELETE_MESSAGES_COUNT.get();
 
         // remove the first entry
         ChatMemoryRemover.remove(chatWithSeparateMemoryForEachUser, FIRST_MEMORY_ID);
@@ -195,6 +194,6 @@ public class CustomChatMemoryStoreTest extends OpenAiBaseTest {
         assertThat(chatMemoryStore.getMessages(SECOND_MEMORY_ID)).isEmpty();
 
         // now assert that our store was used for delete
-        assertThat(CustomChatMemoryStore.DELETE_MESSAGES_COUNT).hasValue(2);
+        assertThat(CustomChatMemoryStore.DELETE_MESSAGES_COUNT).hasValue(deleteCount + 2);
     }
 }

--- a/quarkus-integrations/websockets-next/tests/src/test/java/io/quarkiverse/langchain4j/websockets/next/tests/WebSocketsNextTest.java
+++ b/quarkus-integrations/websockets-next/tests/src/test/java/io/quarkiverse/langchain4j/websockets/next/tests/WebSocketsNextTest.java
@@ -113,14 +113,12 @@ public class WebSocketsNextTest extends OpenAiBaseTest {
                                     // the bot has already chatted, so there should be some memory
                                     assertThat(chatMemoryStore.idsFromGetMessages).hasSize(1)
                                             .hasOnlyElementsOfType(String.class);
-                                    assertThat(chatMemoryStore.idsFromDeleteMessaged).isEmpty();
 
                                     webSocket.writeTextMessage("what is your name?", (firstWriteResult -> {
                                         if (firstWriteResult.succeeded()) {
                                             // the message has been written
                                             assertThat(chatMemoryStore.idsFromGetMessages).hasSize(1)
                                                     .hasOnlyElementsOfType(String.class);
-                                            assertThat(chatMemoryStore.idsFromDeleteMessaged).isEmpty();
 
                                             latch.countDown();
 
@@ -174,7 +172,6 @@ public class WebSocketsNextTest extends OpenAiBaseTest {
 
                                 assertThat(chatMemoryStore.idsFromGetMessages).hasSize(2)
                                         .hasOnlyElementsOfType(String.class);
-                                assertThat(chatMemoryStore.idsFromDeleteMessaged).hasSize(1);
 
                                 webSocket.close().onComplete((closeResult) -> {
                                     if (closeResult.succeeded()) {


### PR DESCRIPTION
This is done by only committing the messages to memory when the AiService completes successfully.

- Fixes: #748