### PR TITLE
Typo fixes in samples and JandexUtil + EmbeddingStoreJsonRPCService from core

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/JandexUtil.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/JandexUtil.java
@@ -229,7 +229,7 @@ class JandexUtil {
         // figure out which arguments we passed to the supertype
         List<Type> appliedArguments;
 
-        // we passed them explicitely
+        // we passed them explicitly
         if (appliedType.kind() == Type.Kind.PARAMETERIZED_TYPE) {
             appliedArguments = appliedType.asParameterizedType().arguments();
         } else {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/devui/EmbeddingStoreJsonRPCService.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/devui/EmbeddingStoreJsonRPCService.java
@@ -72,7 +72,7 @@ public class EmbeddingStoreJsonRPCService {
     private static final Pattern COMMA_OR_NEWLINE = Pattern.compile(",|\\r?\\n");
 
     public String add(String id, String text, String metadata) {
-        verifyEmbedingModelAndStore();
+        verifyEmbeddingModelAndStore();
         if (id == null || id.isEmpty()) {
             return embeddingStore.add(embeddingModel.embed(text).content(), TextSegment.from(text, parseMetadata(metadata)));
         } else {
@@ -96,7 +96,7 @@ public class EmbeddingStoreJsonRPCService {
     // FIXME: the limit argument can be changed to int after https://github.com/quarkusio/quarkus/issues/37481 is fixed
     // LangChain4jDevUIJsonRpcTest will need to be adjusted accordingly
     public JsonArray findRelevant(String text, String limit) {
-        verifyEmbedingModelAndStore();
+        verifyEmbeddingModelAndStore();
         int limitInt = Integer.parseInt(limit);
         JsonArray result = new JsonArray();
         for (EmbeddingMatch<TextSegment> match : embeddingStore.findRelevant(embeddingModel.embed(text).content(), limitInt)) {
@@ -119,7 +119,7 @@ public class EmbeddingStoreJsonRPCService {
         return result;
     }
 
-    private void verifyEmbedingModelAndStore() {
+    private void verifyEmbeddingModelAndStore() {
         if (embeddingModel == null) {
             throw new RuntimeException("No embedding model found in CDI. Please add an embedding model to your application.");
         }

--- a/samples/email-a-poem/README.md
+++ b/samples/email-a-poem/README.md
@@ -77,7 +77,7 @@ echo http://localhost:$GRAFANA_PORT
 
 Open your browser at `http://localhost:${GRAFANA_PORT}`
 
-When prompted to login, use `admin:admin`  as the username / password combination.
+When prompted to log in, use `admin:admin`  as the username / password combination.
 
 From the menu on the top left, click on `Explore`. On the page, select `Tempo` as the datasource (next to `Outline`), then go to `Query type`, select `Search` and select `quarkus-langchain4j-sample-poem` from the dropdown options of `Service Name`.
 Now hit `Run query` in the top right corner.

--- a/samples/secure-fraud-detection/README.md
+++ b/samples/secure-fraud-detection/README.md
@@ -23,7 +23,7 @@ To enable fraud detection, we provide the LLM with access to the custom [FraudDe
 
 `FraudDetectionContentRetriever` is registered by [FraudDetectionRetrievalAugmentor](./src/main/java/io/quarkiverse/langchain4j/samples/FraudDetectionRetrievalAugmentor.java).
 
-It can only be accessed securely and it retrieves transaction data for the currently authenticated user through two Panache repositories:
+It can only be accessed securely, and it retrieves transaction data for the currently authenticated user through two Panache repositories:
 
 - [CustomerRepository.java](./src/main/java/io/quarkiverse/langchain4j/samples/CustomerRepository.java)
 - [TransactionRepository.java](./src/main/java/io/quarkiverse/langchain4j/samples/TransactionRepository.java)

--- a/samples/secure-poem-multiple-models/README.md
+++ b/samples/secure-poem-multiple-models/README.md
@@ -4,9 +4,9 @@ This advanced secure poem demo showcases how users authenticated with Google can
 
 ## The Demo
 
-Demo asks either Vertex AI Gemini or Azure OpenAI LLM to write a short 1 paragraph poem, using the access token acquired during the OIDC authorization code flow with either Google or Microsoft Entra ID OpenId Connect provider.
+Demo asks either Vertex AI Gemini or Azure OpenAI LLM to write a short 1-paragraph poem, using the access token acquired during the OIDC authorization code flow with either Google or Microsoft Entra ID OpenId Connect provider.
 
-### OpenId Connect authenticaion
+### OpenId Connect authentication
 
 This demo requires users to authenticate with either Google or Microsoft Entra ID.
 
@@ -96,7 +96,7 @@ quarkus.langchain4j.azure-openai.openai.log-responses=true
 
 ### ChatLanguageModel
 
-This demo leverages ChatLanguageModel instead of the the AI service abstraction to simplify managing multiple models, with the interaction between the LLM and the application handled through the ChatLanguageModel interface.
+This demo leverages ChatLanguageModel instead of the AI service abstraction to simplify managing multiple models, with the interaction between the LLM and the application handled through the ChatLanguageModel interface.
 
 ```java
 package io.quarkiverse.langchain4j.sample;
@@ -167,7 +167,7 @@ mvn quarkus:dev
 ```
 
 Access `http://localhost:8080`, login to Quarkus PoemResource using either Google or Microsoft Entra ID, and follow a provided application link to read the poem.
-Use the logout link to logout and try another OpenId Connect provider and model. For example, if you've started with Google and Vertex AI Gemini, try Microsoft Entra ID and Azure OpenAI next, or vice versa.
+Use the logout link to log out and try another OpenId Connect provider and model. For example, if you've started with Google and Vertex AI Gemini, try Microsoft Entra ID and Azure OpenAI next, or vice versa.
 
 You do not have to have both Google and Microsoft Entra ID accounts enabled in order to run this demo.
 

--- a/samples/secure-sql-chatbot/README.md
+++ b/samples/secure-sql-chatbot/README.md
@@ -80,9 +80,9 @@ It eliminates a risk of non-authenticated users attempting to trick LLM.
 Even though browsers do not enforce Single Origin Policy (SOP) for WebSockets HTTP upgrade requests, enabling
 CORS origin check can add an extra protection in combination with verifying the expected authentication credentials.
 
-For example, attackers can set `Origin` themselves but they will not have the HTTPS bound authentication session cookie
+For example, attackers can set `Origin` themselves, but they will not have the HTTPS bound authentication session cookie
 which can be used to authenticate a WSS WebSockets upgrade request.
-Or if the authenticated user is tricked into visiting an unfriendly web site, then a WSS WebSockets upgrade request will fail
+Or if the authenticated user is tricked into visiting an unfriendly website, then a WSS WebSockets upgrade request will fail
 at the Quarkus CORS check level.
 
 ### Custom WebSocket ticket system


### PR DESCRIPTION
* Typo fixes in JandexUtil and EmbeddingStoreJsonRPCService
* Typo fixes in samples

for login vs. log in I followed explanation from https://www.reddit.com/r/webdev/comments/aml4hb/login_vs_log_in_are_we_using_these_wrong/