### PR TITLE
Add keys to override config for chat, embedding and image-model for Azure OpenAI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,9 @@ release.properties
 # Quarkus CLI
 .quarkus
 
+# dotenv
+.env
+
 #Dolphin
 .directory
 /samples/chatbot/dev.sh

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
@@ -30,7 +30,6 @@ import io.quarkiverse.langchain4j.azure.openai.AzureOpenAiEmbeddingModel;
 import io.quarkiverse.langchain4j.azure.openai.AzureOpenAiImageModel;
 import io.quarkiverse.langchain4j.azure.openai.AzureOpenAiStreamingChatModel;
 import io.quarkiverse.langchain4j.azure.openai.runtime.config.ChatModelConfig;
-import io.quarkiverse.langchain4j.azure.openai.runtime.config.EmbeddingModelConfig;
 import io.quarkiverse.langchain4j.azure.openai.runtime.config.LangChain4jAzureOpenAiConfig;
 import io.quarkiverse.langchain4j.azure.openai.runtime.config.LangChain4jAzureOpenAiConfig.AzureAiConfig.EndpointType;
 import io.quarkiverse.langchain4j.openai.common.QuarkusOpenAiClient;
@@ -58,17 +57,16 @@ public class AzureOpenAiRecorder {
         LangChain4jAzureOpenAiConfig.AzureAiConfig azureAiConfig = correspondingAzureOpenAiConfig(runtimeConfig, configName);
 
         if (azureAiConfig.enableIntegration()) {
-            ChatModelConfig chatModelConfig = azureAiConfig.chatModel();
-            String apiKey = azureAiConfig.apiKey().orElse(null);
-            String adToken = azureAiConfig.adToken().orElse(null);
-
+            var chatModelConfig = azureAiConfig.chatModel();
+            var apiKey = firstOrDefault(null, chatModelConfig.apiKey(), azureAiConfig.apiKey());
+            var adToken = firstOrDefault(null, chatModelConfig.adToken(), azureAiConfig.adToken());
             var builder = AzureOpenAiChatModel.builder()
                     .endpoint(getEndpoint(azureAiConfig, configName, EndpointType.CHAT))
                     .configName(NamedConfigUtil.isDefault(configName) ? null : configName)
                     .apiKey(apiKey)
                     .adToken(adToken)
                     // .tokenizer(new OpenAiTokenizer("<modelName>")) TODO: Set the tokenizer, it is always null!!
-                    .apiVersion(azureAiConfig.apiVersion())
+                    .apiVersion(chatModelConfig.apiVersion().orElse(azureAiConfig.apiVersion()))
                     .timeout(azureAiConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .maxRetries(azureAiConfig.maxRetries())
                     .logRequests(firstOrDefault(false, chatModelConfig.logRequests(), azureAiConfig.logRequests()))
@@ -158,15 +156,15 @@ public class AzureOpenAiRecorder {
         LangChain4jAzureOpenAiConfig.AzureAiConfig azureAiConfig = correspondingAzureOpenAiConfig(runtimeConfig, configName);
 
         if (azureAiConfig.enableIntegration()) {
-            EmbeddingModelConfig embeddingModelConfig = azureAiConfig.embeddingModel();
-            String apiKey = azureAiConfig.apiKey().orElse(null);
-            String adToken = azureAiConfig.adToken().orElse(null);
+            var embeddingModelConfig = azureAiConfig.embeddingModel();
+            var apiKey = firstOrDefault(null, embeddingModelConfig.apiKey(), azureAiConfig.apiKey());
+            var adToken = firstOrDefault(null, embeddingModelConfig.adToken(), azureAiConfig.adToken());
             var builder = AzureOpenAiEmbeddingModel.builder()
                     .endpoint(getEndpoint(azureAiConfig, configName, EndpointType.EMBEDDING))
                     .apiKey(apiKey)
                     .adToken(adToken)
                     .configName(NamedConfigUtil.isDefault(configName) ? null : configName)
-                    .apiVersion(azureAiConfig.apiVersion())
+                    .apiVersion(embeddingModelConfig.apiVersion().orElse(azureAiConfig.apiVersion()))
                     .timeout(azureAiConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .maxRetries(azureAiConfig.maxRetries())
                     .logRequests(firstOrDefault(false, embeddingModelConfig.logRequests(), azureAiConfig.logRequests()))
@@ -195,15 +193,14 @@ public class AzureOpenAiRecorder {
         LangChain4jAzureOpenAiConfig.AzureAiConfig azureAiConfig = correspondingAzureOpenAiConfig(runtimeConfig, configName);
 
         if (azureAiConfig.enableIntegration()) {
-            var apiKey = azureAiConfig.apiKey().orElse(null);
-            String adToken = azureAiConfig.adToken().orElse(null);
-
             var imageModelConfig = azureAiConfig.imageModel();
+            var apiKey = firstOrDefault(null, imageModelConfig.apiKey(), azureAiConfig.apiKey());
+            var adToken = firstOrDefault(null, imageModelConfig.adToken(), azureAiConfig.adToken());
             var builder = AzureOpenAiImageModel.builder()
                     .endpoint(getEndpoint(azureAiConfig, configName, EndpointType.IMAGE))
                     .apiKey(apiKey)
                     .adToken(adToken)
-                    .apiVersion(azureAiConfig.apiVersion())
+                    .apiVersion(imageModelConfig.apiVersion().orElse(azureAiConfig.apiVersion()))
                     .timeout(azureAiConfig.timeout().orElse(Duration.ofSeconds(10)))
                     .maxRetries(azureAiConfig.maxRetries())
                     .logRequests(firstOrDefault(false, imageModelConfig.logRequests(), azureAiConfig.logRequests()))

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/ChatModelConfig.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/ChatModelConfig.java
@@ -37,6 +37,23 @@ public interface ChatModelConfig {
     Optional<String> endpoint();
 
     /**
+     * The Azure AD token to use for this operation.
+     * If present, then the requests towards OpenAI will include this in the Authorization header.
+     * Note that this property overrides the functionality of {@code quarkus.langchain4j.azure-openai.embedding-model.api-key}.
+     */
+    Optional<String> adToken();
+
+    /**
+     * The API version to use for this operation. This follows the YYYY-MM-DD format
+     */
+    Optional<String> apiVersion();
+
+    /**
+     * Azure OpenAI API key
+     */
+    Optional<String> apiKey();
+
+    /**
      * What sampling temperature to use, with values between 0 and 2.
      * Higher values means the model will take more risks.
      * A value of 0.9 is good for more creative applications, while 0 (argmax sampling) is good for ones with a well-defined

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/EmbeddingModelConfig.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/EmbeddingModelConfig.java
@@ -32,6 +32,23 @@ public interface EmbeddingModelConfig {
     Optional<String> endpoint();
 
     /**
+     * The Azure AD token to use for this operation.
+     * If present, then the requests towards OpenAI will include this in the Authorization header.
+     * Note that this property overrides the functionality of {@code quarkus.langchain4j.azure-openai.embedding-model.api-key}.
+     */
+    Optional<String> adToken();
+
+    /**
+     * The API version to use for this operation. This follows the YYYY-MM-DD format
+     */
+    Optional<String> apiVersion();
+
+    /**
+     * Azure OpenAI API key
+     */
+    Optional<String> apiKey();
+
+    /**
      * Whether embedding model requests should be logged
      */
     @ConfigDocDefault("false")

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/ImageModelConfig.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/ImageModelConfig.java
@@ -34,6 +34,23 @@ public interface ImageModelConfig {
     Optional<String> endpoint();
 
     /**
+     * The Azure AD token to use for this operation.
+     * If present, then the requests towards OpenAI will include this in the Authorization header.
+     * Note that this property overrides the functionality of {@code quarkus.langchain4j.azure-openai.embedding-model.api-key}.
+     */
+    Optional<String> adToken();
+
+    /**
+     * The API version to use for this operation. This follows the YYYY-MM-DD format
+     */
+    Optional<String> apiVersion();
+
+    /**
+     * Azure OpenAI API key
+     */
+    Optional<String> apiKey();
+
+    /**
      * Model name to use
      */
     @WithDefault("dall-e-3")

--- a/model-providers/openai/azure-openai/runtime/src/test/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorderEndpointTests.java
+++ b/model-providers/openai/azure-openai/runtime/src/test/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorderEndpointTests.java
@@ -220,6 +220,21 @@ class AzureOpenAiRecorderEndpointTests {
                 }
 
                 @Override
+                public Optional<String> adToken() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> apiVersion() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> apiKey() {
+                    return Optional.empty();
+                }
+
+                @Override
                 public Double temperature() {
                     return null;
                 }
@@ -286,6 +301,21 @@ class AzureOpenAiRecorderEndpointTests {
                 }
 
                 @Override
+                public Optional<String> adToken() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> apiVersion() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> apiKey() {
+                    return Optional.empty();
+                }
+
+                @Override
                 public Optional<Boolean> logRequests() {
                     return Optional.empty();
                 }
@@ -294,6 +324,7 @@ class AzureOpenAiRecorderEndpointTests {
                 public Optional<Boolean> logResponses() {
                     return Optional.empty();
                 }
+
             };
         }
 
@@ -317,6 +348,21 @@ class AzureOpenAiRecorderEndpointTests {
 
                 @Override
                 public Optional<String> endpoint() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> adToken() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> apiVersion() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> apiKey() {
                     return Optional.empty();
                 }
 


### PR DESCRIPTION
For chat, embedding, and image-model: api-key, ad-token, api-version

- Closes: #1154