### PR TITLE
Update watsonx.ai test classes

### DIFF
--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ChatDefaultPropertiesTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ChatDefaultPropertiesTest.java
@@ -19,10 +19,10 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
 import dev.langchain4j.model.chat.TokenCountEstimator;
+import dev.langchain4j.model.chat.response.ChatResponse;
 import io.quarkiverse.langchain4j.watsonx.bean.TextChatMessage;
 import io.quarkiverse.langchain4j.watsonx.bean.TextChatMessage.TextChatMessageSystem;
 import io.quarkiverse.langchain4j.watsonx.bean.TextChatMessage.TextChatMessageUser;
@@ -109,8 +109,8 @@ public class ChatDefaultPropertiesTest extends WireMockAbstract {
                 .response(WireMockUtil.RESPONSE_WATSONX_CHAT_API)
                 .build();
 
-        assertEquals("AI Response", chatModel.generate(dev.langchain4j.data.message.SystemMessage.from("SystemMessage"),
-                dev.langchain4j.data.message.UserMessage.from("UserMessage")).content().text());
+        assertEquals("AI Response", chatModel.chat(dev.langchain4j.data.message.SystemMessage.from("SystemMessage"),
+                dev.langchain4j.data.message.UserMessage.from("UserMessage")).aiMessage().text());
     }
 
     @Test
@@ -153,14 +153,14 @@ public class ChatDefaultPropertiesTest extends WireMockAbstract {
                 dev.langchain4j.data.message.SystemMessage.from("SystemMessage"),
                 dev.langchain4j.data.message.UserMessage.from("UserMessage"));
 
-        var streamingResponse = new AtomicReference<AiMessage>();
-        streamingChatModel.generate(messages, WireMockUtil.streamingResponseHandler(streamingResponse));
+        var streamingResponse = new AtomicReference<ChatResponse>();
+        streamingChatModel.chat(messages, WireMockUtil.streamingChatResponseHandler(streamingResponse));
 
         await().atMost(Duration.ofMinutes(1))
                 .pollInterval(Duration.ofSeconds(2))
                 .until(() -> streamingResponse.get() != null);
 
-        assertThat(streamingResponse.get().text())
+        assertThat(streamingResponse.get().aiMessage().text())
                 .isNotNull()
                 .isEqualTo(" Hello");
     }

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/GenerationAllPropertiesTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/GenerationAllPropertiesTest.java
@@ -28,7 +28,6 @@ import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.exception.UnsupportedFeatureException;
-import dev.langchain4j.model.StreamingResponseHandler;
 import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
 import dev.langchain4j.model.chat.TokenCountEstimator;
@@ -431,8 +430,8 @@ public class GenerationAllPropertiesTest extends WireMockAbstract {
                 .response(WireMockUtil.RESPONSE_WATSONX_GENERATION_API)
                 .build();
 
-        assertEquals("AI Response", chatModel.generate(dev.langchain4j.data.message.SystemMessage.from("SystemMessage"),
-                dev.langchain4j.data.message.UserMessage.from("UserMessage")).content().text());
+        assertEquals("AI Response", chatModel.chat(dev.langchain4j.data.message.SystemMessage.from("SystemMessage"),
+                dev.langchain4j.data.message.UserMessage.from("UserMessage")).aiMessage().text());
     }
 
     @Test
@@ -533,9 +532,9 @@ public class GenerationAllPropertiesTest extends WireMockAbstract {
                 dev.langchain4j.data.message.UserMessage.from("UserMessage"));
 
         var streamingResponse = new AtomicReference<AiMessage>();
