### PR TITLE
Do not log error in AiServiceMethodImplementationSupport

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
@@ -117,7 +117,6 @@ public class AiServiceMethodImplementationSupport {
             }
             return result;
         } catch (Exception e) {
-            log.errorv(e, "Execution of {0}#{1} failed", createInfo.getInterfaceName(), createInfo.getMethodName());
             if (audit != null) {
                 audit.onFailure(e);
                 auditService.complete(audit);


### PR DESCRIPTION
The error is thrown anyway and handled by the error handler. Logging here makes the error logged twice in your typical REST setup (and probably any setup).

Fixes #863