### PR TITLE
Create common Gemini ChatModel and EmbeddingModel code

### DIFF
--- a/model-providers/google/gemini/ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/ai/runtime/gemini/AiGeminiChatLanguageModel.java
+++ b/model-providers/google/gemini/ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/ai/runtime/gemini/AiGeminiChatLanguageModel.java
@@ -1,72 +1,30 @@
 package io.quarkiverse.langchain4j.ai.runtime.gemini;
 
-import static dev.langchain4j.data.message.AiMessage.aiMessage;
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.model.chat.Capability.RESPONSE_FORMAT_JSON_SCHEMA;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
-import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.client.api.LoggingScope;
 
-import dev.langchain4j.agent.tool.ToolExecutionRequest;
-import dev.langchain4j.agent.tool.ToolSpecification;
-import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.model.chat.Capability;
-import dev.langchain4j.model.chat.ChatLanguageModel;
-import dev.langchain4j.model.chat.listener.ChatModelErrorContext;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
-import dev.langchain4j.model.chat.listener.ChatModelRequest;
-import dev.langchain4j.model.chat.listener.ChatModelRequestContext;
-import dev.langchain4j.model.chat.listener.ChatModelResponse;
-import dev.langchain4j.model.chat.listener.ChatModelResponseContext;
-import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.request.ResponseFormat;
-import dev.langchain4j.model.chat.request.ResponseFormatType;
-import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
-import dev.langchain4j.model.output.FinishReason;
-import dev.langchain4j.model.output.Response;
-import dev.langchain4j.model.output.TokenUsage;
-import io.quarkiverse.langchain4j.gemini.common.ContentMapper;
-import io.quarkiverse.langchain4j.gemini.common.FinishReasonMapper;
+import io.quarkiverse.langchain4j.gemini.common.GeminiChatLanguageModel;
 import io.quarkiverse.langchain4j.gemini.common.GenerateContentRequest;
 import io.quarkiverse.langchain4j.gemini.common.GenerateContentResponse;