-        streamingChatModel.generate(messages, new StreamingResponseHandler<>() {
+        streamingChatModel.chat(messages, new StreamingChatResponseHandler() {
             @Override
-            public void onNext(String token) {
+            public void onPartialResponse(String token) {
             }
 
             @Override
@@ -544,12 +543,12 @@ public class GenerationAllPropertiesTest extends WireMockAbstract {
             }
 
             @Override
-            public void onComplete(Response<AiMessage> response) {
+            public void onCompleteResponse(ChatResponse response) {
                 assertEquals(FinishReason.LENGTH, response.finishReason());
                 assertEquals(2, response.tokenUsage().inputTokenCount());
                 assertEquals(14, response.tokenUsage().outputTokenCount());
                 assertEquals(16, response.tokenUsage().totalTokenCount());
-                streamingResponse.set(response.content());
+                streamingResponse.set(response.aiMessage());
             }
         });
 

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/GenerationDefaultPropertiesTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/GenerationDefaultPropertiesTest.java
@@ -21,11 +21,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import dev.langchain4j.data.embedding.Embedding;
-import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
 import dev.langchain4j.model.chat.TokenCountEstimator;
+import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.scoring.ScoringModel;
@@ -122,8 +122,8 @@ public class GenerationDefaultPropertiesTest extends WireMockAbstract {
                 .response(WireMockUtil.RESPONSE_WATSONX_GENERATION_API)
                 .build();
 
-        assertEquals("AI Response", chatModel.generate(dev.langchain4j.data.message.SystemMessage.from("SystemMessage"),
-                dev.langchain4j.data.message.UserMessage.from("UserMessage")).content().text());
+        assertEquals("AI Response", chatModel.chat(dev.langchain4j.data.message.SystemMessage.from("SystemMessage"),
+                dev.langchain4j.data.message.UserMessage.from("UserMessage")).aiMessage().text());
     }
 
     @Test
@@ -226,14 +226,14 @@ public class GenerationDefaultPropertiesTest extends WireMockAbstract {
                 dev.langchain4j.data.message.SystemMessage.from("SystemMessage"),
                 dev.langchain4j.data.message.UserMessage.from("UserMessage"));
 
-        var streamingResponse = new AtomicReference<AiMessage>();
-        streamingChatModel.generate(messages, WireMockUtil.streamingResponseHandler(streamingResponse));
+        var streamingResponse = new AtomicReference<ChatResponse>();
+        streamingChatModel.chat(messages, WireMockUtil.streamingChatResponseHandler(streamingResponse));
 
         await().atMost(Duration.ofMinutes(1))
                 .pollInterval(Duration.ofSeconds(2))
                 .until(() -> streamingResponse.get() != null);
 
-        assertThat(streamingResponse.get().text())
+        assertThat(streamingResponse.get().aiMessage().text())
                 .isNotNull()
                 .isEqualTo(". I'm a beginner");
     }

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/HttpErrorTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/HttpErrorTest.java
@@ -59,7 +59,7 @@ public class HttpErrorTest extends WireMockAbstract {
                         """)
                 .build();
 
-        WatsonxException ex = assertThrowsExactly(WatsonxException.class, () -> chatModel.generate("message"));
+        WatsonxException ex = assertThrowsExactly(WatsonxException.class, () -> chatModel.chat("message"));
         assertEquals(500, ex.details().statusCode());
         assertNotNull(ex.details().errors());
         assertEquals(1, ex.details().errors().size());
@@ -91,7 +91,7 @@ public class HttpErrorTest extends WireMockAbstract {
                         """)
                 .build();
 
-        WatsonxException ex = assertThrowsExactly(WatsonxException.class, () -> chatModel.generate("message"));
+        WatsonxException ex = assertThrowsExactly(WatsonxException.class, () -> chatModel.chat("message"));
         assertEquals(400, ex.details().statusCode());
         assertNotNull(ex.details().errors());
         assertEquals(1, ex.details().errors().size());
@@ -122,7 +122,7 @@ public class HttpErrorTest extends WireMockAbstract {
                                 """)
                 .build();
 
-        WatsonxException ex = assertThrowsExactly(WatsonxException.class, () -> chatModel.generate("message"));
+        WatsonxException ex = assertThrowsExactly(WatsonxException.class, () -> chatModel.chat("message"));
         assertNotNull(ex.details());
         assertNotNull(ex.details().trace());
         assertEquals(400, ex.details().statusCode());
@@ -154,7 +154,7 @@ public class HttpErrorTest extends WireMockAbstract {
                         """)
                 .build();
 
-        WatsonxException ex = assertThrowsExactly(WatsonxException.class, () -> chatModel.generate("message"));
+        WatsonxException ex = assertThrowsExactly(WatsonxException.class, () -> chatModel.chat("message"));
         assertNotNull(ex.details());
         assertNotNull(ex.details().trace());
         assertEquals(404, ex.details().statusCode());
@@ -185,7 +185,7 @@ public class HttpErrorTest extends WireMockAbstract {
                         """)
                 .build();
 
-        WatsonxException ex = assertThrowsExactly(WatsonxException.class, () -> chatModel.generate("message"));
+        WatsonxException ex = assertThrowsExactly(WatsonxException.class, () -> chatModel.chat("message"));
         assertNotNull(ex.details());
         assertNotNull(ex.details().trace());
         assertEquals(400, ex.details().statusCode());
@@ -216,7 +216,7 @@ public class HttpErrorTest extends WireMockAbstract {
                         """)
                 .build();
 
-        WatsonxException ex = assertThrowsExactly(WatsonxException.class, () -> chatModel.generate("message"));
+        WatsonxException ex = assertThrowsExactly(WatsonxException.class, () -> chatModel.chat("message"));
         assertNotNull(ex.details());
         assertNotNull(ex.details().trace());
         assertEquals(400, ex.details().statusCode());
@@ -237,7 +237,7 @@ public class HttpErrorTest extends WireMockAbstract {
                 .response("{")
                 .build();
 
-        WatsonxException ex = assertThrowsExactly(WatsonxException.class, () -> chatModel.generate("message"));
+        WatsonxException ex = assertThrowsExactly(WatsonxException.class, () -> chatModel.chat("message"));
         assertEquals(500, ex.statusCode());
     }
 
@@ -249,7 +249,7 @@ public class HttpErrorTest extends WireMockAbstract {
                 .build();
 
         ClientWebApplicationException ex = assertThrows(ClientWebApplicationException.class,
-                () -> chatModel.generate("message"));
+                () -> chatModel.chat("message"));
         assertEquals(500, ex.getResponse().getStatus());
         assertTrue(ex.getMessage().contains("HTTP 500 Server Error"));
     }
@@ -270,7 +270,7 @@ public class HttpErrorTest extends WireMockAbstract {
 
         ClientWebApplicationException ex = assertThrowsExactly(
                 ClientWebApplicationException.class,
-                () -> chatModel.generate("message"));
+                () -> chatModel.chat("message"));
         assertEquals(400, ex.getResponse().getStatus());
         assertTrue(ex.getMessage().contains("\"quarkus.langchain4j.watsonx.api-key\" is incorrect"));
     }
@@ -282,7 +282,7 @@ public class HttpErrorTest extends WireMockAbstract {
                 .response("SUPER FATAL ERROR!")
                 .build();
         WebApplicationException ex = assertThrowsExactly(ClientWebApplicationException.class,
-                () -> chatModel.generate("message"));
+                () -> chatModel.chat("message"));
         assertEquals(500, ex.getResponse().getStatus());
         assertTrue(ex.getMessage().contains("SUPER FATAL ERROR!"));
     }

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/WireMockAbstract.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/WireMockAbstract.java
@@ -44,12 +44,12 @@ public abstract class WireMockAbstract {
     }
 
     @BeforeEach
