### PR TITLE
Shadows api key from tavily logs

### DIFF
--- a/web-search-engines/tavily/runtime/src/main/java/io/quarkiverse/langchain4j/tavily/QuarkusTavilyWebSearchEngine.java
+++ b/web-search-engines/tavily/runtime/src/main/java/io/quarkiverse/langchain4j/tavily/QuarkusTavilyWebSearchEngine.java
@@ -169,7 +169,8 @@ public class QuarkusTavilyWebSearchEngine implements WebSearchEngine {
             if (body == null) {
                 return "";
             }
-            return body.toString();
+
+            return ShadowSensitiveData.process(body, "api_key");
         }
 
         private String inOneLine(io.vertx.core.MultiMap headers) {

--- a/web-search-engines/tavily/runtime/src/main/java/io/quarkiverse/langchain4j/tavily/ShadowSensitiveData.java
+++ b/web-search-engines/tavily/runtime/src/main/java/io/quarkiverse/langchain4j/tavily/ShadowSensitiveData.java
@@ -1,0 +1,29 @@
+package io.quarkiverse.langchain4j.tavily;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+
+public class ShadowSensitiveData {
+
+    private static final int NUMBER_VISIBLE_CHARS = 7;
+
+    static String process(Buffer buffer, String field) {
+
+        final JsonObject bodyJson = buffer.toJsonObject();
+        if (bodyJson.containsKey(field)) {
+
+            final String apiKeyField = bodyJson.getString(field);
+            String shadowedData;
+            if (apiKeyField.length() < NUMBER_VISIBLE_CHARS) {
+                shadowedData = "*".repeat(apiKeyField.length());
+            } else {
+                shadowedData = apiKeyField.substring(0, NUMBER_VISIBLE_CHARS) +
+                        "*".repeat(apiKeyField.length() - NUMBER_VISIBLE_CHARS);
+            }
+            bodyJson.put(field, shadowedData);
+
+        }
+        return bodyJson.toString();
+    }
+
+}

--- a/web-search-engines/tavily/runtime/src/test/java/io/quarkiverse/langchain4j/tavily/ShadowSensitiveDataTest.java
+++ b/web-search-engines/tavily/runtime/src/test/java/io/quarkiverse/langchain4j/tavily/ShadowSensitiveDataTest.java
@@ -1,0 +1,57 @@
+package io.quarkiverse.langchain4j.tavily;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.buffer.Buffer;
+
+public class ShadowSensitiveDataTest {
+
+    @Test
+    public void testShadowLongApiKey() {
+
+        String body = """
+                {
+                    "api_key":"tvly-Lv123456789QWERTYUIOPlZXCVBNMASD"
+                }
+                """;
+
+        final Buffer buffer = Buffer.buffer(body);
+        final String shadowedBody = ShadowSensitiveData.process(buffer, "api_key");
+
+        assertThat(shadowedBody)
+                .isEqualTo("{\"api_key\":\"tvly-Lv******************************\"}");
+    }
+
+    @Test
+    public void testShadowSmallApiKey() {
+        String body = """
+                {
+                    "api_key":"tvly"
+                }
+                """;
+
+        final Buffer buffer = Buffer.buffer(body);
+        final String shadowedBody = ShadowSensitiveData.process(buffer, "api_key");
+
+        assertThat(shadowedBody)
+                .isEqualTo("{\"api_key\":\"****\"}");
+    }
+
+    @Test
+    public void testNoFieldtoShadow() {
+        String body = """
+                {
+                    "api":"tvly"
+                }
+                """;
+
+        final Buffer buffer = Buffer.buffer(body);
+        final String shadowedBody = ShadowSensitiveData.process(buffer, "api_key");
+
+        assertThat(shadowedBody)
+                .isEqualTo("{\"api\":\"tvly\"}");
+    }
+
+}


### PR DESCRIPTION
Fixes the #958 issue. 

There are two design decisions taken here that we might discuss for sure.

The first one is that the class is local to be used by the Tavily module, but it could be located in a "common" module so that any other system can use this feature for passwords. Maybe for now, we can leave it as is,  but it is something we can have in mind.

The second was to figure out whether to use the VertX JSON feature to parse the body or start using some string manipulations. To keep things simple, I decided to use JSON instead of String manipulation utilities. I know this has an impact on performance, but it is INFO logs, so I am not sure if they would be enabled in production. Also, to avoid having potential IndexOutOfBound errors.

