### PR TITLE
Improve web-search sample

### DIFF
--- a/samples/chatbot-web-search/src/main/java/io/quarkiverse/langchain4j/sample/chatbot/Bot.java
+++ b/samples/chatbot-web-search/src/main/java/io/quarkiverse/langchain4j/sample/chatbot/Bot.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.langchain4j.sample.chatbot;
 
+import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.web.search.WebSearchTool;
 import io.quarkiverse.langchain4j.RegisterAiService;
@@ -9,6 +10,13 @@ import jakarta.enterprise.context.SessionScoped;
 @SessionScoped
 public interface Bot {
 
+    @SystemMessage("""
+            You have access to a function that looks up data using the Tavily web search engine.
+            The web search engine doesn't understand the concept of 'today',
+            so if the user asks something
+            that requires the knowledge of today's date, use the getTodaysDate function before
+            calling the search engine.
+            """)
     String chat(@UserMessage String question);
 
 }


### PR DESCRIPTION
This seems to make answering questions like "Give me yesterday's news headlines" more reliable, because otherwise it sometimes uses a query like "news headlines yesterday", but the search engine doesn't understand this concept, so it returns completely random old news (it did that during my recent demo :) ).