### PR TITLE
Fix issue with Image generation in AiService

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
@@ -541,7 +541,7 @@ public class AiServicesProcessor {
             // if we want to support it, the injectStreamingChatModelBean needs to be recorded per injection point
             for (MethodInfo method : declarativeAiServiceClassInfo.methods()) {
                 if (!isImageOrImageResultResult(method.returnType())) {
-                    break;
+                    continue;
                 }
                 injectImageModel = true;
             }

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/org/acme/examples/aiservices/DeclarativeAiServicesTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/org/acme/examples/aiservices/DeclarativeAiServicesTest.java
@@ -468,6 +468,8 @@ public class DeclarativeAiServicesTest extends OpenAiBaseTest {
     @ApplicationScoped
     interface ImageDescriber {
 
+        Image generate(String input);
+
         @UserMessage("This is image was reported on a GitHub issue. If this is a snippet of Java code, please respond"
                 + " with only the {language} code. If it is not, respond with '{notImageResponse}'")
         String describe(String language, @ImageUrl String url, String notImageResponse);


### PR DESCRIPTION
The issue would occur when an AiService contained
multiple methods, one of which did not generate an Image