### PR TITLE
[watsonx.ai] Enable tools in streaming API

### DIFF
--- a/docs/modules/ROOT/pages/watsonx.adoc
+++ b/docs/modules/ROOT/pages/watsonx.adoc
@@ -8,7 +8,7 @@ IMPORTANT: Supported only for IBM watsonx as a service on link:https://www.ibm.c
 
 == Using watsonx.ai
 
-To employ watsonx.ai LLMs, integrate the following dependency into your project:
+To employ *watsonx.ai* LLMs, integrate the following dependency into your project:
 
 [source,xml,subs=attributes+]
 ----
@@ -64,20 +64,18 @@ NOTE: To determine the API key, go to https://cloud.ibm.com/iam/apikeys and gene
 
 ==== Writing prompts
 
-When creating prompts using watsonx.ai, it's important to follow the guidelines of the model you choose. Depending on the model, some special instructions may be required to ensure the desired output. For best results, always refer to the documentation provided for each model to maximize the effectiveness of your prompts.
+When creating prompts using *watsonx.ai*, it's important to follow the guidelines of the model you choose. Depending on the model, some special instructions may be required to ensure the desired output. For best results, always refer to the documentation provided for each model to maximize the effectiveness of your prompts.
 
-To simplify the process of prompt creation, you can use the `prompt-formatter` property to automatically handle the addition of tags to your prompts. This property allows you to avoid manually adding tags by letting the system handle the formatting based on the model's requirements. This functionality is particularly useful for models such as `ibm/granite-13b-chat-v2`, `meta-llama/llama-3-405b-instruct`, and other supported models, ensuring consistent and accurate prompt structures without additional effort.
+By default, the *watsonx.ai* module uses the `prompt-formatter` property to simplify the prompt creation process. This property automatically handles the addition of tags to your prompts based on the requirements of the model, ensuring consistent and accurate prompt structures without additional effort. This functionality is particularly useful for models such as `ibm/granite-13b-chat-v2`, `meta-llama/llama-3-70b-instruct`, `mistralai/mistral-large` and other supported models.
 
-To enable this functionality, configure the `prompt-formatter` property in your `application.properties` file as follows:
+This helps maintain prompt clarity and improves interaction with the LLM by ensuring that prompts follow the required structure. If, for any reason, you need to disable this functionality and manually manage tags, you can configure the `prompt-formatter` property in your `application.properties` file as follows:
 
 [source,properties,subs=attributes+]
 ----
-quarkus.langchain4j.watsonx.chat-model.prompt-formatter=true
+quarkus.langchain4j.watsonx.chat-model.prompt-formatter=false
 ----
 
-When this property is set to `true`, the system will automatically format prompts with the appropriate tags. This helps to maintain prompt clarity and improves interaction with the LLM by ensuring that prompts follow the required structure. If set to `false`, you'll need to manage the tags manually.
-
-For example, if you choose to use `ibm/granite-13b-chat-v2` without using the `prompt-formatter`, you will need to manually add the `<|system|>`, `<|user|>` and `<|assistant|>` instructions:
+For example, if you choose to disable the `prompt-formatter` and use `ibm/granite-13b-chat-v2`, you will need to manually add the `<|system|>`, `<|user|>`, and `<|assistant|>` instructions:
 
 [source,properties,subs=attributes+]
 ----
@@ -108,14 +106,13 @@ public interface LLMService {
 }
 ----
 
-Enabling the `prompt-formatter` will result in:
+When `prompt-formatter` is enabled, the system will format prompts automatically, without requiring tags:
 
 [source,properties,subs=attributes+]
 ----
 quarkus.langchain4j.watsonx.api-key=hG-...
 quarkus.langchain4j.watsonx.base-url=https://us-south.ml.cloud.ibm.com
 quarkus.langchain4j.watsonx.chat-model.model-id=ibm/granite-13b-chat-v2
-quarkus.langchain4j.watsonx.chat-model.prompt-formatter=true
 ----
 
 [source,java]
@@ -154,19 +151,21 @@ The `prompt-formatter` supports the following models:
 * `ibm/granite-3b-code-instruct`
 * `ibm/granite-8b-code-instruct`
 
+If a model that does not support the `prompt-formatter` is selected, a warning will be displayed during the application startup. In such cases, the prompt formatting will not be applied, and no tags will be automatically added to the prompts.
+
 ==== Tool Execution with Prompt Formatter
 
 In addition to simplifying prompt creation, the `prompt-formatter` property also enables the execution of tools for specific models. Tools allow for dynamic interactions within the model, enabling the AI to perform specific actions or fetch data as part of its response.
 
 When the `prompt-formatter` is enabled and a supported model is selected, the prompt will be automatically formatted to use the tools. More information about tools is available in the xref:./agent-and-tools.adoc[Agent and Tools] page.
 
-Currently, the following model supports tool execution:
+Currently, the following models support tool execution:
 
 * `mistralai/mistral-large`
 * `meta-llama/llama-3-405b-instruct`
 * `meta-llama/llama-3-1-70b-instruct`
 
