### PR TITLE
[FEATURE] ToolProvider | Select tools dynamically on incoming message

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/DeclarativeAiServiceBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/DeclarativeAiServiceBuildItem.java
@@ -16,6 +16,7 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
     private final DotName chatLanguageModelSupplierClassDotName;
     private final DotName streamingChatLanguageModelSupplierClassDotName;
     private final List<DotName> toolDotNames;
+    private final DotName toolProviderClassDotName;
 
     private final DotName chatMemoryProviderSupplierClassDotName;
     private final DotName retrieverClassDotName;
@@ -46,7 +47,8 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
             DotName cdiScope,
             String chatModelName,
             String moderationModelName,
-            String imageModelName) {
+            String imageModelName,
+            DotName toolProviderClassDotName) {
         this.serviceClassInfo = serviceClassInfo;
         this.chatLanguageModelSupplierClassDotName = chatLanguageModelSupplierClassDotName;
         this.streamingChatLanguageModelSupplierClassDotName = streamingChatLanguageModelSupplierClassDotName;
@@ -63,6 +65,7 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
         this.chatModelName = chatModelName;
         this.moderationModelName = moderationModelName;
         this.imageModelName = imageModelName;
+        this.toolProviderClassDotName = toolProviderClassDotName;
     }
 
     public ClassInfo getServiceClassInfo() {
@@ -127,5 +130,9 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
 
     public String getImageModelName() {
         return imageModelName;
+    }
+
+    public DotName getToolProviderClassDotName() {
+        return toolProviderClassDotName;
     }
 }

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/LangChain4jDotNames.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/LangChain4jDotNames.java
@@ -97,6 +97,9 @@ public class LangChain4jDotNames {
     static final DotName BEAN_IF_EXISTS_IMAGE_MODEL_SUPPLIER = DotName.createSimple(
             RegisterAiService.BeanIfExistsImageModelSupplier.class);
 
+    static final DotName BEAN_IF_EXISTS_TOOL_PROVIDER_SUPPLIER = DotName.createSimple(
+            RegisterAiService.BeanIfExistsToolProviderSupplier.class);
+
     static final DotName QUARKUS_AI_SERVICE_CONTEXT_QUALIFIER = DotName.createSimple(
             QuarkusAiServiceContextQualifier.class);
 
@@ -106,4 +109,5 @@ public class LangChain4jDotNames {
     static final DotName WEB_SEARCH_ENGINE = DotName.createSimple(WebSearchEngine.class);
     static final DotName IMAGE = DotName.createSimple(Image.class);
     static final DotName RESULT = DotName.createSimple(Result.class);
+    static final DotName TOOL_PROVIDER = DotName.createSimple(ToolProcessor.class);
 }

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/ToolProviderMetaBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/ToolProviderMetaBuildItem.java
@@ -1,0 +1,21 @@
+package io.quarkiverse.langchain4j.deployment;
+
+import java.util.List;
+
+import io.quarkiverse.langchain4j.deployment.devui.ToolProviderInfo;
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Holds metadata about toolProviders discovered at build time
+ */
+public final class ToolProviderMetaBuildItem extends SimpleBuildItem {
+    List<ToolProviderInfo> metadata;
+
+    public ToolProviderMetaBuildItem(List<ToolProviderInfo> metaData) {
+        this.metadata = metaData;
+    }
+
+    public List<ToolProviderInfo> getMetadata() {
+        return metadata;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/devui/LangChain4jDevUIProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/devui/LangChain4jDevUIProcessor.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import io.quarkiverse.langchain4j.deployment.DeclarativeAiServiceBuildItem;
 import io.quarkiverse.langchain4j.deployment.EmbeddingStoreBuildItem;
 import io.quarkiverse.langchain4j.deployment.LangChain4jDotNames;
+import io.quarkiverse.langchain4j.deployment.ToolProviderMetaBuildItem;
 import io.quarkiverse.langchain4j.deployment.ToolsMetadataBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.ChatModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.EmbeddingModelProviderCandidateBuildItem;
@@ -28,6 +29,7 @@ public class LangChain4jDevUIProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
     CardPageBuildItem cardPage(List<DeclarativeAiServiceBuildItem> aiServices,
+            ToolProviderMetaBuildItem toolProviderMetaBuildItem,
             ToolsMetadataBuildItem toolsMetadataBuildItem,
             List<EmbeddingModelProviderCandidateBuildItem> embeddingModelCandidateBuildItems,
             List<InProcessEmbeddingBuildItem> inProcessEmbeddingModelBuildItems,
@@ -60,6 +62,10 @@ public class LangChain4jDevUIProcessor {
 
             additionalDevUiCardBuildItem.getBuildTimeData().forEach((k, v) -> card.addBuildTimeData(k, v));
         }
+
+        List<ToolProviderInfo> toolProviderInfos = toolProviderMetaBuildItem.getMetadata();
+        card.addBuildTimeData("toolProviders", toolProviderInfos);
+
         return card;
     }
 

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/devui/ToolProviderInfo.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/devui/ToolProviderInfo.java
@@ -1,0 +1,27 @@
+package io.quarkiverse.langchain4j.deployment.devui;
+
+public class ToolProviderInfo {
+    private String className;
+    private String aiServiceName;
+
+    public ToolProviderInfo(String className, String aiServiceName) {
+        this.className = className;
+        this.aiServiceName = aiServiceName;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public void setClassName(String className) {
+        this.className = className;
+    }
+
+    public String getAiServiceName() {
+        return aiServiceName;
+    }
+
+    public void setAiServiceName(String aiServiceName) {
+        this.aiServiceName = aiServiceName;
+    }
+}

--- a/core/deployment/src/main/resources/dev-ui/qwc-tools.js
+++ b/core/deployment/src/main/resources/dev-ui/qwc-tools.js
@@ -1,8 +1,8 @@
-import { LitElement, html, css} from 'lit';
+import {css, html, LitElement} from 'lit';
 import '@vaadin/grid';
 import '@vaadin/grid/vaadin-grid-sort-column.js';
 
-import {tools} from 'build-time-data';
+import {toolProviders, tools} from 'build-time-data';
 
 
 export class QwcTools extends LitElement {
@@ -12,6 +12,7 @@ export class QwcTools extends LitElement {
             height: 100%;
             display: flex;
         }
+
         vaadin-grid {
             margin-left: 15px;
             margin-right: 15px;
@@ -21,38 +22,57 @@ export class QwcTools extends LitElement {
 
     static properties = {
         "_tools": {state: true},
+        "_toolProviders": {state: true},
     }
 
     constructor() {
         super();
         this._tools = tools;
+        this._toolProviders = toolProviders;
     }
 
     render() {
-        if (this._tools) {
+        if (this._toolProviders.length > 0) {
+            return this._renderToolProvider();
+        } else if (this._tools) {
             return this._renderToolTable();
         } else {
             return html`<span>No tools found</span>`;
         }
     }
 
+    _renderToolProvider() {
+        return html`
+            <vaadin-grid .items="${this._toolProviders}" theme="no-border">
+                <vaadin-grid-sort-column auto-width
+                                         path="className"
+                                         header="Class name">
+                </vaadin-grid-sort-column>
+                <vaadin-grid-column auto-width
+                                    path="aiServiceName"
+                                    header="AiService">
+                </vaadin-grid-column>
+            </vaadin-grid>`;
+    }
+
     _renderToolTable() {
         return html`
-                <vaadin-grid .items="${this._tools}" theme="no-border">
-                    <vaadin-grid-sort-column auto-width
-                                        path="className"
-                                        header="Class name">
-                    </vaadin-grid-sort-column>
-                    <vaadin-grid-column auto-width
-                                        path="name"
-                                        header="Tool name">
-                    </vaadin-grid-column>
-                    <vaadin-grid-column auto-width
-                                        path="description"
-                                        header="Description">
-                    </vaadin-grid-column>
-                </vaadin-grid>`;
+            <vaadin-grid .items="${this._tools}" theme="no-border">
+                <vaadin-grid-sort-column auto-width
+                                         path="className"
+                                         header="Class name">
+                </vaadin-grid-sort-column>
+                <vaadin-grid-column auto-width
+                                    path="name"
+                                    header="Tool name">
+                </vaadin-grid-column>
+                <vaadin-grid-column auto-width
+                                    path="description"
+                                    header="Description">
+                </vaadin-grid-column>
+            </vaadin-grid>`;
     }
 
 }
+
 customElements.define('qwc-tools', QwcTools);

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ToolProviderTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ToolProviderTest.java
@@ -1,0 +1,135 @@
+package io.quarkiverse.langchain4j.test;
+
+import static dev.langchain4j.data.message.ChatMessageType.TOOL_EXECUTION_RESULT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.tool.ToolExecutor;
+import dev.langchain4j.service.tool.ToolProvider;
+import dev.langchain4j.service.tool.ToolProviderRequest;
+import dev.langchain4j.service.tool.ToolProviderResult;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkus.test.QuarkusUnitTest;
+
+class ToolProviderTest {
+    @Inject
+    MyServiceWithCustomToolProvider myServiceWithTools;
+
+    @Inject
+    MyServiceWithDefaultToolProviderConfig myServiceWithoutTools;
+
+    @ApplicationScoped
+    public static class MyCustomToolProviderSupplier implements Supplier<ToolProvider> {
+        @Inject
+        MyCustomToolProvider myCustomToolProvider;
+
+        @Override
+        public ToolProvider get() {
+            return myCustomToolProvider;
+        }
+    }
+
+    @ApplicationScoped
+    public static class MyCustomToolProvider implements ToolProvider {
+        @Inject
+        MyServiceWithDefaultToolProviderConfig myServiceWithoutTools;
+
+        @Override
+        public ToolProviderResult provideTools(ToolProviderRequest request) {
+            assertNotNull(myServiceWithoutTools);
+
+            ToolSpecification toolSpecification = ToolSpecification.builder()
+                    .name("get_booking_details")
+                    .description("Returns booking details")
+                    .build();
+            ToolExecutor toolExecutor = (t, m) -> "0";
+            return ToolProviderResult.builder()
+                    .add(toolSpecification, toolExecutor)
+                    .build();
+        }
+    }
+
+    public static class TestAiSupplier implements Supplier<ChatLanguageModel> {
+        @Override
+        public ChatLanguageModel get() {
+            return new TestAiModel();
+        }
+    }
+
+    public static class TestAiModel implements ChatLanguageModel {
+        @Override
+        public Response<AiMessage> generate(List<ChatMessage> messages) {
+            return new Response<>(new AiMessage("42"));
+        }
+
+        @Override
+        public Response<AiMessage> generate(List<ChatMessage> messages, List<ToolSpecification> toolSpecifications) {
+            ChatMessage lastMsg = messages.get(messages.size() - 1);
+            boolean isLastMsgToolResponse = lastMsg.type().equals(TOOL_EXECUTION_RESULT);
+            if (isLastMsgToolResponse) {
+                ToolExecutionResultMessage msg = (ToolExecutionResultMessage) lastMsg;
+                return new Response<>(new AiMessage(msg.text()));
+            }
+            ToolSpecification toolSpecification = toolSpecifications.get(0);
+            ToolExecutionRequest toolExecutionRequest = ToolExecutionRequest.builder()
+                    .name(toolSpecification.name())
+                    .id(toolSpecification.name())
+                    .build();
+            TokenUsage usage = new TokenUsage(42, 42);
+            return new Response<>(AiMessage.from(toolExecutionRequest), usage, FinishReason.TOOL_EXECUTION);
+        }
+    }
+
+    @RegisterAiService(toolProviderSupplier = MyCustomToolProviderSupplier.class, chatLanguageModelSupplier = TestAiSupplier.class)
+    interface MyServiceWithCustomToolProvider {
+        String chat(@UserMessage String msg, @MemoryId Object id);
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = BlockingChatLanguageModelSupplierTest.MyModelSupplier.class, chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
+    interface MyServiceWithDefaultToolProviderConfig {
+        String chat(String msg);
+    }
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyServiceWithCustomToolProvider.class, MyCustomToolProvider.class,
+                            BlockingChatLanguageModelSupplierTest.MyModelSupplier.class));
+
+    @Test
+    @ActivateRequestContext
+    void testCall() {
+        String answer = myServiceWithTools.chat("hello", 1);
+        assertEquals("0", answer);
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testCallNoTools() {
+        String answer = myServiceWithoutTools.chat("hello");
+        assertEquals("42", answer);
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/RegisterAiService.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/RegisterAiService.java
@@ -19,6 +19,7 @@ import dev.langchain4j.model.moderation.ModerationModel;
 import dev.langchain4j.rag.RetrievalAugmentor;
 import dev.langchain4j.retriever.Retriever;
 import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.store.memory.chat.ChatMemoryStore;
 import dev.langchain4j.store.memory.chat.InMemoryChatMemoryStore;
 import io.quarkiverse.langchain4j.audit.AuditService;
@@ -68,7 +69,7 @@ public @interface RegisterAiService {
      * If not set, the default model (i.e. the one configured without setting the model name) is used.
      * An example of the default model configuration is the following:
      * {@code quarkus.langchain4j.openai.chat-model.model-name=gpt-4-turbo-preview}
-     *
+     * <p>
      * If set, it uses the model configured by name. For example if this is set to {@code somename}
      * an example configuration value for that named model could be:
      * {@code quarkus.langchain4j.somename.openai.chat-model.model-name=gpt-4-turbo-preview}
@@ -116,7 +117,7 @@ public @interface RegisterAiService {
      * typically it will, so consider adding a bean-defining annotation to
      * it). If it is not a CDI bean, Quarkus will create an instance
      * by calling its no-arg constructor.
-     *
+     * <p>
      * If unspecified, Quarkus will attempt to locate a CDI bean that
      * implements {@link RetrievalAugmentor} and use it if one exists.
      */
@@ -139,6 +140,11 @@ public @interface RegisterAiService {
      * needs to be provided.
      */
     Class<? extends Supplier<ModerationModel>> moderationModelSupplier() default BeanIfExistsModerationModelSupplier.class;
+
+    /**
+     * Configures a toolProviderSupplier. Either a toolProviderSupplier or "normal" tools can be used, but not both
+     */
+    Class<? extends Supplier<ToolProvider>> toolProviderSupplier() default BeanIfExistsToolProviderSupplier.class;
 
     /**
      * Marker that is used to tell Quarkus to use the {@link ChatLanguageModel} that has been configured as a CDI bean by
@@ -259,6 +265,18 @@ public @interface RegisterAiService {
 
         @Override
         public ImageModel get() {
+            throw new UnsupportedOperationException("should never be called");
+        }
+    }
+
+    /**
+     * Marker that is used to tell Quarkus to use the {@link ToolProvider} that the user has configured as a CDI bean.
+     * If no such bean exists, then no tool provider will be used.
+     */
+    final class BeanIfExistsToolProviderSupplier implements Supplier<ToolProvider> {
+
+        @Override
+        public ToolProvider get() {
             throw new UnsupportedOperationException("should never be called");
         }
     }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/AiServicesRecorder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/AiServicesRecorder.java
@@ -21,6 +21,7 @@ import dev.langchain4j.model.image.ImageModel;
 import dev.langchain4j.model.moderation.ModerationModel;
 import dev.langchain4j.rag.RetrievalAugmentor;
 import dev.langchain4j.retriever.Retriever;
+import dev.langchain4j.service.tool.ToolProvider;
 import io.quarkiverse.langchain4j.ModelName;
 import io.quarkiverse.langchain4j.RegisterAiService;
 import io.quarkiverse.langchain4j.audit.AuditService;
@@ -156,6 +157,15 @@ public class AiServicesRecorder {
                             tools.add(tool);
                         }
                         quarkusAiServices.tools(tools);
+                    }
+
+                    if (!RegisterAiService.BeanIfExistsToolProviderSupplier.class.getName()
+                            .equals(info.toolProviderSupplier())) {
+                        Class<?> toolProviderClass = Thread.currentThread().getContextClassLoader()
+                                .loadClass(info.toolProviderSupplier());
+                        Supplier<? extends ToolProvider> toolProvider = (Supplier<? extends ToolProvider>) creationalContext
+                                .getInjectedReference(toolProviderClass);
+                        quarkusAiServices.toolProvider(toolProvider.get());
                     }
 
                     if (info.chatMemoryProviderSupplierClassName() != null) {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/DeclarativeAiServiceCreateInfo.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/DeclarativeAiServiceCreateInfo.java
@@ -7,6 +7,7 @@ public record DeclarativeAiServiceCreateInfo(
         String languageModelSupplierClassName,
         String streamingChatLanguageModelSupplierClassName,
         List<String> toolsClassNames,
+        String toolProviderSupplier,
         String chatMemoryProviderSupplierClassName,
         String retrieverClassName,
         String retrievalAugmentorSupplierClassName,

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/devui/ChatJsonRPCService.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/devui/ChatJsonRPCService.java
@@ -1,5 +1,17 @@
 package io.quarkiverse.langchain4j.runtime.devui;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
@@ -36,17 +48,6 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.subscription.MultiEmitter;
 import io.vertx.core.json.JsonObject;
-import jakarta.enterprise.context.control.ActivateRequestContext;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
 
 @ActivateRequestContext
 public class ChatJsonRPCService {
@@ -67,12 +68,12 @@ public class ChatJsonRPCService {
     private final ToolProvider toolProvider;
 
     public ChatJsonRPCService(@All List<ChatLanguageModel> models, // don't use ChatLanguageModel model because it results in the default model not being configured
-                              @All List<StreamingChatLanguageModel> streamingModels,
-                              @All List<Supplier<RetrievalAugmentor>> retrievalAugmentorSuppliers,
-                              @All List<RetrievalAugmentor> retrievalAugmentors,
-                              ChatMemoryProvider memoryProvider,
-                              QuarkusToolExecutorFactory toolExecutorFactory,
-                              @All List<Supplier<ToolProvider>> toolProviders) {
+            @All List<StreamingChatLanguageModel> streamingModels,
+            @All List<Supplier<RetrievalAugmentor>> retrievalAugmentorSuppliers,
+            @All List<RetrievalAugmentor> retrievalAugmentors,
+            ChatMemoryProvider memoryProvider,
+            QuarkusToolExecutorFactory toolExecutorFactory,
+            @All List<Supplier<ToolProvider>> toolProviders) {
         this.model = models.get(0);
         this.toolProvider = getToolProvider(toolProviders);
         this.streamingModel = streamingModels.isEmpty() ? Optional.empty() : Optional.of(streamingModels.get(0));
@@ -175,7 +176,7 @@ public class ChatJsonRPCService {
                 }
 
                 StreamingChatLanguageModel streamingModel = this.streamingModel.orElseThrow(IllegalStateException::new);
-                boolean hasToolProvider = setToolsViaProviderIfAvaible(memory, userMessage);
+                boolean hasToolProvider = setToolsViaProviderIfAvailable(memory, userMessage);
 
                 // invoke tools if applicable
                 Response<AiMessage> modelResponse;
@@ -236,7 +237,7 @@ public class ChatJsonRPCService {
                 memory.add(new UserMessage(message));
             }
 
-            boolean hasToolProvider = setToolsViaProviderIfAvaible(memory, userMessage);
+            boolean hasToolProvider = setToolsViaProviderIfAvailable(memory, userMessage);
 
             Response<AiMessage> modelResponse;
             if (toolSpecifications.isEmpty()) {
@@ -291,8 +292,8 @@ public class ChatJsonRPCService {
     }
 
     private void executeWithToolsAndStreaming(ChatMemory memory,
-                                              MultiEmitter<? super JsonObject> em,
-                                              int toolExecutionsLeft) {
+            MultiEmitter<? super JsonObject> em,
+            int toolExecutionsLeft) {
         toolExecutionsLeft--;
         if (toolExecutionsLeft == 0) {
             throw new RuntimeException(
@@ -355,7 +356,7 @@ public class ChatJsonRPCService {
         return null;
     }
 
-    private boolean setToolsViaProviderIfAvaible(ChatMemory memory, UserMessage userMessage) {
+    private boolean setToolsViaProviderIfAvailable(ChatMemory memory, UserMessage userMessage) {
         boolean hasToolProvider = toolProvider != null;
         if (hasToolProvider) {
             ToolProviderRequest toolRequest = new ToolProviderRequest(memory, userMessage);

--- a/docs/modules/ROOT/pages/agent-and-tools.adoc
+++ b/docs/modules/ROOT/pages/agent-and-tools.adoc
@@ -172,7 +172,7 @@ If you prefer more control, you can work directly with `ToolSpecification` and `
 
 === Important Rule
 
-You can configure either static tools (via `tools`) or a dynamic `ToolProvider` (via `toolProviderSupplier`), but *not both* in the same service.
+You can configure either static tools (via `tools`) or a dynamic `ToolProvider` (via `toolProviderSupplier`), but *not both* in the same AI service.
 
 == How do tools work?
 

--- a/docs/modules/ROOT/pages/agent-and-tools.adoc
+++ b/docs/modules/ROOT/pages/agent-and-tools.adoc
@@ -90,6 +90,90 @@ If a method of an AI Service needs to use tools other than the ones configured o
 In this case  `@Toolbox` completely overrides `@RegisterAiService(tools=...)`
 ====
 
+== Dynamically Use Tools at Runtime
+
+By default, tools in Quarkus are static, defined during the build phase.
+However, if you want to dynamically change the tools available at runtime, you can use a `ToolProvider`.
+This allows you to decide which tools to provide on the fly.
+
+You can configure an AI service with a dynamic `ToolProvider` like this:
+
+[source,java]
+----
+@RegisterAiService(toolProviderSupplier = MyToolProviderSupplier.class)
+public interface MyAiService {
+    // Service methods
+}
+----
+
+=== Implementing a ToolProvider
+
+To support dynamic tool selection, you'll need to create a `ToolProviderSupplier`, which must be marked as `@ApplicationScoped`.
+Here's an example:
+
+[source,java]
+----
+@ApplicationScoped
+public class MyToolProviderSupplier implements Supplier<ToolProvider> {
+    @Inject
+    MyCustomToolProvider myCustomToolProvider;
+
+    @Override
+    public ToolProvider get() {
+        return myCustomToolProvider;
+    }
+}
+----
+
+=== Example: Conditional Tool Provision
+
+In this example, a specific tool (e.g., a booking tool) is only provided if the user's message contains the keyword "booking".
+
+[source,java]
+----
+@ApplicationScoped
+public class MyCustomToolProvider implements ToolProvider {
+    @Inject
+    BookingTool bookingTool;
+
+    @Override
+    public ToolProviderResult provideTools(ToolProviderRequest request) {
+        boolean containsBooking = request.userMessage().singleText().contains("booking");
+        if (!containsBooking) {
+            return ToolProviderResult.builder().build();  // No tools
+        }
+        return buildToolProviderResult(List.of(bookingTool));  // Provide booking tool
+    }
+
+    private ToolProviderResult buildToolProviderResult(List<Object> toolObjects) {
+        List<ToolSpecification> specifications = new ArrayList<>();
+        Map<String, ToolExecutor> executors = new HashMap<>();
+        Map<ToolSpecification, ToolExecutor> tools = new HashMap<>();
+
+        // Populate tool metadata
+        ToolsRecorder.populateToolMetadata(toolObjects, specifications, executors);
+
+        // Map specifications to executors
+        for (ToolSpecification specification : specifications) {
+            tools.put(specification, executors.get(specification.name()));
+        }
+
+        // Return the result
+        return ToolProviderResult.builder()
+                .addAll(tools)
+                .build();
+    }
+}
+----
+
+=== Alternative: Using `ToolSpecification` and `ToolExecutor`
+
+If you prefer more control, you can work directly with `ToolSpecification` and `ToolExecutor` to provide tools.
+
+=== Important Rule
+
+You can configure either static tools (via `tools`) or a dynamic `ToolProvider` (via `toolProviderSupplier`), but *not both* in the same service.
+
 == How do tools work?
 
 The question of how tools work naturally arises given the fact that no code needs to be written that wires up their usage.


### PR DESCRIPTION
In this PR, the idea is to implement the selection of tools dynamically on incoming message

# New Feature
Make ToolProvider from LangChain4J Quarkus ready

We can set our ToolProvider like this:
```JAVA
@RegisterAiService(toolProviderSupplier = MyCustomToolProviderSupplier.class)
interface MyServiceWithToolProvider {
     String chat(@UserMessage String msg, @MemoryId Object id);
}
```

Add a simple Supplier like this:

```JAVA
@ApplicationScoped
public class MyCustomToolProviderSupplier implements Supplier<ToolProvider> {
    @Inject
    MyCustomToolProvider myCustomToolProvider;

    @Override
    public ToolProvider get() {
        return myCustomToolProvider;
    }
}
``` 

Now, we can select tools dynamically in our ToolProvider like this:
```Java
@ApplicationScoped
public class MyCustomToolProvider implements ToolProvider {

    @Override
    public ToolProviderResult provideTools(ToolProviderRequest request) {
        boolean containsBooking = request.userMessage().singleText().contains("booking");
	if (!containsBooking) {
	      return ToolProviderResult.builder().build();
	}

        ToolSpecification toolSpecification = ToolSpecification.builder()
                .name("get_booking_advice")
                .description("Returns booking advice")
                .build();
        ToolExecutor toolExecutor = (t, m) -> "You should book your vacation now :)";
        return ToolProviderResult.builder()
                .add(toolSpecification, toolExecutor)
                .build();
    }
}
```

- Closes: #962 