### PR TITLE
Fix ONNX Runtime Execution in Native Executable

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/OnnxRuntimeProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/OnnxRuntimeProcessor.java
@@ -1,0 +1,77 @@
+package io.quarkiverse.langchain4j.deployment;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import io.quarkiverse.langchain4j.deployment.items.InProcessEmbeddingBuildItem;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.Consume;
+import io.quarkus.deployment.builditem.nativeimage.JniRuntimeAccessBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourcePatternsBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedPackageBuildItem;
+
+/**
+ * A processor configuring the native image build for the OnnxRuntime.
+ * Only enabled if the `RequireOnnxRuntimeBuildItem` build item is present.
+ */
+public class OnnxRuntimeProcessor {
+
+    @BuildStep
+    @Consume(RequireOnnxRuntimeBuildItem.class)
+    void onxxRuntimeNative(
+            BuildProducer<NativeImageResourcePatternsBuildItem> nativePatternProducer,
+            BuildProducer<ReflectiveClassBuildItem> reflectionProducer,
+            BuildProducer<JniRuntimeAccessBuildItem> jniProducer) {
+        List<String> classesInstantiatedFromNative = List.of(
+                "ai.onnxruntime.TensorInfo",
+                "ai.onnxruntime.SequenceInfo",
+                "ai.onnxruntime.MapInfo",
+                "ai.onnxruntime.OrtException",
+                "ai.onnxruntime.OnnxSparseTensor");
+
+        reflectionProducer.produce(
+                ReflectiveClassBuildItem.builder(classesInstantiatedFromNative.toArray(new String[0]))
+                        .fields().methods().constructors().build());
+
+        jniProducer.produce(
+                new JniRuntimeAccessBuildItem(true, true, true, classesInstantiatedFromNative.toArray(new String[0])));
+
+        // TODO should only select the target architecture's libs
+        nativePatternProducer
+                .produce(NativeImageResourcePatternsBuildItem.builder()
+                        .includeGlobs("ai/onnxruntime/native/**", "native/lib/**").build());
+
+        reflectionProducer
+                .produce(ReflectiveClassBuildItem.builder("opennlp.tools.sentdetect.SentenceDetectorFactory").build());
+        reflectionProducer.produce(
+                ReflectiveClassBuildItem.builder("ai.onnxruntime.OnnxTensor").methods().fields().constructors().build());
+    }
+
+    @BuildStep
+    @Consume(RequireOnnxRuntimeBuildItem.class)
+    void onnxRuntimeClasses(
+            List<InProcessEmbeddingBuildItem> inProcessEmbeddingBuildItems,
+            BuildProducer<RuntimeInitializedClassBuildItem> classProducer,
+            BuildProducer<RuntimeInitializedPackageBuildItem> packageProducer) {
+        Stream.of(
+                "dev.langchain4j.model.embedding.OnnxBertBiEncoder",
+                "dev.langchain4j.model.embedding.HuggingFaceTokenizer",
+                "ai.djl.huggingface.tokenizers.HuggingFaceTokenizer",
+                "ai.djl.huggingface.tokenizers.jni.TokenizersLibrary",
+                "ai.djl.huggingface.tokenizers.jni.LibUtils",
+                "ai.djl.util.Platform",
+                "ai.onnxruntime.OrtEnvironment",
+                "ai.onnxruntime.OnnxRuntime",
+                "ai.onnxruntime.OnnxTensorLike",
+                "ai.onnxruntime.OrtAllocator",
+                "ai.onnxruntime.OrtSession$SessionOptions",
+                "ai.onnxruntime.OrtSession")
+                .filter(QuarkusClassLoader::isClassPresentAtRuntime)
+                .map(RuntimeInitializedClassBuildItem::new).forEach(classProducer::produce);
+    }
+
+}

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/RequireOnnxRuntimeBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/RequireOnnxRuntimeBuildItem.java
@@ -1,0 +1,9 @@
+package io.quarkiverse.langchain4j.deployment;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * A build item that is used to require the OnnxRuntime to be built into the native image.
+ */
+public final class RequireOnnxRuntimeBuildItem extends SimpleBuildItem {
+}

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/items/InProcessEmbeddingBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/items/InProcessEmbeddingBuildItem.java
@@ -9,12 +9,22 @@ public final class InProcessEmbeddingBuildItem extends MultiBuildItem implements
     private final String vocabularyPath;
 
     private final String className;
+    private boolean requireOnnxRuntime;
 
     public InProcessEmbeddingBuildItem(String modelName, String className, String onnxModelPath, String vocabularyPath) {
         this.modelName = modelName;
         this.className = className;
         this.onnxModelPath = onnxModelPath;
         this.vocabularyPath = vocabularyPath;
+        this.requireOnnxRuntime = true;
+    }
+
+    public boolean requireOnnxRuntime() {
+        return requireOnnxRuntime;
+    }
+
+    public void setRequireOnnxRuntime(boolean requireOnnxRuntime) {
+        this.requireOnnxRuntime = requireOnnxRuntime;
     }
 
     public String modelName() {

--- a/integration-tests/embed-all-minilm-l6-v2/pom.xml
+++ b/integration-tests/embed-all-minilm-l6-v2/pom.xml
@@ -11,23 +11,17 @@
     <artifactId>quarkus-langchain4j-integration-test-embed-all-minilm-l6-v2</artifactId>
     <name>Quarkus LangChain4j - Integration Tests - embeddings-all-minilm-l6-v2</name>
 
-    <dependencies>
-        <dependency>
-            <groupId>io.quarkiverse.langchain4j</groupId>
-            <artifactId>quarkus-langchain4j-parsers-base</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
+    <dependencies>    
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-all-minilm-l6-v2</artifactId>
             <version>${langchain4j-embeddings.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>dev.langchain4j</groupId>
-                    <artifactId>langchain4j-core</artifactId>
-                </exclusion>
-            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkiverse.langchain4j</groupId>
+            <artifactId>quarkus-langchain4j-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/integration-tests/embed-all-minilm-l6-v2/src/main/java/org/acme/test/InProcessEmbeddingResource.java
+++ b/integration-tests/embed-all-minilm-l6-v2/src/main/java/org/acme/test/InProcessEmbeddingResource.java
@@ -18,6 +18,7 @@ public class InProcessEmbeddingResource {
 
     @POST
     public String computeEmbedding(String sentence) {
+
         var r1 = allMiniLmL6V2QuantizedEmbeddingModel.embed(sentence);
         var r2 = embeddingModel.embed(sentence);
 


### PR DESCRIPTION
The ONNX Runtime, which relies on JNI, requires specific configuration for native image compilation due to its unique code structure. This commit adds the necessary JNI configurations to ensure native execution.

Additionally, it consolidates the native instructions related to the ONNX Runtime by moving them from being spread across `core` and `base-parsers` to solely within the `core` module. This change reflects the broader applicability of local / in-process embedding models (requiring the ONNX Runtime) beyond RAG use cases.
