### PR TITLE
Provide Evaluations in same order as they where submitted

### DIFF
--- a/testing/scorer/scorer-core/src/main/java/io/quarkiverse/langchain4j/testing/scorer/EvaluationReport.java
+++ b/testing/scorer/scorer-core/src/main/java/io/quarkiverse/langchain4j/testing/scorer/EvaluationReport.java
@@ -8,9 +8,9 @@ import java.util.List;
 /**
  * Report of the evaluation of a set of samples.
  */
-public class EvaluationReport {
+public class EvaluationReport<T> {
 
-    private final List<Scorer.EvaluationResult<?>> evaluations;
+    private final List<Scorer.EvaluationResult<T>> evaluations;
     private final double score;
 
     /**
@@ -18,7 +18,7 @@ public class EvaluationReport {
      *
      * @param evaluations the evaluations, must not be {@code null}, must not be empty.
      */
-    public EvaluationReport(List<Scorer.EvaluationResult<?>> evaluations) {
+    public EvaluationReport(List<Scorer.EvaluationResult<T>> evaluations) {
         this.evaluations = evaluations;
         this.score = 100.0 * evaluations.stream().filter(Scorer.EvaluationResult::passed).count() / evaluations.size();
     }
@@ -33,7 +33,7 @@ public class EvaluationReport {
     /**
      * @return the evaluations
      */
-    public List<Scorer.EvaluationResult<?>> evaluations() {
+    public List<Scorer.EvaluationResult<T>> evaluations() {
         return evaluations;
     }
 

--- a/testing/scorer/scorer-core/src/main/java/io/quarkiverse/langchain4j/testing/scorer/Scorer.java
+++ b/testing/scorer/scorer-core/src/main/java/io/quarkiverse/langchain4j/testing/scorer/Scorer.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.langchain4j.testing.scorer;
 
 import java.io.Closeable;
+import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -28,50 +29,64 @@ public class Scorer implements Closeable {
     }
 
     @SuppressWarnings({ "unchecked" })
-    public <T> EvaluationReport evaluate(Samples<T> samples, Function<Parameters, T> function,
-            EvaluationStrategy<T>... strategies) {
-        List<EvaluationResult<?>> evaluations = new CopyOnWriteArrayList<>();
+    public <T> EvaluationReport<T> evaluate(
+            Samples<T> samples, Function<Parameters, T> function, EvaluationStrategy<T>... strategies) {
+        List<OrderedEvaluationResult<T>> evaluations = new CopyOnWriteArrayList<>();
         CountDownLatch latch = new CountDownLatch(samples.size());
+        var index = 0;
         for (EvaluationSample<T> sample : samples) {
             // TODO Should we handle the context somehow.
-            executor.submit(() -> {
-                try {
-                    var response = execute(sample, function);
-                    LOG.infof("Evaluating sample `%s`", sample.name());
-                    for (EvaluationStrategy<T> strategy : strategies) {
-                        EvaluationResult<T> evaluation = EvaluationResult.fromCompletedEvaluation(sample,
-                                response, strategy.evaluate(sample, response));
-                        LOG.infof("Evaluation of sample `%s` with strategy `%s`: %s", sample.name(),
-                                strategy.getClass().getSimpleName(),
-                                evaluation.passed() ? "OK" : "KO");
-                        evaluations.add(evaluation);
-                    }
-                } catch (Throwable e) {
-                    LOG.errorf(e, "Failed to evaluate sample `%s`", sample.name());
-                    evaluations.add(EvaluationResult.fromEvaluationThrowable(sample, e));
-                } finally {
-                    latch.countDown();
-                }
-            });
+            var currentIndex = index++;
+            executor.submit(
+                    () -> {
+                        try {
+                            var response = execute(sample, function);
+                            LOG.infof("Evaluating sample `%s`", sample.name());
+                            for (EvaluationStrategy<T> strategy : strategies) {
+                                EvaluationResult<T> evaluation = EvaluationResult.fromCompletedEvaluation(
+                                        sample, response, strategy.evaluate(sample, response));
+                                LOG.infof(
+                                        "Evaluation of sample `%s` with strategy `%s`: %s",
+                                        sample.name(),
+                                        strategy.getClass().getSimpleName(),
+                                        evaluation.passed() ? "OK" : "KO");
+                                evaluations.add(new OrderedEvaluationResult(currentIndex, evaluation));
+                            }
+                        } catch (Throwable e) {
+                            LOG.errorf(e, "Failed to evaluate sample `%s`", sample.name());
+                            evaluations.add(
+                                    new OrderedEvaluationResult(
+                                            currentIndex, EvaluationResult.fromEvaluationThrowable(sample, e)));
+                        } finally {
+                            latch.countDown();
+                        }
+                    });
         }
         try {
             latch.await();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
-        return new EvaluationReport(evaluations);
+        var orderedEvalutions = evaluations.stream()
+                .sorted(Comparator.comparing(OrderedEvaluationResult::index))
+                .map(OrderedEvaluationResult::evaluation)
+                .toList();
+        return new EvaluationReport<>(orderedEvalutions);
     }
 
     public void close() {
         executor.shutdown();
     }
 
-    public record EvaluationResult<T>(EvaluationSample<T> sample, T result, Throwable thrown, boolean passed) {
-        public static <T> EvaluationResult<T> fromCompletedEvaluation(EvaluationSample<T> sample, T result, boolean passed) {
+    public record EvaluationResult<T>(
+            EvaluationSample<T> sample, T result, Throwable thrown, boolean passed) {
+        public static <T> EvaluationResult<T> fromCompletedEvaluation(
+                EvaluationSample<T> sample, T result, boolean passed) {
             return new EvaluationResult<>(sample, result, null, passed);
         }
 
-        public static <T> EvaluationResult<T> fromEvaluationThrowable(EvaluationSample<T> sample, Throwable thrown) {
+        public static <T> EvaluationResult<T> fromEvaluationThrowable(
+                EvaluationSample<T> sample, Throwable thrown) {
             return new EvaluationResult<>(sample, null, thrown, false);
         }
     }
@@ -84,4 +99,6 @@ public class Scorer implements Closeable {
         }
     }
 
+    private record OrderedEvaluationResult<T>(int index, EvaluationResult<T> evaluation) {
+    }
 }


### PR DESCRIPTION
as discussed https://github.com/quarkiverse/quarkus-langchain4j/pull/1209/files#r1908303398

this change provides 
* stable order for `scorer.evaluate(...)`
* generic typed `EvaluationReport<T> report = scorer.evaluate(...);`
  @cescoffier or is it by purpose that `EvaluationReport` was not generically typed? i stumbled upon it having some compile-issues when sorting