### PR TITLE
Make gpt-4o-mini the default OpenAI model

### DIFF
--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/ChatModelConfig.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/ChatModelConfig.java
@@ -13,7 +13,7 @@ public interface ChatModelConfig {
     /**
      * Model name to use
      */
-    @WithDefault("gpt-3.5-turbo")
+    @WithDefault("gpt-4o-mini")
     String modelName();
 
     /**

--- a/samples/review-triage/src/main/resources/application.properties
+++ b/samples/review-triage/src/main/resources/application.properties
@@ -1,9 +1,5 @@
 quarkus.langchain4j.openai.chat-model.temperature=0.5
 quarkus.langchain4j.timeout=60s
 
-# using a json_object response format requires at least gpt-3.5-turbo-1106 or more recent
-# see https://platform.openai.com/docs/api-reference/chat/create#chat-create-response_format
-quarkus.langchain4j.openai.chat-model.model-name=gpt-3.5-turbo-0125
-
 quarkus.langchain4j.log-requests=true
 quarkus.langchain4j.log-responses=true

--- a/samples/secure-fraud-detection/README.md
+++ b/samples/secure-fraud-detection/README.md
@@ -1,7 +1,7 @@
 # Secure Fraud Detection Demo
 
 This demo showcases the implementation of a secure fraud detection system which is available only to users authenticated with Google.
-It uses the `gpt-3.5-turbo` LLM, use `quarkus.langchain4j.openai.chat-model.model-name` property to select a different model.
+It uses the `gpt-4o-mini` LLM, use `quarkus.langchain4j.openai.chat-model.model-name` property to select a different model.
 
 ## The Demo
 


### PR DESCRIPTION
This is done as gpt-4o-mini is better than gpt-3.5-turbo in all aspects

See https://openai.com/index/gpt-4o-mini-advancing-cost-efficient-intelligence/ for more details