### PR TITLE
Extensions descriptors updates

### DIFF
--- a/core/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/core/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,4 +1,4 @@
-name: LangChain4j
+name: LangChain4j Core
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
 description: Provides the basic integration with LangChain4j
 metadata:

--- a/embedding-stores/neo4j/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/embedding-stores/neo4j/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,12 @@
+name: LangChain4j Neo4j embedding store
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+description: Provides the Neo4j embedding store for Quarkus LangChain4j
+metadata:
+   keywords:
+    - ai
+    - langchain4j
+    - neo4j
+   guide: "https://docs.quarkiverse.io/quarkus-langchain4j/dev/index.html"
+   categories:
+     - "ai"
+   status: "experimental"

--- a/embedding-stores/pgvector/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/embedding-stores/pgvector/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -10,4 +10,4 @@ metadata:
    guide: "https://docs.quarkiverse.io/quarkus-langchain4j/dev/index.html"
    categories:
      - "ai"
-   status: "preview"
+   status: "experimental"

--- a/embedding-stores/pgvector/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/embedding-stores/pgvector/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,4 +1,4 @@
-name: Quarkus LangChain4j pgvector embedding store
+name: LangChain4j pgvector embedding store
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
 description: Provides the pgvector Embedding store for Quarkus LangChain4j
 metadata:

--- a/model-providers/watsonx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/model-providers/watsonx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -9,4 +9,4 @@ metadata:
    guide: "https://docs.quarkiverse.io/quarkus-langchain4j/dev/index.html"
    categories:
      - "ai"
-   status: "preview"
+   status: "experimental"

--- a/model-providers/watsonx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/model-providers/watsonx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,4 +1,4 @@
-name: Quarkus LangChain4j Watsonx
+name: LangChain4j Watsonx
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
 description: Provides integration of Quarkus LangChain4j with the IBM Watsonx API
 metadata:


### PR DESCRIPTION
 * quarkus-extension.yaml for Neo4j embedding store
 * Sync extensions naming (Watsonx, pgvector, core)
 * Sync extensions status (Watsonx, pgvector)

`quarkus extension list --installable --category ai` command:
<img width="809" alt="Screenshot 2025-01-31 at 9 47 18" src="https://github.com/user-attachments/assets/435c5777-85d0-476d-9250-23cfa4d7465d" />

Watsonx and pgvector extensions have `status: "preview"`, all the other extensions have `status: "experimental"`
 * see https://code.quarkus.io/?extension-search=quarkus-langchain4j