### PR TITLE
When creating fastJar don't try to include models more than once

### DIFF
--- a/model-providers/jlama/deployment/src/main/java/io/quarkiverse/langchain4j/jlama/deployment/JlamaProcessor.java
+++ b/model-providers/jlama/deployment/src/main/java/io/quarkiverse/langchain4j/jlama/deployment/JlamaProcessor.java
@@ -11,7 +11,9 @@ import java.math.RoundingMode;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -271,7 +273,8 @@ public class JlamaProcessor {
         Path quarkusAppDir = jarPath.getParent();
         Path jlamaInQuarkusAppDir = quarkusAppDir.resolve("jlama");
 
-        for (ModelDownloadedBuildItem bi : models) {
+        // Using LinkedHashSet to guarantee uniqueness of models
+        for (ModelDownloadedBuildItem bi : new LinkedHashSet<>(models)) {
             try {
                 JlamaModelRegistry.ModelInfo modelInfo = JlamaModelRegistry.ModelInfo.from(bi.getModelName());
                 Path targetDir = jlamaInQuarkusAppDir.resolve(modelInfo.toFileName());
@@ -300,6 +303,20 @@ public class JlamaProcessor {
 
         public Path getDirectory() {
             return directory;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof ModelDownloadedBuildItem that)) {
+                return false;
+            }
+
+            return Objects.equals(modelName, that.modelName) && Objects.equals(directory, that.directory);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(modelName, directory);
         }
     }
 }


### PR DESCRIPTION
If my app has more than one AIService that both use the same model, I get the following error when trying to package my app. This PR fixes this issue.

```shell
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:54 min
[INFO] Finished at: 2024-11-21T14:57:52-05:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal io.quarkus.platform:quarkus-maven-plugin:3.16.4:build (default) on project insurance-app: Failed to build quarkus application: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
[ERROR]         [error]: Build step io.quarkiverse.langchain4j.jlama.deployment.JlamaProcessor#copyToFastJar threw an exception: java.io.UncheckedIOException: java.nio.file.FileAlreadyExistsException: /Users/edeandre/workspaces/workshops/rad-roadshow/parasol-insurance-edeandrea/app/target/quarkus-app/jlama/tjake_Mistral-7B-Instruct-v0.3-JQ4/model.safetensors
[ERROR]         at io.quarkiverse.langchain4j.jlama.deployment.JlamaProcessor.copyToFastJar(JlamaProcessor.java:281)
[ERROR]         at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:733)
[ERROR]         at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:856)
[ERROR]         at io.quarkus.builder.BuildContext.run(BuildContext.java:256)
[ERROR]         at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
[ERROR]         at org.jboss.threads.EnhancedQueueExecutor$Task.doRunWith(EnhancedQueueExecutor.java:2675)
[ERROR]         at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2654)
[ERROR]         at org.jboss.threads.EnhancedQueueExecutor.runThreadBody(EnhancedQueueExecutor.java:1627)
[ERROR]         at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1594)
[ERROR]         at java.base/java.lang.Thread.run(Thread.java:1583)
[ERROR]         at org.jboss.threads.JBossThread.run(JBossThread.java:499)
[ERROR] Caused by: java.nio.file.FileAlreadyExistsException: /Users/edeandre/workspaces/workshops/rad-roadshow/parasol-insurance-edeandrea/app/target/quarkus-app/jlama/tjake_Mistral-7B-Instruct-v0.3-JQ4/model.safetensors
[ERROR]         at java.base/sun.nio.fs.UnixFileSystem.copy(UnixFileSystem.java:1044)
[ERROR]         at java.base/sun.nio.fs.UnixFileSystemProvider.copy(UnixFileSystemProvider.java:300)
[ERROR]         at java.base/java.nio.file.Files.copy(Files.java:1304)
[ERROR]         at org.apache.commons.io.file.CopyDirectoryVisitor.copy(CopyDirectoryVisitor.java:90)
[ERROR]         at org.apache.commons.io.file.CopyDirectoryVisitor.visitFile(CopyDirectoryVisitor.java:174)
[ERROR]         at org.apache.commons.io.file.CopyDirectoryVisitor.visitFile(CopyDirectoryVisitor.java:37)
[ERROR]         at java.base/java.nio.file.Files.walkFileTree(Files.java:2786)
[ERROR]         at java.base/java.nio.file.Files.walkFileTree(Files.java:2857)
[ERROR]         at org.apache.commons.io.file.PathUtils.visitFileTree(PathUtils.java:1730)
[ERROR]         at org.apache.commons.io.file.PathUtils.copyDirectory(PathUtils.java:294)
[ERROR]         at io.quarkiverse.langchain4j.jlama.deployment.JlamaProcessor.copyToFastJar(JlamaProcessor.java:279)
[ERROR]         ... 10 more
[ERROR] -> [Help 1]
```

See https://github.com/rh-rad-ai-roadshow/parasol-insurance/actions/runs/11960310463/job/33344027662#step:5:4652