### PR TITLE
Bump wc-chatbot from 0.2.0 to 0.2.1 and increase wc-chatbot window size

### DIFF
--- a/codestarts/chatbot/runtime/pom.xml
+++ b/codestarts/chatbot/runtime/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.mvnpm</groupId>
             <artifactId>wc-chatbot</artifactId>
-            <version>0.2.0</version>
+            <version>0.2.1</version>
             <scope>runtime</scope>
         </dependency>
     </dependencies>

--- a/codestarts/chatbot/runtime/src/main/codestarts/quarkus/langchain4j-chatbot-codestart/base/src/main/resources/META-INF/resources/index.html
+++ b/codestarts/chatbot/runtime/src/main/codestarts/quarkus/langchain4j-chatbot-codestart/base/src/main/resources/META-INF/resources/index.html
@@ -44,6 +44,8 @@
             --chatbot-header-title-color: #FFFFFF;
             --chatbot-body-bg-color: var(--main-bg-color);
             --chatbot-send-button-color: rgba(237, 98, 128);
+            --chatbot-container-width: 500px;
+            --chatbot-container-height: 600px;
         }
 
          chat-bot::part(chat-bubble) {

--- a/samples/chatbot-easy-rag/pom.xml
+++ b/samples/chatbot-easy-rag/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.mvnpm</groupId>
             <artifactId>wc-chatbot</artifactId>
-            <version>0.2.0</version>
+            <version>0.2.1</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/samples/chatbot-easy-rag/src/main/resources/META-INF/resources/index.html
+++ b/samples/chatbot-easy-rag/src/main/resources/META-INF/resources/index.html
@@ -38,10 +38,12 @@
         chat-bot {
             --chatbot-avatar-bg-color: var(--main-highlight-text-color);
             --chatbot-avatar-margin: 10%;
-            --chatbot-header-bg-color: var(--main-highlight-text-color);;
+            --chatbot-header-bg-color: var(--main-highlight-text-color);
             --chatbot-header-title-color: #FFFFFF;
             --chatbot-body-bg-color: var(--main-bg-color);
-            --chatbot-send-button-color: var(--main-highlight-text-color);;
+            --chatbot-send-button-color: var(--main-highlight-text-color);
+            --chatbot-container-width: 500px;
+            --chatbot-container-height: 600px;
         }
 
         .middle {

--- a/samples/chatbot-web-search/pom.xml
+++ b/samples/chatbot-web-search/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.mvnpm</groupId>
             <artifactId>wc-chatbot</artifactId>
-            <version>0.2.0</version>
+            <version>0.2.1</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/samples/chatbot-web-search/src/main/resources/META-INF/resources/index.html
+++ b/samples/chatbot-web-search/src/main/resources/META-INF/resources/index.html
@@ -38,10 +38,12 @@
         chat-bot {
             --chatbot-avatar-bg-color: var(--main-highlight-text-color);
             --chatbot-avatar-margin: 10%;
-            --chatbot-header-bg-color: var(--main-highlight-text-color);;
+            --chatbot-header-bg-color: var(--main-highlight-text-color);
             --chatbot-header-title-color: #FFFFFF;
             --chatbot-body-bg-color: var(--main-bg-color);
-            --chatbot-send-button-color: var(--main-highlight-text-color);;
+            --chatbot-send-button-color: var(--main-highlight-text-color);
+            --chatbot-container-width: 500px;
+            --chatbot-container-height: 600px;
         }
 
         .middle {

--- a/samples/chatbot/pom.xml
+++ b/samples/chatbot/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.mvnpm</groupId>
             <artifactId>wc-chatbot</artifactId>
-            <version>0.2.0</version>
+            <version>0.2.1</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/samples/chatbot/src/main/resources/META-INF/resources/index.html
+++ b/samples/chatbot/src/main/resources/META-INF/resources/index.html
@@ -38,10 +38,12 @@
         chat-bot {
             --chatbot-avatar-bg-color: var(--main-highlight-text-color);
             --chatbot-avatar-margin: 10%;
-            --chatbot-header-bg-color: var(--main-highlight-text-color);;
+            --chatbot-header-bg-color: var(--main-highlight-text-color);
             --chatbot-header-title-color: #FFFFFF;
             --chatbot-body-bg-color: var(--main-bg-color);
-            --chatbot-send-button-color: var(--main-highlight-text-color);;
+            --chatbot-send-button-color: var(--main-highlight-text-color);
+            --chatbot-container-width: 500px;
+            --chatbot-container-height: 600px;
         }
 
         .middle {

--- a/samples/mcp-sse-client-server/mcp-client/pom.xml
+++ b/samples/mcp-sse-client-server/mcp-client/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.mvnpm</groupId>
             <artifactId>wc-chatbot</artifactId>
-            <version>0.2.0</version>
+            <version>0.2.1</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/samples/mcp-sse-client-server/mcp-client/src/main/resources/META-INF/resources/index.html
+++ b/samples/mcp-sse-client-server/mcp-client/src/main/resources/META-INF/resources/index.html
@@ -38,10 +38,12 @@
         chat-bot {
             --chatbot-avatar-bg-color: var(--main-highlight-text-color);
             --chatbot-avatar-margin: 10%;
-            --chatbot-header-bg-color: var(--main-highlight-text-color);;
+            --chatbot-header-bg-color: var(--main-highlight-text-color);
             --chatbot-header-title-color: #FFFFFF;
             --chatbot-body-bg-color: var(--main-bg-color);
-            --chatbot-send-button-color: var(--main-highlight-text-color);;
+            --chatbot-send-button-color: var(--main-highlight-text-color);
+            --chatbot-container-width: 500px;
+            --chatbot-container-height: 600px;
         }
 
         .middle {

--- a/samples/mcp-tools/pom.xml
+++ b/samples/mcp-tools/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.mvnpm</groupId>
             <artifactId>wc-chatbot</artifactId>
-            <version>0.2.0</version>
+            <version>0.2.1</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/samples/mcp-tools/src/main/resources/META-INF/resources/index.html
+++ b/samples/mcp-tools/src/main/resources/META-INF/resources/index.html
@@ -38,10 +38,12 @@
         chat-bot {
             --chatbot-avatar-bg-color: var(--main-highlight-text-color);
             --chatbot-avatar-margin: 10%;
-            --chatbot-header-bg-color: var(--main-highlight-text-color);;
+            --chatbot-header-bg-color: var(--main-highlight-text-color);
             --chatbot-header-title-color: #FFFFFF;
             --chatbot-body-bg-color: var(--main-bg-color);
-            --chatbot-send-button-color: var(--main-highlight-text-color);;
+            --chatbot-send-button-color: var(--main-highlight-text-color);
+            --chatbot-container-width: 500px;
+            --chatbot-container-height: 600px;
         }
 
         .middle {

--- a/samples/secure-sql-chatbot/pom.xml
+++ b/samples/secure-sql-chatbot/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>org.mvnpm</groupId>
             <artifactId>wc-chatbot</artifactId>
-            <version>0.2.0</version>
+            <version>0.2.1</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/samples/secure-sql-chatbot/src/main/resources/templates/movieMuse.html
+++ b/samples/secure-sql-chatbot/src/main/resources/templates/movieMuse.html
@@ -71,10 +71,12 @@ customElements.define('demo-chat', DemoChat);
         chat-bot {
             --chatbot-avatar-bg-color: var(--main-highlight-text-color);
             --chatbot-avatar-margin: 10%;
-            --chatbot-header-bg-color: var(--main-highlight-text-color);;
+            --chatbot-header-bg-color: var(--main-highlight-text-color);
             --chatbot-header-title-color: #FFFFFF;
             --chatbot-body-bg-color: var(--main-bg-color);
-            --chatbot-send-button-color: var(--main-highlight-text-color);;
+            --chatbot-send-button-color: var(--main-highlight-text-color);
+            --chatbot-container-width: 500px;
+            --chatbot-container-height: 600px;
         }
 
        .title {

--- a/samples/sql-chatbot/pom.xml
+++ b/samples/sql-chatbot/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.mvnpm</groupId>
             <artifactId>wc-chatbot</artifactId>
-            <version>0.2.0</version>
+            <version>0.2.1</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/samples/sql-chatbot/src/main/resources/META-INF/resources/index.html
+++ b/samples/sql-chatbot/src/main/resources/META-INF/resources/index.html
@@ -38,10 +38,12 @@
         chat-bot {
             --chatbot-avatar-bg-color: var(--main-highlight-text-color);
             --chatbot-avatar-margin: 10%;
-            --chatbot-header-bg-color: var(--main-highlight-text-color);;
+            --chatbot-header-bg-color: var(--main-highlight-text-color);
             --chatbot-header-title-color: #FFFFFF;
             --chatbot-body-bg-color: var(--main-bg-color);
-            --chatbot-send-button-color: var(--main-highlight-text-color);;
+            --chatbot-send-button-color: var(--main-highlight-text-color);
+            --chatbot-container-width: 500px;
+            --chatbot-container-height: 600px;
         }
 
         .middle {


### PR DESCRIPTION
Bump wc-chatbot from 0.2.0 to 0.2.1 and increase wc-chatbot window size

Window size is adjustable since https://github.com/yishiashia/wc-chatbot/pull/7

Changing from the default 360 x 500 to 500 x 600 px to have more space for the interaction and returned content.