### PR TITLE
Make stdio the default MCP transport

### DIFF
--- a/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/config/McpClientConfig.java
+++ b/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/config/McpClientConfig.java
@@ -16,6 +16,7 @@ public interface McpClientConfig {
     /**
      * Transport type
      */
+    @WithDefault("stdio")
     McpTransportType transportType();
 
     /**


### PR DESCRIPTION
Fixes https://github.com/quarkiverse/quarkus-langchain4j/issues/1346