### PR TITLE
Allow for Ollama configuration to make `quarkus.langchain4j.foo.chat-model.provider` unnecessary

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/BeansProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/BeansProcessor.java
@@ -32,6 +32,7 @@ import io.quarkiverse.langchain4j.deployment.items.AutoCreateEmbeddingModelBuild
 import io.quarkiverse.langchain4j.deployment.items.ChatModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.EmbeddingModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.ImageModelProviderCandidateBuildItem;
+import io.quarkiverse.langchain4j.deployment.items.ImplicitlyUserConfiguredChatProviderBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.InProcessEmbeddingBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.ModerationModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.ProviderHolder;
@@ -81,6 +82,7 @@ public class BeansProcessor {
             List<RequestChatModelBeanBuildItem> requestChatModelBeanItems,
             List<RequestModerationModelBeanBuildItem> requestModerationModelBeanBuildItems,
             List<RequestImageModelBeanBuildItem> requestImageModelBeanBuildItems,
+            List<ImplicitlyUserConfiguredChatProviderBuildItem> userConfiguredProviderBuildItems,
             LangChain4jBuildConfig buildConfig,
             Optional<AutoCreateEmbeddingModelBuildItem> autoCreateEmbeddingModelBuildItem,
             BuildProducer<SelectedChatModelProviderBuildItem> selectedChatProducer,
@@ -146,6 +148,15 @@ public class BeansProcessor {
                         userSelectedProvider = Optional.empty();
                     }
                     configNamespace = modelName + ".chat-model";
+                }
+                if (userSelectedProvider.isEmpty() && !NamedConfigUtil.isDefault(modelName)) {
+                    // let's see if the user has configured a model name for one of the named providers
+                    List<ImplicitlyUserConfiguredChatProviderBuildItem> matchingImplicitlyUserConfiguredChatProviders = userConfiguredProviderBuildItems
+                            .stream().filter(bi -> bi.getConfigName().equals(modelName))
+                            .toList();
+                    if (matchingImplicitlyUserConfiguredChatProviders.size() == 1) {
+                        userSelectedProvider = Optional.of(matchingImplicitlyUserConfiguredChatProviders.get(0).getProvider());
+                    }
                 }
 
                 String provider = selectProvider(

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/devservice/DevServicesOllamaProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/devservice/DevServicesOllamaProcessor.java
@@ -41,7 +41,7 @@ public class DevServicesOllamaProcessor {
     private static final String OLLAMA_PROVIDER = "ollama";
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    @BuildStep
+    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = Langchain4jDevServicesEnabled.class)
     private void handleModels(List<DevServicesChatModelRequiredBuildItem> devServicesChatModels,
             List<DevServicesEmbeddingModelRequiredBuildItem> devServicesEmbeddingModels,
             LoggingSetupBuildItem loggingSetupBuildItem,

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/items/ImplicitlyUserConfiguredChatProviderBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/items/ImplicitlyUserConfiguredChatProviderBuildItem.java
@@ -1,0 +1,27 @@
+package io.quarkiverse.langchain4j.deployment.items;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Contains information about what provider has been configured for a certain model based on user configuration.
+ * This only emitted when the configuration is runtime fixed and can be conclusively determined at build time.
+ * The usefulness of this is to aid the provider resolution process.
+ */
+public final class ImplicitlyUserConfiguredChatProviderBuildItem extends MultiBuildItem {
+
+    private final String configName;
+    private final String provider;
+
+    public ImplicitlyUserConfiguredChatProviderBuildItem(String configName, String provider) {
+        this.configName = configName;
+        this.provider = provider;
+    }
+
+    public String getConfigName() {
+        return configName;
+    }
+
+    public String getProvider() {
+        return provider;
+    }
+}

--- a/integration-tests/multiple-providers/src/main/resources/application.properties
+++ b/integration-tests/multiple-providers/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+quarkus.langchain4j.devservices.enabled=false
+
 quarkus.langchain4j.chat-model.provider=openai
 quarkus.langchain4j.moderation-model.provider=openai
 quarkus.langchain4j.openai.api-key=test1
@@ -38,6 +40,9 @@ quarkus.langchain4j.watsonx.c8.base-url=https://somecluster.somedomain.ai:443/ap
 quarkus.langchain4j.watsonx.c8.api-key=test9
 quarkus.langchain4j.watsonx.c8.project-id=proj
 quarkus.langchain4j.watsonx.c8.mode=generation
+
+# this shouldn't need a 'quarkus.langchain4j.c9.chat-model.provider=ollama' because the chat model name is runtime fixed
+quarkus.langchain4j.ollama.c9.chat-model.model-id=granite3-dense
 
 quarkus.langchain4j.e1.embedding-model.provider=openai
 quarkus.langchain4j.openai.e1.api-key=test5

--- a/integration-tests/multiple-providers/src/test/java/org/acme/example/multiple/MultipleChatProvidersTest.java
+++ b/integration-tests/multiple-providers/src/test/java/org/acme/example/multiple/MultipleChatProvidersTest.java
@@ -52,6 +52,10 @@ public class MultipleChatProvidersTest {
     @ModelName("c8")
     ChatLanguageModel eighthNamedModel;
 
+    @Inject
+    @ModelName("c9")
+    ChatLanguageModel ninthNamedModel;
+
     @Test
     void defaultModel() {
         assertThat(ClientProxy.unwrap(defaultModel)).isInstanceOf(OpenAiChatModel.class);
@@ -90,5 +94,10 @@ public class MultipleChatProvidersTest {
     @Test
     void eighthNamedModel() {
         assertThat(ClientProxy.unwrap(eighthNamedModel)).isInstanceOf(WatsonxGenerationModel.class);
+    }
+
+    @Test
+    void ninthNamedModel() {
+        assertThat(ClientProxy.unwrap(ninthNamedModel)).isInstanceOf(OllamaChatLanguageModel.class);
     }
 }

--- a/model-providers/ollama/deployment/src/main/java/io/quarkiverse/langchain4j/ollama/deployment/OllamaProcessor.java
+++ b/model-providers/ollama/deployment/src/main/java/io/quarkiverse/langchain4j/ollama/deployment/OllamaProcessor.java
@@ -21,6 +21,7 @@ import io.quarkiverse.langchain4j.deployment.items.ChatModelProviderCandidateBui
 import io.quarkiverse.langchain4j.deployment.items.DevServicesChatModelRequiredBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.DevServicesEmbeddingModelRequiredBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.EmbeddingModelProviderCandidateBuildItem;
+import io.quarkiverse.langchain4j.deployment.items.ImplicitlyUserConfiguredChatProviderBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedChatModelProviderBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedEmbeddingModelCandidateBuildItem;
 import io.quarkiverse.langchain4j.ollama.runtime.OllamaRecorder;
@@ -65,6 +66,14 @@ public class OllamaProcessor {
         if (config.embeddingModel().enabled().isEmpty() || config.embeddingModel().enabled().get()) {
             embeddingProducer.produce(new EmbeddingModelProviderCandidateBuildItem(PROVIDER));
         }
+    }
+
+    @BuildStep
+    public void implicitlyConfiguredProviders(LangChain4jOllamaFixedRuntimeConfig fixedRuntimeConfig,
+            BuildProducer<ImplicitlyUserConfiguredChatProviderBuildItem> producer) {
+        fixedRuntimeConfig.namedConfig().keySet().forEach(configName -> {
+            producer.produce(new ImplicitlyUserConfiguredChatProviderBuildItem(configName, PROVIDER));
+        });
     }
 
     @BuildStep(onlyIfNot = IsNormal.class, onlyIf = Langchain4jDevServicesEnabled.class)


### PR DESCRIPTION
In Ollama (and others in the future) this is possible because
the model-id is a build time property

- Fixes: https://github.com/quarkiverse/quarkus-langchain4j/issues/1055