-    void beforeEach() {
+    void beforeEach() throws Exception {
         watsonxServer.resetAll();
         iamServer.resetAll();
         handlerBeforeEach();
     }
 
-    void handlerBeforeEach() {
+    void handlerBeforeEach() throws Exception {
     };
 }

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/WireMockUtil.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/WireMockUtil.java
@@ -18,11 +18,8 @@ import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 
-import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.model.StreamingResponseHandler;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
-import dev.langchain4j.model.output.Response;
 
 public class WireMockUtil {
 
@@ -233,24 +230,6 @@ public class WireMockUtil {
 
     public WatsonxBuilder mockWatsonxBuilder(String apiURL, int status, String version) {
         return new WatsonxBuilder(watsonServer, apiURL, status, version);
-    }
-
-    public static StreamingResponseHandler<AiMessage> streamingResponseHandler(AtomicReference<AiMessage> streamingResponse) {
-        return new StreamingResponseHandler<>() {
-            @Override
-            public void onNext(String token) {
-            }
-
-            @Override
-            public void onError(Throwable error) {
-                fail("Streaming failed: %s".formatted(error.getMessage()), error);
-            }
-
-            @Override
-            public void onComplete(Response<AiMessage> response) {
-                streamingResponse.set(response.content());
-            }
-        };
     }
 
     public static StreamingChatResponseHandler streamingChatResponseHandler(AtomicReference<ChatResponse> streamingResponse) {

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxChatModel.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxChatModel.java
@@ -158,6 +158,7 @@ public class WatsonxChatModel extends Watsonx implements ChatLanguageModel, Stre
         context.put(COMPLETE_MESSAGE_CONTEXT, new StringBuilder());
 
         client.streamingChat(request, version)
+                .onFailure(WatsonxUtils::isTokenExpired).retry().atMost(1)
                 .subscribe()
                 .with(context,
                         new Consumer<TextStreamingChatResponse>() {

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxGenerationModel.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxGenerationModel.java
@@ -129,6 +129,7 @@ public class WatsonxGenerationModel extends Watsonx
         context.put(GENERATED_TOKEN_COUNT_CONTEXT, 0);
 
         client.generationStreaming(request, version)
+                .onFailure(WatsonxUtils::isTokenExpired).retry().atMost(1)
                 .subscribe()
                 .with(context,
                         new Consumer<TextGenerationResponse>() {

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/WatsonxRecorder.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/WatsonxRecorder.java
@@ -3,6 +3,7 @@ package io.quarkiverse.langchain4j.watsonx.runtime;
 import static dev.langchain4j.model.chat.request.ToolChoice.REQUIRED;
 import static io.quarkiverse.langchain4j.runtime.OptionalUtil.firstOrDefault;
 
+import java.net.URI;
 import java.net.URL;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -186,7 +187,7 @@ public class WatsonxRecorder {
 
             URL url;
             try {
-                url = new URL(firstOrDefault(null, watsonConfig.baseUrl(), runtimeConfig.defaultConfig().baseUrl()));
+                url = URI.create(firstOrDefault(null, watsonConfig.baseUrl(), runtimeConfig.defaultConfig().baseUrl())).toURL();
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
@@ -237,7 +238,7 @@ public class WatsonxRecorder {
 
         URL url;
         try {
-            url = new URL(firstOrDefault(null, watsonConfig.baseUrl(), runtimeConfig.defaultConfig().baseUrl()));
+            url = URI.create(firstOrDefault(null, watsonConfig.baseUrl(), runtimeConfig.defaultConfig().baseUrl())).toURL();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -277,7 +278,7 @@ public class WatsonxRecorder {
 
         URL url;
         try {
-            url = new URL(firstOrDefault(null, watsonConfig.baseUrl(), runtimeConfig.defaultConfig().baseUrl()));
+            url = URI.create(firstOrDefault(null, watsonConfig.baseUrl(), runtimeConfig.defaultConfig().baseUrl())).toURL();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -336,7 +337,7 @@ public class WatsonxRecorder {
 
         URL url;
         try {
-            url = new URL(firstOrDefault(null, watsonConfig.baseUrl(), runtimeConfig.defaultConfig().baseUrl()));
+            url = URI.create(firstOrDefault(null, watsonConfig.baseUrl(), runtimeConfig.defaultConfig().baseUrl())).toURL();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
With the beta2 release of langchain4j the `generate` method in the `ChatLanguageModel` and `StreamingChatLanguageModel` interfaces will no longer be available. I have updated the tests in the watsonx.ai module to be ready for the new release.