### PR TITLE
doc: fix wrong property name in pgvector documentation

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-pgvector.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-pgvector.adoc
@@ -136,9 +136,9 @@ a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-metadata-storage-
 --
 Metadata type:
 
- - COLUMN_PER_KEY: for static metadata, when you know in advance the list of metadata fields. In this case, you should also override the `quarkus.langchain4j.pgvector.metadata.definition` property to define the right columns.
+ - COLUMN_PER_KEY: for static metadata, when you know in advance the list of metadata fields. In this case, you should also override the `quarkus.langchain4j.pgvector.metadata.column-definitions` property to define the right columns.
  - COMBINED_JSON: For dynamic metadata, when you don't know the list of metadata fields that will be used.
- - COMBINED_JSONB: Same as JSON, but stored in a binary way. Optimized for query on large dataset. In this case, you should also override the `quarkus.langchain4j.pgvector.metadata.definition` property to change the type of the `metadata` column to COMBINED_JSONB.
+ - COMBINED_JSONB: Same as JSON, but stored in a binary way. Optimized for query on large dataset. In this case, you should also override the `quarkus.langchain4j.pgvector.metadata.column-definitions` property to change the type of the `metadata` column to COMBINED_JSONB.
 
 Default value: COMBINED_JSON
 

--- a/embedding-stores/pgvector/runtime/src/main/java/io/quarkiverse/langchain4j/pgvector/runtime/PgVectorEmbeddingStoreConfig.java
+++ b/embedding-stores/pgvector/runtime/src/main/java/io/quarkiverse/langchain4j/pgvector/runtime/PgVectorEmbeddingStoreConfig.java
@@ -66,7 +66,8 @@ public interface PgVectorEmbeddingStoreConfig {
          * Metadata type:
          * <ul>
          * <li>COLUMN_PER_KEY: for static metadata, when you know in advance the list of metadata fields. In this case,
-         * you should also override the `quarkus.langchain4j.pgvector.metadata.column-definitions` property to define the right columns.
+         * you should also override the `quarkus.langchain4j.pgvector.metadata.column-definitions` property to define the right
+         * columns.
          * <li>COMBINED_JSON: For dynamic metadata, when you don't know the list of metadata fields that will be used.
          * <li>COMBINED_JSONB: Same as JSON, but stored in a binary way. Optimized for query on large dataset. In this case,
          * you should also override the `quarkus.langchain4j.pgvector.metadata.column-definitions` property to change the

--- a/embedding-stores/pgvector/runtime/src/main/java/io/quarkiverse/langchain4j/pgvector/runtime/PgVectorEmbeddingStoreConfig.java
+++ b/embedding-stores/pgvector/runtime/src/main/java/io/quarkiverse/langchain4j/pgvector/runtime/PgVectorEmbeddingStoreConfig.java
@@ -66,10 +66,10 @@ public interface PgVectorEmbeddingStoreConfig {
          * Metadata type:
          * <ul>
          * <li>COLUMN_PER_KEY: for static metadata, when you know in advance the list of metadata fields. In this case,
-         * you should also override the `quarkus.langchain4j.pgvector.metadata.definition` property to define the right columns.
+         * you should also override the `quarkus.langchain4j.pgvector.metadata.column-definitions` property to define the right columns.
          * <li>COMBINED_JSON: For dynamic metadata, when you don't know the list of metadata fields that will be used.
          * <li>COMBINED_JSONB: Same as JSON, but stored in a binary way. Optimized for query on large dataset. In this case,
-         * you should also override the `quarkus.langchain4j.pgvector.metadata.definition` property to change the
+         * you should also override the `quarkus.langchain4j.pgvector.metadata.column-definitions` property to change the
          * type of the `metadata` column to COMBINED_JSONB.
          * </ul>
          * <p>


### PR DESCRIPTION
In the quarkus-langchain4j extension documentation there is :

[quarkus.langchain4j.pgvector.metadata.storage-mode](https://docs.quarkiverse.io/quarkus-langchain4j/dev/pgvector-store.html#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-metadata-storage-mode)

```quote
quarkus.langchain4j.pgvector.metadata.storage-mode
Metadata type:
COLUMN_PER_KEY: for static metadata, when you know in advance the list of metadata fields. In this case, you should also override the quarkus.langchain4j.pgvector.metadata.definition property to define the right columns.
COMBINED_JSON: For dynamic metadata, when you don’t know the list of metadata fields that will be used.
COMBINED_JSONB: Same as JSON, but stored in a binary way. Optimized for query on large dataset. In this case, you should also override the quarkus.langchain4j.pgvector.metadata.definition property to change the type of the metadata column to COMBINED_JSONB.
Default value: COMBINED_JSON
Environment variable: QUARKUS_LANGCHAIN4J_PGVECTOR_METADATA_STORAGE_MODE
```

There is a mistake on **quarkus.langchain4j.pgvector.metadata.definition** property name.
It should be **quarkus.langchain4j.pgvector.metadata.column-definitions**