### PR TITLE
Fix BeanIfExistsToolProviderSupplier, introduce NoToolProviderSupplier

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
@@ -349,10 +349,14 @@ public class AiServicesProcessor {
             DotName toolProviderClassName = LangChain4jDotNames.BEAN_IF_EXISTS_TOOL_PROVIDER_SUPPLIER;
             AnnotationValue toolProviderValue = instance.value("toolProviderSupplier");
             if (toolProviderValue != null) {
-                toolProviderClassName = toolProviderValue.asClass().name();
-                validateSupplierAndRegisterForReflection(toolProviderClassName, index, reflectiveClassProducer);
-                toolProviderInfos.add(new ToolProviderInfo(toolProviderClassName.toString(),
-                        declarativeAiServiceClassInfo.simpleName()));
+                if (LangChain4jDotNames.NO_TOOL_PROVIDER_SUPPLIER.equals(toolProviderValue.asClass().name())) {
+                    toolProviderClassName = null;
+                } else {
+                    toolProviderClassName = toolProviderValue.asClass().name();
+                    validateSupplierAndRegisterForReflection(toolProviderClassName, index, reflectiveClassProducer);
+                    toolProviderInfos.add(new ToolProviderInfo(toolProviderClassName.toString(),
+                            declarativeAiServiceClassInfo.simpleName()));
+                }
             }
 
             DotName imageModelSupplierClassName = LangChain4jDotNames.BEAN_IF_EXISTS_IMAGE_MODEL_SUPPLIER;
@@ -753,7 +757,11 @@ public class AiServicesProcessor {
                 needsImageModelBean = true;
             }
 
-            if (!RegisterAiService.BeanIfExistsToolProviderSupplier.class.getName()
+            if (RegisterAiService.BeanIfExistsToolProviderSupplier.class.getName()
+                    .equals(toolProviderSupplierClassName)) {
+                configurator.addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                        new Type[] { ClassType.create(LangChain4jDotNames.TOOL_PROVIDER) }, null));
+            } else if (!RegisterAiService.BeanIfExistsToolProviderSupplier.class.getName()
                     .equals(toolProviderSupplierClassName) && toolProviderSupplierClassName != null) {
                 DotName toolProvider = DotName.createSimple(toolProviderSupplierClassName);
                 configurator.addInjectionPoint(ClassType.create(toolProvider));

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/LangChain4jDotNames.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/LangChain4jDotNames.java
@@ -25,6 +25,7 @@ import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.TokenStream;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.UserName;
+import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.web.search.WebSearchEngine;
 import dev.langchain4j.web.search.WebSearchTool;
 import io.quarkiverse.langchain4j.CreatedAware;
@@ -104,6 +105,9 @@ public class LangChain4jDotNames {
     static final DotName BEAN_IF_EXISTS_TOOL_PROVIDER_SUPPLIER = DotName.createSimple(
             RegisterAiService.BeanIfExistsToolProviderSupplier.class);
 
+    static final DotName NO_TOOL_PROVIDER_SUPPLIER = DotName.createSimple(
+            RegisterAiService.NoToolProviderSupplier.class);
+
     static final DotName QUARKUS_AI_SERVICE_CONTEXT_QUALIFIER = DotName.createSimple(
             QuarkusAiServiceContextQualifier.class);
 
@@ -113,5 +117,5 @@ public class LangChain4jDotNames {
     static final DotName WEB_SEARCH_ENGINE = DotName.createSimple(WebSearchEngine.class);
     static final DotName IMAGE = DotName.createSimple(Image.class);
     static final DotName RESULT = DotName.createSimple(Result.class);
-    static final DotName TOOL_PROVIDER = DotName.createSimple(ToolProcessor.class);
+    static final DotName TOOL_PROVIDER = DotName.createSimple(ToolProvider.class);
 }

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ToolProviderTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ToolProviderTest.java
@@ -39,7 +39,10 @@ class ToolProviderTest {
     MyServiceWithCustomToolProvider myServiceWithTools;
 
     @Inject
-    MyServiceWithDefaultToolProviderConfig myServiceWithoutTools;
+    MyServiceWithDefaultToolProviderConfig myServiceWithIfExistsTools;
+
+    @Inject
+    MyServiceWithNoToolProvider myServiceWithNoToolProvider;
 
     @ApplicationScoped
     public static class MyCustomToolProviderSupplier implements Supplier<ToolProvider> {
@@ -108,9 +111,14 @@ class ToolProviderTest {
         String chat(@UserMessage String msg, @MemoryId Object id);
     }
 
-    @RegisterAiService(chatLanguageModelSupplier = BlockingChatLanguageModelSupplierTest.MyModelSupplier.class, chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
+    @RegisterAiService(chatLanguageModelSupplier = TestAiSupplier.class)
     interface MyServiceWithDefaultToolProviderConfig {
-        String chat(String msg);
+        String chat(@UserMessage String msg, @MemoryId Object id);
+    }
+
+    @RegisterAiService(toolProviderSupplier = RegisterAiService.NoToolProviderSupplier.class, chatLanguageModelSupplier = TestAiSupplier.class, chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
+    interface MyServiceWithNoToolProvider {
+        String chat(@UserMessage String msg, @MemoryId Object id);
     }
 
     @RegisterExtension
@@ -128,8 +136,15 @@ class ToolProviderTest {
 
     @Test
     @ActivateRequestContext
+    void testCallDefaultTools() {
+        String answer = myServiceWithIfExistsTools.chat("hello", 1);
+        assertEquals("0", answer);
+    }
+
+    @Test
+    @ActivateRequestContext
     void testCallNoTools() {
-        String answer = myServiceWithoutTools.chat("hello");
+        String answer = myServiceWithNoToolProvider.chat("hello", 1);
         assertEquals("42", answer);
     }
 }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/RegisterAiService.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/RegisterAiService.java
@@ -210,6 +210,17 @@ public @interface RegisterAiService {
     }
 
     /**
+     * Marker that is used when the user does not want any tool provider
+     */
+    final class NoToolProviderSupplier implements Supplier<ToolProvider> {
+
+        @Override
+        public ToolProvider get() {
+            throw new UnsupportedOperationException("should never be called");
+        }
+    }
+
+    /**
      * Marker that is used to tell Quarkus to use the {@link RetrievalAugmentor} that the user has configured as a CDI bean.
      * If no such bean exists, then no retrieval augmentor will be used.
      */


### PR DESCRIPTION
This makes tool provider autowiring work the same as for retrieval augmentors, audit service, moderation model...

Prerequisite for https://github.com/quarkiverse/quarkus-langchain4j/issues/1146 (draft PR coming soon)