### PR TITLE
Allow rewriting of user messages from input guardrails

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/InputGuardrailRewritingTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/InputGuardrailRewritingTest.java
@@ -1,0 +1,96 @@
+package io.quarkiverse.langchain4j.test.guardrails;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.guardrails.InputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.InputGuardrailResult;
+import io.quarkiverse.langchain4j.guardrails.InputGuardrails;
+import io.quarkiverse.langchain4j.runtime.aiservice.NoopChatMemory;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class InputGuardrailRewritingTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyAiService.class, MessageTruncatingGuardrail.class, EchoChatModel.class,
+                            MyChatModelSupplier.class, MyMemoryProviderSupplier.class));
+
+    @Inject
+    MyAiService aiService;
+
+    @Test
+    @ActivateRequestContext
+    void testRewriting() {
+        assertEquals(MessageTruncatingGuardrail.MAX_LENGTH, aiService.test("first prompt", "second prompt").length());
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = MyMemoryProviderSupplier.class)
+    public interface MyAiService {
+
+        @UserMessage("Given {first} and {second} do something")
+        @InputGuardrails(MessageTruncatingGuardrail.class)
+        String test(String first, String second);
+
+    }
+
+    @RequestScoped
+    public static class MessageTruncatingGuardrail implements InputGuardrail {
+
+        static final int MAX_LENGTH = 20;
+
+        @Override
+        public InputGuardrailResult validate(dev.langchain4j.data.message.UserMessage um) {
+            String text = um.singleText();
+            return successWith(text.substring(0, MAX_LENGTH));
+        }
+    }
+
+    public static class MyChatModelSupplier implements Supplier<ChatLanguageModel> {
+
+        @Override
+        public ChatLanguageModel get() {
+            return new EchoChatModel();
+        }
+    }
+
+    public static class EchoChatModel implements ChatLanguageModel {
+
+        @Override
+        public Response<AiMessage> generate(List<ChatMessage> messages) {
+            return new Response<>(new AiMessage(((dev.langchain4j.data.message.UserMessage) messages.get(0)).singleText()));
+        }
+    }
+
+    public static class MyMemoryProviderSupplier implements Supplier<ChatMemoryProvider> {
+        @Override
+        public ChatMemoryProvider get() {
+            return new ChatMemoryProvider() {
+                @Override
+                public ChatMemory get(Object memoryId) {
+                    return new NoopChatMemory();
+                }
+            };
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/GuardrailResult.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/GuardrailResult.java
@@ -29,10 +29,14 @@ public interface GuardrailResult<GR extends GuardrailResult> {
         FATAL
     }
 
-    boolean isSuccess();
+    Result getResult();
+
+    default boolean isSuccess() {
+        return getResult() == Result.SUCCESS || getResult() == Result.SUCCESS_WITH_RESULT;
+    }
 
     default boolean hasRewrittenResult() {
-        return false;
+        return getResult() == Result.SUCCESS_WITH_RESULT;
     }
 
     default GuardrailResult<GR> blockRetry() {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/InputGuardrail.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/InputGuardrail.java
@@ -48,6 +48,14 @@ public interface InputGuardrail extends Guardrail<InputGuardrailParams, InputGua
     }
 
     /**
+     * @return The result of a successful input guardrail validation with a specific text.
+     * @param successfulText The text of the successful result.
+     */
+    default InputGuardrailResult successWith(String successfulText) {
+        return InputGuardrailResult.successWith(successfulText);
+    }
+
+    /**
      * @param message A message describing the failure.
      * @return The result of a failed input guardrail validation.
      */

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/InputGuardrailParams.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/InputGuardrailParams.java
@@ -1,7 +1,11 @@
 package io.quarkiverse.langchain4j.guardrails;
 
+import java.util.List;
 import java.util.Map;
 
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.ContentType;
+import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.rag.AugmentationResult;
@@ -21,6 +25,14 @@ public record InputGuardrailParams(UserMessage userMessage, ChatMemory memory,
 
     @Override
     public InputGuardrailParams withText(String text) {
-        throw new UnsupportedOperationException();
+        return new InputGuardrailParams(rewriteUserMessage(userMessage, text), memory, augmentationResult, userMessageTemplate,
+                variables);
+    }
+
+    public static UserMessage rewriteUserMessage(UserMessage userMessage, String text) {
+        List<Content> rewrittenContent = userMessage.contents().stream()
+                .map(c -> c.type() == ContentType.TEXT ? new TextContent(text) : c).toList();
+        return userMessage.name() == null ? new UserMessage(rewrittenContent)
+                : new UserMessage(userMessage.name(), rewrittenContent);
     }
 }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/InputGuardrailResult.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/InputGuardrailResult.java
@@ -10,20 +10,29 @@ import java.util.stream.Collectors;
  * @param result The result of the input guardrail validation.
  * @param failures The list of failures, empty if the validation succeeded.
  */
-public record InputGuardrailResult(Result result, List<Failure> failures) implements GuardrailResult<InputGuardrailResult> {
+public record InputGuardrailResult(Result result, String successfulText,
+        List<Failure> failures) implements GuardrailResult<InputGuardrailResult> {
 
     private static final InputGuardrailResult SUCCESS = new InputGuardrailResult();
 
     private InputGuardrailResult() {
-        this(Result.SUCCESS, Collections.emptyList());
+        this(Result.SUCCESS, null, Collections.emptyList());
+    }
+
+    private InputGuardrailResult(String successfulText) {
+        this(Result.SUCCESS_WITH_RESULT, successfulText, Collections.emptyList());
     }
 
     InputGuardrailResult(List<Failure> failures, boolean fatal) {
-        this(fatal ? Result.FATAL : Result.FAILURE, failures);
+        this(fatal ? Result.FATAL : Result.FAILURE, null, failures);
     }
 
     public static InputGuardrailResult success() {
         return InputGuardrailResult.SUCCESS;
+    }
+
+    public static InputGuardrailResult successWith(String successfulText) {
+        return new InputGuardrailResult(successfulText);
     }
 
     public static InputGuardrailResult failure(List<? extends GuardrailResult.Failure> failures) {
@@ -31,8 +40,8 @@ public record InputGuardrailResult(Result result, List<Failure> failures) implem
     }
 
     @Override
-    public boolean isSuccess() {
-        return result == Result.SUCCESS;
+    public Result getResult() {
+        return result;
     }
 
     @Override
@@ -54,7 +63,7 @@ public record InputGuardrailResult(Result result, List<Failure> failures) implem
     @Override
     public String toString() {
         if (isSuccess()) {
-            return "success";
+            return hasRewrittenResult() ? "Success with '" + successfulText + "'" : "Success";
         }
         return failures.stream().map(Failure::toString).collect(Collectors.joining(", "));
     }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/OutputGuardrailResult.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/OutputGuardrailResult.java
@@ -48,13 +48,8 @@ public record OutputGuardrailResult(Result result, String successfulText, Object
     }
 
     @Override
-    public boolean isSuccess() {
-        return result == Result.SUCCESS || result == Result.SUCCESS_WITH_RESULT;
-    }
-
-    @Override
-    public boolean hasRewrittenResult() {
-        return result == Result.SUCCESS_WITH_RESULT;
+    public Result getResult() {
+        return result;
     }
 
     public boolean isRetry() {


### PR DESCRIPTION
This pull request introduces the possibility of rewriting the user messages from the input guardrails. At the moment it is only possible to read and rewrite the complete materialized user message immediately before submitting it to the LLM. I don't know if it would make sense to also allow a rewrite on the single input parameters level (before materializing the complete user message), but if required I'm open to iterate on this and eventually also add this possibility.

/cc @lordofthejars @cescoffier @geoand 