### PR TITLE
Enhance output message when output guardrails fail

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/GuardrailsSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/GuardrailsSupport.java
@@ -7,7 +7,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import jakarta.enterprise.inject.spi.CDI;
 
@@ -106,7 +108,15 @@ public class GuardrailsSupport {
         }
 
         if (attempt == max) {
-            throw new GuardrailException("Output validation failed. The guardrails have reached the maximum number of retries");
+            var failureMessages = Optional.ofNullable(result.failures())
+                    .orElseGet(List::of)
+                    .stream()
+                    .map(OutputGuardrailResult.Failure::message)
+                    .collect(Collectors.joining(System.lineSeparator()));
+
+            throw new GuardrailException(
+                    "Output validation failed. The guardrails have reached the maximum number of retries. Guardrail messages:"
+                            + System.lineSeparator() + failureMessages);
         }
 
         if (result.hasRewrittenResult()) {


### PR DESCRIPTION
Enhance the message shown to the user when output guardrails fail. If the user has multiple guardrails the current message doesn't at all indicate which guardrail failed. This is what they see:

```
io.quarkiverse.langchain4j.runtime.aiservice.GuardrailException: Output validation failed. The guardrails have reached the maximum number of retries

	at io.quarkiverse.langchain4j.runtime.aiservice.GuardrailsSupport.invokeOutputGuardrails(GuardrailsSupport.java:109)
	at io.quarkiverse.langchain4j.runtime.aiservice.AiServiceMethodImplementationSupport.doImplement(AiServiceMethodImplementationSupport.java:420)
	at io.quarkiverse.langchain4j.runtime.aiservice.AiServiceMethodImplementationSupport.implement(AiServiceMethodImplementationSupport.java:138)
	at io.quarkiverse.langchain4j.runtime.aiservice.MethodImplementationSupportProducer$1$1.apply(MethodImplementationSupportProducer.java:31)
	at io.quarkiverse.langchain4j.runtime.aiservice.MethodImplementationSupportProducer$1$1.apply(MethodImplementationSupportProducer.java:28)
	at io.quarkiverse.langchain4j.runtime.aiservice.MetricsCountedWrapper.wrap(MetricsCountedWrapper.java:22)
	at io.quarkiverse.langchain4j.runtime.aiservice.MethodImplementationSupportProducer$1$2.apply(MethodImplementationSupportProducer.java:40)
	at io.quarkiverse.langchain4j.runtime.aiservice.MethodImplementationSupportProducer$1$2.apply(MethodImplementationSupportProducer.java:37)
	at io.quarkiverse.langchain4j.runtime.aiservice.MetricsTimedWrapper$2.get(MetricsTimedWrapper.java:42)
	at io.micrometer.core.instrument.composite.CompositeTimer.record(CompositeTimer.java:69)
	at io.quarkiverse.langchain4j.runtime.aiservice.MetricsTimedWrapper.wrap(MetricsTimedWrapper.java:39)
	at io.quarkiverse.langchain4j.runtime.aiservice.MethodImplementationSupportProducer$1$2.apply(MethodImplementationSupportProducer.java:40)
	at io.quarkiverse.langchain4j.runtime.aiservice.MethodImplementationSupportProducer$1$2.apply(MethodImplementationSupportProducer.java:37)
	at io.quarkiverse.langchain4j.runtime.aiservice.SpanWrapper.wrap(SpanWrapper.java:32)
	at io.quarkiverse.langchain4j.runtime.aiservice.MethodImplementationSupportProducer$1$2.apply(MethodImplementationSupportProducer.java:40)
	at io.quarkiverse.langchain4j.runtime.aiservice.MethodImplementationSupportProducer$1$2.apply(MethodImplementationSupportProducer.java:37)
	at io.quarkiverse.langchain4j.runtime.aiservice.MethodImplementationSupportProducer$1.implement(MethodImplementationSupportProducer.java:46)
	at org.ericoleg.ndnp.ai.GenerateEmailService$$QuarkusImpl.generateEmail(Unknown Source)
	at org.ericoleg.ndnp.ai.GenerateEmailService$$QuarkusImpl_ClientProxy.generateEmail(Unknown Source)
	at org.ericoleg.ndnp.ai.NotificationService.sendEmail(NotificationService.java:78)
	at java.base/java.util.Optional.map(Optional.java:260)
	at org.ericoleg.ndnp.ai.NotificationService.updateStatus(NotificationService.java:57)
	at org.ericoleg.ndnp.ai.NotificationService.lambda$updateClaimStatus$1(NotificationService.java:50)
	at java.base/java.util.Optional.map(Optional.java:260)
	at org.ericoleg.ndnp.ai.NotificationService.updateClaimStatus(NotificationService.java:50)
	at org.ericoleg.ndnp.ai.NotificationService_Subclass.updateClaimStatus$$superforward(Unknown Source)
	at org.ericoleg.ndnp.ai.NotificationService_Subclass$$function$$1.apply(Unknown Source)
	at io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:73)
	at io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:62)
	at io.quarkus.opentelemetry.runtime.tracing.cdi.WithSpanInterceptor.span(WithSpanInterceptor.java:147)
	at io.quarkus.opentelemetry.runtime.tracing.cdi.WithSpanInterceptor_Bean.intercept(Unknown Source)
	at io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:42)
	at io.quarkus.arc.impl.AroundInvokeInvocationContext.perform(AroundInvokeInvocationContext.java:30)
	at io.quarkus.arc.impl.InvocationContexts.performAroundInvoke(InvocationContexts.java:27)
	at org.ericoleg.ndnp.ai.NotificationService_Subclass.updateClaimStatus(Unknown Source)
	at org.ericoleg.ndnp.ai.NotificationService_ClientProxy.updateClaimStatus(Unknown Source)
	at org.ericoleg.ndnp.ai.NotificationServiceTests.emailSendsWhenUserExists(NotificationServiceTests.java:53)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at io.quarkus.test.junit.QuarkusTestExtension.runExtensionMethod(QuarkusTestExtension.java:967)
	at io.quarkus.test.junit.QuarkusTestExtension.interceptTestMethod(QuarkusTestExtension.java:817)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```