### PR TITLE
Enable watsonx.ai to process ImageContent in UserMessage

### DIFF
--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxUtils.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxUtils.java
@@ -1,10 +1,14 @@
 package io.quarkiverse.langchain4j.watsonx;
 
+import java.util.Base64;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 
 import jakarta.ws.rs.WebApplicationException;
 
+import dev.langchain4j.data.image.Image;
+import dev.langchain4j.internal.Utils;
 import io.quarkiverse.langchain4j.watsonx.bean.WatsonxError;
 import io.quarkiverse.langchain4j.watsonx.exception.WatsonxException;
 
@@ -43,5 +47,21 @@ public class WatsonxUtils {
             }
         }
         throw new RuntimeException("Failed after " + maxAttempts + " attempts");
+    }
+
+    public static String base64Image(Image image) {
+
+        if (Objects.nonNull(image.base64Data()))
+            return image.base64Data();
+
+        try {
+            byte[] bytes = switch (image.url().getScheme()) {
+                case "http", "https", "file" -> Utils.readBytes(image.url().toString());
+                default -> throw new RuntimeException("The only supported image schemes are: [http, https, file]");
+            };
+            return Base64.getEncoder().encodeToString(bytes);
+        } catch (Exception e) {
+            throw new RuntimeException("Error converting the image to base64, see the log for more details", e);
+        }
     }
 }

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/bean/TextChatMessage.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/bean/TextChatMessage.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.langchain4j.watsonx.bean;
 
+import static io.quarkiverse.langchain4j.watsonx.WatsonxUtils.base64Image;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -9,6 +11,7 @@ import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
@@ -125,7 +128,18 @@ public sealed interface TextChatMessage
                                 "type", "text",
                                 "text", textContent.text()));
                     }
-                    case AUDIO, IMAGE, PDF, TEXT_FILE, VIDEO ->
+                    case IMAGE -> {
+                        var imageContent = ImageContent.class.cast(content);
+                        var base64 = "data:image/%s;base64,%s".formatted(
+                                imageContent.image().mimeType(),
+                                base64Image(imageContent.image()));
+                        values.add(Map.of(
+                                "type", "image_url",
+                                "image_url", Map.of(
+                                        "url", base64,
+                                        "detail", imageContent.detailLevel().name().toLowerCase())));
+                    }
+                    case AUDIO, PDF, TEXT_FILE, VIDEO ->
                         throw new UnsupportedOperationException("Unimplemented case: " + content.type());
                 }
             }


### PR DESCRIPTION
This allows the use of models like `llama-3-2-90b-vision-instruct`.