### PR TITLE
Get all Gemini function calls included and paired with matching function responses

### DIFF
--- a/samples/secure-poem-multiple-models/src/main/java/io/quarkiverse/langchain4j/sample/PoemResource.java
+++ b/samples/secure-poem-multiple-models/src/main/java/io/quarkiverse/langchain4j/sample/PoemResource.java
@@ -15,7 +15,7 @@ import jakarta.ws.rs.Path;
 public class PoemResource {
 
     static final String USER_MESSAGE = """
-            Write a short 1 paragraph poem about Java programming language.
+            Write a short 1 paragraph poem about a Java programming language feature preferred by the user.
             Set an author name to the model or deployment name which created the poem.
             Please start by greeting the currently logged in user and asking to enjoy reading the poem, address this user by name.""";
 
@@ -61,5 +61,9 @@ public class PoemResource {
             return identity.getPrincipal().getName();
         }
         
+        @Tool("Returns the Java programming language feature preferred by the user")
+        public String getPreferredJavaFeature() {
+            return "record";
+        }
     }
 }


### PR DESCRIPTION
Gemini may request multiple function calls, for example:

```
{
  "candidates": [
    {
      "content": {
        "role": "model",
        "parts": [
          {
            "functionCall": {
              "name": "getLoggedInUserName",
              "args": {}
            }
          },
          {
            "functionCall": {
              "name": "getPreferredJavaFeature",
              "args": {}
            }
          }
        ]
      },
      "finishReason": "STOP"
  ]
```

Currently, on `main`, Vertex AI Gemini model provider does not include all function calls, so after fixing that I got a nearly correct response:

```
{"contents":[

{"role":"user","parts":[{"text":"Write a short 1 paragraph poem about a Java programming language feature preferred by the user.\nSet an author name to the model or deployment name which created the poem.\nPlease start by greeting the currently logged in user and asking to enjoy reading the poem, address this user by name."}]},

{"role":"model","parts":[{"functionCall":{"name":"getLoggedInUserName","args":{}}}]},

{"role":"model","parts":[{"functionCall":{"name":"getPreferredJavaFeature","args":{}}}]},

{"role":"user","parts":[{"functionResponse":{"name":"getLoggedInUserName","response":{"name":"getLoggedInUserName","content":"\"Sergey Beryozkin\""}}}]},

{"role":"user","parts":[{"functionResponse":{"name":"getPreferredJavaFeature","response":{"name":"getPreferredJavaFeature","content":"\"record\""}}}]}

],

"tools":[{"functionDeclarations":[{"name":"getLoggedInUserName","description":"Returns the name of the logged-in user","parameters":{"type":"object","properties":{},"required":[]}},{"name":"getPreferredJavaFeature","description":"Returns the Java programming language feature preferred by the user","parameters":{"type":"object","properties":{},"required":[]}}]}],"generationConfig":{"maxOutputTokens":8192}}
```

Gemini responds with a difficult to understand error:

```
"error": {
    "code": 400,
    "message": "Please ensure that the number of function response parts should be equal to number of function call parts of the function call turn.",
    "status": "INVALID_ARGUMENT"
  }
```

There is no clear guidance in Google forums what to do, so I simply tried to get it produced similarly to how it is documented for OpenAI in the docs here, to make sure the response immediately follows the matching function call, now we get:

```
{"contents":[

{"role":"user","parts":[{"text":"Write a short 1 paragraph poem about a Java programming language feature preferred by the user.\nSet an author name to the model or deployment name which created the poem.\nPlease start by greeting the currently logged in user and asking to enjoy reading the poem, address this user by name."}]},

{"role":"model","parts":[{"functionCall":{"name":"getLoggedInUserName","args":{}}}]},

{"role":"user","parts":[{"functionResponse":{"name":"getLoggedInUserName","response":{"name":"getLoggedInUserName","content":"\"Sergey Beryozkin\""}}}]},

{"role":"model","parts":[{"functionCall":{"name":"getPreferredJavaFeature","args":{}}}]},

{"role":"user","parts":[{"functionResponse":{"name":"getPreferredJavaFeature","response":{"name":"getPreferredJavaFeature","content":"\"record\""}}}]}

],

"tools":[{"functionDeclarations":[{"name":"getLoggedInUserName","description":"Returns the name of the logged-in user","parameters":{"type":"object","properties":{},"required":[]}},{"name":"getPreferredJavaFeature","description":"Returns the Java programming language feature preferred by the user","parameters":{"type":"object","properties":{},"required":[]}}]}],"generationConfig":{"maxOutputTokens":8192}}
```

and it works, for example, in the updated demo I get:

```
Sergey Beryozkin, please enjoy reading the poem below: 

***
By Gemini  

Records, oh records, how concise you are,
A simple syntax, elegant and far.
No more boilerplate, our code now sings,
With clarity and joy, your presence brings. 
*** 
```

I also confirmed it works now with another Gemini demo involving several function calls.

Finally, I've also confirmed a single tool only case works OK.

CC @geoand 