### PR TITLE
Add support for TLS configuration name

### DIFF
--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/OllamaChatLanguageModel.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/OllamaChatLanguageModel.java
@@ -43,11 +43,11 @@ public class OllamaChatLanguageModel implements ChatLanguageModel {
 
     private OllamaChatLanguageModel(Builder builder) {
         client = new OllamaClient(builder.baseUrl, builder.timeout, builder.logRequests, builder.logResponses,
-                builder.configName);
+                builder.configName, builder.tlsConfigurationName);
         model = builder.model;
         format = builder.format;
         options = builder.options;
-        this.listeners = builder.listeners;
+        listeners = builder.listeners;
     }
 
     public static Builder builder() {
@@ -194,6 +194,7 @@ public class OllamaChatLanguageModel implements ChatLanguageModel {
 
     public static final class Builder {
         private String baseUrl = "http://localhost:11434";
+        private String tlsConfigurationName;
         private Duration timeout = Duration.ofSeconds(10);
         private String model;
         private String format;
@@ -209,6 +210,11 @@ public class OllamaChatLanguageModel implements ChatLanguageModel {
 
         public Builder baseUrl(String val) {
             baseUrl = val;
+            return this;
+        }
+
+        public Builder tlsConfigurationName(String tlsConfigurationName) {
+            this.tlsConfigurationName = tlsConfigurationName;
             return this;
         }
 

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/OllamaClient.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/OllamaClient.java
@@ -6,17 +6,23 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
+
 import org.jboss.resteasy.reactive.client.api.LoggingScope;
 
 import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
+import io.quarkus.tls.TlsConfiguration;
+import io.quarkus.tls.TlsConfigurationRegistry;
 import io.smallrye.mutiny.Multi;
 
 public class OllamaClient {
 
     private final OllamaRestApi restApi;
 
-    public OllamaClient(String baseUrl, Duration timeout, boolean logRequests, boolean logResponses, String configName) {
+    public OllamaClient(String baseUrl, Duration timeout, boolean logRequests, boolean logResponses, String configName,
+            String tlsConfigurationName) {
         try {
             // TODO: cache?
             QuarkusRestClientBuilder builder = QuarkusRestClientBuilder.newBuilder()
@@ -31,6 +37,11 @@ public class OllamaClient {
             Optional<ModelAuthProvider> maybeModelAuthProvider = ModelAuthProvider.resolve(configName);
             if (maybeModelAuthProvider.isPresent()) {
                 builder.register(new OllamaRestApi.OllamaRestAPIFilter(maybeModelAuthProvider.get()));
+            }
+            Instance<TlsConfigurationRegistry> tlsConfigurationRegistry = CDI.current().select(TlsConfigurationRegistry.class);
+            if (tlsConfigurationRegistry.isResolvable()) {
+                TlsConfiguration.from(tlsConfigurationRegistry.get(), Optional.ofNullable(tlsConfigurationName))
+                        .ifPresent(builder::tlsConfiguration);
             }
 
             restApi = builder.build(OllamaRestApi.class);

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/OllamaEmbeddingModel.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/OllamaEmbeddingModel.java
@@ -16,7 +16,7 @@ public class OllamaEmbeddingModel implements EmbeddingModel {
 
     private OllamaEmbeddingModel(Builder builder) {
         client = new OllamaClient(builder.baseUrl, builder.timeout, builder.logRequests, builder.logResponses,
-                builder.configName);
+                builder.configName, builder.tlsConfigurationName);
         model = builder.model;
     }
 
@@ -44,6 +44,7 @@ public class OllamaEmbeddingModel implements EmbeddingModel {
 
     public static final class Builder {
         private String baseUrl = "http://localhost:11434";
+        private String tlsConfigurationName;
         private Duration timeout = Duration.ofSeconds(10);
         private String model;
 
@@ -56,6 +57,11 @@ public class OllamaEmbeddingModel implements EmbeddingModel {
 
         public Builder baseUrl(String val) {
             baseUrl = val;
+            return this;
+        }
+
+        public Builder tlsConfigurationName(String tlsConfigurationName) {
+            this.tlsConfigurationName = tlsConfigurationName;
             return this;
         }
 

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/OllamaStreamingChatLanguageModel.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/OllamaStreamingChatLanguageModel.java
@@ -26,7 +26,7 @@ public class OllamaStreamingChatLanguageModel implements StreamingChatLanguageMo
 
     private OllamaStreamingChatLanguageModel(OllamaStreamingChatLanguageModel.Builder builder) {
         client = new OllamaClient(builder.baseUrl, builder.timeout, builder.logRequests, builder.logResponses,
-                builder.configName);
+                builder.configName, builder.tlsConfigurationName);
         model = builder.model;
         format = builder.format;
         options = builder.options;
@@ -101,6 +101,7 @@ public class OllamaStreamingChatLanguageModel implements StreamingChatLanguageMo
         }
 
         private String baseUrl = "http://localhost:11434";
+        private String tlsConfigurationName;
         private Duration timeout = Duration.ofSeconds(10);
         private String model;
         private String format;
@@ -112,6 +113,11 @@ public class OllamaStreamingChatLanguageModel implements StreamingChatLanguageMo
 
         public Builder baseUrl(String val) {
             baseUrl = val;
+            return this;
+        }
+
+        public Builder tlsConfigurationName(String tlsConfigurationName) {
+            this.tlsConfigurationName = tlsConfigurationName;
             return this;
         }
 

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/OllamaRecorder.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/OllamaRecorder.java
@@ -63,6 +63,7 @@ public class OllamaRecorder {
             }
             var builder = OllamaChatLanguageModel.builder()
                     .baseUrl(ollamaConfig.baseUrl().orElse(DEFAULT_BASE_URL))
+                    .tlsConfigurationName(ollamaConfig.tlsConfigurationName().orElse(null))
                     .timeout(ollamaConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .logRequests(firstOrDefault(false, chatModelConfig.logRequests(), ollamaConfig.logRequests()))
                     .logResponses(firstOrDefault(false, chatModelConfig.logResponses(), ollamaConfig.logResponses()))
@@ -109,6 +110,7 @@ public class OllamaRecorder {
 
             var builder = OllamaEmbeddingModel.builder()
                     .baseUrl(ollamaConfig.baseUrl().orElse(DEFAULT_BASE_URL))
+                    .tlsConfigurationName(ollamaConfig.tlsConfigurationName().orElse(null))
                     .timeout(ollamaConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .model(ollamaFixedConfig.embeddingModel().modelId())
                     .logRequests(firstOrDefault(false, embeddingModelConfig.logRequests(), ollamaConfig.logRequests()))
@@ -156,6 +158,7 @@ public class OllamaRecorder {
             }
             var builder = OllamaStreamingChatLanguageModel.builder()
                     .baseUrl(ollamaConfig.baseUrl().orElse(DEFAULT_BASE_URL))
+                    .tlsConfigurationName(ollamaConfig.tlsConfigurationName().orElse(null))
                     .timeout(ollamaConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .logRequests(firstOrDefault(false, chatModelConfig.logRequests(), ollamaConfig.logRequests()))
                     .logResponses(firstOrDefault(false, chatModelConfig.logResponses(), ollamaConfig.logResponses()))

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/config/LangChain4jOllamaConfig.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/config/LangChain4jOllamaConfig.java
@@ -41,6 +41,11 @@ public interface LangChain4jOllamaConfig {
         Optional<String> baseUrl();
 
         /**
+         * If set, the named TLS configuration with the configured name will be applied to the REST Client
+         */
+        Optional<String> tlsConfigurationName();
+
+        /**
          * Timeout for Ollama calls
          */
         @ConfigDocDefault("10s")

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
@@ -33,6 +33,7 @@ import io.quarkiverse.langchain4j.azure.openai.runtime.config.EmbeddingModelConf
 import io.quarkiverse.langchain4j.azure.openai.runtime.config.LangChain4jAzureOpenAiConfig;
 import io.quarkiverse.langchain4j.azure.openai.runtime.config.LangChain4jAzureOpenAiConfig.AzureAiConfig.EndpointType;
 import io.quarkiverse.langchain4j.openai.common.QuarkusOpenAiClient;
+import io.quarkiverse.langchain4j.openai.common.runtime.AdditionalPropertiesHack;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.runtime.ShutdownContext;
@@ -317,6 +318,7 @@ public class AzureOpenAiRecorder {
     }
 
     public void cleanUp(ShutdownContext shutdown) {
+        AdditionalPropertiesHack.reset();
         shutdown.addShutdownTask(new Runnable() {
             @Override
             public void run() {

--- a/model-providers/openai/openai-common/runtime/src/main/java/io/quarkiverse/langchain4j/openai/common/runtime/AdditionalPropertiesHack.java
+++ b/model-providers/openai/openai-common/runtime/src/main/java/io/quarkiverse/langchain4j/openai/common/runtime/AdditionalPropertiesHack.java
@@ -1,0 +1,46 @@
+package io.quarkiverse.langchain4j.openai.common.runtime;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This is done because we have no way of passing Quarkus specific properties from a model to a client.
+ * This only works because:
+ * <ul>
+ * <li>The creation of beans does not happen in parallel</li>
+ * <li>The creation of beans happens on the same thread</li>
+ * <li>Setting up a model builder always precedes setting up a client builder</li>
+ * </ul>
+ */
+public final class AdditionalPropertiesHack {
+
+    private AdditionalPropertiesHack() {
+    }
+
+    static final ThreadLocal<Map<String, String>> PROPS = new ThreadLocal<>();
+    static {
+        reset();
+    }
+
+    public static void reset() {
+        PROPS.set(new HashMap<>());
+    }
+
+    public static void setTlsConfigurationName(String tlsConfigurationName) {
+        Map<String, String> map = PROPS.get();
+        if (map == null) {
+            // this should never happen
+            return;
+        }
+        map.put("tlsConfigurationName", tlsConfigurationName);
+    }
+
+    public static String getAndClearTlsConfigurationName() {
+        Map<String, String> map = PROPS.get();
+        if (map == null) {
+            // this should never happen
+            return null;
+        }
+        return map.remove("tlsConfigurationName");
+    }
+}

--- a/model-providers/openai/openai-vanilla/deployment/pom.xml
+++ b/model-providers/openai/openai-vanilla/deployment/pom.xml
@@ -46,6 +46,12 @@
             <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.smallrye.certs</groupId>
+            <artifactId>smallrye-certificate-generator-junit5</artifactId>
+            <version>0.8.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/model-providers/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/OpenAiProcessor.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/OpenAiProcessor.java
@@ -15,6 +15,10 @@ import org.jboss.jandex.ClassType;
 import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 
+import dev.langchain4j.model.openai.spi.OpenAiChatModelBuilderFactory;
+import dev.langchain4j.model.openai.spi.OpenAiEmbeddingModelBuilderFactory;
+import dev.langchain4j.model.openai.spi.OpenAiModerationModelBuilderFactory;
+import dev.langchain4j.model.openai.spi.OpenAiStreamingChatModelBuilderFactory;
 import io.quarkiverse.langchain4j.ModelName;
 import io.quarkiverse.langchain4j.deployment.DotNames;
 import io.quarkiverse.langchain4j.deployment.items.ChatModelProviderCandidateBuildItem;
@@ -25,6 +29,10 @@ import io.quarkiverse.langchain4j.deployment.items.SelectedChatModelProviderBuil
 import io.quarkiverse.langchain4j.deployment.items.SelectedEmbeddingModelCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedImageModelProviderBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedModerationModelProviderBuildItem;
+import io.quarkiverse.langchain4j.openai.QuarkusOpenAiChatModelBuilderFactory;
+import io.quarkiverse.langchain4j.openai.QuarkusOpenAiEmbeddingModelBuilderFactory;
+import io.quarkiverse.langchain4j.openai.QuarkusOpenAiModerationModelBuilderFactory;
+import io.quarkiverse.langchain4j.openai.QuarkusOpenAiStreamingChatModelBuilderFactory;
 import io.quarkiverse.langchain4j.openai.runtime.OpenAiRecorder;
 import io.quarkiverse.langchain4j.openai.runtime.config.LangChain4jOpenAiConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
@@ -35,6 +43,7 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 
 public class OpenAiProcessor {
 
@@ -156,5 +165,21 @@ public class OpenAiProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     public void cleanUp(OpenAiRecorder recorder, ShutdownContextBuildItem shutdown) {
         recorder.cleanUp(shutdown);
+    }
+
+    @BuildStep
+    void nativeSupport(BuildProducer<ServiceProviderBuildItem> serviceProviderProducer) {
+        serviceProviderProducer
+                .produce(new ServiceProviderBuildItem(OpenAiChatModelBuilderFactory.class.getName(),
+                        QuarkusOpenAiChatModelBuilderFactory.class.getName()));
+        serviceProviderProducer
+                .produce(new ServiceProviderBuildItem(OpenAiEmbeddingModelBuilderFactory.class.getName(),
+                        QuarkusOpenAiEmbeddingModelBuilderFactory.class.getName()));
+        serviceProviderProducer
+                .produce(new ServiceProviderBuildItem(OpenAiModerationModelBuilderFactory.class.getName(),
+                        QuarkusOpenAiModerationModelBuilderFactory.class.getName()));
+        serviceProviderProducer
+                .produce(new ServiceProviderBuildItem(OpenAiStreamingChatModelBuilderFactory.class.getName(),
+                        QuarkusOpenAiStreamingChatModelBuilderFactory.class.getName()));
     }
 }

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/OpenAiChatLanguageModelTlsConfigurationTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/OpenAiChatLanguageModelTlsConfigurationTest.java
@@ -1,0 +1,169 @@
+package io.quarkiverse.langchain4j.openai.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import io.quarkiverse.langchain4j.ModelName;
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.tls.TlsConfiguration;
+import io.quarkus.tls.TlsConfigurationRegistry;
+import io.smallrye.certs.Format;
+import io.smallrye.certs.junit5.Certificate;
+import io.smallrye.certs.junit5.Certificates;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.net.KeyCertOptions;
+import io.vertx.ext.web.Router;
+
+@Certificates(baseDir = "target/certs", certificates = {
+        @Certificate(name = "lc4j", password = "secret", formats = Format.PKCS12),
+        @Certificate(name = "lc4jA", password = "secretA", formats = Format.PKCS12)
+})
+public class OpenAiChatLanguageModelTlsConfigurationTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Setup.class)
+                    .addAsResource(new File("target/certs/lc4j-keystore.p12"), "keystore.p12")
+                    .addAsResource(new File("target/certs/lc4j-truststore.p12"), "truststore.p12")
+                    .addAsResource(new File("target/certs/lc4jA-keystore.p12"), "keystoreA.p12")
+                    .addAsResource(new File("target/certs/lc4jA-truststore.p12"), "truststoreA.p12"))
+
+            .overrideConfigKey("quarkus.tls.server.key-store.jks.path", "keystore.p12")
+            .overrideConfigKey("quarkus.tls.server.key-store.jks.password", "secret")
+
+            .overrideConfigKey("quarkus.tls.serverA.key-store.jks.path", "keystoreA.p12")
+            .overrideConfigKey("quarkus.tls.serverA.key-store.jks.password", "secretA")
+
+            .overrideConfigKey("quarkus.tls.client.trust-store.jks.path", "truststore.p12")
+            .overrideConfigKey("quarkus.tls.client.trust-store.jks.password", "secret")
+
+            .overrideConfigKey("quarkus.tls.clientA.trust-store.jks.path", "truststoreA.p12")
+            .overrideConfigKey("quarkus.tls.clientA.trust-store.jks.password", "secretA")
+
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.tls-configuration-name", "client")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url", "https://localhost:8444/s")
+
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.clientA.tls-configuration-name", "clientA")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.clientA.base-url", "https://localhost:8445/sA");
+
+    @Inject
+    ChatLanguageModel defaultChatLanguageModel;
+
+    @ModelName("clientA")
+    ChatLanguageModel clientAChatLanguageModel;
+
+    @Test
+    void test() {
+        assertThat(defaultChatLanguageModel.generate("hello")).isEqualTo("Hello");
+
+        assertThat(clientAChatLanguageModel.generate("hello")).isEqualTo("HelloA");
+    }
+
+    @ApplicationScoped
+    public static class Setup {
+
+        private final List<HttpServer> servers = Collections.synchronizedList(new ArrayList<>());
+
+        public void start(@Observes StartupEvent ev, Vertx vertx, TlsConfigurationRegistry tlsConfigurationRegistry) {
+            // server for default client
+            servers.add(createServerAndListen(vertx, prepareServer(vertx, tlsConfigurationRegistry, "server", 8444,
+                    "/s", "Hello")));
+
+            // server for clientA
+            servers.add(createServerAndListen(vertx, prepareServer(vertx, tlsConfigurationRegistry, "serverA", 8445,
+                    "/sA", "HelloA")));
+        }
+
+        private HttpServer createServerAndListen(Vertx vertx, ServerPrepareResult serverPrepareResult) {
+            return vertx.createHttpServer(serverPrepareResult.serverOptions())
+                    .requestHandler(serverPrepareResult.router())
+                    .listen().result();
+        }
+
+        private ServerPrepareResult prepareServer(Vertx vertx, TlsConfigurationRegistry tlsConfigurationRegistry,
+                String tlsConfigurationName, int port, String basePath,
+                String chatResponse) {
+            Router router = Router.router(vertx);
+            router.post(basePath + "/chat/completions").handler(rc -> {
+                rc.response().end("""
+                        {
+                          "id": "chatcmpl-123",
+                          "object": "chat.completion",
+                          "created": 1677652288,
+                          "model": "gpt-4o-mini",
+                          "system_fingerprint": "fp_44709d6fcb",
+                          "choices": [
+                            {
+                              "index": 0,
+                              "message": {
+                                "role": "assistant",
+                                "content": "REPLACE_ME"
+                              },
+                              "finish_reason": "stop"
+                            }
+                          ],
+                          "usage": {
+                            "prompt_tokens": 9,
+                            "completion_tokens": 12,
+                            "total_tokens": 21,
+                            "completion_tokens_details": {
+                              "reasoning_tokens": 0
+                            }
+                          }
+                        }
+                        """.replace("REPLACE_ME", chatResponse));
+            });
+
+            TlsConfiguration bucket = tlsConfigurationRegistry.get(tlsConfigurationName).orElseThrow();
+            KeyCertOptions keyStoreOptions = bucket.getKeyStoreOptions();
+            HttpServerOptions serverOptions = new HttpServerOptions();
+
+            serverOptions.setSsl(true);
+            serverOptions.setPort(port);
+            serverOptions.setKeyCertOptions(keyStoreOptions);
+            var other = bucket.getSSLOptions();
+            serverOptions.setSslHandshakeTimeout(other.getSslHandshakeTimeout());
+            serverOptions.setSslHandshakeTimeoutUnit(other.getSslHandshakeTimeoutUnit());
+            for (String suite : other.getEnabledCipherSuites()) {
+                serverOptions.addEnabledCipherSuite(suite);
+            }
+            for (Buffer buffer : other.getCrlValues()) {
+                serverOptions.addCrlValue(buffer);
+            }
+            if (!other.isUseAlpn()) {
+                serverOptions.setUseAlpn(false);
+            }
+            serverOptions.setEnabledSecureTransportProtocols(other.getEnabledSecureTransportProtocols());
+            return new ServerPrepareResult(router, serverOptions);
+        }
+
+        public void shutdown(@Observes ShutdownEvent ev) {
+            for (HttpServer server : servers) {
+                if (server != null) {
+                    server.close();
+                }
+            }
+        }
+
+        private record ServerPrepareResult(Router router, HttpServerOptions serverOptions) {
+        }
+    }
+}

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/QuarkusOpenAiChatModelBuilderFactory.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/QuarkusOpenAiChatModelBuilderFactory.java
@@ -1,0 +1,28 @@
+package io.quarkiverse.langchain4j.openai;
+
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.model.openai.spi.OpenAiChatModelBuilderFactory;
+import io.quarkiverse.langchain4j.openai.common.runtime.AdditionalPropertiesHack;
+
+public class QuarkusOpenAiChatModelBuilderFactory implements OpenAiChatModelBuilderFactory {
+    @Override
+    public OpenAiChatModel.OpenAiChatModelBuilder get() {
+        return new Builder();
+    }
+
+    public static class Builder extends OpenAiChatModel.OpenAiChatModelBuilder {
+
+        private String tlsConfigurationName;
+
+        public Builder tlsConfigurationName(String tlsConfigurationName) {
+            this.tlsConfigurationName = tlsConfigurationName;
+            return this;
+        }
+
+        @Override
+        public OpenAiChatModel build() {
+            AdditionalPropertiesHack.setTlsConfigurationName(tlsConfigurationName);
+            return super.build();
+        }
+    }
+}

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/QuarkusOpenAiEmbeddingModelBuilderFactory.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/QuarkusOpenAiEmbeddingModelBuilderFactory.java
@@ -1,0 +1,29 @@
+package io.quarkiverse.langchain4j.openai;
+
+import dev.langchain4j.model.openai.OpenAiEmbeddingModel;
+import dev.langchain4j.model.openai.spi.OpenAiEmbeddingModelBuilderFactory;
+import io.quarkiverse.langchain4j.openai.common.runtime.AdditionalPropertiesHack;
+
+public class QuarkusOpenAiEmbeddingModelBuilderFactory implements OpenAiEmbeddingModelBuilderFactory {
+
+    @Override
+    public OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder get() {
+        return new Builder();
+    }
+
+    public static class Builder extends OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder {
+
+        private String tlsConfigurationName;
+
+        public Builder tlsConfigurationName(String tlsConfigurationName) {
+            this.tlsConfigurationName = tlsConfigurationName;
+            return this;
+        }
+
+        @Override
+        public OpenAiEmbeddingModel build() {
+            AdditionalPropertiesHack.setTlsConfigurationName(tlsConfigurationName);
+            return super.build();
+        }
+    }
+}

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/QuarkusOpenAiImageModel.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/QuarkusOpenAiImageModel.java
@@ -40,32 +40,30 @@ public class QuarkusOpenAiImageModel implements ImageModel {
 
     private final QuarkusOpenAiClient client;
 
-    public QuarkusOpenAiImageModel(String baseUrl, String apiKey, String organizationId, String modelName, String size,
-            String quality, String style, Optional<String> user, String responseFormat, Duration timeout,
-            Integer maxRetries, Boolean logRequests, Boolean logResponses,
-            Optional<Path> persistDirectory) {
-        this.modelName = modelName;
-        this.size = size;
-        this.quality = quality;
-        this.style = style;
-        this.user = user;
-        this.responseFormat = responseFormat;
-        this.maxRetries = maxRetries;
+    public QuarkusOpenAiImageModel(Builder builder) {
+        this.modelName = builder.modelName;
+        this.size = builder.size;
+        this.quality = builder.quality;
+        this.style = builder.style;
+        this.user = builder.user;
+        this.responseFormat = builder.responseFormat;
+        this.maxRetries = builder.maxRetries;
         if (this.maxRetries < 1) {
             throw new IllegalArgumentException("max-retries must be at least 1");
         }
-        this.persistDirectory = persistDirectory;
+        this.persistDirectory = builder.persistDirectory;
 
         this.client = QuarkusOpenAiClient.builder()
-                .baseUrl(baseUrl)
-                .openAiApiKey(apiKey)
-                .organizationId(organizationId)
-                .callTimeout(timeout)
-                .connectTimeout(timeout)
-                .readTimeout(timeout)
-                .writeTimeout(timeout)
-                .logRequests(logRequests)
-                .logResponses(logResponses)
+                .baseUrl(builder.baseUrl)
+                .tlsConfigurationName(builder.tlsConfigurationName)
+                .openAiApiKey(builder.apiKey)
+                .organizationId(builder.organizationId)
+                .callTimeout(builder.timeout)
+                .connectTimeout(builder.timeout)
+                .readTimeout(builder.timeout)
+                .writeTimeout(builder.timeout)
+                .logRequests(builder.logRequests)
+                .logResponses(builder.logResponses)
                 .build();
     }
 
@@ -141,6 +139,7 @@ public class QuarkusOpenAiImageModel implements ImageModel {
 
     public static class Builder {
         private String baseUrl;
+        private String tlsConfigurationName;
         private String apiKey;
         private String organizationId;
         private String modelName;
@@ -157,6 +156,11 @@ public class QuarkusOpenAiImageModel implements ImageModel {
 
         public Builder baseUrl(String baseUrl) {
             this.baseUrl = baseUrl;
+            return this;
+        }
+
+        public Builder tlsConfigurationName(String tlsConfigurationName) {
+            this.tlsConfigurationName = tlsConfigurationName;
             return this;
         }
 
@@ -226,9 +230,7 @@ public class QuarkusOpenAiImageModel implements ImageModel {
         }
 
         public QuarkusOpenAiImageModel build() {
-            return new QuarkusOpenAiImageModel(baseUrl, apiKey, organizationId, modelName, size, quality, style, user,
-                    responseFormat, timeout, maxRetries, logRequests, logResponses,
-                    persistDirectory);
+            return new QuarkusOpenAiImageModel(this);
         }
     }
 

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/QuarkusOpenAiModerationModelBuilderFactory.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/QuarkusOpenAiModerationModelBuilderFactory.java
@@ -1,0 +1,29 @@
+package io.quarkiverse.langchain4j.openai;
+
+import dev.langchain4j.model.openai.OpenAiModerationModel;
+import dev.langchain4j.model.openai.spi.OpenAiModerationModelBuilderFactory;
+import io.quarkiverse.langchain4j.openai.common.runtime.AdditionalPropertiesHack;
+
+public class QuarkusOpenAiModerationModelBuilderFactory implements OpenAiModerationModelBuilderFactory {
+
+    @Override
+    public OpenAiModerationModel.OpenAiModerationModelBuilder get() {
+        return new Builder();
+    }
+
+    public static class Builder extends OpenAiModerationModel.OpenAiModerationModelBuilder {
+
+        private String tlsConfigurationName;
+
+        public Builder tlsConfigurationName(String tlsConfigurationName) {
+            this.tlsConfigurationName = tlsConfigurationName;
+            return this;
+        }
+
+        @Override
+        public OpenAiModerationModel build() {
+            AdditionalPropertiesHack.setTlsConfigurationName(tlsConfigurationName);
+            return super.build();
+        }
+    }
+}

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/QuarkusOpenAiStreamingChatModelBuilderFactory.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/QuarkusOpenAiStreamingChatModelBuilderFactory.java
@@ -1,0 +1,29 @@
+package io.quarkiverse.langchain4j.openai;
+
+import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
+import dev.langchain4j.model.openai.spi.OpenAiStreamingChatModelBuilderFactory;
+import io.quarkiverse.langchain4j.openai.common.runtime.AdditionalPropertiesHack;
+
+public class QuarkusOpenAiStreamingChatModelBuilderFactory implements OpenAiStreamingChatModelBuilderFactory {
+
+    @Override
+    public OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder get() {
+        return new Builder();
+    }
+
+    public static class Builder extends OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder {
+
+        private String tlsConfigurationName;
+
+        public Builder tlsConfigurationName(String tlsConfigurationName) {
+            this.tlsConfigurationName = tlsConfigurationName;
+            return this;
+        }
+
+        @Override
+        public OpenAiStreamingChatModel build() {
+            AdditionalPropertiesHack.setTlsConfigurationName(tlsConfigurationName);
+            return super.build();
+        }
+    }
+}

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
@@ -31,8 +31,13 @@ import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.model.openai.OpenAiEmbeddingModel;
 import dev.langchain4j.model.openai.OpenAiModerationModel;
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
+import io.quarkiverse.langchain4j.openai.QuarkusOpenAiChatModelBuilderFactory;
+import io.quarkiverse.langchain4j.openai.QuarkusOpenAiEmbeddingModelBuilderFactory;
 import io.quarkiverse.langchain4j.openai.QuarkusOpenAiImageModel;
+import io.quarkiverse.langchain4j.openai.QuarkusOpenAiModerationModelBuilderFactory;
+import io.quarkiverse.langchain4j.openai.QuarkusOpenAiStreamingChatModelBuilderFactory;
 import io.quarkiverse.langchain4j.openai.common.QuarkusOpenAiClient;
+import io.quarkiverse.langchain4j.openai.common.runtime.AdditionalPropertiesHack;
 import io.quarkiverse.langchain4j.openai.runtime.config.ChatModelConfig;
 import io.quarkiverse.langchain4j.openai.runtime.config.EmbeddingModelConfig;
 import io.quarkiverse.langchain4j.openai.runtime.config.ImageModelConfig;
@@ -63,7 +68,10 @@ public class OpenAiRecorder {
                 throw new ConfigValidationException(createApiKeyConfigProblems(configName));
             }
             ChatModelConfig chatModelConfig = openAiConfig.chatModel();
-            var builder = OpenAiChatModel.builder()
+            var builder = (QuarkusOpenAiChatModelBuilderFactory.Builder) OpenAiChatModel.builder();
+
+            builder
+                    .tlsConfigurationName(openAiConfig.tlsConfigurationName().orElse(null))
                     .baseUrl(openAiConfig.baseUrl())
                     .apiKey(apiKey)
                     .timeout(openAiConfig.timeout().orElse(Duration.ofSeconds(10)))
@@ -118,7 +126,9 @@ public class OpenAiRecorder {
                 throw new ConfigValidationException(createApiKeyConfigProblems(configName));
             }
             ChatModelConfig chatModelConfig = openAiConfig.chatModel();
-            var builder = OpenAiStreamingChatModel.builder()
+            var builder = (QuarkusOpenAiStreamingChatModelBuilderFactory.Builder) OpenAiStreamingChatModel.builder();
+            builder
+                    .tlsConfigurationName(openAiConfig.tlsConfigurationName().orElse(null))
                     .baseUrl(openAiConfig.baseUrl())
                     .apiKey(apiKey)
                     .timeout(openAiConfig.timeout().orElse(Duration.ofSeconds(10)))
@@ -169,7 +179,9 @@ public class OpenAiRecorder {
                 throw new ConfigValidationException(createApiKeyConfigProblems(configName));
             }
             EmbeddingModelConfig embeddingModelConfig = openAiConfig.embeddingModel();
-            var builder = OpenAiEmbeddingModel.builder()
+            var builder = (QuarkusOpenAiEmbeddingModelBuilderFactory.Builder) OpenAiEmbeddingModel.builder();
+            builder
+                    .tlsConfigurationName(openAiConfig.tlsConfigurationName().orElse(null))
                     .baseUrl(openAiConfig.baseUrl())
                     .apiKey(apiKey)
                     .timeout(openAiConfig.timeout().orElse(Duration.ofSeconds(10)))
@@ -215,7 +227,9 @@ public class OpenAiRecorder {
                 throw new ConfigValidationException(createApiKeyConfigProblems(configName));
             }
             ModerationModelConfig moderationModelConfig = openAiConfig.moderationModel();
-            var builder = OpenAiModerationModel.builder()
+            var builder = (QuarkusOpenAiModerationModelBuilderFactory.Builder) OpenAiModerationModel.builder();
+            builder
+                    .tlsConfigurationName(openAiConfig.tlsConfigurationName().orElse(null))
                     .baseUrl(openAiConfig.baseUrl())
                     .apiKey(apiKey)
                     .timeout(openAiConfig.timeout().orElse(Duration.ofSeconds(10)))
@@ -258,6 +272,7 @@ public class OpenAiRecorder {
             }
             ImageModelConfig imageModelConfig = openAiConfig.imageModel();
             var builder = QuarkusOpenAiImageModel.builder()
+                    .tlsConfigurationName(openAiConfig.tlsConfigurationName().orElse(null))
                     .baseUrl(openAiConfig.baseUrl())
                     .apiKey(apiKey)
                     .timeout(openAiConfig.timeout().orElse(Duration.ofSeconds(10)))
@@ -337,6 +352,7 @@ public class OpenAiRecorder {
     }
 
     public void cleanUp(ShutdownContext shutdown) {
+        AdditionalPropertiesHack.reset();
         shutdown.addShutdownTask(new Runnable() {
             @Override
             public void run() {

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/LangChain4jOpenAiConfig.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/LangChain4jOpenAiConfig.java
@@ -45,6 +45,11 @@ public interface LangChain4jOpenAiConfig {
         String baseUrl();
 
         /**
+         * If set, the named TLS configuration with the configured name will be applied to the REST Client
+         */
+        Optional<String> tlsConfigurationName();
+
+        /**
          * OpenAI API key
          */
         @WithDefault("dummy") // TODO: this should be Optional but Smallrye Config doesn't like it...

--- a/model-providers/openai/openai-vanilla/runtime/src/main/resources/META-INF/services/dev.langchain4j.model.openai.spi.OpenAiChatModelBuilderFactory
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/resources/META-INF/services/dev.langchain4j.model.openai.spi.OpenAiChatModelBuilderFactory
@@ -1,0 +1,1 @@
+io.quarkiverse.langchain4j.openai.QuarkusOpenAiChatModelBuilderFactory

--- a/model-providers/openai/openai-vanilla/runtime/src/main/resources/META-INF/services/dev.langchain4j.model.openai.spi.OpenAiEmbeddingModelBuilderFactory
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/resources/META-INF/services/dev.langchain4j.model.openai.spi.OpenAiEmbeddingModelBuilderFactory
@@ -1,0 +1,1 @@
+io.quarkiverse.langchain4j.openai.QuarkusOpenAiEmbeddingModelBuilderFactory

--- a/model-providers/openai/openai-vanilla/runtime/src/main/resources/META-INF/services/dev.langchain4j.model.openai.spi.OpenAiModerationModelBuilderFactory
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/resources/META-INF/services/dev.langchain4j.model.openai.spi.OpenAiModerationModelBuilderFactory
@@ -1,0 +1,1 @@
+io.quarkiverse.langchain4j.openai.QuarkusOpenAiModerationModelBuilderFactory

--- a/model-providers/openai/openai-vanilla/runtime/src/main/resources/META-INF/services/dev.langchain4j.model.openai.spi.OpenAiStreamingChatModelBuilderFactory
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/resources/META-INF/services/dev.langchain4j.model.openai.spi.OpenAiStreamingChatModelBuilderFactory
@@ -1,0 +1,1 @@
+io.quarkiverse.langchain4j.openai.QuarkusOpenAiStreamingChatModelBuilderFactory

--- a/samples/email-a-poem/pom.xml
+++ b/samples/email-a-poem/pom.xml
@@ -18,7 +18,7 @@
         <quarkus.platform.version>3.15.1</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.2.5</surefire-plugin.version>
-        <quarkus-langchain4j.version>0.20.3</quarkus-langchain4j.version>
+        <quarkus-langchain4j.version>999-SNAPSHOT</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
This allows the TLS configuration name to
be applied like so:

```properties
quarkus.langchain4j.ollama.tls-configuration-name=foo
```

Where it's expected that the user would have also
done something like:

```properties
quarkus.tls.foo.trust-store.jks.path=truststore.jks
quarkus.tls.foo.trust-store.jks.password=pass
```

- Resolves: #993