### PR TITLE
Allow customization of invalid json reprompt

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/AbstractJsonExtractorOutputGuardrail.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/AbstractJsonExtractorOutputGuardrail.java
@@ -40,9 +40,19 @@ public abstract class AbstractJsonExtractorOutputGuardrail implements OutputGuar
             }
         }
 
-        return reprompt("Invalid JSON",
-                "Make sure you return a valid JSON object following "
-                        + "the specified format");
+        return invokeInvalidJson(responseFromLLM, json);
+    }
+
+    protected OutputGuardrailResult invokeInvalidJson(AiMessage aiMessage, String json) {
+        return reprompt(getInvalidJsonMessage(aiMessage, json), getInvalidJsonReprompt(aiMessage, json));
+    }
+
+    protected String getInvalidJsonMessage(AiMessage aiMessage, String json) {
+        return "Invalid JSON";
+    }
+
+    protected String getInvalidJsonReprompt(AiMessage aiMessage, String json) {
+        return "Make sure you return a valid JSON object following the specified format";
     }
 
     protected Object deserialize(String llmResponse) {


### PR DESCRIPTION
Allow customization of invalid json reprompt.

In some implementations I'm finding that the message `Make sure you return a valid JSON object following the specified format` is too generic. On specific implementations I'd like to include the json format in the reprompt message.

This change allows implementors to override the message, or change the implementation of the reprompt altogether (maybe an implementor just wants to fail?).

This change is 100% backwards compatible with current behavior but allows implementors to customize.