### PR TITLE
Don't depend on internal OTel types in tests

### DIFF
--- a/core/opentelemetry-tests/src/test/java/io/quarkiverse/langchain4j/opentelemetry/test/ListenersProcessorAbstractSpanChatModelListenerTest.java
+++ b/core/opentelemetry-tests/src/test/java/io/quarkiverse/langchain4j/opentelemetry/test/ListenersProcessorAbstractSpanChatModelListenerTest.java
@@ -25,7 +25,6 @@ import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.sdk.trace.internal.data.ExceptionEventData;
 import io.quarkiverse.langchain4j.runtime.listeners.ChatModelSpanContributor;
 import io.quarkiverse.langchain4j.runtime.listeners.SpanChatModelListener;
 import io.quarkus.arc.All;
@@ -87,8 +86,8 @@ abstract class ListenersProcessorAbstractSpanChatModelListenerTest {
         assertThat(actualSpan.getEvents())
                 .hasSize(1)
                 .first()
-                .isInstanceOf(ExceptionEventData.class)
-                .extracting(ex -> ((ExceptionEventData) ex).getException().getMessage())
+                .extracting("exception")
+                .extracting("message")
                 .isEqualTo("--failed--");
         verifyFailedSpan(actualSpan);
     }

--- a/core/opentelemetry-tests/src/test/java/io/quarkiverse/langchain4j/opentelemetry/test/ListenersProcessorTwoChatModelSpanContributorsTest.java
+++ b/core/opentelemetry-tests/src/test/java/io/quarkiverse/langchain4j/opentelemetry/test/ListenersProcessorTwoChatModelSpanContributorsTest.java
@@ -22,7 +22,6 @@ import dev.langchain4j.model.chat.listener.ChatModelRequestContext;
 import dev.langchain4j.model.chat.listener.ChatModelResponseContext;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.sdk.trace.internal.data.ExceptionEventData;
 import io.quarkiverse.langchain4j.runtime.listeners.ChatModelSpanContributor;
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -68,7 +67,8 @@ class ListenersProcessorTwoChatModelSpanContributorsTest
         var actualSpan = exporter.getFinishedSpanItems().get(0);
         assertThat(actualSpan.getEvents())
                 .hasSize(2)
-                .extracting(ex -> ((ExceptionEventData) ex).getException().getMessage())
+                .extracting("exception")
+                .extracting("message")
                 .contains("--failure-on-request-of-contributor--", "--failure-on-request-of-contributor--");
     }
 
@@ -86,7 +86,8 @@ class ListenersProcessorTwoChatModelSpanContributorsTest
         var actualSpan = exporter.getFinishedSpanItems().get(0);
         assertThat(actualSpan.getEvents())
                 .hasSize(2)
-                .extracting(ex -> ((ExceptionEventData) ex).getException().getMessage())
+                .extracting("exception")
+                .extracting("message")
                 .contains(
                         "--failure-on-response-of-contributor--", "--failure-on-response-of-contributor--");
     }
@@ -105,7 +106,8 @@ class ListenersProcessorTwoChatModelSpanContributorsTest
         var actualSpan = exporter.getFinishedSpanItems().get(0);
         assertThat(actualSpan.getEvents())
                 .hasSize(3)
-                .extracting(ex -> ((ExceptionEventData) ex).getException().getMessage())
+                .extracting("exception")
+                .extracting("message")
                 .contains(
                         "--failure-on-error-of-contributor--",
                         "--failure-on-error-of-contributor--",

--- a/pom.xml
+++ b/pom.xml
@@ -66,11 +66,6 @@
         <artifactId>quarkus-extension-processor</artifactId>
         <version>${quarkus.extension-processor.version}</version>
       </dependency>
-      <dependency>
-          <groupId>io.opentelemetry</groupId>
-          <artifactId>opentelemetry-sdk-testing</artifactId>
-          <version>1.47.0</version>
-      </dependency>      
     </dependencies>
   </dependencyManagement>
   <build>


### PR DESCRIPTION
This is needed to make the tests work with
both the latest Quarkus LTS and Quarkus Main