### PR TITLE
Don't require api key when using custom base url for mistralai

### DIFF
--- a/model-providers/mistral/runtime/src/main/java/io/quarkiverse/langchain4j/mistralai/runtime/MistralAiRecorder.java
+++ b/model-providers/mistral/runtime/src/main/java/io/quarkiverse/langchain4j/mistralai/runtime/MistralAiRecorder.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.langchain4j.mistralai.runtime;
 
+import static io.quarkiverse.langchain4j.mistralai.runtime.config.LangChain4jMistralAiConfig.MistralAiConfig.DEFAULT_API_KEY;
+import static io.quarkiverse.langchain4j.mistralai.runtime.config.LangChain4jMistralAiConfig.MistralAiConfig.DEFAULT_BASE_URL;
 import static io.quarkiverse.langchain4j.runtime.OptionalUtil.firstOrDefault;
 
 import java.time.Duration;
@@ -27,22 +29,22 @@ import io.smallrye.config.ConfigValidationException;
 
 @Recorder
 public class MistralAiRecorder {
-    private static final String DUMMY_KEY = "dummy";
 
     public Supplier<ChatLanguageModel> chatModel(LangChain4jMistralAiConfig runtimeConfig, String configName) {
         LangChain4jMistralAiConfig.MistralAiConfig mistralAiConfig = correspondingMistralAiConfig(runtimeConfig,
                 configName);
 
         if (mistralAiConfig.enableIntegration()) {
-            String apiKey = mistralAiConfig.apiKey();
             ChatModelConfig chatModelConfig = mistralAiConfig.chatModel();
 
-            if (DUMMY_KEY.equals(apiKey)) {
+            String apiKey = mistralAiConfig.apiKey();
+            String baseUrl = mistralAiConfig.baseUrl();
+            if (DEFAULT_API_KEY.equals(apiKey) && DEFAULT_BASE_URL.equals(baseUrl)) {
                 throw new ConfigValidationException(createApiKeyConfigProblem(configName));
             }
 
             var builder = MistralAiChatModel.builder()
-                    .baseUrl(mistralAiConfig.baseUrl())
+                    .baseUrl(baseUrl)
                     .apiKey(apiKey)
                     .modelName(chatModelConfig.modelName())
                     .logRequests(firstOrDefault(false, chatModelConfig.logRequests(), mistralAiConfig.logRequests()))
@@ -87,15 +89,16 @@ public class MistralAiRecorder {
                 configName);
 
         if (mistralAiConfig.enableIntegration()) {
-            String apiKey = mistralAiConfig.apiKey();
             ChatModelConfig chatModelConfig = mistralAiConfig.chatModel();
 
-            if (DUMMY_KEY.equals(apiKey)) {
+            String apiKey = mistralAiConfig.apiKey();
+            String baseUrl = mistralAiConfig.baseUrl();
+            if (DEFAULT_API_KEY.equals(apiKey) && DEFAULT_BASE_URL.equals(baseUrl)) {
                 throw new ConfigValidationException(createApiKeyConfigProblem(configName));
             }
 
             var builder = MistralAiStreamingChatModel.builder()
-                    .baseUrl(mistralAiConfig.baseUrl())
+                    .baseUrl(baseUrl)
                     .apiKey(apiKey)
                     .modelName(chatModelConfig.modelName())
                     .logRequests(firstOrDefault(false, chatModelConfig.logRequests(), mistralAiConfig.logRequests()))
@@ -139,10 +142,11 @@ public class MistralAiRecorder {
                 configName);
 
         if (mistralAiConfig.enableIntegration()) {
-            String apiKey = mistralAiConfig.apiKey();
             EmbeddingModelConfig embeddingModelConfig = mistralAiConfig.embeddingModel();
 
-            if (DUMMY_KEY.equals(apiKey)) {
+            String apiKey = mistralAiConfig.apiKey();
+            String baseUrl = mistralAiConfig.baseUrl();
+            if (DEFAULT_API_KEY.equals(apiKey) && DEFAULT_BASE_URL.equals(baseUrl)) {
                 throw new ConfigValidationException(createApiKeyConfigProblem(configName));
             }
 
@@ -175,15 +179,16 @@ public class MistralAiRecorder {
                 configName);
 
         if (mistralAiConfig.enableIntegration()) {
-            String apiKey = mistralAiConfig.apiKey();
             ModerationModelConfig moderationModelConfig = mistralAiConfig.moderationModel();
 
-            if (DUMMY_KEY.equals(apiKey)) {
+            String apiKey = mistralAiConfig.apiKey();
+            String baseUrl = mistralAiConfig.baseUrl();
+            if (DEFAULT_API_KEY.equals(apiKey) && DEFAULT_BASE_URL.equals(baseUrl)) {
                 throw new ConfigValidationException(createApiKeyConfigProblem(configName));
             }
 
             var builder = new MistralAiModerationModel.Builder()
-                    .baseUrl(mistralAiConfig.baseUrl())
+                    .baseUrl(baseUrl)
                     .apiKey(apiKey)
                     .modelName(moderationModelConfig.modelName())
                     .logRequests(firstOrDefault(false, moderationModelConfig.logRequests(), mistralAiConfig.logRequests()))

--- a/model-providers/mistral/runtime/src/main/java/io/quarkiverse/langchain4j/mistralai/runtime/config/LangChain4jMistralAiConfig.java
+++ b/model-providers/mistral/runtime/src/main/java/io/quarkiverse/langchain4j/mistralai/runtime/config/LangChain4jMistralAiConfig.java
@@ -37,16 +37,20 @@ public interface LangChain4jMistralAiConfig {
 
     @ConfigGroup
     interface MistralAiConfig {
+
+        String DEFAULT_BASE_URL = "https://api.mistral.ai/v1/";
+        String DEFAULT_API_KEY = "dummy";
+
         /**
          * Base URL of Mistral API
          */
-        @WithDefault("https://api.mistral.ai/v1/")
+        @WithDefault(DEFAULT_BASE_URL)
         String baseUrl();
 
         /**
          * Mistral API key
          */
-        @WithDefault("dummy") // TODO: this should be optional but Smallrye Config doesn't like it
+        @WithDefault(DEFAULT_API_KEY)
         String apiKey();
 
         /**


### PR DESCRIPTION
This fixes an issue I encountered where Mistral AI requires apiKey even when setting a custom baseUrl.