### PR TITLE
Store local models under `~/.langchain4j/models`

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -15,6 +15,7 @@
 ** xref:huggingface.adoc[HuggingFace]
 ** xref:ollama.adoc[Ollama]
 ** xref:jlama.adoc[Jlama]
+** xref:llama3.adoc[Llama3.java]
 ** xref:podman.adoc[Podman AI Lab]
 ** xref:anthropic.adoc[Anthropic (Claude)]
 ** xref:mistral.adoc[Mistral AI]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-jlama.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-jlama.adoc
@@ -108,7 +108,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_JLAMA_MODELS_PATH+++`
 endif::add-copy-button-to-env-var[]
 --
 |path
-|`${user.home}/.jlama/models`
+|`${user.home}/.langchain4j/models`
 
 a| [[quarkus-langchain4j-jlama_quarkus-langchain4j-jlama-chat-model-temperature]] [.property-path]##link:#quarkus-langchain4j-jlama_quarkus-langchain4j-jlama-chat-model-temperature[`quarkus.langchain4j.jlama.chat-model.temperature`]##
 

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-jlama_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-jlama_quarkus.langchain4j.adoc
@@ -108,7 +108,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_JLAMA_MODELS_PATH+++`
 endif::add-copy-button-to-env-var[]
 --
 |path
-|`${user.home}/.jlama/models`
+|`${user.home}/.langchain4j/models`
 
 a| [[quarkus-langchain4j-jlama_quarkus-langchain4j-jlama-chat-model-temperature]] [.property-path]##link:#quarkus-langchain4j-jlama_quarkus-langchain4j-jlama-chat-model-temperature[`quarkus.langchain4j.jlama.chat-model.temperature`]##
 

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-llama3-java.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-llama3-java.adoc
@@ -108,7 +108,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_LLAMA3_MODELS_PATH+++`
 endif::add-copy-button-to-env-var[]
 --
 |path
-|`${user.home}/.llama3java/models`
+|`${user.home}/.langchain4j/models`
 
 a| [[quarkus-langchain4j-llama3-java_quarkus-langchain4j-llama3-chat-model-temperature]] [.property-path]##link:#quarkus-langchain4j-llama3-java_quarkus-langchain4j-llama3-chat-model-temperature[`quarkus.langchain4j.llama3.chat-model.temperature`]##
 

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-llama3-java_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-llama3-java_quarkus.langchain4j.adoc
@@ -108,7 +108,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_LLAMA3_MODELS_PATH+++`
 endif::add-copy-button-to-env-var[]
 --
 |path
-|`${user.home}/.llama3java/models`
+|`${user.home}/.langchain4j/models`
 
 a| [[quarkus-langchain4j-llama3-java_quarkus-langchain4j-llama3-chat-model-temperature]] [.property-path]##link:#quarkus-langchain4j-llama3-java_quarkus-langchain4j-llama3-chat-model-temperature[`quarkus.langchain4j.llama3.chat-model.temperature`]##
 

--- a/docs/modules/ROOT/pages/jlama.adoc
+++ b/docs/modules/ROOT/pages/jlama.adoc
@@ -35,7 +35,7 @@ Quarkus LangChain4j automatically handles the pulling of the models configured b
 
 WARNING: When running Quarkus in dev mode C2 compilation is not enabled and this can make Jlama excessively slow. This limitation will be fixed with Quarkus 3.17 when `<forceC2>true</forceC2>` is set.
 
-WARNING: Models are huge, so make sure you have enough disk space.
+WARNING: Models are huge, so make sure you have enough disk space. Model location can be controlled using `quarkus.langchain4j.jlama.models-path` property.
 
 NOTE: Due to model's large size, pulling them can take time
 

--- a/docs/modules/ROOT/pages/llama3.adoc
+++ b/docs/modules/ROOT/pages/llama3.adoc
@@ -35,7 +35,7 @@ Quarkus LangChain4j automatically handles the pulling of the models configured b
 
 WARNING: When running Quarkus in dev mode C2 compilation is not enabled and this can make Llama3.java excessively slow. This limitation will be fixed with Quarkus 3.17 when `<forceC2>true</forceC2>` is set.
 