-IMPORTANT: The `@SystemMessage` and `@UserMessage` annotations are joined by default with a new line. If you want to change this behavior, use the property `quarkus.langchain4j.watsonx.chat-model.prompt-joiner=<value>`. By adjusting this property, you can define your preferred way of joining messages and ensure that the prompt structure meets your specific needs. This customization option is available only when the `prompt-formatter` property is set to `false`. When the `prompt-formatter` is enabled (set to `true`), the prompt formatting, including the addition of tags and message joining, is automatically handled. In this case, the `prompt-joiner` property will be ignored, and you will not have the ability to customize how messages are joined.
+IMPORTANT: The `@SystemMessage` and `@UserMessage` annotations are joined by default with a new line. If you want to change this behavior, use the property `quarkus.langchain4j.watsonx.chat-model.prompt-joiner=<value>`. By adjusting this property, you can define your preferred way of joining messages and ensure that the prompt structure meets your specific needs. This customization option is available only when the `prompt-formatter` property is set to `false`. When the `prompt-formatter` is enabled, the prompt formatting, including the addition of tags and message joining, is automatically handled. In this case, the `prompt-joiner` property will be ignored, and you will not have the ability to customize how messages are joined.
 
 NOTE: Sometimes it may be useful to use the `quarkus.langchain4j.watsonx.chat-model.stop-sequences` property to prevent the LLM model from returning more results than desired.
 

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/AiChatServiceTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/AiChatServiceTest.java
@@ -3,9 +3,11 @@ package io.quarkiverse.langchain4j.watsonx.deployment;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Date;
+import java.util.List;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import jakarta.ws.rs.core.MediaType;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -20,6 +22,7 @@ import io.quarkiverse.langchain4j.watsonx.bean.TextGenerationRequest;
 import io.quarkiverse.langchain4j.watsonx.runtime.config.ChatModelConfig;
 import io.quarkiverse.langchain4j.watsonx.runtime.config.LangChain4jWatsonxConfig;
 import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
 
 public class AiChatServiceTest extends WireMockAbstract {
 
@@ -31,21 +34,55 @@ public class AiChatServiceTest extends WireMockAbstract {
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", WireMockUtil.PROJECT_ID)
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
 
-    @RegisterAiService
+    @Override
+    void handlerBeforeEach() {
+        mockServers.mockIAMBuilder(200)
+                .grantType(langchain4jWatsonConfig.defaultConfig().iam().grantType())
+                .response(WireMockUtil.BEARER_TOKEN, new Date())
+                .build();
+    }
+
+    @RegisterAiService(chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
     @Singleton
-    interface NewAIService {
+    interface AIService {
 
         @SystemMessage("This is a systemMessage")
         @UserMessage("This is a userMessage {text}")
         String chat(String text);
+
+        @SystemMessage("This is a systemMessage")
+        @UserMessage("This is a userMessage {text}")
+        Multi<String> streaming(String text);
     }
 
     @Inject
-    NewAIService service;
+    AIService service;
 
     @Test
     void chat() throws Exception {
 
+        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_CHAT_API, 200)
+                .body(mapper.writeValueAsString(generateRequest()))
+                .response(WireMockUtil.RESPONSE_WATSONX_CHAT_API)
+                .build();
+
+        assertEquals("AI Response", service.chat("Hello"));
+    }
+
+    @Test
+    void streamingChat() throws Exception {
+
+        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_CHAT_STREAMING_API, 200)
+                .body(mapper.writeValueAsString(generateRequest()))
+                .responseMediaType(MediaType.SERVER_SENT_EVENTS)
+                .response(WireMockUtil.RESPONSE_WATSONX_STREAMING_API)
+                .build();
+
+        var result = service.streaming("Hello").collect().asList().await().indefinitely();
+        assertEquals(List.of(". ", "I'", "m ", "a beginner"), result);
+    }
+
+    private TextGenerationRequest generateRequest() {
         LangChain4jWatsonxConfig.WatsonConfig watsonConfig = langchain4jWatsonConfig.defaultConfig();
         ChatModelConfig chatModelConfig = watsonConfig.chatModel();
         String modelId = langchain4jWatsonFixedRuntimeConfig.defaultConfig().chatModel().modelId();
@@ -62,17 +99,6 @@ public class AiChatServiceTest extends WireMockAbstract {
                 .maxNewTokens(chatModelConfig.maxNewTokens())
                 .build();
 
-        TextGenerationRequest body = new TextGenerationRequest(modelId, projectId, input, parameters);
-
-        mockServers.mockIAMBuilder(200)
-                .response(WireMockUtil.BEARER_TOKEN, new Date())
-                .build();
-
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_CHAT_API, 200)
-                .body(mapper.writeValueAsString(body))
-                .response(WireMockUtil.RESPONSE_WATSONX_CHAT_API)
-                .build();
-
-        assertEquals("AI Response", service.chat("Hello"));
+        return new TextGenerationRequest(modelId, projectId, input, parameters);
     }
 }

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/AiChatServiceTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/AiChatServiceTest.java
@@ -1,6 +1,8 @@
 package io.quarkiverse.langchain4j.watsonx.deployment;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Date;
 import java.util.List;
@@ -14,8 +16,16 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.service.MemoryId;
 import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.store.memory.chat.ChatMemoryStore;
 import io.quarkiverse.langchain4j.RegisterAiService;
 import io.quarkiverse.langchain4j.watsonx.bean.Parameters;
 import io.quarkiverse.langchain4j.watsonx.bean.TextGenerationRequest;
@@ -32,8 +42,8 @@ public class AiChatServiceTest extends WireMockAbstract {
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", WireMockUtil.URL_IAM_SERVER)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", WireMockUtil.API_KEY)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", WireMockUtil.PROJECT_ID)
-            .overrideConfigKey("quarkus.langchain4j.watsonx.chat-model.prompt-formatter", "false")
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
+            .overrideConfigKey("quarkus.langchain4j.watsonx.chat-model.model-id", "mistralai/mistral-large")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(WireMockUtil.class, Calculator.class));
 
     @Override
     void handlerBeforeEach() {
@@ -41,23 +51,70 @@ public class AiChatServiceTest extends WireMockAbstract {
                 .grantType(langchain4jWatsonConfig.defaultConfig().iam().grantType())
                 .response(WireMockUtil.BEARER_TOKEN, new Date())
                 .build();
+
+        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_EMBEDDING_API, 200)
+                .response("""
+                        {
+                            "model_id": "%s",
+                            "results": [
+                              {
+                                "embedding": [
+                                  -0.006929283,
+                                  -0.005336422,
+                                  -0.024047505
+                                ]
+                              }
+                            ],
+                            "created_at": "2024-02-21T17:32:28Z",
+                            "input_token_count": 10
+                        }
+                        """)
+                .build();
     }
 
