### PR TITLE
Add description for neo4j extension

### DIFF
--- a/embedding-stores/neo4j/pom.xml
+++ b/embedding-stores/neo4j/pom.xml
@@ -9,6 +9,7 @@
     </parent>
     <artifactId>quarkus-langchain4j-neo4j-parent</artifactId>
     <name>Quarkus LangChain4j - Neo4j embedding store - Parent</name>
+    <description>Provides the Neo4j embedding store for LangChain4j</description>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
Without a description, extensions inherit the description of the parent pom:

<img width="239" alt="image" src="https://github.com/user-attachments/assets/cead937f-4b27-43b7-88e9-1c729ec9b5bf">