-import io.quarkiverse.langchain4j.gemini.common.GenerateContentResponseHandler;
-import io.quarkiverse.langchain4j.gemini.common.GenerationConfig;
-import io.quarkiverse.langchain4j.gemini.common.SchemaMapper;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 
-public class AiGeminiChatLanguageModel implements ChatLanguageModel {
-    private static final Logger log = Logger.getLogger(AiGeminiChatLanguageModel.class);
+public class AiGeminiChatLanguageModel extends GeminiChatLanguageModel {
 
     private final AiGeminiRestApi.ApiMetadata apiMetadata;
     private final AiGeminiRestApi restApi;
 
-    private final Double temperature;
-    private final Integer maxOutputTokens;
-    private final Integer topK;
-    private final Double topP;
-    private final ResponseFormat responseFormat;
-    private final List<ChatModelListener> listeners;
-
     private AiGeminiChatLanguageModel(Builder builder) {
-        this.temperature = builder.temperature;
-        this.maxOutputTokens = builder.maxOutputTokens;
-        this.topK = builder.topK;
-        this.topP = builder.topP;
-        this.responseFormat = builder.responseFormat;
-        this.listeners = builder.listeners;
+        super(builder.modelId, builder.temperature, builder.maxOutputTokens, builder.topK, builder.topP, builder.responseFormat,
+                builder.listeners);
 
         this.apiMetadata = AiGeminiRestApi.ApiMetadata
                 .builder()
@@ -93,168 +51,8 @@ public class AiGeminiChatLanguageModel implements ChatLanguageModel {
     }
 
     @Override
-    public Set<Capability> supportedCapabilities() {
-        Set<Capability> capabilities = new HashSet<>();
-        // when response format is not null, it's JSON, either application/json or text/x.enum
-        if (this.responseFormat != null && ResponseFormatType.JSON.equals(this.responseFormat.type())) {
-            capabilities.add(RESPONSE_FORMAT_JSON_SCHEMA);
-        } else if (responseFormat == null) { // when the responseFormat is not set, we default to supporting JSON as Google's models support this
-            capabilities.add(RESPONSE_FORMAT_JSON_SCHEMA);
-        }
-        return capabilities;
-    }
-
-    @Override
-    public dev.langchain4j.model.chat.response.ChatResponse chat(dev.langchain4j.model.chat.request.ChatRequest chatRequest) {
-        ChatRequestParameters requestParameters = chatRequest.parameters();
-        ResponseFormat effectiveResponseFormat = getOrDefault(requestParameters.responseFormat(), responseFormat);
-        GenerationConfig generationConfig = GenerationConfig.builder()
-                .maxOutputTokens(getOrDefault(requestParameters.maxOutputTokens(), this.maxOutputTokens))
-                .responseMimeType(computeMimeType(effectiveResponseFormat))
-                .responseSchema(effectiveResponseFormat != null
-                        ? SchemaMapper.fromJsonSchemaToSchema(effectiveResponseFormat.jsonSchema())
-                        : null)
-                .stopSequences(requestParameters.stopSequences())
-                .temperature(getOrDefault(requestParameters.temperature(), this.temperature))
-                .topK(getOrDefault(requestParameters.topK(), this.topK))
-                .topP(getOrDefault(requestParameters.topP(), this.topP))
-                .build();
-        GenerateContentRequest request = ContentMapper.map(chatRequest.messages(), chatRequest.toolSpecifications(),
-                generationConfig);
-
-        ChatModelRequest modelListenerRequest = createModelListenerRequest(request, chatRequest.messages(),
-                chatRequest.toolSpecifications());
-        Map<Object, Object> attributes = new ConcurrentHashMap<>();
-        ChatModelRequestContext requestContext = new ChatModelRequestContext(modelListenerRequest, attributes);
-        listeners.forEach(listener -> {
-            try {
-                listener.onRequest(requestContext);
-            } catch (Exception e) {
-                log.warn("Exception while calling model listener", e);
-            }
-        });
-
-        try {
-            GenerateContentResponse response = restApi.generateContent(request, apiMetadata);
-
-            String text = GenerateContentResponseHandler.getText(response);
-            List<ToolExecutionRequest> toolExecutionRequests = GenerateContentResponseHandler
-                    .getToolExecutionRequests(response);
-            AiMessage aiMessage = toolExecutionRequests.isEmpty()
-                    ? aiMessage(text)
-                    : aiMessage(text, toolExecutionRequests);
-
-            final TokenUsage tokenUsage = GenerateContentResponseHandler.getTokenUsage(response.usageMetadata());
-            final FinishReason finishReason = FinishReasonMapper.map(GenerateContentResponseHandler.getFinishReason(response));
-            final Response<AiMessage> aiMessageResponse = Response.from(aiMessage, tokenUsage);
-
-            ChatModelResponse modelListenerResponse = createModelListenerResponse(
-                    null,
-                    apiMetadata.modelId,
-                    aiMessageResponse);
-            ChatModelResponseContext responseContext = new ChatModelResponseContext(
-                    modelListenerResponse,
-                    modelListenerRequest,
-                    attributes);
-            listeners.forEach(listener -> {
-                try {
-                    listener.onResponse(responseContext);
-                } catch (Exception e) {
-                    log.warn("Exception while calling model listener", e);
-                }
-            });
-
-            return dev.langchain4j.model.chat.response.ChatResponse.builder()
-                    .aiMessage(aiMessage)
-                    .tokenUsage(GenerateContentResponseHandler.getTokenUsage(response.usageMetadata()))
-                    .finishReason(FinishReasonMapper.map(GenerateContentResponseHandler.getFinishReason(response)))
-                    .build();
-        } catch (RuntimeException e) {
-            ChatModelErrorContext errorContext = new ChatModelErrorContext(
-                    e,
-                    modelListenerRequest,
-                    null,
-                    attributes);
-
-            listeners.forEach(listener -> {
-                try {
-                    listener.onError(errorContext);
-                } catch (Exception e2) {
-                    log.warn("Exception while calling model listener", e2);
-                }
-            });
-
-            throw e;
-        }
-    }
-
-    private ChatModelRequest createModelListenerRequest(GenerateContentRequest request,
-            List<ChatMessage> messages,
-            List<ToolSpecification> toolSpecifications) {
-        var builder = ChatModelRequest.builder()
-                .model(apiMetadata.modelId)
-                .messages(messages)
-                .toolSpecifications(toolSpecifications)
-                .temperature(temperature)
-                .topP(topP)
-                .maxTokens(maxOutputTokens);
-        return builder.build();
-    }
-
-    private ChatModelResponse createModelListenerResponse(String responseId,
-            String responseModel,
-            Response<AiMessage> response) {
-        if (response == null) {
-            return null;
-        }
-
-        return ChatModelResponse.builder()
-                .id(responseId)
-                .model(responseModel)
-                .tokenUsage(response.tokenUsage())
-                .finishReason(response.finishReason())
-                .aiMessage(response.content())
-                .build();
-    }
-
-    private String computeMimeType(ResponseFormat responseFormat) {
-        if (responseFormat == null || ResponseFormatType.TEXT.equals(responseFormat.type())) {
-            return "text/plain";
-        }
-
-        if (ResponseFormatType.JSON.equals(responseFormat.type()) &&
-                responseFormat.jsonSchema() != null &&
-                responseFormat.jsonSchema().rootElement() != null &&
-                responseFormat.jsonSchema().rootElement() instanceof JsonEnumSchema) {
-            return "text/x.enum";
-        }
-
-        return "application/json";
-    }
-
-    @Override
-    public Response<AiMessage> generate(List<ChatMessage> messages, List<ToolSpecification> toolSpecifications) {
-        var chatResponse = chat(dev.langchain4j.model.chat.request.ChatRequest.builder()
-                .messages(messages)
-                .toolSpecifications(toolSpecifications)
-                .build());
-
-        return Response.from(
-                chatResponse.aiMessage(),
-                chatResponse.tokenUsage(),
-                chatResponse.finishReason());
-
-    }
-
-    @Override
-    public Response<AiMessage> generate(List<ChatMessage> messages) {
-        return generate(messages, Collections.emptyList());
-    }
-
-    @Override
-    public Response<AiMessage> generate(List<ChatMessage> messages, ToolSpecification toolSpecification) {
-        return generate(messages,
-                toolSpecification != null ? Collections.singletonList(toolSpecification) : Collections.emptyList());
+    protected GenerateContentResponse generateContext(GenerateContentRequest request) {
+        return restApi.generateContent(request, apiMetadata);
     }
 
     public static Builder builder() {

--- a/model-providers/google/gemini/ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/ai/runtime/gemini/AiGeminiEmbeddingModel.java
+++ b/model-providers/google/gemini/ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/ai/runtime/gemini/AiGeminiEmbeddingModel.java
@@ -3,32 +3,25 @@ package io.quarkiverse.langchain4j.ai.runtime.gemini;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import org.jboss.resteasy.reactive.client.api.LoggingScope;
 
-import dev.langchain4j.data.embedding.Embedding;
-import dev.langchain4j.data.segment.TextSegment;
-import dev.langchain4j.model.embedding.EmbeddingModel;
-import dev.langchain4j.model.output.Response;
-import io.quarkiverse.langchain4j.gemini.common.Content;
 import io.quarkiverse.langchain4j.gemini.common.EmbedContentRequest;
 import io.quarkiverse.langchain4j.gemini.common.EmbedContentRequests;
 import io.quarkiverse.langchain4j.gemini.common.EmbedContentResponse;
 import io.quarkiverse.langchain4j.gemini.common.EmbedContentResponses;
+import io.quarkiverse.langchain4j.gemini.common.GeminiEmbeddingModel;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 
-public class AiGeminiEmbeddingModel implements EmbeddingModel {
+public class AiGeminiEmbeddingModel extends GeminiEmbeddingModel {
 
     private final AiGeminiRestApi restApi;
     private final AiGeminiRestApi.ApiMetadata apiMetadata;
 
-    private final Integer dimension;
-    private final String taskType;
-
     public AiGeminiEmbeddingModel(Builder builder) {
+        super(builder.modelId, builder.dimension, builder.taskType);
         this.apiMetadata = AiGeminiRestApi.ApiMetadata
                 .builder()
                 .modelId(builder.modelId)
@@ -47,58 +40,24 @@ public class AiGeminiEmbeddingModel implements EmbeddingModel {
                 restApiBuilder.clientLogger(new AiGeminiRestApi.AiClientLogger(builder.logRequests,
                         builder.logResponses));
             }
-
-            this.dimension = builder.dimension;
-            this.taskType = builder.taskType;
             restApi = restApiBuilder.build(AiGeminiRestApi.class);
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
     }
 
+    @Override
+    protected EmbedContentResponse embedContent(EmbedContentRequest embedContentRequest) {
+        return restApi.embedContent(embedContentRequest, apiMetadata);
+    }
+
+    @Override
+    protected EmbedContentResponses batchEmbedContents(EmbedContentRequests embedContentRequests) {
+        return restApi.batchEmbedContents(embedContentRequests, apiMetadata);
+    }
+
     public static Builder builder() {
         return new Builder();
-    }
-
-    @Override
-    public Response<Embedding> embed(String text) {
-
-        EmbedContentRequest embedContentRequest = getEmbedContentRequest(this.apiMetadata.modelId, text);
-
-        EmbedContentResponse embedContentResponse = restApi.embedContent(embedContentRequest, this.apiMetadata);
-
-        return Response.from(Embedding.from(embedContentResponse.embedding().values()));
-    }
-
-    @Override
-    public Response<List<Embedding>> embedAll(List<TextSegment> textSegments) {
-        List<EmbedContentRequest> embedContentRequests = textSegments.stream()
-                .map(textSegment -> getEmbedContentRequest(this.apiMetadata.modelId, textSegment.text()))
-                .toList();
-
-        EmbedContentResponses embedContentResponses = restApi.batchEmbedContents(
-                new EmbedContentRequests(embedContentRequests),
-                this.apiMetadata);
-
-        List<Embedding> embeddings = embedContentResponses.embeddings()
-                .stream()
-                .map(embedding -> Embedding.from(embedding.values()))
-                .toList();
-        return Response.from(embeddings);
-    }
-
-    private EmbedContentRequest getEmbedContentRequest(String model, String text) {
-        Content.Part part = Content.Part.ofText(text);
-        Content content = Content.ofPart(part);
-
-        EmbedContentRequest.TaskType embedTaskType = null;
-        if (this.taskType != null) {
-            embedTaskType = EmbedContentRequest.TaskType.valueOf(this.taskType);
-        }
-
-        EmbedContentRequest embedContentRequest = new EmbedContentRequest("models/" + model, content,
-                embedTaskType, null, this.dimension);
-        return embedContentRequest;
     }
 
     public static final class Builder {
@@ -155,4 +114,5 @@ public class AiGeminiEmbeddingModel implements EmbeddingModel {
             return new AiGeminiEmbeddingModel(this);
         }
     }
+
 }

--- a/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/GeminiChatLanguageModel.java
+++ b/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/GeminiChatLanguageModel.java
@@ -1,0 +1,224 @@
+package io.quarkiverse.langchain4j.gemini.common;
+
+import static dev.langchain4j.data.message.AiMessage.aiMessage;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.model.chat.Capability.RESPONSE_FORMAT_JSON_SCHEMA;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.jboss.logging.Logger;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.model.chat.Capability;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.listener.ChatModelErrorContext;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.listener.ChatModelRequest;
+import dev.langchain4j.model.chat.listener.ChatModelRequestContext;
+import dev.langchain4j.model.chat.listener.ChatModelResponse;
+import dev.langchain4j.model.chat.listener.ChatModelResponseContext;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.ResponseFormat;
+import dev.langchain4j.model.chat.request.ResponseFormatType;
+import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.output.TokenUsage;
+
+public abstract class GeminiChatLanguageModel implements ChatLanguageModel {
+    private static final Logger log = Logger.getLogger(GeminiChatLanguageModel.class);
+
+    private final String modelId;
+    private final Double temperature;
+    private final Integer maxOutputTokens;
+    private final Integer topK;
+    private final Double topP;
+    private final ResponseFormat responseFormat;
+    private final List<ChatModelListener> listeners;
+
+    public GeminiChatLanguageModel(String modelId, Double temperature, Integer maxOutputTokens, Integer topK,
+            Double topP, ResponseFormat responseFormat, List<ChatModelListener> listeners) {
+        this.modelId = modelId;
+        this.temperature = temperature;
+        this.maxOutputTokens = maxOutputTokens;
+        this.topK = topK;
+        this.topP = topP;
+        this.responseFormat = responseFormat;
+        this.listeners = listeners;
+    }
+
+    @Override
+    public Set<Capability> supportedCapabilities() {
+        Set<Capability> capabilities = new HashSet<>();
+        // when response format is not null, it's JSON, either application/json or text/x.enum
+        if (this.responseFormat != null && ResponseFormatType.JSON.equals(this.responseFormat.type())) {
+            capabilities.add(RESPONSE_FORMAT_JSON_SCHEMA);
+        } else if (responseFormat == null) { // when the responseFormat is not set, we default to supporting JSON as Google's models support this
+            capabilities.add(RESPONSE_FORMAT_JSON_SCHEMA);
+        }
+        return capabilities;
+    }
+
+    @Override
+    public dev.langchain4j.model.chat.response.ChatResponse chat(dev.langchain4j.model.chat.request.ChatRequest chatRequest) {
+        ChatRequestParameters requestParameters = chatRequest.parameters();
+        ResponseFormat effectiveResponseFormat = getOrDefault(requestParameters.responseFormat(), responseFormat);
+        GenerationConfig generationConfig = GenerationConfig.builder()
+                .maxOutputTokens(getOrDefault(requestParameters.maxOutputTokens(), this.maxOutputTokens))
+                .responseMimeType(computeMimeType(effectiveResponseFormat))
+                .responseSchema(effectiveResponseFormat != null
+                        ? SchemaMapper.fromJsonSchemaToSchema(effectiveResponseFormat.jsonSchema())
+                        : null)
+                .stopSequences(requestParameters.stopSequences())
+                .temperature(getOrDefault(requestParameters.temperature(), this.temperature))
+                .topK(getOrDefault(requestParameters.topK(), this.topK))
+                .topP(getOrDefault(requestParameters.topP(), this.topP))
+                .build();
+        GenerateContentRequest request = ContentMapper.map(chatRequest.messages(), chatRequest.toolSpecifications(),
+                generationConfig);
+
+        ChatModelRequest modelListenerRequest = createModelListenerRequest(request, chatRequest.messages(),
+                chatRequest.toolSpecifications());
+        Map<Object, Object> attributes = new ConcurrentHashMap<>();
+        ChatModelRequestContext requestContext = new ChatModelRequestContext(modelListenerRequest, attributes);
+        listeners.forEach(listener -> {
+            try {
+                listener.onRequest(requestContext);
+            } catch (Exception e) {
+                log.warn("Exception while calling model listener", e);
+            }
+        });
+
+        try {
+            GenerateContentResponse response = generateContext(request);
+
+            String text = GenerateContentResponseHandler.getText(response);
+            List<ToolExecutionRequest> toolExecutionRequests = GenerateContentResponseHandler
+                    .getToolExecutionRequests(response);
+            AiMessage aiMessage = toolExecutionRequests.isEmpty()
+                    ? aiMessage(text)
+                    : aiMessage(text, toolExecutionRequests);
+
+            final TokenUsage tokenUsage = GenerateContentResponseHandler.getTokenUsage(response.usageMetadata());
+            final FinishReason finishReason = FinishReasonMapper.map(GenerateContentResponseHandler.getFinishReason(response));
+            final Response<AiMessage> aiMessageResponse = Response.from(aiMessage, tokenUsage);
+
+            ChatModelResponse modelListenerResponse = createModelListenerResponse(
+                    null,
+                    modelId,
+                    aiMessageResponse);
+            ChatModelResponseContext responseContext = new ChatModelResponseContext(
+                    modelListenerResponse,
+                    modelListenerRequest,
+                    attributes);
+            listeners.forEach(listener -> {
+                try {
+                    listener.onResponse(responseContext);
+                } catch (Exception e) {
+                    log.warn("Exception while calling model listener", e);
+                }
+            });
+
+            return dev.langchain4j.model.chat.response.ChatResponse.builder()
+                    .aiMessage(aiMessage)
+                    .tokenUsage(GenerateContentResponseHandler.getTokenUsage(response.usageMetadata()))
+                    .finishReason(FinishReasonMapper.map(GenerateContentResponseHandler.getFinishReason(response)))
+                    .build();
+        } catch (RuntimeException e) {
+            ChatModelErrorContext errorContext = new ChatModelErrorContext(
+                    e,
+                    modelListenerRequest,
+                    null,
+                    attributes);
+
+            listeners.forEach(listener -> {
+                try {
+                    listener.onError(errorContext);
+                } catch (Exception e2) {
+                    log.warn("Exception while calling model listener", e2);
+                }
+            });
+
+            throw e;
+        }
+    }
+
+    protected abstract GenerateContentResponse generateContext(GenerateContentRequest request);
+
+    private ChatModelRequest createModelListenerRequest(GenerateContentRequest request,
+            List<ChatMessage> messages,
+            List<ToolSpecification> toolSpecifications) {
+        var builder = ChatModelRequest.builder()
+                .model(modelId)
+                .messages(messages)
+                .toolSpecifications(toolSpecifications)
+                .temperature(temperature)
+                .topP(topP)
+                .maxTokens(maxOutputTokens);
+        return builder.build();
+    }
+
+    private ChatModelResponse createModelListenerResponse(String responseId,
+            String responseModel,
+            Response<AiMessage> response) {
+        if (response == null) {
+            return null;
+        }
+
+        return ChatModelResponse.builder()
+                .id(responseId)
+                .model(responseModel)
+                .tokenUsage(response.tokenUsage())
+                .finishReason(response.finishReason())
+                .aiMessage(response.content())
+                .build();
+    }
+
+    private String computeMimeType(ResponseFormat responseFormat) {
+        if (responseFormat == null || ResponseFormatType.TEXT.equals(responseFormat.type())) {
+            return "text/plain";
+        }
+
+        if (ResponseFormatType.JSON.equals(responseFormat.type()) &&
+                responseFormat.jsonSchema() != null &&
+                responseFormat.jsonSchema().rootElement() != null &&
+                responseFormat.jsonSchema().rootElement() instanceof JsonEnumSchema) {
+            return "text/x.enum";
+        }
+
+        return "application/json";
+    }
+
+    @Override
+    public Response<AiMessage> generate(List<ChatMessage> messages, List<ToolSpecification> toolSpecifications) {
+        var chatResponse = chat(dev.langchain4j.model.chat.request.ChatRequest.builder()
+                .messages(messages)
+                .toolSpecifications(toolSpecifications)
+                .build());
+
+        return Response.from(
+                chatResponse.aiMessage(),
+                chatResponse.tokenUsage(),
+                chatResponse.finishReason());
+
+    }
+
+    @Override
+    public Response<AiMessage> generate(List<ChatMessage> messages) {
+        return generate(messages, Collections.emptyList());
+    }
+
+    @Override
+    public Response<AiMessage> generate(List<ChatMessage> messages, ToolSpecification toolSpecification) {
+        return generate(messages,
+                toolSpecification != null ? Collections.singletonList(toolSpecification) : Collections.emptyList());
+    }
+}

--- a/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/GeminiEmbeddingModel.java
+++ b/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/GeminiEmbeddingModel.java
@@ -1,0 +1,66 @@
+package io.quarkiverse.langchain4j.gemini.common;
+
+import java.util.List;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.Response;
+
+public abstract class GeminiEmbeddingModel implements EmbeddingModel {
+
+    private final String modelId;
+    private final Integer dimension;
+    private final String taskType;
+
+    public GeminiEmbeddingModel(String modelId, Integer dimension, String taskType) {
+        this.modelId = modelId;
+        this.dimension = dimension;
+        this.taskType = taskType;
+    }
+
+    @Override
+    public Response<Embedding> embed(String text) {
+
+        EmbedContentRequest embedContentRequest = getEmbedContentRequest(modelId, text);
+
+        EmbedContentResponse embedContentResponse = embedContent(embedContentRequest);
+
+        return Response.from(Embedding.from(embedContentResponse.embedding().values()));
+    }
+
+    @Override
+    public Response<List<Embedding>> embedAll(List<TextSegment> textSegments) {
+        List<EmbedContentRequest> embedContentRequests = textSegments.stream()
+                .map(textSegment -> getEmbedContentRequest(modelId, textSegment.text()))
+                .toList();
+
+        EmbedContentResponses embedContentResponses = batchEmbedContents(
+                new EmbedContentRequests(embedContentRequests));
+
+        List<Embedding> embeddings = embedContentResponses.embeddings()
+                .stream()
+                .map(embedding -> Embedding.from(embedding.values()))
+                .toList();
+        return Response.from(embeddings);
+    }
+
+    private EmbedContentRequest getEmbedContentRequest(String model, String text) {
+        Content.Part part = Content.Part.ofText(text);
+        Content content = Content.ofPart(part);
+
+        EmbedContentRequest.TaskType embedTaskType = null;
+        if (this.taskType != null) {
+            embedTaskType = EmbedContentRequest.TaskType.valueOf(this.taskType);
+        }
+
+        EmbedContentRequest embedContentRequest = new EmbedContentRequest("models/" + model, content,
+                embedTaskType, null, this.dimension);
+        return embedContentRequest;
+    }
+
+    protected abstract EmbedContentResponse embedContent(EmbedContentRequest embedContentRequest);
+
+    protected abstract EmbedContentResponses batchEmbedContents(EmbedContentRequests embedContentRequests);
+
+}

--- a/model-providers/google/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/VertexAiGeminiChatLanguageModel.java
+++ b/model-providers/google/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/VertexAiGeminiChatLanguageModel.java
@@ -1,68 +1,30 @@
 package io.quarkiverse.langchain4j.vertexai.runtime.gemini;
 
-import static dev.langchain4j.data.message.AiMessage.aiMessage;
-import static dev.langchain4j.internal.Utils.getOrDefault;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
-import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.client.api.LoggingScope;
 
-import dev.langchain4j.agent.tool.ToolExecutionRequest;
-import dev.langchain4j.agent.tool.ToolSpecification;
-import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.model.chat.ChatLanguageModel;
-import dev.langchain4j.model.chat.listener.ChatModelErrorContext;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
-import dev.langchain4j.model.chat.listener.ChatModelRequest;
-import dev.langchain4j.model.chat.listener.ChatModelRequestContext;
-import dev.langchain4j.model.chat.listener.ChatModelResponse;
-import dev.langchain4j.model.chat.listener.ChatModelResponseContext;
-import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.request.ResponseFormat;
-import dev.langchain4j.model.chat.request.ResponseFormatType;
-import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
-import dev.langchain4j.model.output.FinishReason;
-import dev.langchain4j.model.output.Response;
-import dev.langchain4j.model.output.TokenUsage;
-import io.quarkiverse.langchain4j.gemini.common.ContentMapper;
-import io.quarkiverse.langchain4j.gemini.common.FinishReasonMapper;
+import io.quarkiverse.langchain4j.gemini.common.GeminiChatLanguageModel;
 import io.quarkiverse.langchain4j.gemini.common.GenerateContentRequest;
 import io.quarkiverse.langchain4j.gemini.common.GenerateContentResponse;
-import io.quarkiverse.langchain4j.gemini.common.GenerateContentResponseHandler;
-import io.quarkiverse.langchain4j.gemini.common.GenerationConfig;
-import io.quarkiverse.langchain4j.gemini.common.SchemaMapper;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 
-public class VertexAiGeminiChatLanguageModel implements ChatLanguageModel {
-    private static final Logger log = Logger.getLogger(VertexAiGeminiChatLanguageModel.class);
-
-    private final Double temperature;
-    private final Integer maxOutputTokens;
-    private final Integer topK;
-    private final Double topP;
-    private final ResponseFormat responseFormat;
-    private final List<ChatModelListener> listeners;
+public class VertexAiGeminiChatLanguageModel extends GeminiChatLanguageModel {
 
     private final VertxAiGeminiRestApi.ApiMetadata apiMetadata;
     private final VertxAiGeminiRestApi restApi;
 
     private VertexAiGeminiChatLanguageModel(Builder builder) {
-        this.temperature = builder.temperature;
-        this.maxOutputTokens = builder.maxOutputTokens;
-        this.topK = builder.topK;
-        this.topP = builder.topP;
-        this.responseFormat = builder.responseFormat;
-        this.listeners = builder.listeners;
+        super(builder.modelId, builder.temperature, builder.maxOutputTokens, builder.topK, builder.topP, builder.responseFormat,
+                builder.listeners);
 
         this.apiMetadata = VertxAiGeminiRestApi.ApiMetadata
                 .builder()
@@ -91,164 +53,14 @@ public class VertexAiGeminiChatLanguageModel implements ChatLanguageModel {
     }
 
     @Override
-    public dev.langchain4j.model.chat.response.ChatResponse chat(dev.langchain4j.model.chat.request.ChatRequest chatRequest) {
-        ChatRequestParameters requestParameters = chatRequest.parameters();
-        ResponseFormat effectiveResponseFormat = getOrDefault(requestParameters.responseFormat(), responseFormat);
-        GenerationConfig generationConfig = GenerationConfig.builder()
-                .maxOutputTokens(getOrDefault(requestParameters.maxOutputTokens(), this.maxOutputTokens))
-                .responseMimeType(computeMimeType(effectiveResponseFormat))
-                .responseSchema(effectiveResponseFormat != null
-                        ? SchemaMapper.fromJsonSchemaToSchema(effectiveResponseFormat.jsonSchema())
-                        : null)
-                .stopSequences(requestParameters.stopSequences())
-                .temperature(getOrDefault(requestParameters.temperature(), this.temperature))
-                .topK(getOrDefault(requestParameters.topK(), this.topK))
-                .topP(getOrDefault(requestParameters.topP(), this.topP))
-                .build();
-
-        GenerateContentRequest request = ContentMapper.map(chatRequest.messages(), chatRequest.toolSpecifications(),
-                generationConfig);
-
-        ChatModelRequest modelListenerRequest = createModelListenerRequest(request, chatRequest.messages(),
-                chatRequest.toolSpecifications());
-        Map<Object, Object> attributes = new ConcurrentHashMap<>();
-        ChatModelRequestContext requestContext = new ChatModelRequestContext(modelListenerRequest, attributes);
-        listeners.forEach(listener -> {
-            try {
-                listener.onRequest(requestContext);
-            } catch (Exception e) {
-                log.warn("Exception while calling model listener", e);
-            }
-        });
-
-        try {
-            GenerateContentResponse response = restApi.generateContent(request, apiMetadata);
-
-            String text = GenerateContentResponseHandler.getText(response);
-            List<ToolExecutionRequest> toolExecutionRequests = GenerateContentResponseHandler
-                    .getToolExecutionRequests(response);
-            AiMessage aiMessage = toolExecutionRequests.isEmpty()
-                    ? aiMessage(text)
-                    : aiMessage(text, toolExecutionRequests);
-
-            final TokenUsage tokenUsage = GenerateContentResponseHandler.getTokenUsage(response.usageMetadata());
-            final FinishReason finishReason = FinishReasonMapper.map(GenerateContentResponseHandler.getFinishReason(response));
-            final Response<AiMessage> aiMessageResponse = Response.from(aiMessage, tokenUsage);
-
-            ChatModelResponse modelListenerResponse = createModelListenerResponse(
-                    null,
-                    apiMetadata.modelId,
-                    aiMessageResponse);
-            ChatModelResponseContext responseContext = new ChatModelResponseContext(
-                    modelListenerResponse,
-                    modelListenerRequest,
-                    attributes);
-            listeners.forEach(listener -> {
-                try {
-                    listener.onResponse(responseContext);
-                } catch (Exception e) {
-                    log.warn("Exception while calling model listener", e);
-                }
-            });
-
-            return dev.langchain4j.model.chat.response.ChatResponse.builder()
-                    .aiMessage(aiMessage)
-                    .tokenUsage(tokenUsage)
-                    .finishReason(finishReason)
-                    .build();
-        } catch (RuntimeException e) {
-            ChatModelErrorContext errorContext = new ChatModelErrorContext(
-                    e,
-                    modelListenerRequest,
-                    null,
-                    attributes);
-
-            listeners.forEach(listener -> {
-                try {
-                    listener.onError(errorContext);
-                } catch (Exception e2) {
-                    log.warn("Exception while calling model listener", e2);
-                }
-            });
-
-            throw e;
-        }
-    }
-
-    @Override
-    public Response<AiMessage> generate(List<ChatMessage> messages, List<ToolSpecification> toolSpecifications) {
-        var chatResponse = chat(dev.langchain4j.model.chat.request.ChatRequest.builder()
-                .messages(messages)
-                .toolSpecifications(toolSpecifications)
-                .build());
-
-        return Response.from(
-                chatResponse.aiMessage(),
-                chatResponse.tokenUsage(),
-                chatResponse.finishReason());
-
-    }
-
-    @Override
-    public Response<AiMessage> generate(List<ChatMessage> messages) {
-        return generate(messages, Collections.emptyList());
-    }
-
-    @Override
-    public Response<AiMessage> generate(List<ChatMessage> messages, ToolSpecification toolSpecification) {
-        return generate(messages,
-                toolSpecification != null ? Collections.singletonList(toolSpecification) : Collections.emptyList());
-    }
-
-    private ChatModelRequest createModelListenerRequest(GenerateContentRequest request,
-            List<ChatMessage> messages,
-            List<ToolSpecification> toolSpecifications) {
-        var builder = ChatModelRequest.builder()
-                .model(apiMetadata.modelId)
-                .messages(messages)
-                .toolSpecifications(toolSpecifications)
-                .temperature(temperature)
-                .topP(topP)
-                .maxTokens(maxOutputTokens);
-        return builder.build();
-    }
-
-    private ChatModelResponse createModelListenerResponse(String responseId,
-            String responseModel,
-            Response<AiMessage> response) {
-        if (response == null) {
-            return null;
-        }
-
-        return ChatModelResponse.builder()
-                .id(responseId)
-                .model(responseModel)
-                .tokenUsage(response.tokenUsage())
-                .finishReason(response.finishReason())
-                .aiMessage(response.content())
-                .build();
-    }
-
-    private String computeMimeType(ResponseFormat responseFormat) {
-        if (responseFormat == null || ResponseFormatType.TEXT.equals(responseFormat.type())) {
-            return "text/plain";
-        }
-
-        if (ResponseFormatType.JSON.equals(responseFormat.type()) &&
-                responseFormat.jsonSchema() != null &&
-                responseFormat.jsonSchema().rootElement() != null &&
-                responseFormat.jsonSchema().rootElement() instanceof JsonEnumSchema) {
-            return "text/x.enum";
-        }
-
-        return "application/json";
+    protected GenerateContentResponse generateContext(GenerateContentRequest request) {
+        return restApi.generateContent(request, apiMetadata);
     }
 
     public static Builder builder() {
         return new Builder();
     }
 
-    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     public static final class Builder {
 
         private Optional<String> baseUrl = Optional.empty();
@@ -340,4 +152,5 @@ public class VertexAiGeminiChatLanguageModel implements ChatLanguageModel {
             return new VertexAiGeminiChatLanguageModel(this);
         }
     }
+
 }


### PR DESCRIPTION
This PR attempts to minimize the duplication between AiGemini and VertexAiGemini by pushing the common `ChatModel` and `EmbeddingModel` code down to the `gemini-common` module.

Some duplication will still remain and can be minimized during some follow-up iterations but, hopefully, with the `ChatModel` and `EmbeddingModel` code becoming shared, it will be much easier to deal with fixing the model or content related issues for both providers at the same time.

CC @geoand @lordofthejars 