### PR TITLE
Add prompt template and variables to input / output guardrails

### DIFF
--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -63,7 +63,11 @@
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-websockets-next</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/InputGuardrailPromptTemplateTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/InputGuardrailPromptTemplateTest.java
@@ -1,0 +1,238 @@
+package io.quarkiverse.langchain4j.test.guardrails;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.guardrails.InputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.InputGuardrailResult;
+import io.quarkiverse.langchain4j.guardrails.InputGuardrails;
+import io.quarkiverse.langchain4j.runtime.aiservice.NoopChatMemory;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class InputGuardrailPromptTemplateTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyAiService.class, MyAiService.class, GuardrailValidation.class,
+                            MyChatModel.class, MyChatModelSupplier.class, MyMemoryProviderSupplier.class));
+    @Inject
+    MyAiService aiService;
+
+    @Inject
+    GuardrailValidation guardrailValidation;
+
+    @Test
+    @ActivateRequestContext
+    void shouldWorkNoParameters() {
+        aiService.getJoke();
+        assertThat(guardrailValidation.spyUserMessageTemplate()).isEqualTo("Tell me a joke");
+        assertThat(guardrailValidation.spyVariables()).isEmpty();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void shouldWorkWithMemoryId() {
+        aiService.getAnotherJoke("memory-id-001");
+        assertThat(guardrailValidation.spyUserMessageTemplate()).isEqualTo("Tell me another joke");
+        assertThat(guardrailValidation.spyVariables()).containsExactlyInAnyOrderEntriesOf(Map.of(
+                "memoryId", "memory-id-001",
+                "it", "memory-id-001" // is this correct?
+        ));
+    }
+
+    @Test
+    @ActivateRequestContext
+    void shouldWorkWithNoMemoryIdAndOneParameter() {
+        aiService.sayHiToMyFriendNoMemory("Rambo");
+        assertThat(guardrailValidation.spyUserMessageTemplate()).isEqualTo("Say hi to my friend {friend}!");
+        assertThat(guardrailValidation.spyVariables())
+                .containsExactlyInAnyOrderEntriesOf(Map.of(
+                        "friend", "Rambo",
+                        "it", "Rambo"));
+    }
+
+    @Test
+    @ActivateRequestContext
+    void shouldWorkWithMemoryIdAndOneParameter() {
+        aiService.sayHiToMyFriend("1", "Chuck Norris");
+        assertThat(guardrailValidation.spyUserMessageTemplate()).isEqualTo("Say hi to my friend {friend}!");
+        assertThat(guardrailValidation.spyVariables())
+                .containsExactlyInAnyOrderEntriesOf(Map.of(
+                        "friend", "Chuck Norris",
+                        "mem", "1"));
+    }
+
+    @Test
+    @ActivateRequestContext
+    void shouldWorkWithNoMemoryIdAndThreeParameters() {
+        aiService.sayHiToMyFriends("Chuck Norris", "Jean-Claude Van Damme", "Silvester Stallone");
+        assertThat(guardrailValidation.spyUserMessageTemplate())
+                .isEqualTo("Tell me something about {topic1}, {topic2}, {topic3}!");
+        assertThat(guardrailValidation.spyVariables())
+                .containsExactlyInAnyOrderEntriesOf(Map.of(
+                        "topic1", "Chuck Norris",
+                        "topic2", "Jean-Claude Van Damme",
+                        "topic3", "Silvester Stallone"));
+    }
+
+    @Test
+    @ActivateRequestContext
+    void shouldWorkWithNoMemoryIdAndList() {
+        aiService.sayHiToMyFriends(List.of("Chuck Norris", "Jean-Claude Van Damme", "Silvester Stallone"));
+        assertThat(guardrailValidation.spyUserMessageText())
+                .isEqualTo("Tell me something about [Chuck Norris, Jean-Claude Van Damme, Silvester Stallone]!");
+        assertThat(guardrailValidation.spyUserMessageTemplate()).isEqualTo("Tell me something about {topics}!");
+        assertThat(guardrailValidation.spyVariables())
+                .containsExactlyInAnyOrderEntriesOf(Map.of(
+                        "topics", List.of("Chuck Norris", "Jean-Claude Van Damme", "Silvester Stallone"),
+                        "it", List.of("Chuck Norris", "Jean-Claude Van Damme", "Silvester Stallone")));
+    }
+
+    @Test
+    @ActivateRequestContext
+    void shouldWorkWithMemoryIdAndList() {
+        aiService.sayHiToMyFriends("memory-id-007", List.of("Chuck Norris", "Jean-Claude Van Damme", "Silvester Stallone"));
+        assertThat(guardrailValidation.spyUserMessageText()).isEqualTo(
+                "Tell me something about [Chuck Norris, Jean-Claude Van Damme, Silvester Stallone]! This is my memory id: memory-id-007");
+        assertThat(guardrailValidation.spyUserMessageTemplate())
+                .isEqualTo("Tell me something about {topics}! This is my memory id: {memoryId}");
+        assertThat(guardrailValidation.spyVariables())
+                .containsExactlyInAnyOrderEntriesOf(Map.of(
+                        "topics", List.of("Chuck Norris", "Jean-Claude Van Damme", "Silvester Stallone"),
+                        "memoryId", "memory-id-007"));
+    }
+
+    @Test
+    @ActivateRequestContext
+    void shouldWorkWithMemoryIdAndOneItemFromList() {
+        aiService.sayHiToMyFriend("memory-id-007", List.of("Chuck Norris", "Jean-Claude Van Damme", "Silvester Stallone"));
+        assertThat(guardrailValidation.spyUserMessageText())
+                .isEqualTo("Tell me something about Chuck Norris! This is my memory id: memory-id-007");
+        assertThat(guardrailValidation.spyUserMessageTemplate())
+                .isEqualTo("Tell me something about {topics[0]}! This is my memory id: {memoryId}");
+        assertThat(guardrailValidation.spyVariables())
+                .containsExactlyInAnyOrderEntriesOf(Map.of(
+                        "topics", List.of("Chuck Norris", "Jean-Claude Van Damme", "Silvester Stallone"),
+                        "memoryId", "memory-id-007"));
+    }
+
+    @Test
+    @ActivateRequestContext
+    void shouldWorkWithNoUserMessage() {
+        // This is a special case where the UserMessage annotation is not present
+        // The prompt template doesn't exist in this case
+        // But the current implementation use the parameter name as prompt template
+        // Not sure if this is the correct behavior, should we always have @UserMessage?
+        // I need some thoughts on this case
+        aiService.saySomething("Is this a parameter or a prompt?");
+        assertThat(guardrailValidation.spyUserMessageTemplate()).isNull();
+        assertThat(guardrailValidation.spyVariables()).isEmpty();
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = MyMemoryProviderSupplier.class)
+    public interface MyAiService {
+
+        @InputGuardrails(GuardrailValidation.class)
+        @UserMessage("Tell me a joke")
+        String getJoke();
+
+        @UserMessage("Tell me another joke")
+        @InputGuardrails(GuardrailValidation.class)
+        String getAnotherJoke(@MemoryId String memoryId);
+
+        @UserMessage("Say hi to my friend {friend}!")
+        @InputGuardrails(GuardrailValidation.class)
+        String sayHiToMyFriendNoMemory(String friend);
+
+        @UserMessage("Say hi to my friend {friend}!")
+        @InputGuardrails(GuardrailValidation.class)
+        String sayHiToMyFriend(@MemoryId String mem, String friend);
+
+        @UserMessage("Tell me something about {topic1}, {topic2}, {topic3}!")
+        @InputGuardrails(GuardrailValidation.class)
+        String sayHiToMyFriends(String topic1, String topic2, String topic3);
+
+        @UserMessage("Tell me something about {topics}!")
+        @InputGuardrails(GuardrailValidation.class)
+        String sayHiToMyFriends(List<String> topics);
+
+        @UserMessage("Tell me something about {topics}! This is my memory id: {memoryId}")
+        @InputGuardrails(GuardrailValidation.class)
+        String sayHiToMyFriends(@MemoryId String memoryId, List<String> topics);
+
+        @UserMessage("Tell me something about {topics[0]}! This is my memory id: {memoryId}")
+        @InputGuardrails(GuardrailValidation.class)
+        String sayHiToMyFriend(@MemoryId String memoryId, List<String> topics);
+
+        @InputGuardrails(GuardrailValidation.class)
+        String saySomething(String isThisAPromptOrAParameter);
+
+    }
+
+    @RequestScoped
+    public static class GuardrailValidation implements InputGuardrail {
+
+        InputGuardrailParams params;
+
+        public InputGuardrailResult validate(InputGuardrailParams params) {
+            this.params = params;
+            return success();
+        }
+
+        public String spyUserMessageTemplate() {
+            return params.userMessageTemplate();
+        }
+
+        public String spyUserMessageText() {
+            return params.userMessage().singleText();
+        }
+
+        public Map<String, Object> spyVariables() {
+            return params.variables();
+        }
+    }
+
+    public static class MyChatModelSupplier implements Supplier<ChatLanguageModel> {
+
+        @Override
+        public ChatLanguageModel get() {
+            return new MyChatModel();
+        }
+    }
+
+    public static class MyChatModel implements ChatLanguageModel {
+
+        @Override
+        public Response<AiMessage> generate(List<ChatMessage> messages) {
+            return new Response<>(new AiMessage("Hi!"));
+        }
+    }
+
+    public static class MyMemoryProviderSupplier implements Supplier<ChatMemoryProvider> {
+        @Override
+        public ChatMemoryProvider get() {
+            return memoryId -> new NoopChatMemory();
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/InputGuardrailPromptTemplateTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/InputGuardrailPromptTemplateTest.java
@@ -142,7 +142,7 @@ public class InputGuardrailPromptTemplateTest {
     void shouldWorkWithNoUserMessage() {
         // UserMessage annotation is not provided, then no user message template should be available
         aiService.saySomething("Is this a parameter or a prompt?");
-        assertThat(guardrailValidation.spyUserMessageTemplate()).isNull();
+        assertThat(guardrailValidation.spyUserMessageTemplate()).isEmpty();
         assertThat(guardrailValidation.spyVariables()).isEmpty();
     }
 

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/OutputGuardrailPromptTemplateTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/OutputGuardrailPromptTemplateTest.java
@@ -139,7 +139,7 @@ public class OutputGuardrailPromptTemplateTest {
     void shouldWorkWithNoUserMessage() {
         // UserMessage annotation is not provided, then no user message template should be available
         aiService.saySomething("Is this a parameter or a prompt?");
-        assertThat(guardrailValidation.spyUserMessageTemplate()).isNull();
+        assertThat(guardrailValidation.spyUserMessageTemplate()).isEmpty();
         assertThat(guardrailValidation.spyVariables()).isEmpty();
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/InputGuardrail.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/InputGuardrail.java
@@ -1,7 +1,6 @@
 package io.quarkiverse.langchain4j.guardrails;
 
 import java.util.Arrays;
-import java.util.Map;
 
 import dev.langchain4j.data.message.UserMessage;
 import io.smallrye.common.annotation.Experimental;

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/InputGuardrail.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/InputGuardrail.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.langchain4j.guardrails;
 
 import java.util.Arrays;
+import java.util.Map;
 
 import dev.langchain4j.data.message.UserMessage;
 import io.smallrye.common.annotation.Experimental;

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/InputGuardrailParams.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/InputGuardrailParams.java
@@ -12,8 +12,8 @@ import dev.langchain4j.rag.AugmentationResult;
  * @param userMessage the user message, cannot be {@code null}
  * @param memory the memory, can be {@code null} or empty
  * @param augmentationResult the augmentation result, can be {@code null}
- * @param userMessageTemplate the user message template, can be {@code null} when @UserMessage is not provided.
- * @param variables the variable to be used with userMessageTemplate, can be {@code null} or empty
+ * @param userMessageTemplate the user message template, cannot be {@code null}
+ * @param variables the variable to be used with userMessageTemplate, cannot be {@code null}
  */
 public record InputGuardrailParams(UserMessage userMessage, ChatMemory memory,
         AugmentationResult augmentationResult, String userMessageTemplate,

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/InputGuardrailParams.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/InputGuardrailParams.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.langchain4j.guardrails;
 
+import java.util.Map;
+
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.rag.AugmentationResult;
@@ -10,7 +12,10 @@ import dev.langchain4j.rag.AugmentationResult;
  * @param userMessage the user message, cannot be {@code null}
  * @param memory the memory, can be {@code null} or empty
  * @param augmentationResult the augmentation result, can be {@code null}
+ * @param userMessageTemplate the user message template, can be {@code null} when @UserMessage is not provided.
+ * @param variables the variable to be used with userMessageTemplate, can be {@code null} or empty
  */
 public record InputGuardrailParams(UserMessage userMessage, ChatMemory memory,
-        AugmentationResult augmentationResult) implements GuardrailParams {
+        AugmentationResult augmentationResult, String userMessageTemplate,
+        Map<String, Object> variables) implements GuardrailParams {
 }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/OutputGuardrailParams.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/OutputGuardrailParams.java
@@ -12,8 +12,8 @@ import dev.langchain4j.rag.AugmentationResult;
  * @param responseFromLLM the response from the LLM
  * @param memory the memory, can be {@code null} or empty
  * @param augmentationResult the augmentation result, can be {@code null}
- * @param userMessageTemplate the user message template, can be {@code null} when @UserMessage is not provided.
- * @param variables the variable to be used with userMessageTemplate, can be {@code null} or empty
+ * @param userMessageTemplate the user message template, cannot be {@code null}
+ * @param variables the variable to be used with userMessageTemplate, cannot be {@code null}
  */
 public record OutputGuardrailParams(AiMessage responseFromLLM, ChatMemory memory,
         AugmentationResult augmentationResult, String userMessageTemplate,

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/OutputGuardrailParams.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/OutputGuardrailParams.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.langchain4j.guardrails;
 
+import java.util.Map;
+
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.rag.AugmentationResult;
@@ -10,7 +12,10 @@ import dev.langchain4j.rag.AugmentationResult;
  * @param responseFromLLM the response from the LLM
  * @param memory the memory, can be {@code null} or empty
  * @param augmentationResult the augmentation result, can be {@code null}
+ * @param userMessageTemplate the user message template, can be {@code null} when @UserMessage is not provided.
+ * @param variables the variable to be used with userMessageTemplate, can be {@code null} or empty
  */
 public record OutputGuardrailParams(AiMessage responseFromLLM, ChatMemory memory,
-        AugmentationResult augmentationResult) implements GuardrailParams {
+        AugmentationResult augmentationResult, String userMessageTemplate,
+        Map<String, Object> variables) implements GuardrailParams {
 }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodCreateInfo.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodCreateInfo.java
@@ -193,6 +193,13 @@ public final class AiServiceMethodCreateInfo {
         return accumulator;
     }
 
+    public String getUserMessageTemplate() {
+        Optional<String> userMessageTemplateOpt = this.getUserMessageInfo().template()
+                .flatMap(AiServiceMethodCreateInfo.TemplateInfo::text);
+
+        return userMessageTemplateOpt.orElse(null);
+    }
+
     public record UserMessageInfo(Optional<TemplateInfo> template,
             Optional<Integer> paramPosition,
             Optional<Integer> userNameParamPosition,

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodCreateInfo.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodCreateInfo.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.langchain4j.runtime.aiservice;
 
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
@@ -197,7 +199,7 @@ public final class AiServiceMethodCreateInfo {
         Optional<String> userMessageTemplateOpt = this.getUserMessageInfo().template()
                 .flatMap(AiServiceMethodCreateInfo.TemplateInfo::text);
 
-        return userMessageTemplateOpt.orElse(null);
+        return userMessageTemplateOpt.orElse(EMPTY);
     }
 
     public record UserMessageInfo(Optional<TemplateInfo> template,

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
@@ -273,7 +273,8 @@ public class AiServiceMethodImplementationSupport {
                         try {
                             result = GuardrailsSupport.invokeOutputGuardrailsForStream(methodCreateInfo,
                                     new OutputGuardrailParams(AiMessage.from(chunk), chatMemory, actualAugmentationResult,
-                                            methodCreateInfo.getUserMessageTemplate(), templateVariables));
+                                            methodCreateInfo.getUserMessageTemplate(),
+                                            Collections.unmodifiableMap(templateVariables)));
                         } catch (Exception e) {
                             throw new GuardrailException(e.getMessage(), e);
                         }
@@ -365,7 +366,7 @@ public class AiServiceMethodImplementationSupport {
         response = GuardrailsSupport.invokeOutputGuardrails(methodCreateInfo, chatMemory, context.chatModel, response,
                 toolSpecifications,
                 new OutputGuardrailParams(response.content(), chatMemory, augmentationResult, userMessageTemplate,
-                        templateVariables));
+                        Collections.unmodifiableMap(templateVariables)));
 
         // everything worked as expected so let's commit the messages
         chatMemory.commit();

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/GuardrailsSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/GuardrailsSupport.java
@@ -2,8 +2,7 @@ package io.quarkiverse.langchain4j.runtime.aiservice;
 
 import static dev.langchain4j.data.message.UserMessage.userMessage;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 import java.util.function.Function;
 
 import jakarta.enterprise.inject.spi.CDI;
@@ -30,11 +29,17 @@ import io.smallrye.mutiny.Multi;
 public class GuardrailsSupport {
 
     public static void invokeInputGuardrails(AiServiceMethodCreateInfo methodCreateInfo, UserMessage userMessage,
-            ChatMemory chatMemory, AugmentationResult augmentationResult) {
+            ChatMemory chatMemory, AugmentationResult augmentationResult, Map<String, Object> templateParams) {
         InputGuardrailResult result;
         try {
+
+            Optional<String> userMessageTemplateOpt = methodCreateInfo.getUserMessageInfo().template()
+                    .flatMap(AiServiceMethodCreateInfo.TemplateInfo::text);
+
+            String userMessageTemplate = userMessageTemplateOpt.orElse(null);
+
             result = invokeInputGuardRails(methodCreateInfo,
-                    new InputGuardrailParams(userMessage, chatMemory, augmentationResult));
+                    new InputGuardrailParams(userMessage, chatMemory, augmentationResult, promptTemplate, templateParams));
         } catch (Exception e) {
             throw new GuardrailException(e.getMessage(), e);
         }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/GuardrailsSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/GuardrailsSupport.java
@@ -37,7 +37,7 @@ public class GuardrailsSupport {
 
             result = invokeInputGuardRails(methodCreateInfo,
                     new InputGuardrailParams(userMessage, chatMemory, augmentationResult, userMessageTemplate,
-                            templateVariables));
+                            Collections.unmodifiableMap(templateVariables)));
         } catch (Exception e) {
             throw new GuardrailException(e.getMessage(), e);
         }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/GuardrailsSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/GuardrailsSupport.java
@@ -29,17 +29,15 @@ import io.smallrye.mutiny.Multi;
 public class GuardrailsSupport {
 
     public static void invokeInputGuardrails(AiServiceMethodCreateInfo methodCreateInfo, UserMessage userMessage,
-            ChatMemory chatMemory, AugmentationResult augmentationResult, Map<String, Object> templateParams) {
+            ChatMemory chatMemory, AugmentationResult augmentationResult, Map<String, Object> templateVariables) {
         InputGuardrailResult result;
         try {
 
-            Optional<String> userMessageTemplateOpt = methodCreateInfo.getUserMessageInfo().template()
-                    .flatMap(AiServiceMethodCreateInfo.TemplateInfo::text);
-
-            String userMessageTemplate = userMessageTemplateOpt.orElse(null);
+            String userMessageTemplate = methodCreateInfo.getUserMessageTemplate();
 
             result = invokeInputGuardRails(methodCreateInfo,
-                    new InputGuardrailParams(userMessage, chatMemory, augmentationResult, promptTemplate, templateParams));
+                    new InputGuardrailParams(userMessage, chatMemory, augmentationResult, userMessageTemplate,
+                            templateVariables));
         } catch (Exception e) {
             throw new GuardrailException(e.getMessage(), e);
         }
@@ -90,7 +88,7 @@ public class GuardrailsSupport {
                 }
                 attempt++;
                 output = new OutputGuardrailParams(response.content(), output.memory(),
-                        output.augmentationResult());
+                        output.augmentationResult(), output.userMessageTemplate(), output.variables());
             } else {
                 break;
             }


### PR DESCRIPTION
I need some thoughts to check if I am going in the right direction.


---

This pull request introduces enhancements to the guardrails feature and adds a new test for input validation in the `langchain4j` project. Key changes include adding a new dependency, creating a comprehensive test class, and modifying existing classes to support template parameters in guardrails.

### Enhancements to Guardrails Feature:

* [`core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/InputGuardrail.java`](diffhunk://#diff-f02c934a84bdd1b3759b7dbbbd749a02c05f688bf1ad7a193b89fea6d2a78357L53-R56): Added `promptTemplate` and `variables` to `InputGuardrailParams` to support template parameters in guardrails.
* [`core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java`](diffhunk://#diff-2dd3bec40934ad6d175f6f14dad1af0e11c234cf5fec69739a89460d472ab55bR143-R148): Added `templateParams` to various methods to pass template parameters to guardrails. [[1]](diffhunk://#diff-2dd3bec40934ad6d175f6f14dad1af0e11c234cf5fec69739a89460d472ab55bR143-R148) [[2]](diffhunk://#diff-2dd3bec40934ad6d175f6f14dad1af0e11c234cf5fec69739a89460d472ab55bR189-R191) [[3]](diffhunk://#diff-2dd3bec40934ad6d175f6f14dad1af0e11c234cf5fec69739a89460d472ab55bL218-R221) [[4]](diffhunk://#diff-2dd3bec40934ad6d175f6f14dad1af0e11c234cf5fec69739a89460d472ab55bL329-R332) [[5]](diffhunk://#diff-2dd3bec40934ad6d175f6f14dad1af0e11c234cf5fec69739a89460d472ab55bL347-R350) [[6]](diffhunk://#diff-2dd3bec40934ad6d175f6f14dad1af0e11c234cf5fec69739a89460d472ab55bL539-R542) [[7]](diffhunk://#diff-2dd3bec40934ad6d175f6f14dad1af0e11c234cf5fec69739a89460d472ab55bR590-R605)
* [`core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/GuardrailsSupport.java`](diffhunk://#diff-74944743e53e0f17d9b9cdd825a6d066d1f97399f212d7ca9c445b038853fd22L29-R38): Updated `invokeInputGuardrails` to accept `templateParams` and `promptTemplate`.

### New Test for Input Validation:

* [`core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/InputGuardrailPromptTemplateTest.java`](diffhunk://#diff-72f49c53b093583fd55ec7f81939f0777237ba01d0b5de7b907f12af6aaeb8e0R1-R189): Created a comprehensive test class to validate different input scenarios for guardrails, ensuring the correct handling of user messages and template parameters.

### Dependency Addition:

* [`core/deployment/pom.xml`](diffhunk://#diff-e68de4ebf5bc0137c10977474f21321913684eb3cc393978b7f7a291ad401a10L66-R70): Added a new dependency on `quarkus-websockets-next` for testing purposes. This is needed to have a test without MemoryId annotation.