### PR TITLE
Polish watsonx code

### DIFF
--- a/model-providers/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/AiChatServiceTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/AiChatServiceTest.java
@@ -12,6 +12,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -39,7 +40,7 @@ public class AiChatServiceTest {
     LangChain4jWatsonxConfig langchain4jWatsonConfig;
 
     @Inject
-    ChatLanguageModel model;
+    ChatLanguageModel chatModel;
 
     static WireMockUtil mockServers;
 
@@ -68,6 +69,12 @@ public class AiChatServiceTest {
     static void afterAll() {
         watsonxServer.stop();
         iamServer.stop();
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        watsonxServer.resetAll();
+        iamServer.resetAll();
     }
 
     @RegisterAiService
@@ -109,21 +116,7 @@ public class AiChatServiceTest {
 
         mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_CHAT_API, 200)
                 .body(mapper.writeValueAsString(body))
-                .response("""
-                            {
-                                "model_id": "meta-llama/llama-2-70b-chat",
-                                "created_at": "2024-01-21T17:06:14.052Z",
-                                "results": [
-                                    {
-                                        "generated_text": "AI Response",
-                                        "generated_token_count": 5,
-                                        "input_token_count": 50,
-                                        "stop_reason": "eos_token",
-                                        "seed": 2123876088
-                                    }
-                                ]
-                            }
-                        """)
+                .response(WireMockUtil.RESPONSE_WATSONX_CHAT_API)
                 .build();
 
         assertEquals("AI Response", service.chat("Hello"));

--- a/model-providers/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/AiEmbeddingTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/AiEmbeddingTest.java
@@ -13,6 +13,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -68,6 +69,12 @@ public class AiEmbeddingTest {
     static void afterAll() {
         watsonxServer.stop();
         iamServer.stop();
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        watsonxServer.resetAll();
+        iamServer.resetAll();
     }
 
     @Inject
@@ -180,22 +187,7 @@ public class AiEmbeddingTest {
 
         mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_EMBEDDING_API, 200)
                 .body(mapper.writeValueAsString(request))
-                .response("""
-                        {
-                            "model_id": "%s",
-                            "results": [
-                              {
-                                "embedding": [
-                                  -0.006929283,
-                                  -0.005336422,
-                                  -0.024047505
-                                ]
-                              }
-                            ],
-                            "created_at": "2024-02-21T17:32:28Z",
-                            "input_token_count": 10
-                        }
-                        """.formatted(WireMockUtil.DEFAULT_EMBEDDING_MODEL))
+                .response(WireMockUtil.RESPONSE_WATSONX_EMBEDDING_API)
                 .build();
 
         return List.of(-0.006929283f, -0.005336422f, -0.024047505f);

--- a/model-providers/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/CacheTokenTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/CacheTokenTest.java
@@ -1,23 +1,23 @@
 package com.ibm.langchain4j.watsonx.deployment;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static com.ibm.langchain4j.watsonx.deployment.WireMockUtil.streamingResponseHandler;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-import java.util.Calendar;
+import java.time.Instant;
 import java.util.Date;
-import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 
 import jakarta.inject.Inject;
-import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 
-import org.jboss.resteasy.reactive.ClientWebApplicationException;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -25,7 +25,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
 
+import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.TokenCountEstimator;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import io.quarkiverse.langchain4j.watsonx.client.WatsonxRestApi;
 import io.quarkiverse.langchain4j.watsonx.runtime.config.LangChain4jWatsonxConfig;
@@ -33,9 +36,23 @@ import io.quarkus.test.QuarkusUnitTest;
 
 public class CacheTokenTest {
 
+    static int cacheTimeout = 2000;
     static WireMockServer watsonxServer;
     static WireMockServer iamServer;
     static ObjectMapper mapper;
+    static String RESPONSE_401 = """
+            {
+                "errors": [
+                    {
+                        "code": "authentication_token_expired",
+                        "message": "Failed to authenticate the request due to an expired token",
+                        "more_info": "https://cloud.ibm.com/apidocs/watsonx-ai"
+                    }
+                ],
+                "trace": "fc4afd38813180730e10a5a3d56c1f25",
+                "status_code": 401
+            }
+            """;
 
     @Inject
     LangChain4jWatsonxConfig config;
@@ -44,7 +61,13 @@ public class CacheTokenTest {
     ChatLanguageModel chatModel;
 
     @Inject
+    StreamingChatLanguageModel streamingChatModel;
+
+    @Inject
     EmbeddingModel embeddingModel;
+
+    @Inject
+    TokenCountEstimator tokenCountEstimator;
 
     static WireMockUtil mockServers;
 
@@ -75,68 +98,16 @@ public class CacheTokenTest {
         iamServer.stop();
     }
 
-    @Test
-    void try_token_chat_cache() throws InterruptedException {
-
-        // Create a token which expires in 3 seconds.
-        Calendar calendar = Calendar.getInstance();
-        calendar.add(Calendar.SECOND, 3);
-        Date date = calendar.getTime();
-
-        // First call returns 200.
-        mockServers.mockIAMBuilder(200)
-                .scenario(Scenario.STARTED, "error")
-                .response("3secondstoken", date)
-                .build();
-
-        // All other call after 3 seconds they will give an error.
-        mockServers.mockIAMBuilder(500)
-                .responseMediaType(MediaType.TEXT_PLAIN)
-                .scenario("error", Scenario.STARTED)
-                .response("3 seconds are passed")
-                .build();
-
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_CHAT_API, 200)
-                .token("3secondstoken")
-                .response("""
-                            {
-                                "model_id": "meta-llama/llama-2-70b-chat",
-                                "created_at": "2024-01-21T17:06:14.052Z",
-                                "results": [
-                                    {
-                                        "generated_text": "AI Response",
-                                        "generated_token_count": 5,
-                                        "input_token_count": 50,
-                                        "stop_reason": "eos_token",
-                                        "seed": 2123876088
-                                    }
-                                ]
-                            }
-                        """)
-                .build();
-
-        // First: call to mockIAMServer.
-        assertEquals("AI Response", chatModel.generate("message"));
-
-        // Second: uses the cache.
-        assertEquals("AI Response", chatModel.generate("message"));
-
-        Thread.sleep(3000);
-
-        // Third: now an error should appear.
-        WebApplicationException ex = assertThrowsExactly(ClientWebApplicationException.class,
-                () -> chatModel.generate("message"));
-        assertEquals(500, ex.getResponse().getStatus());
-        assertTrue(ex.getMessage().contains("3 seconds are passed"));
+    @BeforeEach
+    void beforeEach() {
+        watsonxServer.resetAll();
+        iamServer.resetAll();
     }
 
     @Test
-    void try_token_embedding_cache() throws InterruptedException {
+    void try_token_cache() throws InterruptedException {
 
-        // Create a token which expires in 3 seconds.
-        Calendar calendar = Calendar.getInstance();
-        calendar.add(Calendar.SECOND, 3);
-        Date date = calendar.getTime();
+        Date date = Date.from(Instant.now().plusMillis(cacheTimeout));
 
         // First call returns 200.
         mockServers.mockIAMBuilder(200)
@@ -144,47 +115,96 @@ public class CacheTokenTest {
                 .response("3secondstoken", date)
                 .build();
 
-        // All other call after 3 seconds they will give an error.
-        mockServers.mockIAMBuilder(500)
-                .responseMediaType(MediaType.TEXT_PLAIN)
+        // All other call after 2 seconds they will give an error.
+        mockServers.mockIAMBuilder(401)
                 .scenario("error", Scenario.STARTED)
-                .response("3 seconds are passed")
+                .response("Should never happen")
                 .build();
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_EMBEDDING_API, 200)
-                .token("3secondstoken")
-                .response("""
-                        {
-                            "model_id": "%s",
-                            "results": [
-                              {
-                                "embedding": [
-                                  -0.006929283,
-                                  -0.005336422,
-                                  -0.024047505
-                                ]
-                              }
-                            ],
-                            "created_at": "2024-02-21T17:32:28Z",
-                            "input_token_count": 10
-                          }
-                        """.formatted(WireMockUtil.DEFAULT_EMBEDDING_MODEL))
+        Stream.of(
+                Map.entry(WireMockUtil.URL_WATSONX_CHAT_API, WireMockUtil.RESPONSE_WATSONX_CHAT_API),
+                Map.entry(WireMockUtil.URL_WATSONX_EMBEDDING_API, WireMockUtil.RESPONSE_WATSONX_EMBEDDING_API),
+                Map.entry(WireMockUtil.URL_WATSONX_CHAT_STREAMING_API, WireMockUtil.RESPONSE_WATSONX_STREAMING_API),
+                Map.entry(WireMockUtil.URL_WATSONX_TOKENIZER_API, WireMockUtil.RESPONSE_WATSONX_TOKENIZER_API))
+                .forEach(entry -> {
+                    mockServers.mockWatsonxBuilder(entry.getKey(), 200)
+                            .token("3secondstoken")
+                            .responseMediaType(entry.getKey().equals(WireMockUtil.URL_WATSONX_CHAT_STREAMING_API)
+                                    ? MediaType.SERVER_SENT_EVENTS
+                                    : MediaType.APPLICATION_JSON)
+                            .response(entry.getValue())
+                            .build();
+                });
+
+        // --- Test ChatLanguageModel --- //
+        assertDoesNotThrow(() -> chatModel.generate("message"));
+        assertDoesNotThrow(() -> chatModel.generate("message")); // cache.
+
+        // --- Test EmbeddingModel --- //
+        assertDoesNotThrow(() -> embeddingModel.embed("message")); // cache.
+
+        // --- Test TokenCountEstimator --- //
+        assertDoesNotThrow(() -> tokenCountEstimator.estimateTokenCount("message"));
+
+        // --- Test StreamingChatLanguageModel --- //
+        streamingChatModel.generate("message", streamingResponseHandler(new AtomicReference<AiMessage>())); // cache.
+
+        Thread.sleep(cacheTimeout);
+    }
+
+    @Test
+    void try_token_retry() throws InterruptedException {
+
+        // Return an expired token.
+        mockServers.mockIAMBuilder(200)
+                .scenario(Scenario.STARTED, "retry")
+                .response("expired_token", Date.from(Instant.now().minusSeconds(3)))
                 .build();
 
-        var vector = List.of(-0.006929283f, -0.005336422f, -0.024047505f);
+        // Second call (retryOn) returns 200
+        mockServers.mockIAMBuilder(200)
+                .scenario("retry", Scenario.STARTED)
+                .response("my_super_token", Date.from(Instant.now().plusMillis(cacheTimeout)))
+                .build();
 
-        // First: call to mockIAMServer.
-        assertEquals(vector, embeddingModel.embed("message").content().vectorAsList());
+        Stream.of(
+                Map.entry(WireMockUtil.URL_WATSONX_CHAT_API, WireMockUtil.RESPONSE_WATSONX_CHAT_API),
+                Map.entry(WireMockUtil.URL_WATSONX_EMBEDDING_API, WireMockUtil.RESPONSE_WATSONX_EMBEDDING_API),
+                Map.entry(WireMockUtil.URL_WATSONX_CHAT_STREAMING_API, WireMockUtil.RESPONSE_WATSONX_STREAMING_API),
+                Map.entry(WireMockUtil.URL_WATSONX_TOKENIZER_API, WireMockUtil.RESPONSE_WATSONX_TOKENIZER_API))
+                .forEach(entry -> {
+                    mockServers.mockWatsonxBuilder(entry.getKey(), 401)
+                            .token("expired_token")
+                            .scenario(Scenario.STARTED, "retry")
+                            .response(RESPONSE_401)
+                            .build();
 
-        // Second: uses the cache.
-        assertEquals(vector, embeddingModel.embed("message").content().vectorAsList());
+                    mockServers.mockWatsonxBuilder(entry.getKey(), 200)
+                            .token("my_super_token")
+                            .scenario("retry", Scenario.STARTED)
+                            .responseMediaType(entry.getKey().equals(WireMockUtil.URL_WATSONX_CHAT_STREAMING_API)
+                                    ? MediaType.SERVER_SENT_EVENTS
+                                    : MediaType.APPLICATION_JSON)
+                            .response(entry.getValue())
+                            .build();
+                });
 
-        Thread.sleep(3000);
+        // --- Test ChatLanguageModel --- //
+        assertDoesNotThrow(() -> chatModel.generate("message"));
 
-        // Third: now an error should appear.
-        WebApplicationException ex = assertThrowsExactly(ClientWebApplicationException.class,
-                () -> embeddingModel.embed("message"));
-        assertEquals(500, ex.getResponse().getStatus());
-        assertTrue(ex.getMessage().contains("3 seconds are passed"));
+        Thread.sleep(cacheTimeout);
+
+        // --- Test EmbeddingModel --- //
+        assertDoesNotThrow(() -> embeddingModel.embed("message"));
+
+        Thread.sleep(cacheTimeout);
+
+        // --- Test TokenCountEstimator --- //
+        assertDoesNotThrow(() -> tokenCountEstimator.estimateTokenCount("message"));
+
+        // --- Test StreamingChatLanguageModel --- //
+        // Thread.sleep(cacheTimeout);
+        // Cannot run due to bug #26253
+        // streamingChatModel.generate("message", streamingResponseHandler(new AtomicReference<AiMessage>()));
     }
 }

--- a/model-providers/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/TokenCountEstimatorTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/com/ibm/langchain4j/watsonx/deployment/TokenCountEstimatorTest.java
@@ -12,6 +12,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -70,27 +71,11 @@ public class TokenCountEstimatorTest {
         iamServer.stop();
     }
 
-    private static final String RESPONSE = """
-              {
-              "model_id": "%s",
-              "result": {
-                "token_count": 11,
-                "tokens": [
-                  "Write",
-                  "a",
-                  "tag",
-                  "line",
-                  "for",
-                  "an",
-                  "alumni",
-                  "associ",
-                  "ation:",
-                  "Together",
-                  "we"
-                ]
-              }
-            }
-            """;
+    @BeforeEach
+    void beforeEach() {
+        watsonxServer.resetAll();
+        iamServer.resetAll();
+    }
 
     @Inject
     TokenCountEstimator tokenization;
@@ -143,7 +128,7 @@ public class TokenCountEstimatorTest {
 
         mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_TOKENIZER_API, 200)
                 .body(mapper.writeValueAsString(body))
-                .response(RESPONSE.formatted(modelId))
+                .response(WireMockUtil.RESPONSE_WATSONX_TOKENIZER_API.formatted(modelId))
                 .build();
 
         return input;

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/TokenGenerator.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/TokenGenerator.java
@@ -7,8 +7,6 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
-import org.jboss.logging.Logger;
-
 import io.quarkiverse.langchain4j.watsonx.bean.IdentityTokenRequest;
 import io.quarkiverse.langchain4j.watsonx.bean.IdentityTokenResponse;
 import io.quarkiverse.langchain4j.watsonx.client.IAMRestApi;
@@ -17,7 +15,6 @@ import io.smallrye.mutiny.Uni;
 
 public class TokenGenerator {
 
-    private final static Logger logger = Logger.getLogger(TokenGenerator.class);
     private final static Semaphore lock = new Semaphore(1);
     private final IAMRestApi client;
     private final String apiKey;
@@ -70,9 +67,7 @@ public class TokenGenerator {
 
         } catch (Exception e) {
             lock.release();
-            logger.error(e);
-            return null;
+            throw new RuntimeException(e);
         }
     }
-
 }

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxChatModel.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxChatModel.java
@@ -1,6 +1,5 @@
 package io.quarkiverse.langchain4j.watsonx;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Callable;
@@ -50,11 +49,9 @@ public class WatsonxChatModel extends WatsonxModel implements ChatLanguageModel,
         TextGenerationRequest request = new TextGenerationRequest(modelId, projectId, toInput(messages), parameters);
 
         Result result = retryOn(new Callable<TextGenerationResponse>() {
-
             @Override
             public TextGenerationResponse call() throws Exception {
-                var token = generateBearerToken().await().atMost(Duration.ofSeconds(10));
-                return client.chat(request, token, version);
+                return client.chat(request, version);
             }
         }).results().get(0);
 
@@ -76,8 +73,7 @@ public class WatsonxChatModel extends WatsonxModel implements ChatLanguageModel,
         return retryOn(new Callable<Integer>() {
             @Override
             public Integer call() throws Exception {
-                var token = generateBearerToken().await().atMost(Duration.ofSeconds(10));
-                return client.tokenization(request, token, version).result().tokenCount();
+                return client.tokenization(request, version).result().tokenCount();
             }
         });
     }

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxEmbeddingModel.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxEmbeddingModel.java
@@ -1,6 +1,5 @@
 package io.quarkiverse.langchain4j.watsonx;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Callable;
@@ -34,11 +33,9 @@ public class WatsonxEmbeddingModel extends WatsonxModel implements EmbeddingMode
 
         EmbeddingRequest request = new EmbeddingRequest(modelId, projectId, inputs);
         EmbeddingResponse result = retryOn(new Callable<EmbeddingResponse>() {
-
             @Override
             public EmbeddingResponse call() throws Exception {
-                var token = generateBearerToken().await().atMost(Duration.ofSeconds(10));
-                return client.embeddings(request, token, version);
+                return client.embeddings(request, version);
             }
         });
 
@@ -57,12 +54,10 @@ public class WatsonxEmbeddingModel extends WatsonxModel implements EmbeddingMode
             return 0;
 
         var request = new TokenizationRequest(modelId, text, projectId);
-
         return retryOn(new Callable<Integer>() {
             @Override
             public Integer call() throws Exception {
-                var token = generateBearerToken().await().atMost(Duration.ofSeconds(10));
-                return client.tokenization(request, token, version).result().tokenCount();
+                return client.tokenization(request, version).result().tokenCount();
             }
         });
     }

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxModel.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxModel.java
@@ -16,13 +16,12 @@ import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.model.output.FinishReason;
 import io.quarkiverse.langchain4j.watsonx.bean.WatsonxError;
 import io.quarkiverse.langchain4j.watsonx.client.WatsonxRestApi;
+import io.quarkiverse.langchain4j.watsonx.client.filter.BearerTokenHeaderFactory;
 import io.quarkiverse.langchain4j.watsonx.exception.WatsonxException;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
-import io.smallrye.mutiny.Uni;
 
 public abstract class WatsonxModel {
 
-    private final TokenGenerator tokenGenerator;
     final String modelId;
     final String version;
     final String projectId;
@@ -46,6 +45,7 @@ public abstract class WatsonxModel {
 
         QuarkusRestClientBuilder builder = QuarkusRestClientBuilder.newBuilder()
                 .baseUrl(config.url)
+                .clientHeadersFactory(new BearerTokenHeaderFactory(config.tokenGenerator))
                 .connectTimeout(config.timeout.toSeconds(), TimeUnit.SECONDS)
                 .readTimeout(config.timeout.toSeconds(), TimeUnit.SECONDS);
 
@@ -73,16 +73,11 @@ public abstract class WatsonxModel {
         this.repetitionPenalty = config.repetitionPenalty;
         this.truncateInputTokens = config.truncateInputTokens;
         this.includeStopSequence = config.includeStopSequence;
-        this.tokenGenerator = config.tokenGenerator;
         this.promptJoiner = config.promptJoiner;
     }
 
     public static Builder builder() {
         return new Builder();
-    }
-
-    protected Uni<String> generateBearerToken() {
-        return tokenGenerator.generate();
     }
 
     protected String toInput(List<ChatMessage> messages) {

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxStreamingChatModel.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxStreamingChatModel.java
@@ -1,15 +1,10 @@
 package io.quarkiverse.langchain4j.watsonx;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Callable;
-import java.util.concurrent.Flow.Publisher;
 import java.util.function.Consumer;
-import java.util.function.Function;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
@@ -19,7 +14,6 @@ import dev.langchain4j.model.chat.TokenCountEstimator;
 import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
-import io.quarkiverse.langchain4j.QuarkusJsonCodecFactory;
 import io.quarkiverse.langchain4j.watsonx.bean.Parameters;
 import io.quarkiverse.langchain4j.watsonx.bean.Parameters.LengthPenalty;
 import io.quarkiverse.langchain4j.watsonx.bean.TextGenerationRequest;
@@ -28,8 +22,6 @@ import io.quarkiverse.langchain4j.watsonx.bean.TokenizationRequest;
 import io.smallrye.mutiny.Context;
 
 public class WatsonxStreamingChatModel extends WatsonxModel implements StreamingChatLanguageModel, TokenCountEstimator {
-
-    private final ObjectMapper mapper = QuarkusJsonCodecFactory.SnakeCaseObjectMapperHolder.MAPPER;
 
     public WatsonxStreamingChatModel(WatsonxModel.Builder config) {
         super(config);
@@ -61,28 +53,20 @@ public class WatsonxStreamingChatModel extends WatsonxModel implements Streaming
         TextGenerationRequest request = new TextGenerationRequest(modelId, projectId, toInput(messages), parameters);
         Context context = Context.of("response", new ArrayList<TextGenerationResponse>());
 
-        generateBearerToken().onItem()
-                .transformToMulti(new Function<String, Publisher<? extends String>>() {
-                    @Override
-                    public Publisher<? extends String> apply(String token) {
-                        return client.chatStreaming(request, token, version);
-                    }
-                })
+        client.chatStreaming(request, version)
                 .subscribe()
                 .with(context,
-                        new Consumer<String>() {
+                        new Consumer<TextGenerationResponse>() {
                             @Override
                             @SuppressWarnings("unchecked")
-                            public void accept(String response) {
+                            public void accept(TextGenerationResponse response) {
                                 try {
 
-                                    // Skip empty responses from LLM.
-                                    if (response == null || response.isBlank())
+                                    if (response == null || response.results() == null || response.results().isEmpty())
                                         return;
 
-                                    var obj = mapper.readValue(response, TextGenerationResponse.class);
-                                    ((List<TextGenerationResponse>) context.get("response")).add(obj);
-                                    handler.onNext(obj.results().get(0).generatedText());
+                                    ((List<TextGenerationResponse>) context.get("response")).add(response);
+                                    handler.onNext(response.results().get(0).generatedText());
 
                                 } catch (Exception e) {
                                     handler.onError(e);
@@ -137,8 +121,7 @@ public class WatsonxStreamingChatModel extends WatsonxModel implements Streaming
         return retryOn(new Callable<Integer>() {
             @Override
             public Integer call() throws Exception {
-                var token = generateBearerToken().await().atMost(Duration.ofSeconds(10));
-                return client.tokenization(request, token, version).result().tokenCount();
+                return client.tokenization(request, version).result().tokenCount();
             }
         });
     }

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/bean/TextGenerationResponse.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/bean/TextGenerationResponse.java
@@ -2,12 +2,13 @@ package io.quarkiverse.langchain4j.watsonx.bean;
 
 import java.util.List;
 
-public record TextGenerationResponse(List<Result> results) {
+import com.fasterxml.jackson.annotation.JsonProperty;
 
+public record TextGenerationResponse(List<Result> results) {
     public record Result(
-            String generatedText,
-            int generatedTokenCount,
-            int inputTokenCount,
-            String stopReason) {
+            @JsonProperty("generated_text") String generatedText,
+            @JsonProperty("generated_token_count") int generatedTokenCount,
+            @JsonProperty("input_token_count") int inputTokenCount,
+            @JsonProperty("stop_reason") String stopReason) {
     }
 }

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/client/WatsonxRestApi.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/client/WatsonxRestApi.java
@@ -14,7 +14,6 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
-import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.RestStreamElementType;
 import org.jboss.resteasy.reactive.client.api.ClientLogger;
@@ -31,7 +30,6 @@ import io.quarkiverse.langchain4j.watsonx.bean.TokenizationResponse;
 import io.quarkiverse.langchain4j.watsonx.bean.WatsonxError;
 import io.quarkiverse.langchain4j.watsonx.exception.WatsonxException;
 import io.quarkus.rest.client.reactive.ClientExceptionMapper;
-import io.quarkus.rest.client.reactive.NotBody;
 import io.quarkus.rest.client.reactive.jackson.ClientObjectMapper;
 import io.smallrye.mutiny.Multi;
 import io.vertx.core.Handler;
@@ -48,27 +46,26 @@ import io.vertx.core.http.HttpClientResponse;
 @Path("/ml/v1")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
-@ClientHeaderParam(name = "Authorization", value = "Bearer {token}")
 public interface WatsonxRestApi {
 
     @POST
     @Path("text/generation")
-    TextGenerationResponse chat(TextGenerationRequest request, @NotBody String token, @QueryParam("version") String version)
+    TextGenerationResponse chat(TextGenerationRequest request, @QueryParam("version") String version)
             throws WatsonxException;
 
     @POST
     @Path("text/generation_stream")
-    @RestStreamElementType(MediaType.TEXT_PLAIN)
-    Multi<String> chatStreaming(TextGenerationRequest request, @NotBody String token, @QueryParam("version") String version);
+    @RestStreamElementType(MediaType.APPLICATION_JSON)
+    Multi<TextGenerationResponse> chatStreaming(TextGenerationRequest request, @QueryParam("version") String version);
 
     @POST
     @Path("text/tokenization")
-    public TokenizationResponse tokenization(TokenizationRequest request, @NotBody String token,
+    TokenizationResponse tokenization(TokenizationRequest request,
             @QueryParam("version") String version);
 
     @POST
     @Path("/text/embeddings")
-    public EmbeddingResponse embeddings(EmbeddingRequest request, @NotBody String token,
+    EmbeddingResponse embeddings(EmbeddingRequest request,
             @QueryParam("version") String version);
 
     @ClientExceptionMapper

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/client/filter/BearerTokenHeaderFactory.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/client/filter/BearerTokenHeaderFactory.java
@@ -1,0 +1,42 @@
+package io.quarkiverse.langchain4j.watsonx.client.filter;
+
+import java.util.function.Function;
+
+import jakarta.ws.rs.core.MultivaluedMap;
+
+import io.quarkiverse.langchain4j.watsonx.TokenGenerator;
+import io.quarkus.rest.client.reactive.ReactiveClientHeadersFactory;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Add the bearer token to the watsonx.ai APIs.
+ */
+public class BearerTokenHeaderFactory extends ReactiveClientHeadersFactory {
+
+    private TokenGenerator tokenGenerator;
+
+    public BearerTokenHeaderFactory(TokenGenerator tokenGenerator) {
+        this.tokenGenerator = tokenGenerator;
+    }
+
+    @Override
+    public Uni<MultivaluedMap<String, String>> getHeaders(MultivaluedMap<String, String> incomingHeaders,
+            MultivaluedMap<String, String> clientOutgoingHeaders) {
+
+        return tokenGenerator.generate()
+                .onItem()
+                .transform(new Function<String, String>() {
+                    @Override
+                    public String apply(String token) {
+                        return "Bearer %s".formatted(token);
+                    }
+                })
+                .map(new Function<String, MultivaluedMap<String, String>>() {
+                    @Override
+                    public MultivaluedMap<String, String> apply(String token) {
+                        clientOutgoingHeaders.add("Authorization", token);
+                        return clientOutgoingHeaders;
+                    }
+                });
+    }
+}


### PR DESCRIPTION
What I did:
- Improved tests;
- Removed the ObjectMapper from the WatsonxStreamingChatModel;
- Introduced ReactiveClientHeadersFactory to inject the bearer token;

Just a note, my idea was also to add more tests for the StreamingChatModel part, but I didn't do it for quarkusio/quarkus#26253.