### PR TITLE
Also allow to inject PgVectorEmbeddingStore with upstream type

### DIFF
--- a/embedding-stores/pgvector/deployment/src/main/java/io/quarkiverse/langchain4j/pgvector/deployment/PgVectorEmbeddingStoreProcessor.java
+++ b/embedding-stores/pgvector/deployment/src/main/java/io/quarkiverse/langchain4j/pgvector/deployment/PgVectorEmbeddingStoreProcessor.java
@@ -63,7 +63,8 @@ class PgVectorEmbeddingStoreProcessor {
 
         beanProducer.produce(SyntheticBeanBuildItem
                 .configure(PG_VECTOR_EMBEDDING_STORE)
-                .types(ClassType.create(EmbeddingStore.class),
+                .types(ClassType.create(dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore.class),
+                        ClassType.create(EmbeddingStore.class),
                         ParameterizedType.create(EmbeddingStore.class, ClassType.create(TextSegment.class)))
                 .setRuntimeInit()
                 .defaultBean()


### PR DESCRIPTION
Our PgVectorEmbeddingStore extends the one from LangChain4j and when injecting, it's easy to choose the one from upstream and then you're stuck with injection errors that are a bit hard to figure out as everything looks fine.

Let's make it a bit easier as it doesn't cost us anything.