### PR TITLE
Evaluate 'required' attribute of @P annotation in tool for optional parameters.

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/ToolProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/ToolProcessor.java
@@ -203,7 +203,14 @@ public class ToolProcessor {
                             memoryIdParameter = parameter;
                             continue;
                         }
-                        builder.addParameter(parameter.name(), toJsonSchemaProperties(parameter, index));
+
+                        AnnotationInstance pInstance = parameter.annotation(P);
+                        if (pInstance != null && pInstance.value("required") != null
+                                && !pInstance.value("required").asBoolean()) {
+                            builder.addOptionalParameter(parameter.name(), toJsonSchemaProperties(parameter, index));
+                        } else {
+                            builder.addParameter(parameter.name(), toJsonSchemaProperties(parameter, index));
+                        }
                     }
 
                     Map<String, Integer> nameToParamPosition = toolMethod.parameters().stream().collect(


### PR DESCRIPTION
Currently tool parameters are always added as required parameters.
This PR evaluates the required attribute of the P annotation and adds not required parameters as optional parameters to the ToolSpecification.