-    @RegisterAiService(chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
     @Singleton
+    @RegisterAiService(chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
+    @SystemMessage("This is a systemMessage")
     interface AIService {
-
-        @SystemMessage("This is a systemMessage")
         @UserMessage("This is a userMessage {text}")
         String chat(String text);
 
-        @SystemMessage("This is a systemMessage")
         @UserMessage("This is a userMessage {text}")
         Multi<String> streaming(String text);
     }
 
+    @Singleton
+    @RegisterAiService(tools = Calculator.class)
+    @SystemMessage("This is a systemMessage")
+    interface AIServiceWithTool {
+        String chat(@MemoryId String memoryId, @UserMessage String text);
+
+        Multi<String> streaming(@MemoryId String memoryId, @UserMessage String text);
+    }
+
     @Inject
-    AIService service;
+    AIService aiService;
+
+    @Inject
+    AIServiceWithTool aiServiceWithTool;
+
+    @Inject
+    ChatMemoryStore memory;
+
+    @Singleton
+    static class Calculator {
+
+        @Inject
+        EmbeddingModel embeddingModel;
+
+        @Tool("Execute the sum of two numbers")
+        public int sum(int first, int second) {
+            assertEquals(3, embeddingModel.embed("test").content().vectorAsList().size());
+            return first + second;
+        }
+    }
+
+    static String TOOL_CALL = "[TOOL_CALLS] [{\\\"id\\\":\\\"1\\\",\\\"name\\\":\\\"sum\\\",\\\"arguments\\\":{\\\"first\\\":1,\\\"second\\\":1}}]</s>";
 
     @Test
     void chat() throws Exception {
@@ -67,11 +124,72 @@ public class AiChatServiceTest extends WireMockAbstract {
                 .response(WireMockUtil.RESPONSE_WATSONX_CHAT_API)
                 .build();
 
-        assertEquals("AI Response", service.chat("Hello"));
+        assertEquals("AI Response", aiService.chat("Hello"));
     }
 
     @Test
-    void streamingChat() throws Exception {
+    void chat_with_tool() throws Exception {
+
+        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_CHAT_API, 200)
+                .scenario(Scenario.STARTED, "TOOL_CALL")
+                .response("""
+                        {
+                            "model_id": "mistralai/mistral-large",
+                            "created_at": "2024-01-21T17:06:14.052Z",
+                            "results": [
+                                {
+                                    "generated_text": "%s",
+                                    "generated_token_count": 5,
+                                    "input_token_count": 50,
+                                    "stop_reason": "eos_token",
+                                    "seed": 2123876088
+                                }
+                            ]
+                        }""".formatted(TOOL_CALL))
+                .build();
+
+        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_CHAT_API, 200)
+                .scenario("TOOL_CALL", "AI_RESPONSE")
+                .response("""
+                        {
+                            "model_id": "mistralai/mistral-large",
+                            "created_at": "2024-01-21T17:06:14.052Z",
+                            "results": [
+                                {
+                                    "generated_text": "The result is 2",
+                                    "generated_token_count": 5,
+                                    "input_token_count": 50,
+                                    "stop_reason": "eos_token",
+                                    "seed": 2123876088
+                                }
+                            ]
+                        }""")
+                .build();
+
+        var result = aiServiceWithTool.chat("no_streaming", "Execute the sum of 1 + 1");
+        assertEquals("The result is 2", result);
+
+        var messages = memory.getMessages("no_streaming");
+        assertEquals(messages.get(0).text(), "This is a systemMessage");
+        assertEquals(messages.get(1).text(), "Execute the sum of 1 + 1");
+        assertEquals(messages.get(4).text(), "The result is 2");
+
+        if (messages.get(2) instanceof AiMessage aiMessage) {
+            assertTrue(aiMessage.hasToolExecutionRequests());
+            assertEquals(aiMessage.toolExecutionRequests().get(0).arguments(), "{\"first\":1,\"second\":1}");
+        } else {
+            fail("The third message is not of type AiMessage");
+        }
+
+        if (messages.get(3) instanceof ToolExecutionResultMessage toolResultMessage) {
+            assertEquals(2, Integer.parseInt(toolResultMessage.text()));
+        } else {
+            fail("The fourth message is not of type ToolExecutionResultMessage");
+        }
+    }
+
+    @Test
+    void streaming_chat() throws Exception {
 
         mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_CHAT_STREAMING_API, 200)
                 .body(mapper.writeValueAsString(generateRequest()))
@@ -79,8 +197,77 @@ public class AiChatServiceTest extends WireMockAbstract {
                 .response(WireMockUtil.RESPONSE_WATSONX_STREAMING_API)
                 .build();
 
-        var result = service.streaming("Hello").collect().asList().await().indefinitely();
+        var result = aiService.streaming("Hello").collect().asList().await().indefinitely();
         assertEquals(List.of(". ", "I'", "m ", "a beginner"), result);
+    }
+
+    @Test
+    void streaming_chat_with_tool() throws Exception {
+
+        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_CHAT_STREAMING_API, 200)
+                .responseMediaType(MediaType.SERVER_SENT_EVENTS)
+                .scenario(Scenario.STARTED, "TOOL_CALL")
+                .response(
+                        """
+                                id: 1
+                                event: message
+                                data: {}
+
+                                id: 2
+                                event: message
+                                data: {"modelId":"mistralai/mistral-large","results":[{"generated_text":"","generated_token_count":0,"input_token_count":2,"stop_reason":"not_finished"}]}
+
+                                id: 3
+                                event: message
+                                data: {"modelId":"mistralai/mistral-large","results":[{"generated_text":"%s","generated_token_count":0,"input_token_count":2,"stop_reason":"not_finished"}]}
+
+                                id: 4
+                                event: close"""
+                                .formatted(TOOL_CALL))
+                .build();
+
+        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_CHAT_STREAMING_API, 200)
+                .responseMediaType(MediaType.SERVER_SENT_EVENTS)
+                .scenario("TOOL_CALL", "AI_RESPONSE")
+                .response(
+                        """
+                                id: 1
+                                event: message
+                                data: {}
+
+                                id: 2
+                                event: message
+                                data: {"modelId":"mistralai/mistral-large","results":[{"generated_text":"","generated_token_count":0,"input_token_count":2,"stop_reason":"not_finished"}]}
+
+                                id: 3
+                                event: message
+                                data: {"modelId":"mistralai/mistral-large","results":[{"generated_text":"The result is 2","generated_token_count":0,"input_token_count":2,"stop_reason":"not_finished"}]}
+
+                                id: 4
+                                event: close""")
+                .build();
+
+        var result = aiServiceWithTool.streaming("streaming", "Execute the sum of 1 + 1").collect().asList().await()
+                .indefinitely();
+        assertEquals("The result is 2", result.get(0));
+
+        var messages = memory.getMessages("streaming");
+        assertEquals(messages.get(0).text(), "This is a systemMessage");
+        assertEquals(messages.get(1).text(), "Execute the sum of 1 + 1");
+        assertEquals(messages.get(4).text(), "The result is 2");
+
+        if (messages.get(2) instanceof AiMessage aiMessage) {
+            assertTrue(aiMessage.hasToolExecutionRequests());
+            assertEquals(aiMessage.toolExecutionRequests().get(0).arguments(), "{\"first\":1,\"second\":1}");
+        } else {
+            fail("The third message is not of type AiMessage");
+        }
+
+        if (messages.get(3) instanceof ToolExecutionResultMessage toolResultMessage) {
+            assertEquals(2, Integer.parseInt(toolResultMessage.text()));
+        } else {
+            fail("The fourth message is not of type ToolExecutionResultMessage");
+        }
     }
 
     private TextGenerationRequest generateRequest() {
@@ -89,9 +276,8 @@ public class AiChatServiceTest extends WireMockAbstract {
         String modelId = langchain4jWatsonFixedRuntimeConfig.defaultConfig().chatModel().modelId();
         String projectId = watsonConfig.projectId();
         String input = new StringBuilder()
-                .append("This is a systemMessage")
-                .append("\n")
-                .append("This is a userMessage Hello")
+                .append("<s>[INST] This is a systemMessage [/INST]</s>")
+                .append("[INST] This is a userMessage Hello [/INST]")
                 .toString();
         Parameters parameters = Parameters.builder()
                 .decodingMethod(chatModelConfig.decodingMethod())

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/AiChatServiceTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/AiChatServiceTest.java
@@ -32,6 +32,7 @@ public class AiChatServiceTest extends WireMockAbstract {
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", WireMockUtil.URL_IAM_SERVER)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", WireMockUtil.API_KEY)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", WireMockUtil.PROJECT_ID)
+            .overrideConfigKey("quarkus.langchain4j.watsonx.chat-model.prompt-formatter", "false")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
 
     @Override

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/AllPropertiesTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/AllPropertiesTest.java
@@ -52,7 +52,7 @@ public class AllPropertiesTest extends WireMockAbstract {
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.timeout", "60s")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.grant-type", "grantME")
             .overrideConfigKey("quarkus.langchain4j.watsonx.chat-model.model-id", "my_super_model")
-            .overrideConfigKey("quarkus.langchain4j.watsonx.chat-model.prompt-formatter", "true")
+            .overrideConfigKey("quarkus.langchain4j.watsonx.chat-model.prompt-formatter", "false")
             .overrideConfigKey("quarkus.langchain4j.watsonx.chat-model.prompt-joiner", "@")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.decoding-method", "greedy")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.length-penalty.decay-factor", "1.1")
@@ -143,7 +143,7 @@ public class AllPropertiesTest extends WireMockAbstract {
         assertEquals(0, runtimeConfig.chatModel().truncateInputTokens().get());
         assertEquals(false, runtimeConfig.chatModel().includeStopSequence().get());
         assertEquals("@", runtimeConfig.chatModel().promptJoiner());
-        assertEquals(true, fixedRuntimeConfig.chatModel().promptFormatter());
+        assertEquals(false, fixedRuntimeConfig.chatModel().promptFormatter());
         assertEquals("my_super_embedding_model", runtimeConfig.embeddingModel().modelId());
     }
 

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/CacheTokenTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/CacheTokenTest.java
@@ -49,6 +49,7 @@ public class CacheTokenTest extends WireMockAbstract {
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", WireMockUtil.URL_IAM_SERVER)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", WireMockUtil.API_KEY)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", WireMockUtil.PROJECT_ID)
+            .overrideConfigKey("quarkus.langchain4j.watsonx.chat-model.prompt-formatter", "false")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
 
     @Inject

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ChatMemoryPlaceholderTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ChatMemoryPlaceholderTest.java
@@ -31,6 +31,7 @@ public class ChatMemoryPlaceholderTest extends WireMockAbstract {
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", WireMockUtil.URL_IAM_SERVER)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", WireMockUtil.API_KEY)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", WireMockUtil.PROJECT_ID)
+            .overrideConfigKey("quarkus.langchain4j.watsonx.chat-model.prompt-formatter", "false")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
 
     @Override

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/DefaultPropertiesTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/DefaultPropertiesTest.java
@@ -32,7 +32,7 @@ import io.quarkiverse.langchain4j.watsonx.bean.EmbeddingRequest;
 import io.quarkiverse.langchain4j.watsonx.bean.Parameters;
 import io.quarkiverse.langchain4j.watsonx.bean.TextGenerationRequest;
 import io.quarkiverse.langchain4j.watsonx.bean.TokenizationRequest;
-import io.quarkiverse.langchain4j.watsonx.prompt.impl.NoopPromptFormatter;
+import io.quarkiverse.langchain4j.watsonx.prompt.impl.GranitePromptFormatter;
 import io.quarkus.arc.ClientProxy;
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -75,7 +75,7 @@ public class DefaultPropertiesTest extends WireMockAbstract {
     @Test
     void prompt_formatter() {
         var unwrapChatModel = (WatsonxChatModel) ClientProxy.unwrap(chatModel);
-        assertTrue(unwrapChatModel.getPromptFormatter() instanceof NoopPromptFormatter);
+        assertTrue(unwrapChatModel.getPromptFormatter() instanceof GranitePromptFormatter);
     }
 
     @Test
@@ -97,7 +97,7 @@ public class DefaultPropertiesTest extends WireMockAbstract {
         assertEquals(null, runtimeConfig.chatModel().stopSequences().orElse(null));
         assertEquals(1.0, runtimeConfig.chatModel().temperature());
         assertEquals("\n", runtimeConfig.chatModel().promptJoiner());
-        assertEquals(false, fixedRuntimeConfig.chatModel().promptFormatter());
+        assertEquals(true, fixedRuntimeConfig.chatModel().promptFormatter());
         assertTrue(runtimeConfig.chatModel().topK().isEmpty());
         assertTrue(runtimeConfig.chatModel().topP().isEmpty());
         assertTrue(runtimeConfig.chatModel().repetitionPenalty().isEmpty());
@@ -113,7 +113,8 @@ public class DefaultPropertiesTest extends WireMockAbstract {
         String modelId = langchain4jWatsonFixedRuntimeConfig.defaultConfig().chatModel().modelId();
         String projectId = config.projectId();
 
-        TextGenerationRequest body = new TextGenerationRequest(modelId, projectId, "SystemMessage\nUserMessage", parameters);
+        TextGenerationRequest body = new TextGenerationRequest(modelId, projectId,
+                "<|system|>\nSystemMessage\n<|user|>\nUserMessage\n<|assistant|>\n", parameters);
 
         mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_CHAT_API, 200)
                 .body(mapper.writeValueAsString(body))
@@ -149,7 +150,7 @@ public class DefaultPropertiesTest extends WireMockAbstract {
         String modelId = langchain4jWatsonFixedRuntimeConfig.defaultConfig().chatModel().modelId();
         String projectId = config.projectId();
 
-        var body = new TokenizationRequest(modelId, "test", projectId);
+        var body = new TokenizationRequest(modelId, "<|user|>\ntest\n<|assistant|>\n", projectId);
 
         mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_TOKENIZER_API, 200)
                 .body(mapper.writeValueAsString(body))
@@ -165,7 +166,8 @@ public class DefaultPropertiesTest extends WireMockAbstract {
         String modelId = langchain4jWatsonFixedRuntimeConfig.defaultConfig().chatModel().modelId();
         String projectId = config.projectId();
 
-        TextGenerationRequest body = new TextGenerationRequest(modelId, projectId, "SystemMessage\nUserMessage", parameters);
+        TextGenerationRequest body = new TextGenerationRequest(modelId, projectId,
+                "<|system|>\nSystemMessage\n<|user|>\nUserMessage\n<|assistant|>\n", parameters);
 
         mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_CHAT_STREAMING_API, 200)
                 .body(mapper.writeValueAsString(body))

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/PromptFormatterExceptionTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/PromptFormatterExceptionTest.java
@@ -41,7 +41,6 @@ public class PromptFormatterExceptionTest {
                 .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", WireMockUtil.PROJECT_ID)
                 .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.embedding-model.model-id",
                         WireMockUtil.DEFAULT_CHAT_MODEL)
-                .overrideConfigKey("quarkus.langchain4j.watsonx.chat-model.prompt-formatter", "true")
                 .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(AIService.class, Calculator.class))
                 .assertException(t -> {
                     assertThat(t).isInstanceOf(RuntimeException.class)

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/PromptFormatterForceDefaultTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/PromptFormatterForceDefaultTest.java
@@ -32,13 +32,11 @@ public class PromptFormatterForceDefaultTest {
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.model1.iam.base-url", WireMockUtil.URL_IAM_SERVER)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.model1.api-key", WireMockUtil.API_KEY)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.model1.project-id", WireMockUtil.PROJECT_ID)
-            .overrideConfigKey("quarkus.langchain4j.watsonx.model1.chat-model.prompt-formatter", "true")
             .overrideRuntimeConfigKey("quarkus.langchain4j.model2.chat-model.provider", "watsonx")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.model2.base-url", WireMockUtil.URL_WATSONX_SERVER)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.model2.iam.base-url", WireMockUtil.URL_IAM_SERVER)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.model2.api-key", WireMockUtil.API_KEY)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.model2.project-id", WireMockUtil.PROJECT_ID)
-            .overrideConfigKey("quarkus.langchain4j.watsonx.model2.chat-model.prompt-formatter", "true")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClass(WireMockUtil.class));
 

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/PromptFormatterTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/PromptFormatterTest.java
@@ -32,7 +32,6 @@ public class PromptFormatterTest extends WireMockAbstract {
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", WireMockUtil.API_KEY)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", WireMockUtil.PROJECT_ID)
             .overrideConfigKey("quarkus.langchain4j.watsonx.chat-model.model-id", "mistralai/mistral-large")
-            .overrideConfigKey("quarkus.langchain4j.watsonx.chat-model.prompt-formatter", "true")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addAsResource("messages/system.txt")
                     .addAsResource("messages/user.txt")

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/PromptFormatterToolsTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/PromptFormatterToolsTest.java
@@ -32,7 +32,7 @@ public class PromptFormatterToolsTest {
 
             ToolSpecification.builder()
                     .name("sum")
-                    .description("Perform a subtraction between two numbers")
+                    .description("Perform a sum between two numbers")
                     .parameters(
                             ToolParameters.builder()
                                     .properties(Map.of("firstNumber", Map.of("type", "integer"), "secondNumber",
@@ -72,7 +72,7 @@ public class PromptFormatterToolsTest {
 
         String expected = """
                 <s>%s[AVAILABLE_TOOLS] \
-                [{"type":"function","function":{"name":"sum","description":"Perform a subtraction between two numbers","parameters":{"type":"object","properties":{%s},"required":["firstNumber","secondNumber"]}}}] \
+                [{"type":"function","function":{"name":"sum","description":"Perform a sum between two numbers","parameters":{"type":"object","properties":{%s},"required":["firstNumber","secondNumber"]}}}] \
                 [/AVAILABLE_TOOLS][INST] 2 + 2 [/INST]\
                 [TOOL_CALLS] [{"id":"1","name":"sum","arguments":{"firstNumber":2,"secondNumber":2}}]</s>\
                 [TOOL_RESULTS] {"content":4,"id":"1"} [/TOOL_RESULTS] The result is 4</s>""";
@@ -123,7 +123,7 @@ public class PromptFormatterToolsTest {
 
                 You have access to the following functions. To call a function, respond with JSON for a function call. When you access a function respond always in the format {"name": function name, "parameters": dictionary of argument name and its value}. Do not use variables.
 
-                {"type":"function","function":{"name":"sum","description":"Perform a subtraction between two numbers","parameters":{"type":"object","properties":{%s},"required":["firstNumber","secondNumber"]}}}
+                {"type":"function","function":{"name":"sum","description":"Perform a sum between two numbers","parameters":{"type":"object","properties":{%s},"required":["firstNumber","secondNumber"]}}}
 
                 %s<|eot_id|><|start_header_id|>user<|end_header_id|>
 

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ResponseSchemaOffTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ResponseSchemaOffTest.java
@@ -25,6 +25,7 @@ public class ResponseSchemaOffTest {
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", WireMockUtil.API_KEY)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", WireMockUtil.PROJECT_ID)
             .overrideConfigKey("quarkus.langchain4j.response-schema", "false")
+            .overrideConfigKey("quarkus.langchain4j.watsonx.chat-model.prompt-formatter", "false")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
 
     @RegisterAiService

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ResponseSchemaOnTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ResponseSchemaOnTest.java
@@ -33,6 +33,7 @@ public class ResponseSchemaOnTest extends WireMockAbstract {
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", WireMockUtil.API_KEY)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", WireMockUtil.PROJECT_ID)
             .overrideConfigKey("quarkus.langchain4j.response-schema", "true")
+            .overrideConfigKey("quarkus.langchain4j.watsonx.chat-model.prompt-formatter", "false")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
 
     static String SCHEMA = "\nYou must answer strictly in the following JSON format: {\n\"text\": (type: string)\n}";

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/TokenCountEstimatorTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/TokenCountEstimatorTest.java
@@ -30,6 +30,7 @@ public class TokenCountEstimatorTest extends WireMockAbstract {
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", WireMockUtil.URL_IAM_SERVER)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", WireMockUtil.API_KEY)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", WireMockUtil.PROJECT_ID)
+            .overrideConfigKey("quarkus.langchain4j.watsonx.chat-model.prompt-formatter", "false")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
 
     @Override

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxModel.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxModel.java
@@ -94,17 +94,11 @@ public abstract class WatsonxModel {
     }
 
     protected String toInput(List<ChatMessage> messages) {
-        var prompt = promptFormatter.format(messages, List.of());
-        log.debugf("""
-                Formatted prompt:
-                -----------------
-                %s
-                -----------------""", prompt);
-        return prompt;
+        return toInput(messages, null);
     }
 
     protected String toInput(List<ChatMessage> messages, List<ToolSpecification> tools) {
-        var prompt = promptFormatter.format(messages, tools);
+        var prompt = promptFormatter.format(messages, tools == null ? List.of() : tools);
         log.debugf("""
                 Formatted prompt:
                 -----------------
@@ -117,6 +111,7 @@ public abstract class WatsonxModel {
         return switch (stopReason) {
             case "max_tokens" -> FinishReason.LENGTH;
             case "eos_token", "stop_sequence" -> FinishReason.STOP;
+            case "not_finished" -> FinishReason.OTHER;
             default -> throw new IllegalArgumentException("%s not supported".formatted(stopReason));
         };
     }

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxStreamingChatModel.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxStreamingChatModel.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 
+import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.model.StreamingResponseHandler;
@@ -29,28 +30,7 @@ public class WatsonxStreamingChatModel extends WatsonxModel implements Streaming
 
     @Override
     public void generate(List<ChatMessage> messages, StreamingResponseHandler<AiMessage> handler) {
-
-        LengthPenalty lengthPenalty = null;
-        if (Objects.nonNull(decayFactor) || Objects.nonNull(startIndex)) {
-            lengthPenalty = new LengthPenalty(decayFactor, startIndex);
-        }
-
-        Parameters parameters = Parameters.builder()
-                .decodingMethod(decodingMethod)
-                .lengthPenalty(lengthPenalty)
-                .minNewTokens(minNewTokens)
-                .maxNewTokens(maxNewTokens)
-                .randomSeed(randomSeed)
-                .stopSequences(stopSequences)
-                .temperature(temperature)
-                .topP(topP)
-                .topK(topK)
-                .repetitionPenalty(repetitionPenalty)
-                .truncateInputTokens(truncateInputTokens)
-                .includeStopSequence(includeStopSequence)
-                .build();
-
-        TextGenerationRequest request = new TextGenerationRequest(modelId, projectId, toInput(messages), parameters);
+        TextGenerationRequest request = generateRequest(messages, null);
         Context context = Context.of("response", new ArrayList<TextGenerationResponse>());
 
         client.chatStreaming(request, version)
@@ -65,8 +45,13 @@ public class WatsonxStreamingChatModel extends WatsonxModel implements Streaming
                                     if (response == null || response.results() == null || response.results().isEmpty())
                                         return;
 
+                                    String chunk = response.results().get(0).generatedText();
+
+                                    if (chunk.isEmpty())
+                                        return;
+
                                     ((List<TextGenerationResponse>) context.get("response")).add(response);
-                                    handler.onNext(response.results().get(0).generatedText());
+                                    handler.onNext(chunk);
 
                                 } catch (Exception e) {
                                     handler.onError(e);
@@ -114,6 +99,111 @@ public class WatsonxStreamingChatModel extends WatsonxModel implements Streaming
     }
 
     @Override
+    public void generate(List<ChatMessage> messages, List<ToolSpecification> toolSpecifications,
+            StreamingResponseHandler<AiMessage> handler) {
+        TextGenerationRequest request = generateRequest(messages, toolSpecifications);
+        Context context = Context.of("response", new ArrayList<TextGenerationResponse>(), "toolExecution", false);
+
+        client.chatStreaming(request, version)
+                .subscribe()
+                .with(context,
+                        new Consumer<TextGenerationResponse>() {
+                            @Override
+                            @SuppressWarnings("unchecked")
+                            public void accept(TextGenerationResponse response) {
+                                try {
+
+                                    if (response == null || response.results() == null || response.results().isEmpty())
+                                        return;
+
+                                    String chunk = response.results().get(0).generatedText();
+
+                                    if (chunk.isEmpty())
+                                        return;
+
+                                    ((List<TextGenerationResponse>) context.get("response")).add(response);
+                                    boolean isToolExecutionState = ((Boolean) context.get("toolExecution"));
+
+                                    if (isToolExecutionState) {
+                                        // If we are in the tool execution state, the chunk is associated with the tool execution,
+                                        // which means that it must not be sent to the client.
+                                    } else {
+
+                                        // Check if the chunk contains the "ToolExecution" tag.
+                                        if (chunk.startsWith(promptFormatter.toolExecution().trim())) {
+                                            // If true, enter in the ToolExecutionState.
+                                            context.put("toolExecution", true);
+                                            return;
+                                        }
+
+                                        // Send the chunk to the client.
+                                        handler.onNext(chunk);
+                                    }
+
+                                } catch (Exception e) {
+                                    handler.onError(e);
+                                }
+                            }
+                        },
+                        new Consumer<Throwable>() {
+                            @Override
+                            public void accept(Throwable error) {
+                                handler.onError(error);
+                            }
+                        },
+                        new Runnable() {
+                            @Override
+                            @SuppressWarnings("unchecked")
+                            public void run() {
+                                var list = ((List<TextGenerationResponse>) context.get("response"));
+                                boolean isToolExecutionState = ((Boolean) context.get("toolExecution"));
+
+                                int inputTokenCount = 0;
+                                int outputTokenCount = 0;
+                                String stopReason = null;
+                                StringBuilder builder = new StringBuilder();
+
+                                for (int i = 0; i < list.size(); i++) {
+
+                                    TextGenerationResponse.Result response = list.get(i).results().get(0);
+
+                                    if (i == 0)
+                                        inputTokenCount = response.inputTokenCount();
+
+                                    if (i == list.size() - 1) {
+                                        outputTokenCount = response.generatedTokenCount();
+                                        stopReason = response.stopReason();
+                                    }
+
+                                    builder.append(response.generatedText());
+                                }
+
+                                AiMessage content;
+                                TokenUsage tokenUsage = new TokenUsage(inputTokenCount, outputTokenCount);
+                                FinishReason finishReason = toFinishReason(stopReason);
+
+                                String message = builder.toString();
+
+                                if (isToolExecutionState) {
+                                    context.put("toolExecution", false);
+                                    var tools = message.replace(promptFormatter.toolExecution(), "");
+                                    content = AiMessage.from(promptFormatter.toolExecutionRequestFormatter(tools));
+                                } else {
+                                    content = AiMessage.from(message);
+                                }
+
+                                handler.onComplete(Response.from(content, tokenUsage, finishReason));
+                            }
+                        });
+    }
+
+    @Override
+    public void generate(List<ChatMessage> messages, ToolSpecification toolSpecification,
+            StreamingResponseHandler<AiMessage> handler) {
+        generate(messages, List.of(toolSpecification), handler);
+    }
+
+    @Override
     public int estimateTokenCount(List<ChatMessage> messages) {
 
         var input = toInput(messages);
@@ -124,5 +214,29 @@ public class WatsonxStreamingChatModel extends WatsonxModel implements Streaming
                 return client.tokenization(request, version).result().tokenCount();
             }
         });
+    }
+
+    private TextGenerationRequest generateRequest(List<ChatMessage> messages, List<ToolSpecification> toolSpecifications) {
+        LengthPenalty lengthPenalty = null;
+        if (Objects.nonNull(decayFactor) || Objects.nonNull(startIndex)) {
+            lengthPenalty = new LengthPenalty(decayFactor, startIndex);
+        }
+
+        Parameters parameters = Parameters.builder()
+                .decodingMethod(decodingMethod)
+                .lengthPenalty(lengthPenalty)
+                .minNewTokens(minNewTokens)
+                .maxNewTokens(maxNewTokens)
+                .randomSeed(randomSeed)
+                .stopSequences(stopSequences)
+                .temperature(temperature)
+                .topP(topP)
+                .topK(topK)
+                .repetitionPenalty(repetitionPenalty)
+                .truncateInputTokens(truncateInputTokens)
+                .includeStopSequence(includeStopSequence)
+                .build();
+
+        return new TextGenerationRequest(modelId, projectId, toInput(messages, toolSpecifications), parameters);
     }
 }

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxStreamingChatModel.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxStreamingChatModel.java
@@ -21,6 +21,7 @@ import io.quarkiverse.langchain4j.watsonx.bean.TextGenerationRequest;
 import io.quarkiverse.langchain4j.watsonx.bean.TextGenerationResponse;
 import io.quarkiverse.langchain4j.watsonx.bean.TokenizationRequest;
 import io.smallrye.mutiny.Context;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
 
 public class WatsonxStreamingChatModel extends WatsonxModel implements StreamingChatLanguageModel, TokenCountEstimator {
 
@@ -105,6 +106,7 @@ public class WatsonxStreamingChatModel extends WatsonxModel implements Streaming
         Context context = Context.of("response", new ArrayList<TextGenerationResponse>(), "toolExecution", false);
 
         client.chatStreaming(request, version)
+                .emitOn(Infrastructure.getDefaultWorkerPool())
                 .subscribe()
                 .with(context,
                         new Consumer<TextGenerationResponse>() {

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/ChatModelFixedRuntimeConfig.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/ChatModelFixedRuntimeConfig.java
@@ -25,6 +25,6 @@ public interface ChatModelFixedRuntimeConfig {
      * <li><code>false</code>: Prompts will not be enriched with the model's tags.</li>
      * </ul>
      */
-    @WithDefault("false")
+    @WithDefault("true")
     boolean promptFormatter();
 }


### PR DESCRIPTION
These changes enable `watsonx.ai` module to execute tools in the streaming api.
I also set the default value of the `prompt-formatter` property to `true`.