### PR TITLE
Easy RAG extension: don't depend on the upstream Easy RAG module

### DIFF
--- a/rag/easy-rag/runtime/pom.xml
+++ b/rag/easy-rag/runtime/pom.xml
@@ -16,17 +16,7 @@
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
-            <artifactId>langchain4j-easy-rag</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>xml-apis</groupId>
-                    <artifactId>xml-apis</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>dev.langchain4j</groupId>
-                    <artifactId>langchain4j-embeddings-bge-small-en-v15-q</artifactId>
-                </exclusion>
-            </exclusions>
+            <artifactId>langchain4j-document-parser-apache-tika</artifactId>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>


### PR DESCRIPTION
This cleans up the dependency tree a bit

Fixes: https://github.com/quarkiverse/quarkus-langchain4j/issues/1077