### PR TITLE
Support no authorization header being set when null is returned from ModelAuthProvider

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/auth/ModelAuthProvider.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/auth/ModelAuthProvider.java
@@ -23,6 +23,7 @@ public interface ModelAuthProvider {
      *
      * @param input representation of an HTTP request to the model provider.
      * @return authorization data which must include an HTTP Authorization scheme value, for example: "Bearer the_access_token".
+     *         Returning null will result in no Authorization header being set.
      */
     String getAuthorization(Input input);
 

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/OllamaRestApi.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/OllamaRestApi.java
@@ -170,10 +170,13 @@ public interface OllamaRestApi {
 
         @Override
         public void filter(ClientRequestContext context) {
-            context.getHeaders().putSingle(
-                    "Authorization",
-                    authorizer
-                            .getAuthorization(new AuthInputImpl(context.getMethod(), context.getUri(), context.getHeaders())));
+            String authValue = authorizer.getAuthorization(new AuthInputImpl(
+                    context.getMethod(),
+                    context.getUri(),
+                    context.getHeaders()));
+            if (authValue != null) {
+                context.getHeaders().putSingle("Authorization", authValue);
+            }
         }
 
         private record AuthInputImpl(

--- a/model-providers/ollama/runtime/src/test/java/io/quarkiverse/langchain4j/ollama/OllamaRestApiFilterTest.java
+++ b/model-providers/ollama/runtime/src/test/java/io/quarkiverse/langchain4j/ollama/OllamaRestApiFilterTest.java
@@ -1,0 +1,52 @@
+package io.quarkiverse.langchain4j.ollama;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.*;
+
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
+
+class OllamaRestApiFilterTest {
+
+    private ModelAuthProvider authProvider;
+    private ClientRequestContext context;
+    private MultivaluedHashMap<Object, Object> headers;
+    private OllamaRestApi.OllamaRestAPIFilter ollamaRestApiFilter;
+
+    @BeforeEach
+    void setUpFilter() {
+        context = mock(ClientRequestContext.class);
+        headers = new MultivaluedHashMap<>();
+        doReturn(headers).when(context).getHeaders();
+
+        authProvider = mock(ModelAuthProvider.class);
+
+        ollamaRestApiFilter = new OllamaRestApi.OllamaRestAPIFilter(authProvider);
+    }
+
+    @Test
+    void nullDoesNotSetAuthorization() {
+        doReturn(null).when(authProvider).getAuthorization(any());
+
+        ollamaRestApiFilter.filter(context);
+
+        assertNull(headers.getFirst("Authorization"));
+    }
+
+    @Test
+    void valueDoesSetAuthorization() {
+        var token = "token";
+        doReturn(token).when(authProvider).getAuthorization(any());
+
+        ollamaRestApiFilter.filter(context);
+
+        assertEquals(token, headers.getFirst("Authorization"));
+    }
+
+}

--- a/model-providers/openai/openai-common/runtime/pom.xml
+++ b/model-providers/openai/openai-common/runtime/pom.xml
@@ -26,6 +26,16 @@
             <artifactId>quarkus-langchain4j-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>dev.langchain4j</groupId>

--- a/model-providers/openai/openai-common/runtime/src/main/java/io/quarkiverse/langchain4j/openai/common/OpenAiRestApi.java
+++ b/model-providers/openai/openai-common/runtime/src/main/java/io/quarkiverse/langchain4j/openai/common/OpenAiRestApi.java
@@ -192,10 +192,11 @@ public interface OpenAiRestApi {
 
         @Override
         public void filter(ResteasyReactiveClientRequestContext requestContext) {
-            requestContext
-                    .getHeaders()
-                    .putSingle("Authorization", authorizer.getAuthorization(new AuthInputImpl(requestContext.getMethod(),
-                            requestContext.getUri(), requestContext.getHeaders())));
+            String authValue = authorizer.getAuthorization(new AuthInputImpl(requestContext.getMethod(),
+                    requestContext.getUri(), requestContext.getHeaders()));
+            if (authValue != null) {
+                requestContext.getHeaders().putSingle("Authorization", authValue);
+            }
         }
 
         private record AuthInputImpl(

--- a/model-providers/openai/openai-common/runtime/src/test/java/io/quarkiverse/langchain4j/openai/common/OpenAIRestAPIFilterTest.java
+++ b/model-providers/openai/openai-common/runtime/src/test/java/io/quarkiverse/langchain4j/openai/common/OpenAIRestAPIFilterTest.java
@@ -1,0 +1,52 @@
+package io.quarkiverse.langchain4j.openai.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.*;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+
+import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientRequestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
+
+public class OpenAIRestAPIFilterTest {
+
+    private ModelAuthProvider authProvider;
+    private ResteasyReactiveClientRequestContext context;
+    private MultivaluedHashMap<Object, Object> headers;
+    private OpenAiRestApi.OpenAIRestAPIFilter ollamaRestApiFilter;
+
+    @BeforeEach
+    void setUpFilter() {
+        context = mock(ResteasyReactiveClientRequestContext.class);
+        headers = new MultivaluedHashMap<>();
+        doReturn(headers).when(context).getHeaders();
+
+        authProvider = mock(ModelAuthProvider.class);
+
+        ollamaRestApiFilter = new OpenAiRestApi.OpenAIRestAPIFilter(authProvider);
+    }
+
+    @Test
+    void nullDoesNotSetAuthorization() {
+        doReturn(null).when(authProvider).getAuthorization(any());
+
+        ollamaRestApiFilter.filter(context);
+
+        assertNull(headers.getFirst("Authorization"));
+    }
+
+    @Test
+    void valueDoesSetAuthorization() {
+        var token = "token";
+        doReturn(token).when(authProvider).getAuthorization(any());
+
+        ollamaRestApiFilter.filter(context);
+
+        assertEquals(token, headers.getFirst("Authorization"));
+    }
+
+}

--- a/model-providers/vertex-ai-gemini/runtime/pom.xml
+++ b/model-providers/vertex-ai-gemini/runtime/pom.xml
@@ -35,8 +35,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-mockito</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/model-providers/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/VertxAiGeminiRestApi.java
+++ b/model-providers/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/VertxAiGeminiRestApi.java
@@ -146,11 +146,10 @@ public interface VertxAiGeminiRestApi {
                 public void run() {
                     try {
                         final Input authInput = new AuthInputImpl(context.getMethod(), context.getUri(), context.getHeaders());
-                        String authorization = authorizer != null ? authorizer.getAuthorization(authInput) : null;
-                        if (authorization == null) {
-                            authorization = defaultAuthorizer.getAuthorization(authInput);
+                        var auth = (authorizer != null ? authorizer : defaultAuthorizer).getAuthorization(authInput);
+                        if (auth != null) {
+                            context.getHeaders().add("Authorization", auth);
                         }
-                        context.getHeaders().add("Authorization", authorization);
                         context.resume();
                     } catch (Exception e) {
                         context.resume(e);

--- a/model-providers/vertex-ai-gemini/runtime/src/test/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/VertxAiGeminiRestApiTokenFilterTest.java
+++ b/model-providers/vertex-ai-gemini/runtime/src/test/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/VertxAiGeminiRestApiTokenFilterTest.java
@@ -1,0 +1,77 @@
+package io.quarkiverse.langchain4j.vertexai.runtime.gemini;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientRequestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class VertxAiGeminiRestApiTokenFilterTest {
+
+    @InjectMock
+    MyModelAuthProvider authProvider;
+
+    private ResteasyReactiveClientRequestContext context;
+    private MultivaluedHashMap<Object, Object> headers;
+    private VertxAiGeminiRestApi.TokenFilter ollamaRestApiFilter;
+
+    @BeforeEach
+    void setUpFilter() {
+        context = mock(ResteasyReactiveClientRequestContext.class);
+        headers = new MultivaluedHashMap<>();
+        doReturn(headers).when(context).getHeaders();
+
+        ollamaRestApiFilter = new VertxAiGeminiRestApi.TokenFilter(mockSyncExecutor());
+    }
+
+    private static ManagedExecutor mockSyncExecutor() {
+        ManagedExecutor executor = mock(ManagedExecutor.class);
+        // execute the runnable immediately, to avoid any async issues
+        doAnswer(invocation -> {
+            ((Runnable) invocation.getArgument(0)).run();
+            return null;
+        }).when(executor).submit(any(Runnable.class));
+        return executor;
+    }
+
+    @Test
+    void nullDoesNotSetAuthorization() {
+        doReturn(null).when(authProvider).getAuthorization(any());
+
+        ollamaRestApiFilter.filter(context);
+
+        assertNull(headers.getFirst("Authorization"));
+    }
+
+    @Test
+    void valueDoesSetAuthorization() {
+        var token = "token";
+        doReturn(token).when(authProvider).getAuthorization(any());
+
+        ollamaRestApiFilter.filter(context);
+
+        assertEquals(token, headers.getFirst("Authorization"));
+    }
+
+    @ApplicationScoped
+    static class MyModelAuthProvider implements ModelAuthProvider {
+
+        @Override
+        public String getAuthorization(Input input) {
+            fail("should never be called");
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
A typical use case is when the Authorization header is injected by a proxy (sidecar container).

Closes #1128