### PR TITLE
Move JsonGuardrailsUtilsTest to the deployment module

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/JsonGuardrailsUtilsTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/JsonGuardrailsUtilsTest.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.langchain4j.guardrails;
+package io.quarkiverse.langchain4j.test.guardrails;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -6,14 +6,21 @@ import java.util.List;
 
 import jakarta.inject.Inject;
 
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
-import io.quarkus.test.junit.QuarkusTest;
+import io.quarkiverse.langchain4j.guardrails.JsonGuardrailsUtils;
+import io.quarkus.test.QuarkusUnitTest;
 
-@QuarkusTest
 class JsonGuardrailsUtilsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
 
     @Inject
     JsonGuardrailsUtils jsonGuardrailsUtils;

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/JsonGuardrailsUtils.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/JsonGuardrailsUtils.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @ApplicationScoped
-class JsonGuardrailsUtils {
+public class JsonGuardrailsUtils {
 
     @Inject
     ObjectMapper objectMapper;
@@ -16,7 +16,7 @@ class JsonGuardrailsUtils {
     private JsonGuardrailsUtils() {
     }
 
-    String trimNonJson(String llmResponse) {
+    public String trimNonJson(String llmResponse) {
         int jsonMapStart = llmResponse.indexOf('{');
         int jsonListStart = llmResponse.indexOf('[');
         if (jsonMapStart < 0 && jsonListStart < 0) {
@@ -29,7 +29,7 @@ class JsonGuardrailsUtils {
         return jsonEnd >= 0 && jsonStart < jsonEnd ? llmResponse.substring(jsonStart, jsonEnd + 1) : null;
     }
 
-    <T> T deserialize(String json, Class<T> expectedOutputClass) {
+    public <T> T deserialize(String json, Class<T> expectedOutputClass) {
         try {
             return objectMapper.readValue(json, expectedOutputClass);
         } catch (JsonProcessingException e) {
@@ -37,7 +37,7 @@ class JsonGuardrailsUtils {
         }
     }
 
-    <T> T deserialize(String json, TypeReference<T> expectedOutputType) {
+    public <T> T deserialize(String json, TypeReference<T> expectedOutputType) {
         try {
             return objectMapper.readValue(json, expectedOutputType);
         } catch (JsonProcessingException e) {


### PR DESCRIPTION
The test being in `runtime` breaks the build order, see the recent failures in https://github.com/quarkiverse/quarkus-langchain4j/actions/workflows/build-push.yml

I've moved it to the deployment module and rewritten it from `@QuarkusTest` to the internal framework. I had to make `JsonGuardrailsUtils` public though... 