### PR TITLE
Filter logs of low value related to djl tokenizers

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/BeansProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/BeansProcessor.java
@@ -12,6 +12,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 import org.jboss.jandex.AnnotationInstance;
@@ -49,6 +50,7 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
+import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
 import io.quarkus.runtime.configuration.ConfigurationException;
 
 public class BeansProcessor {
@@ -365,4 +367,11 @@ public class BeansProcessor {
         unremoveableProducer.produce(UnremovableBeanBuildItem.beanTypes(ModelAuthProvider.class));
     }
 
+    @BuildStep
+    void logCleanupFilters(BuildProducer<LogCleanupFilterBuildItem> logCleanupFilters) {
+        logCleanupFilters
+                .produce(new LogCleanupFilterBuildItem("ai.djl.util.Platform", Level.INFO, "Found matching platform from"));
+        logCleanupFilters
+                .produce(new LogCleanupFilterBuildItem("ai.djl.huggingface.tokenizers.jni.LibUtils", Level.INFO, "Extracting"));
+    }
 }


### PR DESCRIPTION
I noticed:
2024-09-03 16:05:11,759 INFO  [ai.djl.uti.Platform] (Quarkus Main Thread) Found matching platform from: jar:file:///home/gsmet/.m2/repository/ai/djl/huggingface/tokenizers/0.26.0/tokenizers-0.26.0.jar!/native/lib/tokenizers.properties 2024-09-03 16:05:11,760 INFO  [ai.djl.hug.tok.jni.LibUtils] (Quarkus Main Thread) Extracting native/lib/linux-x86_64/libtokenizers.so to cache ...

when starting my app (the second is only there for the first start).

I don't think they have much value so filtering them.