### PR TITLE
Fix incorrect model-id parameter in WatsonxRecorder

### DIFF
--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ChatAllPropertiesTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ChatAllPropertiesTest.java
@@ -89,9 +89,9 @@ public class ChatAllPropertiesTest extends WireMockAbstract {
     @Test
     void check_config() throws Exception {
         var runtimeConfig = langchain4jWatsonConfig.defaultConfig();
-        assertEquals(WireMockUtil.URL_WATSONX_SERVER, runtimeConfig.baseUrl().toString());
+        assertEquals(WireMockUtil.URL_WATSONX_SERVER, runtimeConfig.baseUrl().orElse(null).toString());
         assertEquals(WireMockUtil.URL_IAM_SERVER, runtimeConfig.iam().baseUrl().toString());
-        assertEquals(WireMockUtil.API_KEY, runtimeConfig.apiKey());
+        assertEquals(WireMockUtil.API_KEY, runtimeConfig.apiKey().orElse(null));
         assertEquals("my-space-id", runtimeConfig.spaceId().orElse(null));
         assertEquals(WireMockUtil.PROJECT_ID, runtimeConfig.projectId().orElse(null));
         assertEquals(Duration.ofSeconds(60), runtimeConfig.timeout().get());

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ChatAllPropertiesTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ChatAllPropertiesTest.java
@@ -114,7 +114,7 @@ public class ChatAllPropertiesTest extends WireMockAbstract {
     @Test
     void check_chat_model_config() throws Exception {
         var config = langchain4jWatsonConfig.defaultConfig();
-        String modelId = config.generationModel().modelId();
+        String modelId = config.chatModel().modelId();
         String spaceId = config.spaceId().orElse(null);
         String projectId = config.projectId().orElse(null);
 
@@ -135,7 +135,7 @@ public class ChatAllPropertiesTest extends WireMockAbstract {
     @Test
     void check_token_count_estimator() throws Exception {
         var config = langchain4jWatsonConfig.defaultConfig();
-        String modelId = config.generationModel().modelId();
+        String modelId = config.chatModel().modelId();
         String spaceId = config.spaceId().orElse(null);
         String projectId = config.projectId().orElse(null);
 
@@ -152,7 +152,7 @@ public class ChatAllPropertiesTest extends WireMockAbstract {
     @Test
     void check_chat_streaming_model_config() throws Exception {
         var config = langchain4jWatsonConfig.defaultConfig();
-        String modelId = config.generationModel().modelId();
+        String modelId = config.chatModel().modelId();
         String spaceId = config.spaceId().orElse(null);
         String projectId = config.projectId().orElse(null);
 

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ChatDefaultPropertiesTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ChatDefaultPropertiesTest.java
@@ -91,7 +91,7 @@ public class ChatDefaultPropertiesTest extends WireMockAbstract {
     @Test
     void check_chat_model_config() throws Exception {
         var config = langchain4jWatsonConfig.defaultConfig();
-        String modelId = config.generationModel().modelId();
+        String modelId = config.chatModel().modelId();
         String spaceId = config.spaceId().orElse(null);
         String projectId = config.projectId().orElse(null);
 
@@ -113,7 +113,7 @@ public class ChatDefaultPropertiesTest extends WireMockAbstract {
     @Test
     void check_token_count_estimator() throws Exception {
         var config = langchain4jWatsonConfig.defaultConfig();
-        String modelId = config.generationModel().modelId();
+        String modelId = config.chatModel().modelId();
         String spaceId = config.spaceId().orElse(null);
         String projectId = config.projectId().orElse(null);
 
@@ -130,7 +130,7 @@ public class ChatDefaultPropertiesTest extends WireMockAbstract {
     @Test
     void check_chat_streaming_model_config() throws Exception {
         var config = langchain4jWatsonConfig.defaultConfig();
-        String modelId = config.generationModel().modelId();
+        String modelId = config.chatModel().modelId();
         String spaceId = config.spaceId().orElse(null);
         String projectId = config.projectId().orElse(null);
 

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/GenerationAllPropertiesTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/GenerationAllPropertiesTest.java
@@ -120,9 +120,9 @@ public class GenerationAllPropertiesTest extends WireMockAbstract {
     @Test
     void check_config() throws Exception {
         var runtimeConfig = langchain4jWatsonConfig.defaultConfig();
-        assertEquals(WireMockUtil.URL_WATSONX_SERVER, runtimeConfig.baseUrl().toString());
+        assertEquals(WireMockUtil.URL_WATSONX_SERVER, runtimeConfig.baseUrl().orElse(null).toString());
         assertEquals(WireMockUtil.URL_IAM_SERVER, runtimeConfig.iam().baseUrl().toString());
-        assertEquals(WireMockUtil.API_KEY, runtimeConfig.apiKey());
+        assertEquals(WireMockUtil.API_KEY, runtimeConfig.apiKey().orElse(null));
         assertEquals("my-space-id", runtimeConfig.spaceId().orElse(null));
         assertEquals(WireMockUtil.PROJECT_ID, runtimeConfig.projectId().orElse(null));
         assertEquals(Duration.ofSeconds(60), runtimeConfig.timeout().get());

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/WatsonxRecorder.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/WatsonxRecorder.java
@@ -284,7 +284,7 @@ public class WatsonxRecorder {
                 .version(watsonRuntimeConfig.version())
                 .spaceId(watsonRuntimeConfig.spaceId().orElse(null))
                 .projectId(watsonRuntimeConfig.projectId().orElse(null))
-                .modelId(watsonRuntimeConfig.generationModel().modelId())
+                .modelId(watsonRuntimeConfig.chatModel().modelId())
                 .frequencyPenalty(chatModelConfig.frequencyPenalty())
                 .logprobs(chatModelConfig.logprobs())
                 .topLogprobs(chatModelConfig.topLogprobs().orElse(null))

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/LangChain4jWatsonxConfig.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/LangChain4jWatsonxConfig.java
@@ -40,16 +40,14 @@ public interface LangChain4jWatsonxConfig {
         /**
          * Base URL of the watsonx.ai API.
          */
-        @WithDefault("https://dummy.ai/api")
-        String baseUrl();
+        Optional<String> baseUrl();
 
         /**
          * IBM Cloud API key.
          * <p>
          * To create a new API key, follow this <a href="https://cloud.ibm.com/iam/apikeys">link</a>.
          */
-        @WithDefault("dummy")
-        String apiKey();
+        Optional<String> apiKey();
 
         /**
          * Timeout for watsonx.ai calls.


### PR DESCRIPTION
This PR fixes an issue that prevented model selection in watsonx.ai when using `chat` mode. Additionally, it introduces support for inheriting `api-key`, `base-url`, `space-id`, and `project-id` properties across different AIServices.

For example, suppose that a developer has two different AiServices, the `application.properties` can be set up as follows:
```properties
quarkus.langchain4j.watsonx.base-url=<url>
quarkus.langchain4j.watsonx.api-key=<api-key>
quarkus.langchain4j.watsonx.project-id=<project-id>

quarkus.langchain4j.watsonx.extractor.log-requests=true
quarkus.langchain4j.watsonx.extractor.chat-model.model-id=ibm/granite-13b-instruct-v2

quarkus.langchain4j.watsonx.rephrase.log-requests=true
quarkus.langchain4j.watsonx.rephrase.chat-model.model-id=meta-llama/llama-3-1-70b-instruct
```