### PR TITLE
Replace Singleton with ApplicationScoped

### DIFF
--- a/docs/modules/ROOT/examples/io/quarkiverse/langchain4j/samples/RetrievalAugmentorExample.java
+++ b/docs/modules/ROOT/examples/io/quarkiverse/langchain4j/samples/RetrievalAugmentorExample.java
@@ -2,7 +2,7 @@ package io.quarkiverse.langchain4j.samples;
 
 import java.util.function.Supplier;
 
-import jakarta.inject.Singleton;
+import jakarta.enterprise.context.ApplicationScoped;
 
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.rag.DefaultRetrievalAugmentor;
@@ -10,7 +10,7 @@ import dev.langchain4j.rag.RetrievalAugmentor;
 import dev.langchain4j.rag.content.retriever.EmbeddingStoreContentRetriever;
 import io.quarkiverse.langchain4j.redis.RedisEmbeddingStore;
 
-@Singleton
+@ApplicationScoped
 public class RetrievalAugmentorExample implements Supplier<RetrievalAugmentor> {
 
     private final RetrievalAugmentor augmentor;


### PR DESCRIPTION
This aligns with the rest of the examples in the documentation page. There might be a good reason as I'm not an expert but it felt odd to see singleton here. If there is no reason, better align tot he more accepted `ApplicationScoped` and be consistent with the rest of the examples in the doc page.