### PR TITLE
Update Azure OpenAI to check ModelAuthProvider during Embedding and Image model creation

### DIFF
--- a/model-providers/openai/azure-openai/deployment/src/main/java/io/quarkiverse/langchain4j/azure/openai/deployment/AzureOpenAiProcessor.java
+++ b/model-providers/openai/azure-openai/deployment/src/main/java/io/quarkiverse/langchain4j/azure/openai/deployment/AzureOpenAiProcessor.java
@@ -121,13 +121,17 @@ public class AzureOpenAiProcessor {
         for (var selected : selectedEmbedding) {
             if (PROVIDER.equals(selected.getProvider())) {
                 String configName = selected.getConfigName();
+
+                var embeddingModel = recorder.embeddingModel(config, configName);
                 var builder = SyntheticBeanBuildItem
                         .configure(EMBEDDING_MODEL)
                         .setRuntimeInit()
                         .unremovable()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.embeddingModel(config, configName));
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ClassType.create(DotNames.MODEL_AUTH_PROVIDER) }, null))
+                        .createWith(embeddingModel);
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }
@@ -136,12 +140,16 @@ public class AzureOpenAiProcessor {
         for (var selected : selectedImage) {
             if (PROVIDER.equals(selected.getProvider())) {
                 String configName = selected.getConfigName();
+
+                var imageModel = recorder.imageModel(config, configName);
                 var builder = SyntheticBeanBuildItem
                         .configure(IMAGE_MODEL)
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.imageModel(config, configName));
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ClassType.create(DotNames.MODEL_AUTH_PROVIDER) }, null))
+                        .createWith(imageModel);
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }

--- a/model-providers/openai/azure-openai/runtime/src/test/java/io/quarkiverse/langchain4j/azure/openai/runtime/DisabledModelsAzureOpenAiRecorderTest.java
+++ b/model-providers/openai/azure-openai/runtime/src/test/java/io/quarkiverse/langchain4j/azure/openai/runtime/DisabledModelsAzureOpenAiRecorderTest.java
@@ -45,14 +45,14 @@ class DisabledModelsAzureOpenAiRecorderTest {
 
     @Test
     void disabledEmbeddingModel() {
-        assertThat(recorder.embeddingModel(config, NamedConfigUtil.DEFAULT_NAME).get())
+        assertThat(recorder.embeddingModel(config, NamedConfigUtil.DEFAULT_NAME).apply(null))
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledEmbeddingModel.class);
     }
 
     @Test
     void disabledImageModel() {
-        assertThat(recorder.imageModel(config, NamedConfigUtil.DEFAULT_NAME).get())
+        assertThat(recorder.imageModel(config, NamedConfigUtil.DEFAULT_NAME).apply(null))
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledImageModel.class);
     }


### PR DESCRIPTION
Fixes #1155.

@geoand I've updated it the same way we did checks for `ChatModel` and `StreamingChatModel`.

I've confirmed that with this PR, after deploying `text-embedding-ada-002` in my Azure OpenAI account, with the `secure-poem-multiple-providers` demo, that if I add

```
quarkus.langchain4j.openai.embedding-model.provider=azure-openai
quarkus.langchain4j.azure-openai.embedding-model.resource-name=quarkus-langchain4j
#default deployment name
quarkus.langchain4j.azure-openai.embedding-model.deployment-name=text-embedding-ada-002
quarkus.langchain4j.azure-openai.embedding-model.log-requests=true
quarkus.langchain4j.azure-openai.embedding-model.log-responses=true
``` 

and have `EmbeddingModel` injected and the Azure OpenAI related method updated to

```
@GET
@Path("azure-openai")
public String getPoemAzureOpenAI() {
    Response<AiMessage> response = azureOpenAI.generate(USER_MESSAGE);
    TokenUsage tokenUsage = embeddingModel.embed(response.content().text()).tokenUsage();
    return response.content().text() + ". Input token: " + tokenUsage.inputTokenCount();
}
``` 

I get the token count and logs confirming the remote call was successful, with the user authentication token:


```
Request:
- method: POST
- url: https://quarkus-langchain4j.openai.azure.com/openai/deployments/text-embedding-ada-002/embeddings?api-version=2023-05-15
- headers: [Accept: application/json], [Authorization: Be...Mw], [Content-Type: application/json], [User-Agent: langchain4j-quarkus-azure-openai], [content-length: 226]
- body: {
  "model" : "text-embedding-ada-002",
  "input" : [ "Java, oh Java, language of code,\nYou make my programs run and decode.\nWith syntax clean and concise,\nYou bring my projects to life.\n\n- Written by the ModelMaster" ]
}

```

```
Response:

 headers: [Content-Length: 33488], [Content-Type: application/json], [apim-request-id: ...], [x-ratelimit-remaining-requests: 119], ..., [x-ms-region: West Europe], [azureml-model-session: ...], [x-ratelimit-remaining-tokens: 119959], [Date: Sat, 14 Dec 2024 17:41:07 GMT]
- body: {
  "object": "list",
  "data": [
    {
      "object": "embedding",
      "index": 0,
      "embedding": [
        0.0070286347,
        -0.007915613,
        -0.0083591025,
         ...
        -0.018787824
      ]
    }
  ],
  "model": "ada",
  "usage": {
    "prompt_tokens": 36,
    "total_tokens": 36
  }
}

```

I haven't actually updated the demo, because Google authentication plus Gemini is also shown there and it is not clear to me yet what Vertex-AI offers for embedding models, while having Azure OpenAI only embedding model would impact users who only want to try the demo with Gemini... May be we can do an advanced, everything Azure OpenAI kind of demo later, but for now, I can confirm the updates in this PR are sufficient. 