### PR TITLE
Add initial Ollama support for tool invocation

### DIFF
--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/ChatRequest.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/ChatRequest.java
@@ -2,7 +2,8 @@ package io.quarkiverse.langchain4j.ollama;
 
 import java.util.List;
 
-public record ChatRequest(String model, List<Message> messages, Options options, String format, Boolean stream) {
+public record ChatRequest(String model, List<Message> messages, List<Tool> tools, Options options, String format,
+        Boolean stream) {
 
     public static Builder builder() {
         return new Builder();
@@ -11,6 +12,7 @@ public record ChatRequest(String model, List<Message> messages, Options options,
     public static class Builder {
         private String model;
         private List<Message> messages;
+        private List<Tool> tools;
         private Options options;
         private String format;
         private Boolean stream;
@@ -22,6 +24,11 @@ public record ChatRequest(String model, List<Message> messages, Options options,
 
         public Builder messages(List<Message> messages) {
             this.messages = messages;
+            return this;
+        }
+
+        public Builder tools(List<Tool> tools) {
+            this.tools = tools;
             return this;
         }
 
@@ -50,7 +57,7 @@ public record ChatRequest(String model, List<Message> messages, Options options,
         }
 
         public ChatRequest build() {
-            return new ChatRequest(model, messages, options, format, stream);
+            return new ChatRequest(model, messages, tools, options, format, stream);
         }
     }
 

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/ChatResponse.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/ChatResponse.java
@@ -1,9 +1,12 @@
 package io.quarkiverse.langchain4j.ollama;
 
+import java.util.Collections;
+
 public record ChatResponse(String model, String createdAt, Message message, Boolean done, Integer promptEvalCount,
         Integer evalCount) {
 
     public static ChatResponse emptyNotDone() {
-        return new ChatResponse(null, null, new Message(Role.ASSISTANT, "", null), true, null, null);
+        return new ChatResponse(null, null, new Message(Role.ASSISTANT, "", Collections.emptyList(), Collections.emptyList()),
+                true, null, null);
     }
 }

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/Message.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/Message.java
@@ -2,7 +2,7 @@ package io.quarkiverse.langchain4j.ollama;
 
 import java.util.List;
 
-public record Message(Role role, String content, List<String> images) {
+public record Message(Role role, String content, List<ToolCall> toolCalls, List<String> images) {
 
     public static Builder builder() {
         return new Builder();
@@ -11,6 +11,7 @@ public record Message(Role role, String content, List<String> images) {
     public static class Builder {
         private Role role;
         private String content;
+        private List<ToolCall> toolCalls;
         private List<String> images;
 
         public Builder role(Role role) {
@@ -23,13 +24,18 @@ public record Message(Role role, String content, List<String> images) {
             return this;
         }
 
+        public Builder toolCalls(List<ToolCall> toolCalls) {
+            this.toolCalls = toolCalls;
+            return this;
+        }
+
         public Builder images(List<String> images) {
             this.images = images;
             return this;
         }
 
         public Message build() {
-            return new Message(role, content, images);
+            return new Message(role, content, toolCalls, images);
         }
     }
 

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/MessageMapper.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/MessageMapper.java
@@ -1,36 +1,58 @@
 package io.quarkiverse.langchain4j.ollama;
 
+import static dev.langchain4j.data.message.ChatMessageType.TOOL_EXECUTION_RESULT;
 import static dev.langchain4j.data.message.ContentType.IMAGE;
 import static dev.langchain4j.data.message.ContentType.TEXT;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolParameters;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ChatMessageType;
 import dev.langchain4j.data.message.Content;
 import dev.langchain4j.data.message.ContentType;
 import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
+import io.quarkiverse.langchain4j.QuarkusJsonCodecFactory;
 
+// TODO: this could use a lot of refactoring
 final class MessageMapper {
+
+    static {
+        new TypeReference<>() {
+        };
+    }
 
     private MessageMapper() {
     }
 
-    private final static Predicate<ChatMessage> isUserMessage = chatMessage -> chatMessage instanceof UserMessage;
     private final static Predicate<UserMessage> hasImages = userMessage -> userMessage.contents().stream()
             .anyMatch(content -> IMAGE.equals(content.type()));
 
     static List<Message> toOllamaMessages(List<ChatMessage> messages) {
-        return messages.stream()
-                .map(message -> isUserMessage.test(message) && hasImages.test((UserMessage) message)
-                        ? messagesWithImageSupport((UserMessage) message)
-                        : otherMessages(message))
-                .collect(Collectors.toList());
+        List<Message> result = new ArrayList<>(messages.size());
+        for (ChatMessage chatMessage : messages) {
+            if ((chatMessage instanceof UserMessage userMessage) && hasImages.test(userMessage)) {
+                result.add(messagesWithImageSupport(userMessage));
+            } else {
+                result.add(otherMessages(chatMessage));
+            }
+        }
+        return result;
     }
 
     private static Message messagesWithImageSupport(UserMessage userMessage) {
@@ -54,10 +76,46 @@ final class MessageMapper {
                 .build();
     }
 
-    private static Message otherMessages(ChatMessage chatMessage) {
+    private static Message otherMessages(ChatMessage message) {
+        if (message instanceof AiMessage aiMessage) {
+            if (!aiMessage.hasToolExecutionRequests()) {
+                return Message.builder()
+                        .role(toOllamaRole(ChatMessageType.AI))
+                        .content(aiMessage.text())
+                        .build();
+            }
+
+            try {
+                List<ToolExecutionRequest> toolExecutionRequests = aiMessage.toolExecutionRequests();
+                List<ToolCall> toolCalls = new ArrayList<>(toolExecutionRequests.size());
+                for (ToolExecutionRequest toolExecutionRequest : toolExecutionRequests) {
+                    String argumentsStr = toolExecutionRequest.arguments();
+                    String name = toolExecutionRequest.name();
+                    // TODO: we need to update LangChain4j to make ToolExecutionRequest use a map instead of a String
+                    Map<String, Object> arguments = QuarkusJsonCodecFactory.ObjectMapperHolder.MAPPER.readValue(argumentsStr,
+                            Map.class);
+                    toolCalls.add(ToolCall.fromFunctionCall(name, arguments));
+                }
+
+                return Message.builder()
+                        .role(toOllamaRole(ChatMessageType.AI))
+                        .toolCalls(toolCalls)
+                        .build();
+            } catch (JsonProcessingException e) {
+                throw new IllegalStateException("Unable to perform conversion of tool response", e);
+            }
+        }
+
+        if (message instanceof ToolExecutionResultMessage) {
+            return Message.builder()
+                    .role(toOllamaRole(TOOL_EXECUTION_RESULT))
+                    .content(message.text())
+                    .build();
+        }
+
         return Message.builder()
-                .role(toOllamaRole(chatMessage.type()))
-                .content(chatMessage.text())
+                .role(toOllamaRole(message.type()))
+                .content(message.text())
                 .build();
     }
 
@@ -66,7 +124,30 @@ final class MessageMapper {
             case SYSTEM -> Role.SYSTEM;
             case USER -> Role.USER;
             case AI -> Role.ASSISTANT;
-            default -> throw new IllegalArgumentException("Unknown ChatMessageType: " + chatMessageType);
+            case TOOL_EXECUTION_RESULT -> Role.TOOL;
         };
+    }
+
+    static List<Tool> toTools(Collection<ToolSpecification> toolSpecifications) {
+        if (toolSpecifications.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<Tool> result = new ArrayList<>(toolSpecifications.size());
+        for (ToolSpecification toolSpecification : toolSpecifications) {
+            result.add(toTool(toolSpecification));
+        }
+        return result;
+    }
+
+    private static Tool toTool(ToolSpecification toolSpecification) {
+        return new Tool(Tool.Type.FUNCTION, new Tool.Function(toolSpecification.name(), toolSpecification.description(),
+                toFunctionParameters(toolSpecification.parameters())));
+    }
+
+    private static Tool.Function.Parameters toFunctionParameters(ToolParameters toolParameters) {
+        if (toolParameters == null) {
+            return Tool.Function.Parameters.empty();
+        }
+        return Tool.Function.Parameters.objectType(toolParameters.properties(), toolParameters.required());
     }
 }

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/Role.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/Role.java
@@ -12,5 +12,6 @@ public enum Role {
 
     SYSTEM,
     USER,
-    ASSISTANT
+    ASSISTANT,
+    TOOL
 }

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/Tool.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/Tool.java
@@ -1,0 +1,40 @@
+package io.quarkiverse.langchain4j.ollama;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import io.quarkiverse.langchain4j.ollama.runtime.jackson.ToolTypeDeserializer;
+import io.quarkiverse.langchain4j.ollama.runtime.jackson.ToolTypeSerializer;
+
+public record Tool(Type type, Function function) {
+
+    public static Tool from(Function function) {
+        return new Tool(Type.FUNCTION, function);
+    }
+
+    @JsonDeserialize(using = ToolTypeDeserializer.class)
+    @JsonSerialize(using = ToolTypeSerializer.class)
+    public enum Type {
+        FUNCTION
+    }
+
+    public record Function(String name, String description, Parameters parameters) {
+
+        public record Parameters(String type, Map<String, Map<String, Object>> properties, List<String> required) {
+
+            private static final String OBJECT_TYPE = "object";
+
+            public static Parameters objectType(Map<String, Map<String, Object>> properties, List<String> required) {
+                return new Parameters(OBJECT_TYPE, properties, required);
+            }
+
+            public static Parameters empty() {
+                return new Parameters(OBJECT_TYPE, Collections.emptyMap(), Collections.emptyList());
+            }
+        }
+    }
+}

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/ToolCall.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/ToolCall.java
@@ -1,0 +1,14 @@
+package io.quarkiverse.langchain4j.ollama;
+
+import java.util.Map;
+
+public record ToolCall(FunctionCall function) {
+
+    public static ToolCall fromFunctionCall(String name, Map<String, Object> arguments) {
+        return new ToolCall(new FunctionCall(name, arguments));
+    }
+
+    public record FunctionCall(String name, Map<String, Object> arguments) {
+
+    }
+}

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/jackson/ToolTypeDeserializer.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/jackson/ToolTypeDeserializer.java
@@ -1,0 +1,24 @@
+package io.quarkiverse.langchain4j.ollama.runtime.jackson;
+
+import java.io.IOException;
+import java.util.Locale;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import io.quarkiverse.langchain4j.ollama.Tool;
+
+public class ToolTypeDeserializer extends StdDeserializer<Tool.Type> {
+    public ToolTypeDeserializer() {
+        super(Tool.Type.class);
+    }
+
+    @Override
+    public Tool.Type deserialize(JsonParser jp, DeserializationContext deserializationContext)
+            throws IOException, JacksonException {
+        return Tool.Type.valueOf(jp.getValueAsString().toUpperCase(Locale.ROOT));
+    }
+
+}

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/jackson/ToolTypeSerializer.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/jackson/ToolTypeSerializer.java
@@ -1,0 +1,22 @@
+package io.quarkiverse.langchain4j.ollama.runtime.jackson;
+
+import java.io.IOException;
+import java.util.Locale;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import io.quarkiverse.langchain4j.ollama.Tool;
+
+public class ToolTypeSerializer extends StdSerializer<Tool.Type> {
+    public ToolTypeSerializer() {
+        super(Tool.Type.class);
+    }
+
+    @Override
+    public void serialize(Tool.Type toolType, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+            throws IOException {
+        jsonGenerator.writeString(toolType.toString().toLowerCase(Locale.ROOT));
+    }
+}


### PR DESCRIPTION
Ollama 0.3.0 now has official support for tools,
see https://ollama.com/blog/tool-support for more
details.

This PR brings in the basic support for getting
tools to work

- Closes: #305