### PR TITLE
Avoid NPE when converting template param value

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
@@ -572,8 +572,11 @@ public class AiServiceMethodImplementationSupport {
     }
 
     private static Object transformTemplateParamValue(Object value) {
+        if (value == null) {
+            return "";
+        }
         if (value.getClass().isArray()) {
-            // Qute does not transform these values but LangChain4j expects to be converted to a [item1, item2, item3] like systax
+            // Qute does not transform these values but LangChain4j expects to be converted to a [item1, item2, item3] like syntax
             return Arrays.toString((Object[]) value);
         }
         return value;


### PR DESCRIPTION
A null can be converted to an empty string. It happened to me because I was testing a service passing a title and a description and the description was sometimes null.