### PR TITLE
Fix switched input/output token usage in ollama streaming

### DIFF
--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/OllamaStreamingChatLanguageModel.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/OllamaStreamingChatLanguageModel.java
@@ -124,8 +124,8 @@ public class OllamaStreamingChatLanguageModel implements StreamingChatLanguageMo
 
                                         if (response.evalCount() != null && response.promptEvalCount() != null) {
                                             TokenUsage tokenUsage = new TokenUsage(
-                                                    response.evalCount(),
                                                     response.promptEvalCount(),
+                                                    response.evalCount(),
                                                     response.evalCount() + response.promptEvalCount());
                                             context.put(TOKEN_USAGE_CONTEXT, tokenUsage);
                                         }


### PR DESCRIPTION
The input and output token count in OllamaStreamingChatLanguageModel seems to be switched.