### PR TITLE
Use user.home as default for models-path for jlama and llama3 docs

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-jlama.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-jlama.adoc
@@ -108,7 +108,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_JLAMA_MODELS_PATH+++`
 endif::add-copy-button-to-env-var[]
 --
 |path
-|`${user.name}/.jlama/models`
+|`${user.home}/.jlama/models`
 
 a| [[quarkus-langchain4j-jlama_quarkus-langchain4j-jlama-chat-model-temperature]] [.property-path]##link:#quarkus-langchain4j-jlama_quarkus-langchain4j-jlama-chat-model-temperature[`quarkus.langchain4j.jlama.chat-model.temperature`]##
 

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-jlama_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-jlama_quarkus.langchain4j.adoc
@@ -108,7 +108,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_JLAMA_MODELS_PATH+++`
 endif::add-copy-button-to-env-var[]
 --
 |path
-|`${user.name}/.jlama/models`
+|`${user.home}/.jlama/models`
 
 a| [[quarkus-langchain4j-jlama_quarkus-langchain4j-jlama-chat-model-temperature]] [.property-path]##link:#quarkus-langchain4j-jlama_quarkus-langchain4j-jlama-chat-model-temperature[`quarkus.langchain4j.jlama.chat-model.temperature`]##
 

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-llama3-java.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-llama3-java.adoc
@@ -108,7 +108,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_LLAMA3_MODELS_PATH+++`
 endif::add-copy-button-to-env-var[]
 --
 |path
-|`${user.name}/.llama3java/models`
+|`${user.home}/.llama3java/models`
 
 a| [[quarkus-langchain4j-llama3-java_quarkus-langchain4j-llama3-chat-model-temperature]] [.property-path]##link:#quarkus-langchain4j-llama3-java_quarkus-langchain4j-llama3-chat-model-temperature[`quarkus.langchain4j.llama3.chat-model.temperature`]##
 

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-llama3-java_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-llama3-java_quarkus.langchain4j.adoc
@@ -108,7 +108,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_LLAMA3_MODELS_PATH+++`
 endif::add-copy-button-to-env-var[]
 --
 |path
-|`${user.name}/.llama3java/models`
+|`${user.home}/.llama3java/models`
 
 a| [[quarkus-langchain4j-llama3-java_quarkus-langchain4j-llama3-chat-model-temperature]] [.property-path]##link:#quarkus-langchain4j-llama3-java_quarkus-langchain4j-llama3-chat-model-temperature[`quarkus.langchain4j.llama3.chat-model.temperature`]##
 

--- a/model-providers/jlama/runtime/src/main/java/io/quarkiverse/langchain4j/jlama/runtime/config/LangChain4jJlamaFixedRuntimeConfig.java
+++ b/model-providers/jlama/runtime/src/main/java/io/quarkiverse/langchain4j/jlama/runtime/config/LangChain4jJlamaFixedRuntimeConfig.java
@@ -38,7 +38,7 @@ public interface LangChain4jJlamaFixedRuntimeConfig {
      * Location on the file-system which serves as a cache for the models
      *
      */
-    @ConfigDocDefault("${user.name}/.jlama/models")
+    @ConfigDocDefault("${user.home}/.jlama/models")
     Optional<Path> modelsPath();
 
     @ConfigGroup

--- a/model-providers/llama3-java/runtime/src/main/java/io/quarkiverse/langchain4j/llama3/runtime/config/LangChain4jLlama3FixedRuntimeConfig.java
+++ b/model-providers/llama3-java/runtime/src/main/java/io/quarkiverse/langchain4j/llama3/runtime/config/LangChain4jLlama3FixedRuntimeConfig.java
@@ -38,7 +38,7 @@ public interface LangChain4jLlama3FixedRuntimeConfig {
      * Location on the file-system which serves as a cache for the models
      *
      */
-    @ConfigDocDefault("${user.name}/.llama3java/models")
+    @ConfigDocDefault("${user.home}/.llama3java/models")
     Optional<Path> modelsPath();
 
     @ConfigGroup


### PR DESCRIPTION
Use `user.home` as default for models-path for jlama and llama3 docs

Code is using `user.home`:
 * https://github.com/quarkiverse/quarkus-langchain4j/blob/main/model-providers/jlama/runtime/src/main/java/io/quarkiverse/langchain4j/jlama/JlamaModelRegistry.java#L20
 * https://github.com/quarkiverse/quarkus-langchain4j/blob/main/model-providers/llama3-java/runtime/src/main/java/io/quarkiverse/langchain4j/llama3/Llama3ModelRegistry.java#L41

But the config docs default was using `user.name`