-WARNING: Models are huge, so make sure you have enough disk space.
+WARNING: Models are huge, so make sure you have enough disk space. Models location can be controlled using `quarkus.langchain4j.llama3.models-path` property.
 
 NOTE: Due to model's large size, pulling them can take time
 

--- a/model-providers/jlama/runtime/src/main/java/io/quarkiverse/langchain4j/jlama/JlamaModelRegistry.java
+++ b/model-providers/jlama/runtime/src/main/java/io/quarkiverse/langchain4j/jlama/JlamaModelRegistry.java
@@ -17,7 +17,7 @@ import com.github.tjake.jlama.util.ProgressReporter;
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class JlamaModelRegistry {
 
-    private static final String DEFAULT_MODEL_CACHE_PATH = System.getProperty("user.home", "") + File.separator + ".jlama"
+    private static final String DEFAULT_MODEL_CACHE_PATH = System.getProperty("user.home", "") + File.separator + ".langchain4j"
             + File.separator + "models";
     private final Path modelCachePath;
 

--- a/model-providers/jlama/runtime/src/main/java/io/quarkiverse/langchain4j/jlama/runtime/config/LangChain4jJlamaFixedRuntimeConfig.java
+++ b/model-providers/jlama/runtime/src/main/java/io/quarkiverse/langchain4j/jlama/runtime/config/LangChain4jJlamaFixedRuntimeConfig.java
@@ -38,7 +38,7 @@ public interface LangChain4jJlamaFixedRuntimeConfig {
      * Location on the file-system which serves as a cache for the models
      *
      */
-    @ConfigDocDefault("${user.home}/.jlama/models")
+    @ConfigDocDefault("${user.home}/.langchain4j/models")
     Optional<Path> modelsPath();
 
     @ConfigGroup

--- a/model-providers/llama3-java/runtime/src/main/java/io/quarkiverse/langchain4j/llama3/Llama3ModelRegistry.java
+++ b/model-providers/llama3-java/runtime/src/main/java/io/quarkiverse/langchain4j/llama3/Llama3ModelRegistry.java
@@ -38,7 +38,7 @@ public class Llama3ModelRegistry {
 
     private static final Logger log = Logger.getLogger(Llama3ModelRegistry.class);
 
-    private static final String DEFAULT_MODEL_CACHE_PATH = System.getProperty("user.home", "") + File.separator + ".llama3java"
+    private static final String DEFAULT_MODEL_CACHE_PATH = System.getProperty("user.home", "") + File.separator + ".langchain4j"
             + File.separator + "models";
     public static String FINISHED_MARKER = ".finished";
 

--- a/model-providers/llama3-java/runtime/src/main/java/io/quarkiverse/langchain4j/llama3/runtime/config/LangChain4jLlama3FixedRuntimeConfig.java
+++ b/model-providers/llama3-java/runtime/src/main/java/io/quarkiverse/langchain4j/llama3/runtime/config/LangChain4jLlama3FixedRuntimeConfig.java
@@ -38,7 +38,7 @@ public interface LangChain4jLlama3FixedRuntimeConfig {
      * Location on the file-system which serves as a cache for the models
      *
      */
-    @ConfigDocDefault("${user.home}/.llama3java/models")
+    @ConfigDocDefault("${user.home}/.langchain4j/models")
     Optional<Path> modelsPath();
 
     @ConfigGroup


### PR DESCRIPTION
Store local models under `~/.langchain4j/models`

Fixes https://github.com/quarkiverse/quarkus-langchain4j/issues/1133

Location of cached models changes from `${user.home}/.jlama/models` and `${user.home}/.llama3java/models` to single `${user.home}/.langchain4j/models`.
Current `quarkus-langchain4j-jlama` and `quarkus-langchain4j-llama3-java` users can rename the old directory to `${user.home}/.langchain4j` to avoid new downloads of the models after upgrade.

I have included some minor changes in this PR (separate commits) related to jlama and llama3:
 * Include Llama3.java in navigation
 * Hint about models-path property in jlama and llama3 docs