### PR TITLE
Fix AI services as tools lookup using @ToolBox annotation

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
@@ -1120,8 +1120,10 @@ public class AiServicesProcessor {
                                 ignoredPredicates,
                                 tools, toolQualifierProviderItems);
                         if (!methodCreateInfo.getToolClassInfo().isEmpty()) {
-                            unremovableBeanProducer.produce(UnremovableBeanBuildItem
-                                    .beanClassNames(methodCreateInfo.getToolClassInfo().keySet().toArray(EMPTY_STRING_ARRAY)));
+                            methodCreateInfo.getToolClassInfo().keySet().stream()
+                                    .map(DotName::createSimple)
+                                    .map(UnremovableBeanBuildItem::beanTypes)
+                                    .forEach(unremovableBeanProducer::produce);
                         }
                         perMethodMetadata.put(methodId, methodCreateInfo);
 

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/AiServicesRecorder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/AiServicesRecorder.java
@@ -91,6 +91,9 @@ public class AiServicesRecorder {
                                     tool = Arc.container().instance(
                                             Thread.currentThread().getContextClassLoader().loadClass(entry.getKey())).get();
                                 }
+                                if (tool == null) {
+                                    throw new IllegalStateException("Unknown tool: " + entry.getKey());
+                                }
                                 objectWithTools.add(tool);
                             }
                             ToolsRecorder.populateToolMetadata(objectWithTools, methodCreateInfo.getToolSpecifications(),
@@ -170,7 +173,9 @@ public class AiServicesRecorder {
                                 tool = creationalContext.getInjectedReference(
                                         Thread.currentThread().getContextClassLoader().loadClass(entry.getKey()));
                             }
-
+                            if (tool == null) {
+                                throw new IllegalStateException("Unknown tool: " + entry.getKey());
+                            }
                             tools.add(tool);
                         }
                         quarkusAiServices.tools(tools);

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/org/acme/examples/aiservices/AiServiceAsToolBoxTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/org/acme/examples/aiservices/AiServiceAsToolBoxTest.java
@@ -1,0 +1,176 @@
+package org.acme.examples.aiservices;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.ToolBox;
+import io.quarkiverse.langchain4j.guardrails.InputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.InputGuardrailResult;
+import io.quarkiverse.langchain4j.guardrails.InputGuardrails;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class AiServiceAsToolBoxTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "whatever")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"))
+            .overrideConfigKey("quarkus.rest-client.rest-calculator.url", "http://localhost:${quarkus.http.test-port:8081}");
+
+    private static final String scenario = "tools";
+    private static final String secondState = "second";
+
+    @BeforeEach
+    void setUp() {
+        wiremock().resetMappings();
+        wiremock().resetRequests();
+    }
+
+    @Inject
+    Bot bot;
+
+    @Test
+    @ActivateRequestContext
+    void should_execute_tool_then_answer() throws IOException {
+        var firstResponse = """
+                {
+                  "id": "chatcmpl-8D88Dag1gAKnOPP9Ed4bos7vSpaNz",
+                  "object": "chat.completion",
+                  "created": 1698140213,
+                  "model": "gpt-3.5-turbo-0613",
+                  "choices": [
+                    {
+                      "index": 0,
+                      "message": {
+                        "role": "assistant",
+                        "content": null,
+                        "function_call": {
+                          "name": "extractCity",
+                          "arguments": "{\\n  \\"question\\": \\"What is the weather in Rome?\\"\\n}"
+                        }
+                      },
+                      "finish_reason": "function_call"
+                    }
+                  ],
+                  "usage": {
+                    "prompt_tokens": 65,
+                    "completion_tokens": 20,
+                    "total_tokens": 85
+                  }
+                }
+                """;
+
+        var secondResponse = """
+                        {
+                          "id": "chatcmpl-8D88FIAUWSpwLaShFr0w8G1SWuVdl",
+                          "object": "chat.completion",
+                          "created": 1698140215,
+                          "model": "gpt-3.5-turbo-0613",
+                          "choices": [
+                            {
+                              "index": 0,
+                              "message": {
+                                "role": "assistant",
+                                "content": "Rome"
+                              },
+                              "finish_reason": "stop"
+                            }
+                          ],
+                          "usage": {
+                            "prompt_tokens": 102,
+                            "completion_tokens": 33,
+                            "total_tokens": 135
+                          }
+                        }
+                """;
+
+        wiremock().register(
+                post(urlEqualTo("/v1/chat/completions"))
+                        .withHeader("Authorization", equalTo("Bearer whatever"))
+                        .inScenario(scenario)
+                        .whenScenarioStateIs(Scenario.STARTED)
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(firstResponse)));
+        wiremock().register(
+                post(urlEqualTo("/v1/chat/completions"))
+                        .withHeader("Authorization", equalTo("Bearer whatever"))
+                        .inScenario(scenario)
+                        .whenScenarioStateIs(secondState)
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(secondResponse)));
+
+        wiremock().setSingleScenarioState(scenario, Scenario.STARTED);
+
+        String userMessage = "What is the weather in Rome?";
+
+        String answer = bot.chat(userMessage);
+
+        assertThat(answer).isEqualTo("Rome");
+
+        assertThat(wiremock().getServeEvents()).hasSize(1);
+    }
+
+    @RegisterAiService
+    interface Bot {
+        @ToolBox(CityExtractorAgent.class)
+        @InputGuardrails(SecondStateGuardrail.class)
+        String chat(String message);
+    }
+
+    @RegisterAiService
+    public interface CityExtractorAgent {
+        @UserMessage("""
+                You are given one question and you have to extract city name from it
+                Only reply the city name if it exists or reply 'unknown_city' if there is no city name in question
+
+                Here is the question: {question}
+                """)
+        @Tool("Extracts the city from a question")
+        String extractCity(String question);
+    }
+
+    @ApplicationScoped
+    public static class SecondStateGuardrail implements InputGuardrail {
+        private final Integer wiremockPort;
+
+        public SecondStateGuardrail(@ConfigProperty(name = "quarkus.wiremock.devservices.port") Integer wiremockPort) {
+            this.wiremockPort = wiremockPort;
+        }
+
+        @Override
+        public InputGuardrailResult validate(dev.langchain4j.data.message.UserMessage userMessage) {
+            WireMock wireMock = new WireMock(wiremockPort);
+            wireMock.setSingleScenarioState(scenario, secondState);
+            return success();
+        }
+    }
+}

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/org/acme/examples/aiservices/AiServiceAsToolTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/org/acme/examples/aiservices/AiServiceAsToolTest.java
@@ -1,0 +1,174 @@
+package org.acme.examples.aiservices;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.guardrails.InputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.InputGuardrailResult;
+import io.quarkiverse.langchain4j.guardrails.InputGuardrails;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class AiServiceAsToolTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "whatever")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"))
+            .overrideConfigKey("quarkus.rest-client.rest-calculator.url", "http://localhost:${quarkus.http.test-port:8081}");
+
+    private static final String scenario = "tools";
+    private static final String secondState = "second";
+
+    @BeforeEach
+    void setUp() {
+        wiremock().resetMappings();
+        wiremock().resetRequests();
+    }
+
+    @Inject
+    Bot bot;
+
+    @Test
+    @ActivateRequestContext
+    void should_execute_tool_then_answer() throws IOException {
+        var firstResponse = """
+                {
+                  "id": "chatcmpl-8D88Dag1gAKnOPP9Ed4bos7vSpaNz",
+                  "object": "chat.completion",
+                  "created": 1698140213,
+                  "model": "gpt-3.5-turbo-0613",
+                  "choices": [
+                    {
+                      "index": 0,
+                      "message": {
+                        "role": "assistant",
+                        "content": null,
+                        "function_call": {
+                          "name": "extractCity",
+                          "arguments": "{\\n  \\"question\\": \\"What is the weather in Rome?\\"\\n}"
+                        }
+                      },
+                      "finish_reason": "function_call"
+                    }
+                  ],
+                  "usage": {
+                    "prompt_tokens": 65,
+                    "completion_tokens": 20,
+                    "total_tokens": 85
+                  }
+                }
+                """;
+
+        var secondResponse = """
+                        {
+                          "id": "chatcmpl-8D88FIAUWSpwLaShFr0w8G1SWuVdl",
+                          "object": "chat.completion",
+                          "created": 1698140215,
+                          "model": "gpt-3.5-turbo-0613",
+                          "choices": [
+                            {
+                              "index": 0,
+                              "message": {
+                                "role": "assistant",
+                                "content": "Rome"
+                              },
+                              "finish_reason": "stop"
+                            }
+                          ],
+                          "usage": {
+                            "prompt_tokens": 102,
+                            "completion_tokens": 33,
+                            "total_tokens": 135
+                          }
+                        }
+                """;
+
+        wiremock().register(
+                post(urlEqualTo("/v1/chat/completions"))
+                        .withHeader("Authorization", equalTo("Bearer whatever"))
+                        .inScenario(scenario)
+                        .whenScenarioStateIs(Scenario.STARTED)
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(firstResponse)));
+        wiremock().register(
+                post(urlEqualTo("/v1/chat/completions"))
+                        .withHeader("Authorization", equalTo("Bearer whatever"))
+                        .inScenario(scenario)
+                        .whenScenarioStateIs(secondState)
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(secondResponse)));
+
+        wiremock().setSingleScenarioState(scenario, Scenario.STARTED);
+
+        String userMessage = "What is the weather in Rome?";
+
+        String answer = bot.chat(userMessage);
+
+        assertThat(answer).isEqualTo("Rome");
+
+        assertThat(wiremock().getServeEvents()).hasSize(1);
+    }
+
+    @RegisterAiService(tools = CityExtractorAgent.class)
+    interface Bot {
+        @InputGuardrails(SecondStateGuardrail.class)
+        String chat(String message);
+    }
+
+    @RegisterAiService
+    public interface CityExtractorAgent {
+        @UserMessage("""
+                You are given one question and you have to extract city name from it
+                Only reply the city name if it exists or reply 'unknown_city' if there is no city name in question
+
+                Here is the question: {question}
+                """)
+        @Tool("Extracts the city from a question")
+        String extractCity(String question);
+    }
+
+    @ApplicationScoped
+    public static class SecondStateGuardrail implements InputGuardrail {
+        private final Integer wiremockPort;
+
+        public SecondStateGuardrail(@ConfigProperty(name = "quarkus.wiremock.devservices.port") Integer wiremockPort) {
+            this.wiremockPort = wiremockPort;
+        }
+
+        @Override
+        public InputGuardrailResult validate(dev.langchain4j.data.message.UserMessage userMessage) {
+            WireMock wireMock = new WireMock(wiremockPort);
+            wireMock.setSingleScenarioState(scenario, secondState);
+            return success();
+        }
+    }
+}


### PR DESCRIPTION
Fixes bug discussed here https://github.com/mariofusco/quarkus-agentic-ai/commit/0516a93f1313ee78a1609c5d96b476d5ebba8991#commitcomment-152919896

Adding the AI service tool among the unremoveable beans using its class name is wrong because that actual bean that shouldn't be removed is the generated one that implements the AI service but has a different class name. Conversely, registering its bean type using its class fixes the problem.

/cc @geoand 