### PR TITLE
Revert "Upgrade to Quarkus Antora 0.0.4 - fix podman issues"

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -81,11 +81,6 @@
             <artifactId>quarkus-langchain4j-easy-rag</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>io.quarkiverse.antora</groupId>
-            <artifactId>quarkus-antora</artifactId>
-            <version>${quarkus-antora.version}</version>
-        </dependency>
 
         <!-- Test dependencies -->
         <dependency>
@@ -378,4 +373,21 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>antora</id>
+            <activation>
+                    <property>
+                        <name>antora</name>
+                    </property>
+                </activation>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.quarkiverse.antora</groupId>
+                        <artifactId>quarkus-antora</artifactId>
+                        <version>${quarkus-antora.version}</version>
+                    </dependency>
+                </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/docs/src/test/java/io/quarkiverse/langchain4j/docs/it/AntoraTest.java
+++ b/docs/src/test/java/io/quarkiverse/langchain4j/docs/it/AntoraTest.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
 import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -14,6 +15,7 @@ import io.restassured.http.ContentType;
 public class AntoraTest {
 
     @Test
+    @Disabled("Antora is not enabled by default as its broken on podman machine")
     public void antoraSite() throws TimeoutException, IOException, InterruptedException {
         RestAssured
                 .given()


### PR DESCRIPTION
This reverts commit 03c416042b12ca55d7c6843bc8501ba23f2def7f.

+ moves antora to a separate profile and use -Dantora to use it.



see https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/antora.20in.20quarkiverse.20or.20just.20langchain4j.20when.20using.20podma.3F for discussion.

in short - podman can't run antora so at least me and @cescoffier can't build langchain without removing the docs build.

Thus i suggest to make antora a profile flag to enable.

relates to:
https://github.com/quarkiverse/quarkus-langchain4j/pull/533
https://github.com/quarkiverse/quarkus-langchain4j/issues/493