### PR TITLE
Enable text extraction and built-in services in watsonx.ai

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/LangChain4jDotNames.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/LangChain4jDotNames.java
@@ -65,7 +65,7 @@ public class LangChain4jDotNames {
     static final DotName STRUCTURED_PROMPT_PROCESSOR = DotName.createSimple(StructuredPromptProcessor.class);
     static final DotName V = DotName.createSimple(dev.langchain4j.service.V.class);
 
-    static final DotName MODEL_NAME = DotName.createSimple(ModelName.class);
+    public static final DotName MODEL_NAME = DotName.createSimple(ModelName.class);
     public static final DotName REGISTER_AI_SERVICES = DotName.createSimple(RegisterAiService.class);
 
     static final DotName BEAN_CHAT_MODEL_SUPPLIER = DotName.createSimple(

--- a/docs/modules/ROOT/pages/watsonx.adoc
+++ b/docs/modules/ROOT/pages/watsonx.adoc
@@ -141,6 +141,132 @@ public interface AiService {
 
 NOTE: The `@SystemMessage` and `@UserMessage` annotations are joined by default with no separator (an empty string `""`). If you want to change this behavior, use the property `quarkus.langchain4j.watsonx.generation-model.prompt-joiner=<value>`.
 
+== Text Extraction
+
+The `TextExtraction` feature enables developers to extract text from high-value business documents stored in IBM Cloud Object Storage. Extracted text can be used for AI processing, key information identification, or further document analysis.
+
+The API supports text extraction from the following file types:
+
+* PDF
+* GIF
+* JPG
+* PNG
+* TIFF
+
+The extracted text can be output in the following formats:
+
+* JSON
+* Markdown
+
+=== Configuration
+
+To enable `TextExtraction` in your application, configure the following properties:
+
+[source,properties]
+----
+quarkus.langchain4j.watsonx.text-extraction.base-url=<base-url>
+quarkus.langchain4j.watsonx.text-extraction.document-reference.connection=<connection-id>
+quarkus.langchain4j.watsonx.text-extraction.document-reference.bucket-name=<bucket-name>
+quarkus.langchain4j.watsonx.text-extraction.results-reference.connection=<connection-id>
+quarkus.langchain4j.watsonx.text-extraction.results-reference.bucket-name=<bucket-name>
+----
+
+- **`base-url`**: The endpoint where the IBM Cloud Object Storage instance is deployed. To find the appropriate value, refer to the https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-endpoints#regionalendpointtable1[IBM Cloud Object Storage endpoint table].  
+- **`document-reference.connection`**: The connection asset ID containing credentials to access the source storage.  
+- **`document-reference.bucket-name`**: The bucket where documents to be processed will be uploaded.  
+- **`results-reference.connection`**: The connection asset ID containing credentials to access the output storage.  
+- **`results-reference.bucket-name`**: The bucket where extracted text documents will be saved as new files.  
+
+The `document reference` properties define the source storage for input and uloaded files, while the `results reference` properties specify where the extracted content is stored. Both can refer to the same bucket or different ones.
+
+NOTE: For more information on how to get the connection parameter for the `document-reference` and `results-reference` you can refer to the documentation at this https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-api-files.html?context=wx&audience=wdp[link].
+
+=== Using Text Extraction
+
+The `TextExtraction` class provides multiple methods for extracting text from documents. You can either extract text from an existing file in IBM Cloud Object Storage or upload a file and extract its content. To use `TextExtraction`, you need to inject an instance into your application. If multiple configurations are defined, you can specify the appropriate one using the `@ModelName` qualifier.
+
+[source,java]
+----
+@Inject
+TextExtraction textExtraction;
+
+@Inject
+@ModelName("custom")
+TextExtraction customTextExtraction;
+----
+
+You can start the extraction process in two ways. 
+
+First, if the document is already stored in IBM Cloud Object Storage, you can initiate the extraction by using the following method:
+
+[source,java]
+----
+String extractionId = textExtraction.startExtraction("path/to/document.pdf", List.of(Language.ENGLISH));
+----
+
+Alternatively, if you're working with a local file, you can upload it and start the extraction process with:
+
+[source,java]
+----
+File file = new File("path/to/document.pdf");
+String extractionId = textExtraction.uploadAndStartExtraction(file, List.of(Language.ENGLISH));
+----
+
+After starting the extraction, you can check its status by calling:
+
+[source,java]
+----
+TextExtractionResponse response = textExtraction.checkExtractionStatus(extractionId);
+----
+
+If you need to extract and retrieve the text immediately, you have two options.
+
+You can either extract text from an existing file directly:
+
+[source,java]
+----
+String extractedText = textExtraction.extractAndFetch("path/to/document.pdf", List.of(Language.ENGLISH));
+----
+
+Or upload the file and retrieve the extracted text immediately:
+
+[source,java]
+----
+File file = new File("path/to/document.pdf");
+String extractedText = textExtraction.uploadExtractAndFetch(file, List.of(Language.ENGLISH));
+----
+
+
+All extraction methods can also accept an `Options` object as parameter.
+
+The `Options` object allows customization of extraction behavior, including:  
+
+- Whether uploaded files should be deleted after processing.  
+- Whether extracted text files should be removed from the results bucket after retrieval.  
+- Overriding default properties values configured.  
+
+[source,java]
+----
+Options options = 
+    Options.create(List.of(ENGLISH))
+        .removeOutputFile(true)
+        .removeUploadedFile(true);
+
+File file = new File("path/to/document.pdf");
+String extractedText = textExtraction.uploadExtractAndFetch(file, options));
+----
+
+To perform Retrieval-Augmented Generation (RAG) on the extracted files in IBM Cloud Object Storage, you can use the following dependency to interact with the storage as it uses the S3 protocol:
+
+[source,xml]
+----
+<dependency>
+    <groupId>dev.langchain4j</groupId>
+    <artifactId>langchain4j-document-loader-amazon-s3</artifactId>
+    <version>...</version>
+</dependency>
+----
+
 ==== All configuration properties
 
 include::includes/quarkus-langchain4j-watsonx.adoc[leveloffset=+1,opts=optional]

--- a/docs/modules/ROOT/pages/watsonx.adoc
+++ b/docs/modules/ROOT/pages/watsonx.adoc
@@ -34,6 +34,7 @@ The `base-url` property depends on the region of the provided service instance, 
 * London: https://eu-gb.ml.cloud.ibm.com
 * Tokyo: https://jp-tok.ml.cloud.ibm.com
 * Sydney: https://au-syd.ml.cloud.ibm.com
+* Toronto: https://ca-tor.ml.cloud.ibm.com
 
 [source,properties,subs=attributes+]
 ----
@@ -138,7 +139,7 @@ public interface AiService {
 }
 ----
 
-NOTE: The `@SystemMessage` and `@UserMessage` annotations are joined by default with no separator (an empty string `""`). If you want to change this behavior, use the property `quarkus.langchain4j.watsonx.generation-model.prompt-joiner=<value>`. 
+NOTE: The `@SystemMessage` and `@UserMessage` annotations are joined by default with no separator (an empty string `""`). If you want to change this behavior, use the property `quarkus.langchain4j.watsonx.generation-model.prompt-joiner=<value>`.
 
 ==== All configuration properties
 

--- a/model-providers/watsonx/deployment/pom.xml
+++ b/model-providers/watsonx/deployment/pom.xml
@@ -18,6 +18,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-client-jackson-deployment</artifactId>
         </dependency>
+         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jaxb-deployment</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.quarkiverse.langchain4j</groupId>
             <artifactId>quarkus-langchain4j-core-deployment</artifactId>

--- a/model-providers/watsonx/deployment/src/main/java/io/quarkiverse/langchain4j/watsonx/deployment/WatsonxDotNames.java
+++ b/model-providers/watsonx/deployment/src/main/java/io/quarkiverse/langchain4j/watsonx/deployment/WatsonxDotNames.java
@@ -2,6 +2,7 @@ package io.quarkiverse.langchain4j.watsonx.deployment;
 
 import org.jboss.jandex.DotName;
 
+import io.quarkiverse.langchain4j.watsonx.runtime.TextExtraction;
 import io.quarkiverse.langchain4j.watsonx.services.GoogleSearchService;
 import io.quarkiverse.langchain4j.watsonx.services.WeatherService;
 import io.quarkiverse.langchain4j.watsonx.services.WebCrawlerService;
@@ -10,4 +11,5 @@ public class WatsonxDotNames {
     public static final DotName WEB_CRAWLER_SERVICE = DotName.createSimple(WebCrawlerService.class);
     public static final DotName GOOGLE_SEARCH_SERVICE = DotName.createSimple(GoogleSearchService.class);
     public static final DotName WEATHER_SERVICE = DotName.createSimple(WeatherService.class);
+    public static final DotName TEXT_EXTRACTION = DotName.createSimple(TextExtraction.class);
 }

--- a/model-providers/watsonx/deployment/src/main/java/io/quarkiverse/langchain4j/watsonx/deployment/WatsonxDotNames.java
+++ b/model-providers/watsonx/deployment/src/main/java/io/quarkiverse/langchain4j/watsonx/deployment/WatsonxDotNames.java
@@ -1,0 +1,13 @@
+package io.quarkiverse.langchain4j.watsonx.deployment;
+
+import org.jboss.jandex.DotName;
+
+import io.quarkiverse.langchain4j.watsonx.services.GoogleSearchService;
+import io.quarkiverse.langchain4j.watsonx.services.WeatherService;
+import io.quarkiverse.langchain4j.watsonx.services.WebCrawlerService;
+
+public class WatsonxDotNames {
+    public static final DotName WEB_CRAWLER_SERVICE = DotName.createSimple(WebCrawlerService.class);
+    public static final DotName GOOGLE_SEARCH_SERVICE = DotName.createSimple(GoogleSearchService.class);
+    public static final DotName WEATHER_SERVICE = DotName.createSimple(WeatherService.class);
+}

--- a/model-providers/watsonx/deployment/src/main/java/io/quarkiverse/langchain4j/watsonx/deployment/items/BuiltinServiceBuildItem.java
+++ b/model-providers/watsonx/deployment/src/main/java/io/quarkiverse/langchain4j/watsonx/deployment/items/BuiltinServiceBuildItem.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.langchain4j.watsonx.deployment.items;
+
+import org.jboss.jandex.DotName;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class BuiltinServiceBuildItem extends MultiBuildItem {
+
+    private DotName dotName;
+
+    public BuiltinServiceBuildItem(DotName dotName) {
+        this.dotName = dotName;
+    }
+
+    public DotName getDotName() {
+        return dotName;
+    }
+}

--- a/model-providers/watsonx/deployment/src/main/java/io/quarkiverse/langchain4j/watsonx/deployment/items/TextExtractionClassBuildItem.java
+++ b/model-providers/watsonx/deployment/src/main/java/io/quarkiverse/langchain4j/watsonx/deployment/items/TextExtractionClassBuildItem.java
@@ -1,0 +1,16 @@
+package io.quarkiverse.langchain4j.watsonx.deployment.items;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class TextExtractionClassBuildItem extends MultiBuildItem {
+
+    private String qualifier;
+
+    public TextExtractionClassBuildItem(String qualifier) {
+        this.qualifier = qualifier;
+    }
+
+    public String getQualifier() {
+        return qualifier;
+    }
+}

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/AiChatCacheTokenTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/AiChatCacheTokenTest.java
@@ -1,5 +1,14 @@
 package io.quarkiverse.langchain4j.watsonx.deployment;
 
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.API_KEY;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.PROJECT_ID;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.RESPONSE_WATSONX_CHAT_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.RESPONSE_WATSONX_CHAT_STREAMING_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_IAM_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_CHAT_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_CHAT_STREAMING_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.streamingChatResponseHandler;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -25,7 +34,6 @@ import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
 import dev.langchain4j.model.chat.response.ChatResponse;
-import io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.WatsonxBuilder;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class AiChatCacheTokenTest extends WireMockAbstract {
@@ -47,10 +55,10 @@ public class AiChatCacheTokenTest extends WireMockAbstract {
 
     @RegisterExtension
     static QuarkusUnitTest unitTest = new QuarkusUnitTest()
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", WireMockUtil.URL_WATSONX_SERVER)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", WireMockUtil.URL_IAM_SERVER)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", WireMockUtil.API_KEY)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", WireMockUtil.PROJECT_ID)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", URL_WATSONX_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", URL_IAM_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", PROJECT_ID)
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
 
     @Inject
@@ -70,38 +78,37 @@ public class AiChatCacheTokenTest extends WireMockAbstract {
         Date date = Date.from(Instant.now().plusMillis(cacheTimeout));
 
         // First call returns 200.
-        mockServers.mockIAMBuilder(200)
+        mockIAMBuilder(200)
                 .scenario(Scenario.STARTED, "error")
                 .response("3secondstoken", date)
                 .build();
 
         // All other call after 2 seconds they will give an error.
-        mockServers.mockIAMBuilder(401)
+        mockIAMBuilder(401)
                 .scenario("error", Scenario.STARTED)
                 .response("Should never happen")
                 .build();
 
         Stream.of(
-                Map.entry(WireMockUtil.URL_WATSONX_CHAT_API, WireMockUtil.RESPONSE_WATSONX_CHAT_API),
-                Map.entry(WireMockUtil.URL_WATSONX_CHAT_STREAMING_API,
-                        WireMockUtil.RESPONSE_WATSONX_CHAT_STREAMING_API))
+                Map.entry(URL_WATSONX_CHAT_API, RESPONSE_WATSONX_CHAT_API),
+                Map.entry(URL_WATSONX_CHAT_STREAMING_API, RESPONSE_WATSONX_CHAT_STREAMING_API))
                 .forEach(entry -> {
 
-                    WatsonxBuilder builder = mockServers.mockWatsonxBuilder(entry.getKey(), 200);
+                    WatsonxBuilder builder = mockWatsonxBuilder(entry.getKey(), 200);
 
                     builder.token("3secondstoken")
-                            .responseMediaType(entry.getKey().equals(WireMockUtil.URL_WATSONX_CHAT_STREAMING_API)
+                            .responseMediaType(entry.getKey().equals(URL_WATSONX_CHAT_STREAMING_API)
                                     ? MediaType.SERVER_SENT_EVENTS
                                     : MediaType.APPLICATION_JSON)
                             .response(entry.getValue())
                             .build();
 
                     switch (entry.getKey()) {
-                        case WireMockUtil.URL_WATSONX_CHAT_API -> {
+                        case URL_WATSONX_CHAT_API -> {
                             assertDoesNotThrow(() -> chatModel.chat("message"));
                             assertDoesNotThrow(() -> chatModel.chat("message")); // cache
                         }
-                        case WireMockUtil.URL_WATSONX_CHAT_STREAMING_API ->
+                        case URL_WATSONX_CHAT_STREAMING_API ->
                             assertDoesNotThrow(() -> chatModel.chat("message")); // cache.
                     }
                 });
@@ -111,43 +118,42 @@ public class AiChatCacheTokenTest extends WireMockAbstract {
     void try_token_retry() throws InterruptedException {
 
         // Return an expired token.
-        mockServers.mockIAMBuilder(200)
+        mockIAMBuilder(200)
                 .scenario(Scenario.STARTED, "retry")
                 .response("expired_token", Date.from(Instant.now().minusSeconds(3)))
                 .build();
 
         // Second call (retryOn) returns 200
-        mockServers.mockIAMBuilder(200)
+        mockIAMBuilder(200)
                 .scenario("retry", Scenario.STARTED)
                 .response("my_super_token", Date.from(Instant.now().plusMillis(cacheTimeout)))
                 .build();
 
         Stream.of(
-                Map.entry(WireMockUtil.URL_WATSONX_CHAT_API, WireMockUtil.RESPONSE_WATSONX_CHAT_API),
-                Map.entry(WireMockUtil.URL_WATSONX_CHAT_STREAMING_API,
-                        WireMockUtil.RESPONSE_WATSONX_CHAT_STREAMING_API))
+                Map.entry(URL_WATSONX_CHAT_API, RESPONSE_WATSONX_CHAT_API),
+                Map.entry(URL_WATSONX_CHAT_STREAMING_API, RESPONSE_WATSONX_CHAT_STREAMING_API))
                 .forEach(entry -> {
-                    mockServers.mockWatsonxBuilder(entry.getKey(), 401)
+                    mockWatsonxBuilder(entry.getKey(), 401)
                             .token("expired_token")
                             .scenario(Scenario.STARTED, "retry")
                             .response(RESPONSE_401)
                             .build();
 
-                    mockServers.mockWatsonxBuilder(entry.getKey(), 200)
+                    mockWatsonxBuilder(entry.getKey(), 200)
                             .token("my_super_token")
                             .scenario("retry", Scenario.STARTED)
-                            .responseMediaType(entry.getKey().equals(WireMockUtil.URL_WATSONX_CHAT_STREAMING_API)
+                            .responseMediaType(entry.getKey().equals(URL_WATSONX_CHAT_STREAMING_API)
                                     ? MediaType.SERVER_SENT_EVENTS
                                     : MediaType.APPLICATION_JSON)
                             .response(entry.getValue())
                             .build();
 
                     switch (entry.getKey()) {
-                        case WireMockUtil.URL_WATSONX_CHAT_API -> assertDoesNotThrow(() -> chatModel.chat("message"));
-                        case WireMockUtil.URL_WATSONX_CHAT_STREAMING_API -> {
+                        case URL_WATSONX_CHAT_API -> assertDoesNotThrow(() -> chatModel.chat("message"));
+                        case URL_WATSONX_CHAT_STREAMING_API -> {
                             var streamingResponse = new AtomicReference<ChatResponse>();
                             assertDoesNotThrow(() -> streamingChatModel.chat("message",
-                                    WireMockUtil.streamingChatResponseHandler(streamingResponse)));
+                                    streamingChatResponseHandler(streamingResponse)));
                             await().atMost(Duration.ofSeconds(6))
                                     .pollInterval(Duration.ofSeconds(2))
                                     .until(() -> streamingResponse.get() != null);

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/AiGenerationServiceTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/AiGenerationServiceTest.java
@@ -1,5 +1,13 @@
 package io.quarkiverse.langchain4j.watsonx.deployment;
 
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.API_KEY;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.BEARER_TOKEN;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.DEFAULT_TIME_LIMIT;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.PROJECT_ID;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.RESPONSE_WATSONX_GENERATION_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_IAM_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_GENERATION_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_SERVER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Date;
@@ -27,19 +35,19 @@ public class AiGenerationServiceTest extends WireMockAbstract {
 
     @RegisterExtension
     static QuarkusUnitTest unitTest = new QuarkusUnitTest()
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", WireMockUtil.URL_WATSONX_SERVER)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", WireMockUtil.URL_IAM_SERVER)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", WireMockUtil.API_KEY)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", WireMockUtil.PROJECT_ID)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", URL_WATSONX_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", URL_IAM_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", PROJECT_ID)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.generation-model.model-id", "mistralai/mistral-large")
             .overrideConfigKey("quarkus.langchain4j.watsonx.mode", "generation")
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(WireMockUtil.class));
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
 
     @Override
     void handlerBeforeEach() {
-        mockServers.mockIAMBuilder(200)
+        mockIAMBuilder(200)
                 .grantType(langchain4jWatsonConfig.defaultConfig().iam().grantType())
-                .response(WireMockUtil.BEARER_TOKEN, new Date())
+                .response(BEARER_TOKEN, new Date())
                 .build();
     }
 
@@ -63,9 +71,9 @@ public class AiGenerationServiceTest extends WireMockAbstract {
     @Test
     void chat() throws Exception {
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 200)
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 200)
                 .body(mapper.writeValueAsString(generateRequest()))
-                .response(WireMockUtil.RESPONSE_WATSONX_GENERATION_API)
+                .response(RESPONSE_WATSONX_GENERATION_API)
                 .build();
 
         assertEquals("AI Response", aiService.chat("Hello"));
@@ -87,7 +95,7 @@ public class AiGenerationServiceTest extends WireMockAbstract {
                 .temperature(chatModelConfig.temperature())
                 .minNewTokens(chatModelConfig.minNewTokens())
                 .maxNewTokens(chatModelConfig.maxNewTokens())
-                .timeLimit(WireMockUtil.DEFAULT_TIME_LIMIT)
+                .timeLimit(DEFAULT_TIME_LIMIT)
                 .build();
 
         return new TextGenerationRequest(modelId, spaceId, projectId, input, parameters);

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/BuiltinServiceBaseUrlExceptionTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/BuiltinServiceBaseUrlExceptionTest.java
@@ -1,0 +1,43 @@
+package io.quarkiverse.langchain4j.watsonx.deployment;
+
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.API_KEY;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.PROJECT_ID;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_IAM_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_SERVER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.langchain4j.watsonx.services.WebCrawlerService;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class BuiltinServiceBaseUrlExceptionTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", URL_WATSONX_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", URL_IAM_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", PROJECT_ID)
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class).addClasses(WireMockUtil.class, WebCrawlerService.class))
+            .assertException(t -> {
+                assertThat(t).isInstanceOf(RuntimeException.class)
+                        .hasMessage(
+                                "The property 'quarkus.langchain4j.watsonx.base-url' does not have a correct url. Use one of the urls given in the documentation or use the property 'quarkus.langchain4j.watsonx.built-in-service.base-url' to set a custom url.");
+            });
+
+    @Inject
+    WebCrawlerService tool;
+
+    @Test
+    void test() {
+        fail("Should not be called");
+    }
+}

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/BuiltinServiceCacheTokenTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/BuiltinServiceCacheTokenTest.java
@@ -1,0 +1,133 @@
+package io.quarkiverse.langchain4j.watsonx.deployment;
+
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.API_KEY;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.PROJECT_ID;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_IAM_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WX_SERVER;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.time.Instant;
+import java.util.Date;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+
+import io.quarkiverse.langchain4j.watsonx.services.GoogleSearchService;
+import io.quarkiverse.langchain4j.watsonx.services.WeatherService;
+import io.quarkiverse.langchain4j.watsonx.services.WebCrawlerService;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class BuiltinServiceCacheTokenTest extends WireMockAbstract {
+
+    static int cacheTimeout = 2000;
+    static String RESPONSE_401 = """
+            {
+                "code": 401,
+                "error": "Unauthorized",
+                "reason": "Unauthorized",
+                "message": "Access denied",
+                "description": "jwt expired"
+            }
+            """;
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", URL_WATSONX_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.built-in-service.base-url", URL_WX_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", URL_IAM_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", PROJECT_ID)
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
+
+    @AfterEach
+    void afterEach() throws Exception {
+        Thread.sleep(cacheTimeout);
+    }
+
+    @Inject
+    WeatherService weatherTool;
+
+    @Test
+    void try_weather_tool_retry() throws InterruptedException {
+
+        var response = """
+                {
+                    "output": "Current weather in Naples:\\nTemperature: 12.1°C\\nRain: 0mm\\nRelative humidity: 94%\\nWind: 5km/h\\n"
+                }""";
+
+        mockIAMServer();
+        mockWXServer(response);
+        assertDoesNotThrow(() -> weatherTool.find("naples", null));
+    }
+
+    @Inject
+    WebCrawlerService webCrawlerTool;
+
+    @Test
+    void try_webcrawler_tool_retry() throws InterruptedException {
+
+        String response = "{" +
+                "\"output\": \"\\\"{\\\\\\\"url\\\\\\\":\\\\\\\"https://www.ibm.com/us-en\\\\\\\"," +
+                "\\\\\\\"contentType\\\\\\\":\\\\\\\"text/html;charset=utf-8\\\\\\\"," +
+                "\\\\\\\"content\\\\\\\":\\\\\\\"IBM - United States\\\\n\\\\nBoost developer productivity with AI..." +
+                "\\\\n\\\\nExplore jobs\\\\n\\\\nStart learning\\\\\\\"}\\\"\"\n" +
+                "}";
+
+        mockIAMServer();
+        mockWXServer(response);
+        assertDoesNotThrow(() -> webCrawlerTool.process("http://supersite.com"));
+    }
+
+    @Inject
+    GoogleSearchService googleSearchTool;
+
+    @Test
+    void try_googlesearh_tool_retry() throws InterruptedException {
+
+        String response = """
+                {
+                  "output": "[{\\"title\\":\\"Quarkus - Supersonic Subatomic Java\\",\\"description\\":\\"Quarkus streamlines framework optimizations in the build phase to reduce runtime dependencies and improve efficiency. By precomputing metadata and optimizing ...\\",\\"url\\":\\"https://quarkus.io/\\"}]"
+                }
+                """;
+
+        mockIAMServer();
+        mockWXServer(response);
+        assertDoesNotThrow(() -> googleSearchTool.search("quarkus", 1));
+    }
+
+    private void mockIAMServer() {
+        // Return an expired token.
+        mockServers.mockIAMBuilder(200)
+                .scenario(Scenario.STARTED, "retry")
+                .response("expired_token", Date.from(Instant.now().minusSeconds(3)))
+                .build();
+
+        // Second call (retryOn) returns 200
+        mockServers.mockIAMBuilder(200)
+                .scenario("retry", Scenario.STARTED)
+                .response("my_super_token", Date.from(Instant.now().plusMillis(cacheTimeout)))
+                .build();
+    }
+
+    private void mockWXServer(String response) {
+        mockServers.mockWxBuilder(WireMockUtil.URL_WX_AGENT_TOOL_RUN, 401)
+                .token("expired_token")
+                .scenario(Scenario.STARTED, "retry")
+                .response(RESPONSE_401)
+                .build();
+
+        mockServers.mockWxBuilder(WireMockUtil.URL_WX_AGENT_TOOL_RUN, 200)
+                .token("my_super_token")
+                .scenario("retry", Scenario.STARTED)
+                .response(response)
+                .build();
+    }
+}

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/BuiltinServiceInjectTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/BuiltinServiceInjectTest.java
@@ -1,0 +1,171 @@
+package io.quarkiverse.langchain4j.watsonx.deployment;
+
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.API_KEY;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.PROJECT_ID;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_IAM_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WX_AGENT_TOOL_RUN;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WX_SERVER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Date;
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.langchain4j.watsonx.bean.GoogleSearchResult;
+import io.quarkiverse.langchain4j.watsonx.bean.WebCrawlerResult;
+import io.quarkiverse.langchain4j.watsonx.services.GoogleSearchService;
+import io.quarkiverse.langchain4j.watsonx.services.WeatherService;
+import io.quarkiverse.langchain4j.watsonx.services.WebCrawlerService;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class BuiltinServiceInjectTest extends WireMockAbstract {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.built-in-service.base-url", URL_WX_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", URL_WATSONX_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", URL_IAM_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", PROJECT_ID)
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
+
+    @Override
+    void handlerBeforeEach() {
+        mockServers.mockIAMBuilder(200)
+                .grantType(langchain4jWatsonConfig.defaultConfig().iam().grantType())
+                .response(WireMockUtil.BEARER_TOKEN, new Date())
+                .build();
+    }
+
+    @Inject
+    WebCrawlerService webCrawlerTool;
+
+    @Inject
+    GoogleSearchService googleSearchTool;
+
+    @Inject
+    WeatherService weatherTool;
+
+    @Test
+    void testWebCrawler() throws Exception {
+
+        String body = """
+                {
+                    "tool_name": "WebCrawler",
+                    "input": {
+                        "url": "https://www.ibm.com/us-en"
+                    }
+                }""";
+
+        String response = "{" +
+                "\"output\": \"\\\"{\\\\\\\"url\\\\\\\":\\\\\\\"https://www.ibm.com/us-en\\\\\\\"," +
+                "\\\\\\\"contentType\\\\\\\":\\\\\\\"text/html;charset=utf-8\\\\\\\"," +
+                "\\\\\\\"content\\\\\\\":\\\\\\\"IBM - United States\\\\n\\\\nBoost developer productivity with AI..." +
+                "\\\\n\\\\nExplore jobs\\\\n\\\\nStart learning\\\\\\\"}\\\"\"\n" +
+                "}";
+
+        mockServers.mockWxBuilder(URL_WX_AGENT_TOOL_RUN, 200)
+                .body(body)
+                .response(response)
+                .build();
+
+        WebCrawlerResult result = webCrawlerTool.process("https://www.ibm.com/us-en");
+        assertEquals("https://www.ibm.com/us-en", result.url());
+        assertEquals("text/html;charset=utf-8", result.contentType());
+        assertTrue(result.content().startsWith("IBM - United States"));
+    }
+
+    @Test
+    void testWeather() throws Exception {
+
+        String body = """
+                {
+                    "tool_name" : "Weather",
+                    "input" : {
+                        "name": "naples",
+                        "country": "italy"
+                    }
+                }""";
+
+        String response = """
+                {
+                    "output": "Current weather in Naples:\\nTemperature: 12.1°C\\nRain: 0mm\\nRelative humidity: 94%\\nWind: 5km/h\\n"
+                }
+                """;
+
+        mockServers.mockWxBuilder(URL_WX_AGENT_TOOL_RUN, 200)
+                .body(body)
+                .response(response)
+                .build();
+
+        String result = weatherTool.find("naples", "italy");
+        assertTrue(result.startsWith("Current weather in Naples:"));
+    }
+
+    @Test
+    void testGoogleSearch() throws Exception {
+
+        String body = """
+                {
+                  "tool_name": "GoogleSearch",
+                  "input": "What was the weather in Toronto on January 13th 2025?",
+                  "config": {
+                    "maxResults": 10
+                  }
+                }""";
+
+        String response = """
+                {
+                  "output": "[{\\"title\\":\\"Toronto, Ontario, Canada Monthly Weather | AccuWeather\\",\\"description\\":\\"January. January February March April May June July August September October November December. 2025 ... 13°. 29. 37°. 18°. 30. 34°. 16°. 31. 36°. 18°. 1. 18°. 11 ...\\",\\"url\\":\\"https://www.accuweather.com/en/ca/toronto/m5h/january-weather/55488\\"},
+                  {\\"title\\":\\"Anthony Slater on X: \\\\\\"Draymond Green missed the Warriors ...\\\\\\"\\",\\"description\\":\\"Draymond Green missed the Warriors shootaround in Toronto this morning. Under the weather. He is questionable tonight with an illness. 4:45 PM · Jan 13, ...\\",\\"url\\":\\"https://x.com/anthonyVslater/status/1878845945854730255\\"},
+                  {\\"title\\":\\"Canada weather forecast for Tuesday, 13 January 2026\\",\\"description\\":\\"Weather in Canada during the last few years on January 13 ; 2025 - January 13, 32 ° / 26 °, 0 in ; 2024 - January 13, 39 ° / 26 °, 0.46 in ; 2023 - January 13, 32 ...\\",\\"url\\":\\"https://www.weather25.com/north-america/canada?page=date&date=13-1\\"}]"
+                }
+                """;
+
+        mockServers.mockWxBuilder(URL_WX_AGENT_TOOL_RUN, 200)
+                .body(body)
+                .response(response)
+                .build();
+
+        List<GoogleSearchResult> results = googleSearchTool.search("What was the weather in Toronto on January 13th 2025?");
+        assertEquals(3, results.size());
+    }
+
+    @Test
+    void testGoogleSearchWithCustomParameters() throws Exception {
+
+        String body = """
+                {
+                  "tool_name": "GoogleSearch",
+                  "input": "What was the weather in Toronto on January 13th 2025?",
+                  "config": {
+                    "maxResults": 3
+                  }
+                }""";
+
+        String response = """
+                {
+                  "output": "[{\\"title\\":\\"Toronto, Ontario, Canada Monthly Weather | AccuWeather\\",\\"description\\":\\"January. January February March April May June July August September October November December. 2025 ... 13°. 29. 37°. 18°. 30. 34°. 16°. 31. 36°. 18°. 1. 18°. 11 ...\\",\\"url\\":\\"https://www.accuweather.com/en/ca/toronto/m5h/january-weather/55488\\"},
+                  {\\"title\\":\\"Anthony Slater on X: \\\\\\"Draymond Green missed the Warriors ...\\\\\\"\\",\\"description\\":\\"Draymond Green missed the Warriors shootaround in Toronto this morning. Under the weather. He is questionable tonight with an illness. 4:45 PM · Jan 13, ...\\",\\"url\\":\\"https://x.com/anthonyVslater/status/1878845945854730255\\"},
+                  {\\"title\\":\\"Canada weather forecast for Tuesday, 13 January 2026\\",\\"description\\":\\"Weather in Canada during the last few years on January 13 ; 2025 - January 13, 32 ° / 26 °, 0 in ; 2024 - January 13, 39 ° / 26 °, 0.46 in ; 2023 - January 13, 32 ...\\",\\"url\\":\\"https://www.weather25.com/north-america/canada?page=date&date=13-1\\"}]"
+                }
+                """;
+
+        mockServers.mockWxBuilder(URL_WX_AGENT_TOOL_RUN, 200)
+                .body(body)
+                .response(response)
+                .build();
+
+        List<GoogleSearchResult> results = googleSearchTool.search("What was the weather in Toronto on January 13th 2025?",
+                3);
+        assertEquals(3, results.size());
+    }
+}

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/BuiltinServiceInjectTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/BuiltinServiceInjectTest.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.langchain4j.watsonx.deployment;
 
 import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.API_KEY;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.BEARER_TOKEN;
 import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.PROJECT_ID;
 import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_IAM_SERVER;
 import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_SERVER;
@@ -39,9 +40,9 @@ public class BuiltinServiceInjectTest extends WireMockAbstract {
 
     @Override
     void handlerBeforeEach() {
-        mockServers.mockIAMBuilder(200)
+        mockIAMBuilder(200)
                 .grantType(langchain4jWatsonConfig.defaultConfig().iam().grantType())
-                .response(WireMockUtil.BEARER_TOKEN, new Date())
+                .response(BEARER_TOKEN, new Date())
                 .build();
     }
 
@@ -72,7 +73,7 @@ public class BuiltinServiceInjectTest extends WireMockAbstract {
                 "\\\\n\\\\nExplore jobs\\\\n\\\\nStart learning\\\\\\\"}\\\"\"\n" +
                 "}";
 
-        mockServers.mockWxBuilder(URL_WX_AGENT_TOOL_RUN, 200)
+        mockWxBuilder(URL_WX_AGENT_TOOL_RUN, 200)
                 .body(body)
                 .response(response)
                 .build();
@@ -101,7 +102,7 @@ public class BuiltinServiceInjectTest extends WireMockAbstract {
                 }
                 """;
 
-        mockServers.mockWxBuilder(URL_WX_AGENT_TOOL_RUN, 200)
+        mockWxBuilder(URL_WX_AGENT_TOOL_RUN, 200)
                 .body(body)
                 .response(response)
                 .build();
@@ -130,7 +131,7 @@ public class BuiltinServiceInjectTest extends WireMockAbstract {
                 }
                 """;
 
-        mockServers.mockWxBuilder(URL_WX_AGENT_TOOL_RUN, 200)
+        mockWxBuilder(URL_WX_AGENT_TOOL_RUN, 200)
                 .body(body)
                 .response(response)
                 .build();
@@ -159,7 +160,7 @@ public class BuiltinServiceInjectTest extends WireMockAbstract {
                 }
                 """;
 
-        mockServers.mockWxBuilder(URL_WX_AGENT_TOOL_RUN, 200)
+        mockWxBuilder(URL_WX_AGENT_TOOL_RUN, 200)
                 .body(body)
                 .response(response)
                 .build();

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ChatAllPropertiesTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ChatAllPropertiesTest.java
@@ -73,6 +73,8 @@ public class ChatAllPropertiesTest extends WireMockAbstract {
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.top-p", "0.5")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.response-format", "json_object")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.tool-choice", "myfunction")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.built-in-service.log-requests", "true")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.built-in-service.log-responses", "true")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
 
     @Override
@@ -137,6 +139,8 @@ public class ChatAllPropertiesTest extends WireMockAbstract {
         assertEquals(0.5, runtimeConfig.chatModel().topP());
         assertEquals("json_object", runtimeConfig.chatModel().responseFormat().orElse(null));
         assertEquals("myfunction", runtimeConfig.chatModel().toolChoice().orElse(null));
+        assertEquals(true, langchain4jWatsonConfig.builtInService().logRequests().orElse(false));
+        assertEquals(true, langchain4jWatsonConfig.builtInService().logResponses().orElse(false));
     }
 
     @Test

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ChatDefaultPropertiesTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ChatDefaultPropertiesTest.java
@@ -89,6 +89,8 @@ public class ChatDefaultPropertiesTest extends WireMockAbstract {
         assertEquals(1.0, runtimeConfig.chatModel().topP());
         assertEquals(Optional.empty(), runtimeConfig.chatModel().toolChoice());
         assertEquals("urn:ibm:params:oauth:grant-type:apikey", runtimeConfig.iam().grantType());
+        assertEquals(false, langchain4jWatsonConfig.builtInService().logRequests().orElse(false));
+        assertEquals(false, langchain4jWatsonConfig.builtInService().logResponses().orElse(false));
     }
 
     @Test

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ChatMemoryPlaceholderTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ChatMemoryPlaceholderTest.java
@@ -1,5 +1,12 @@
 package io.quarkiverse.langchain4j.watsonx.deployment;
 
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.API_KEY;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.DEFAULT_TIME_LIMIT;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.PROJECT_ID;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_IAM_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_GENERATION_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_SERVER;
+
 import java.util.Date;
 import java.util.List;
 
@@ -27,16 +34,16 @@ public class ChatMemoryPlaceholderTest extends WireMockAbstract {
 
     @RegisterExtension
     static QuarkusUnitTest unitTest = new QuarkusUnitTest()
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", WireMockUtil.URL_WATSONX_SERVER)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", WireMockUtil.URL_IAM_SERVER)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", WireMockUtil.API_KEY)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", WireMockUtil.PROJECT_ID)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", URL_WATSONX_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", URL_IAM_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", PROJECT_ID)
             .overrideConfigKey("quarkus.langchain4j.watsonx.mode", "generation")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
 
     @Override
     void handlerBeforeEach() {
-        mockServers.mockIAMBuilder(200)
+        mockIAMBuilder(200)
                 .response("my_super_token", new Date())
                 .build();
     }
@@ -106,7 +113,7 @@ public class ChatMemoryPlaceholderTest extends WireMockAbstract {
 
                 Hello""";
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 200)
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 200)
                 .body(mapper.writeValueAsString(createRequest(input)))
                 .response("""
                         {
@@ -132,7 +139,7 @@ public class ChatMemoryPlaceholderTest extends WireMockAbstract {
                 Hi!
                 What is your name?""";
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 200)
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 200)
                 .body(mapper.writeValueAsString(createRequest(input)))
                 .response("""
                         {
@@ -161,7 +168,7 @@ public class ChatMemoryPlaceholderTest extends WireMockAbstract {
 
                 Hello""";
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 200)
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 200)
                 .body(mapper.writeValueAsString(createRequest(input)))
                 .response("""
                         {
@@ -186,7 +193,7 @@ public class ChatMemoryPlaceholderTest extends WireMockAbstract {
                 Hi!
                 What is your name?""";
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 200)
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 200)
                 .body(mapper.writeValueAsString(createRequest(input)))
                 .response("""
                         {
@@ -215,7 +222,7 @@ public class ChatMemoryPlaceholderTest extends WireMockAbstract {
 
                 Hello""";
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 200)
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 200)
                 .body(mapper.writeValueAsString(createRequest(input)))
                 .response("""
                         {
@@ -240,7 +247,7 @@ public class ChatMemoryPlaceholderTest extends WireMockAbstract {
                 Hi!
                 What is your name?""";
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 200)
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 200)
                 .body(mapper.writeValueAsString(createRequest(input)))
                 .response("""
                         {
@@ -271,7 +278,7 @@ public class ChatMemoryPlaceholderTest extends WireMockAbstract {
                 Assistant: My name is AiBot
                 Hello""";
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 200)
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 200)
                 .body(mapper.writeValueAsString(createRequest(input)))
                 .response("""
                         {
@@ -300,7 +307,7 @@ public class ChatMemoryPlaceholderTest extends WireMockAbstract {
                 .temperature(chatModelConfig.temperature())
                 .minNewTokens(chatModelConfig.minNewTokens())
                 .maxNewTokens(chatModelConfig.maxNewTokens())
-                .timeLimit(WireMockUtil.DEFAULT_TIME_LIMIT)
+                .timeLimit(DEFAULT_TIME_LIMIT)
                 .build();
 
         return new TextGenerationRequest(modelId, spaceId, projectId, input, parameters);

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/GenerationAllPropertiesTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/GenerationAllPropertiesTest.java
@@ -1,6 +1,21 @@
 package io.quarkiverse.langchain4j.watsonx.deployment;
 
 import static dev.langchain4j.model.chat.request.ToolChoice.AUTO;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.API_KEY;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.BEARER_TOKEN;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.PROJECT_ID;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.RESPONSE_WATSONX_EMBEDDING_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.RESPONSE_WATSONX_GENERATION_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.RESPONSE_WATSONX_GENERATION_STREAMING_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.RESPONSE_WATSONX_SCORING_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.RESPONSE_WATSONX_TOKENIZER_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_IAM_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_EMBEDDING_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_GENERATION_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_GENERATION_STREAMING_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_SCORING_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_TOKENIZER_API;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -57,15 +72,15 @@ public class GenerationAllPropertiesTest extends WireMockAbstract {
 
     @RegisterExtension
     static QuarkusUnitTest unitTest = new QuarkusUnitTest()
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", WireMockUtil.URL_WATSONX_SERVER)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", WireMockUtil.API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", URL_WATSONX_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", API_KEY)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.space-id", "my-space-id")
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", WireMockUtil.PROJECT_ID)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", PROJECT_ID)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.timeout", "60s")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.log-requests", "true")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.log-responses", "true")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.version", "aaaa-mm-dd")
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", WireMockUtil.URL_IAM_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", URL_IAM_SERVER)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.timeout", "60s")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.grant-type", "grantME")
             .overrideConfigKey("quarkus.langchain4j.watsonx.mode", "generation")
@@ -92,9 +107,9 @@ public class GenerationAllPropertiesTest extends WireMockAbstract {
 
     @Override
     void handlerBeforeEach() {
-        mockServers.mockIAMBuilder(200)
+        mockIAMBuilder(200)
                 .grantType(langchain4jWatsonConfig.defaultConfig().iam().grantType())
-                .response(WireMockUtil.BEARER_TOKEN, new Date())
+                .response(BEARER_TOKEN, new Date())
                 .build();
     }
 
@@ -136,11 +151,11 @@ public class GenerationAllPropertiesTest extends WireMockAbstract {
     @Test
     void check_config() throws Exception {
         var runtimeConfig = langchain4jWatsonConfig.defaultConfig();
-        assertEquals(WireMockUtil.URL_WATSONX_SERVER, runtimeConfig.baseUrl().orElse(null).toString());
-        assertEquals(WireMockUtil.URL_IAM_SERVER, runtimeConfig.iam().baseUrl().toString());
-        assertEquals(WireMockUtil.API_KEY, runtimeConfig.apiKey().orElse(null));
+        assertEquals(URL_WATSONX_SERVER, runtimeConfig.baseUrl().orElse(null).toString());
+        assertEquals(URL_IAM_SERVER, runtimeConfig.iam().baseUrl().toString());
+        assertEquals(API_KEY, runtimeConfig.apiKey().orElse(null));
         assertEquals("my-space-id", runtimeConfig.spaceId().orElse(null));
-        assertEquals(WireMockUtil.PROJECT_ID, runtimeConfig.projectId().orElse(null));
+        assertEquals(PROJECT_ID, runtimeConfig.projectId().orElse(null));
         assertEquals(Duration.ofSeconds(60), runtimeConfig.timeout().get());
         assertEquals(Duration.ofSeconds(60), runtimeConfig.iam().timeout().get());
         assertEquals("grantME", runtimeConfig.iam().grantType());
@@ -179,9 +194,9 @@ public class GenerationAllPropertiesTest extends WireMockAbstract {
         TextGenerationRequest body = new TextGenerationRequest(modelId, spaceId, projectId,
                 "You are an helpful assistant@Hello, how are you?",
                 parameters);
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 200, "aaaa-mm-dd")
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 200, "aaaa-mm-dd")
                 .body(mapper.writeValueAsString(body))
-                .response(WireMockUtil.RESPONSE_WATSONX_GENERATION_API)
+                .response(RESPONSE_WATSONX_GENERATION_API)
                 .build();
 
         List<ChatMessage> chatMessages = List.of(
@@ -242,9 +257,9 @@ public class GenerationAllPropertiesTest extends WireMockAbstract {
                         .includeStopSequence(true)
                         .build());
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 200, "aaaa-mm-dd")
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 200, "aaaa-mm-dd")
                 .body(mapper.writeValueAsString(body))
-                .response(WireMockUtil.RESPONSE_WATSONX_GENERATION_API)
+                .response(RESPONSE_WATSONX_GENERATION_API)
                 .build();
 
         response = chatModel.chat(request);
@@ -285,10 +300,10 @@ public class GenerationAllPropertiesTest extends WireMockAbstract {
         TextGenerationRequest body = new TextGenerationRequest(modelId, spaceId, projectId,
                 "You are an helpful assistant@Hello, how are you?",
                 parameters);
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_STREAMING_API, 200, "aaaa-mm-dd")
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_STREAMING_API, 200, "aaaa-mm-dd")
                 .body(mapper.writeValueAsString(body))
                 .responseMediaType(MediaType.SERVER_SENT_EVENTS)
-                .response(WireMockUtil.RESPONSE_WATSONX_GENERATION_STREAMING_API)
+                .response(RESPONSE_WATSONX_GENERATION_STREAMING_API)
                 .build();
 
         List<ChatMessage> chatMessages = List.of(
@@ -374,10 +389,10 @@ public class GenerationAllPropertiesTest extends WireMockAbstract {
                         .includeStopSequence(true)
                         .build());
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_STREAMING_API, 200, "aaaa-mm-dd")
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_STREAMING_API, 200, "aaaa-mm-dd")
                 .body(mapper.writeValueAsString(body))
                 .responseMediaType(MediaType.SERVER_SENT_EVENTS)
-                .response(WireMockUtil.RESPONSE_WATSONX_GENERATION_STREAMING_API)
+                .response(RESPONSE_WATSONX_GENERATION_STREAMING_API)
                 .build();
 
         streamingChatModel.chat(request, streamingChatResponseHandler);
@@ -425,9 +440,9 @@ public class GenerationAllPropertiesTest extends WireMockAbstract {
 
         TextGenerationRequest body = new TextGenerationRequest(modelId, spaceId, projectId, "SystemMessage@UserMessage",
                 parameters);
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 200, "aaaa-mm-dd")
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 200, "aaaa-mm-dd")
                 .body(mapper.writeValueAsString(body))
-                .response(WireMockUtil.RESPONSE_WATSONX_GENERATION_API)
+                .response(RESPONSE_WATSONX_GENERATION_API)
                 .build();
 
         assertEquals("AI Response", chatModel.chat(dev.langchain4j.data.message.SystemMessage.from("SystemMessage"),
@@ -443,9 +458,9 @@ public class GenerationAllPropertiesTest extends WireMockAbstract {
         EmbeddingRequest request = new EmbeddingRequest(modelId, spaceId, projectId,
                 List.of("Embedding THIS!"), embeddingParameters);
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_EMBEDDING_API, 200, "aaaa-mm-dd")
+        mockWatsonxBuilder(URL_WATSONX_EMBEDDING_API, 200, "aaaa-mm-dd")
                 .body(mapper.writeValueAsString(request))
-                .response(WireMockUtil.RESPONSE_WATSONX_EMBEDDING_API.formatted(modelId))
+                .response(RESPONSE_WATSONX_EMBEDDING_API.formatted(modelId))
                 .build();
 
         Response<Embedding> response = embeddingModel.embed("Embedding THIS!");
@@ -479,9 +494,9 @@ public class GenerationAllPropertiesTest extends WireMockAbstract {
         ScoringRequest request = ScoringRequest.of(modelId, spaceId, projectId, "Who wrote 'To Kill a Mockingbird'?",
                 segments, scoringParameters);
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_SCORING_API, 200, "aaaa-mm-dd")
+        mockWatsonxBuilder(URL_WATSONX_SCORING_API, 200, "aaaa-mm-dd")
                 .body(mapper.writeValueAsString(request))
-                .response(WireMockUtil.RESPONSE_WATSONX_SCORING_API.formatted(modelId))
+                .response(RESPONSE_WATSONX_SCORING_API.formatted(modelId))
                 .build();
 
         Response<List<Double>> response = scoringModel.scoreAll(segments, "Who wrote 'To Kill a Mockingbird'?");
@@ -504,9 +519,9 @@ public class GenerationAllPropertiesTest extends WireMockAbstract {
         String projectId = config.projectId().orElse(null);
         var body = new TokenizationRequest(modelId, "test", spaceId, projectId);
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_TOKENIZER_API, 200, "aaaa-mm-dd")
+        mockWatsonxBuilder(URL_WATSONX_TOKENIZER_API, 200, "aaaa-mm-dd")
                 .body(mapper.writeValueAsString(body))
-                .response(WireMockUtil.RESPONSE_WATSONX_TOKENIZER_API.formatted(modelId))
+                .response(RESPONSE_WATSONX_TOKENIZER_API.formatted(modelId))
                 .build();
 
         assertEquals(11, tokenCountEstimator.estimateTokenCount("test"));
@@ -521,10 +536,10 @@ public class GenerationAllPropertiesTest extends WireMockAbstract {
         TextGenerationRequest body = new TextGenerationRequest(modelId, spaceId, projectId, "SystemMessage@UserMessage",
                 parameters);
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_STREAMING_API, 200, "aaaa-mm-dd")
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_STREAMING_API, 200, "aaaa-mm-dd")
                 .body(mapper.writeValueAsString(body))
                 .responseMediaType(MediaType.SERVER_SENT_EVENTS)
-                .response(WireMockUtil.RESPONSE_WATSONX_GENERATION_STREAMING_API)
+                .response(RESPONSE_WATSONX_GENERATION_STREAMING_API)
                 .build();
 
         var messages = List.of(

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/HttpErrorTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/HttpErrorTest.java
@@ -1,5 +1,11 @@
 package io.quarkiverse.langchain4j.watsonx.deployment;
 
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.API_KEY;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.BEARER_TOKEN;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.PROJECT_ID;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_IAM_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_GENERATION_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_SERVER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -26,10 +32,10 @@ public class HttpErrorTest extends WireMockAbstract {
 
     @RegisterExtension
     static QuarkusUnitTest unitTest = new QuarkusUnitTest()
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", WireMockUtil.URL_WATSONX_SERVER)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", WireMockUtil.URL_IAM_SERVER)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", WireMockUtil.API_KEY)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", WireMockUtil.PROJECT_ID)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", URL_WATSONX_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", URL_IAM_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", PROJECT_ID)
             .overrideConfigKey("quarkus.langchain4j.watsonx.mode", "generation")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
 
@@ -39,11 +45,11 @@ public class HttpErrorTest extends WireMockAbstract {
     @Test
     void not_registered_error() {
 
-        mockServers.mockIAMBuilder(200)
-                .response(WireMockUtil.BEARER_TOKEN, new Date())
+        mockIAMBuilder(200)
+                .response(BEARER_TOKEN, new Date())
                 .build();
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 500)
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 500)
                 .responseMediaType(MediaType.APPLICATION_JSON)
                 .response("""
                         {
@@ -70,11 +76,11 @@ public class HttpErrorTest extends WireMockAbstract {
     @Test
     void error_400_model_no_support_for_function() {
 
-        mockServers.mockIAMBuilder(200)
-                .response(WireMockUtil.BEARER_TOKEN, new Date())
+        mockIAMBuilder(200)
+                .response(BEARER_TOKEN, new Date())
                 .build();
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 404)
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 404)
                 .responseMediaType(MediaType.APPLICATION_JSON)
                 .response("""
                         {
@@ -101,11 +107,11 @@ public class HttpErrorTest extends WireMockAbstract {
     @Test
     void error_400_json_type_error() {
 
-        mockServers.mockIAMBuilder(200)
-                .response(WireMockUtil.BEARER_TOKEN, new Date())
+        mockIAMBuilder(200)
+                .response(BEARER_TOKEN, new Date())
                 .build();
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 400)
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 400)
                 .response(
                         """
                                 {
@@ -134,11 +140,11 @@ public class HttpErrorTest extends WireMockAbstract {
     @Test
     void error_404_model_not_supported() {
 
-        mockServers.mockIAMBuilder(200)
-                .response(WireMockUtil.BEARER_TOKEN, new Date())
+        mockIAMBuilder(200)
+                .response(BEARER_TOKEN, new Date())
                 .build();
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 400)
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 400)
                 .response("""
                         {
                             "errors": [
@@ -166,11 +172,11 @@ public class HttpErrorTest extends WireMockAbstract {
     @Test
     void error_400_json_validation_error() {
 
-        mockServers.mockIAMBuilder(200)
-                .response(WireMockUtil.BEARER_TOKEN, new Date())
+        mockIAMBuilder(200)
+                .response(BEARER_TOKEN, new Date())
                 .build();
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 400)
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 400)
                 .response("""
                         {
                             "errors": [
@@ -197,11 +203,11 @@ public class HttpErrorTest extends WireMockAbstract {
     @Test
     void error_400_invalid_request_entity() {
 
-        mockServers.mockIAMBuilder(200)
-                .response(WireMockUtil.BEARER_TOKEN, new Date())
+        mockIAMBuilder(200)
+                .response(BEARER_TOKEN, new Date())
                 .build();
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 400)
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 400)
                 .response("""
                         {
                             "errors": [
@@ -229,11 +235,11 @@ public class HttpErrorTest extends WireMockAbstract {
     @Test
     void error_500() {
 
-        mockServers.mockIAMBuilder(200)
-                .response(WireMockUtil.BEARER_TOKEN, new Date())
+        mockIAMBuilder(200)
+                .response(BEARER_TOKEN, new Date())
                 .build();
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 500)
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 500)
                 .response("{")
                 .build();
 
@@ -244,7 +250,7 @@ public class HttpErrorTest extends WireMockAbstract {
     @Test
     void error_500_iam_generic() {
 
-        mockServers.mockIAMBuilder(500)
+        mockIAMBuilder(500)
                 .response("{")
                 .build();
 
@@ -256,7 +262,7 @@ public class HttpErrorTest extends WireMockAbstract {
 
     @Test
     void error_400_iam_server() {
-        mockServers.mockIAMBuilder(400)
+        mockIAMBuilder(400)
                 .response("""
                         {
                             "errorCode": "BXNIM0415E",
@@ -277,7 +283,7 @@ public class HttpErrorTest extends WireMockAbstract {
 
     @Test
     void error_500_iam_server() {
-        mockServers.mockIAMBuilder(500)
+        mockIAMBuilder(500)
                 .responseMediaType(MediaType.TEXT_PLAIN)
                 .response("SUPER FATAL ERROR!")
                 .build();

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ResponseSchemaOffTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ResponseSchemaOffTest.java
@@ -2,6 +2,13 @@ package io.quarkiverse.langchain4j.watsonx.deployment;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.API_KEY;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.BEARER_TOKEN;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.PROJECT_ID;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.RESPONSE_WATSONX_GENERATION_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_IAM_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_GENERATION_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_SERVER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -25,19 +32,19 @@ public class ResponseSchemaOffTest extends WireMockAbstract {
 
     @RegisterExtension
     static QuarkusUnitTest unitTest = new QuarkusUnitTest()
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", WireMockUtil.URL_WATSONX_SERVER)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", WireMockUtil.URL_IAM_SERVER)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", WireMockUtil.API_KEY)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", WireMockUtil.PROJECT_ID)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", URL_WATSONX_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", URL_IAM_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", PROJECT_ID)
             .overrideConfigKey("quarkus.langchain4j.watsonx.mode", "generation")
             .overrideConfigKey("quarkus.langchain4j.response-schema", "false")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
 
     @Override
     void handlerBeforeEach() {
-        mockServers.mockIAMBuilder(200)
+        mockIAMBuilder(200)
                 .grantType(langchain4jWatsonConfig.defaultConfig().iam().grantType())
-                .response(WireMockUtil.BEARER_TOKEN, new Date())
+                .response(BEARER_TOKEN, new Date())
                 .build();
     }
 
@@ -86,9 +93,9 @@ public class ResponseSchemaOffTest extends WireMockAbstract {
                 "The {response_schema} placeholder cannot be used if the property quarkus.langchain4j.response-schema is set to false. Found in: io.quarkiverse.langchain4j.watsonx.deployment.ResponseSchemaOffTest$OnMethodAIService",
                 ex.getMessage());
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 200)
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 200)
                 .body(matchingJsonPath("$.input", equalTo("Generate a poem about dog")))
-                .response(WireMockUtil.RESPONSE_WATSONX_GENERATION_API)
+                .response(RESPONSE_WATSONX_GENERATION_API)
                 .build();
 
         assertEquals("AI Response", onMethodAIService.poem1("Generate a poem about {topic}", "dog"));
@@ -96,7 +103,7 @@ public class ResponseSchemaOffTest extends WireMockAbstract {
 
     @Test
     void test_poem_2() {
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 200)
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 200)
                 .body(matchingJsonPath("$.input", equalTo("Generate a poem about dog")))
                 .response(POEM_RESPONSE)
                 .build();
@@ -106,7 +113,7 @@ public class ResponseSchemaOffTest extends WireMockAbstract {
 
     @Test
     void test_poem_3() {
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 200)
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 200)
                 .body(matchingJsonPath("$.input", equalTo("Generate a poem about dog")))
                 .response(POEM_RESPONSE)
                 .build();
@@ -116,7 +123,7 @@ public class ResponseSchemaOffTest extends WireMockAbstract {
 
     @Test
     void test_poem_4() {
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 200)
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 200)
                 .body(matchingJsonPath("$.input", equalTo("SystemMessage\nGenerate a poem about dog")))
                 .response(POEM_RESPONSE)
                 .build();

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ResponseSchemaOnTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ResponseSchemaOnTest.java
@@ -1,5 +1,12 @@
 package io.quarkiverse.langchain4j.watsonx.deployment;
 
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.API_KEY;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.BEARER_TOKEN;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.DEFAULT_TIME_LIMIT;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.PROJECT_ID;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_IAM_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_GENERATION_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_SERVER;
 import static java.util.stream.Collectors.joining;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -30,10 +37,10 @@ public class ResponseSchemaOnTest extends WireMockAbstract {
 
     @RegisterExtension
     static QuarkusUnitTest unitTest = new QuarkusUnitTest()
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", WireMockUtil.URL_WATSONX_SERVER)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", WireMockUtil.URL_IAM_SERVER)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", WireMockUtil.API_KEY)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", WireMockUtil.PROJECT_ID)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", URL_WATSONX_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", URL_IAM_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", PROJECT_ID)
             .overrideConfigKey("quarkus.langchain4j.watsonx.mode", "generation")
             .overrideConfigKey("quarkus.langchain4j.response-schema", "true")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
@@ -72,9 +79,9 @@ public class ResponseSchemaOnTest extends WireMockAbstract {
 
     @Override
     void handlerBeforeEach() {
-        mockServers.mockIAMBuilder(200)
+        mockIAMBuilder(200)
                 .grantType(langchain4jWatsonConfig.defaultConfig().iam().grantType())
-                .response(WireMockUtil.BEARER_TOKEN, new Date())
+                .response(BEARER_TOKEN, new Date())
                 .build();
     }
 
@@ -162,7 +169,7 @@ public class ResponseSchemaOnTest extends WireMockAbstract {
                 dev.langchain4j.data.message.SystemMessage.from("You are a poet"),
                 dev.langchain4j.data.message.UserMessage.from("Generate a poem about dog"));
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 200)
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 200)
                 .body(mapper.writeValueAsString(from(messages)))
                 .response(RESPONSE)
                 .build();
@@ -177,7 +184,7 @@ public class ResponseSchemaOnTest extends WireMockAbstract {
                 dev.langchain4j.data.message.SystemMessage.from("You are a poet"),
                 dev.langchain4j.data.message.UserMessage.from("Generate a poem about dog".concat(SCHEMA)));
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 200)
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 200)
                 .body(mapper.writeValueAsString(from(messages)))
                 .response(RESPONSE)
                 .build();
@@ -192,7 +199,7 @@ public class ResponseSchemaOnTest extends WireMockAbstract {
                 dev.langchain4j.data.message.SystemMessage.from(SCHEMA.concat(" You are a poet")),
                 dev.langchain4j.data.message.UserMessage.from("user", "Generate a poem about dog ".concat(SCHEMA)));
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 200)
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 200)
                 .body(mapper.writeValueAsString(from(messages)))
                 .response(RESPONSE)
                 .build();
@@ -207,7 +214,7 @@ public class ResponseSchemaOnTest extends WireMockAbstract {
                 dev.langchain4j.data.message.SystemMessage.from(SCHEMA.concat(" You are a poet")),
                 dev.langchain4j.data.message.UserMessage.from("Generate a poem about dog"));
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 200)
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 200)
                 .body(mapper.writeValueAsString(from(messages)))
                 .response(RESPONSE)
                 .build();
@@ -221,7 +228,7 @@ public class ResponseSchemaOnTest extends WireMockAbstract {
         List<ChatMessage> messages = List.of(
                 dev.langchain4j.data.message.UserMessage.from(SCHEMA.concat(" Generate a poem about dog")));
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 200)
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 200)
                 .body(mapper.writeValueAsString(from(messages)))
                 .response(RESPONSE)
                 .build();
@@ -237,7 +244,7 @@ public class ResponseSchemaOnTest extends WireMockAbstract {
         List<ChatMessage> messages = List.of(
                 dev.langchain4j.data.message.UserMessage.from(SCHEMA.concat("Generate a poem about dog")));
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 200)
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 200)
                 .body(mapper.writeValueAsString(from(messages)))
                 .response(RESPONSE)
                 .build();
@@ -252,7 +259,7 @@ public class ResponseSchemaOnTest extends WireMockAbstract {
                 dev.langchain4j.data.message.SystemMessage.from(SCHEMA.concat(" You are a poet")),
                 dev.langchain4j.data.message.UserMessage.from("Generate a poem about dog"));
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_GENERATION_API, 200)
+        mockWatsonxBuilder(URL_WATSONX_GENERATION_API, 200)
                 .body(mapper.writeValueAsString(from(messages)))
                 .response(RESPONSE)
                 .build();
@@ -271,7 +278,7 @@ public class ResponseSchemaOnTest extends WireMockAbstract {
                 .temperature(config.generationModel().temperature())
                 .minNewTokens(config.generationModel().minNewTokens())
                 .maxNewTokens(config.generationModel().maxNewTokens())
-                .timeLimit(WireMockUtil.DEFAULT_TIME_LIMIT)
+                .timeLimit(DEFAULT_TIME_LIMIT)
                 .build();
 
         var input = messages.stream().map(

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/TextExtractionInjectTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/TextExtractionInjectTest.java
@@ -1,0 +1,219 @@
+package io.quarkiverse.langchain4j.watsonx.deployment;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.http.RequestMethod.DELETE;
+import static com.github.tomakehurst.wiremock.http.RequestMethod.GET;
+import static com.github.tomakehurst.wiremock.http.RequestMethod.POST;
+import static com.github.tomakehurst.wiremock.http.RequestMethod.PUT;
+import static io.quarkiverse.langchain4j.watsonx.bean.TextExtractionRequest.TextExtractionType.ASSEMBLY_MD;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.API_KEY;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.BEARER_TOKEN;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.PROJECT_ID;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_COS_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_IAM_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_TEXT_EXTRACTION_RESULT_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_TEXT_EXTRACTION_START_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.VERSION;
+import static io.quarkiverse.langchain4j.watsonx.runtime.TextExtraction.Language.ENGLISH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.util.Date;
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.langchain4j.ModelName;
+import io.quarkiverse.langchain4j.watsonx.bean.TextExtractionRequest;
+import io.quarkiverse.langchain4j.watsonx.bean.TextExtractionRequest.TextExtractionDataReference;
+import io.quarkiverse.langchain4j.watsonx.bean.TextExtractionRequest.TextExtractionSteps;
+import io.quarkiverse.langchain4j.watsonx.runtime.TextExtraction;
+import io.quarkiverse.langchain4j.watsonx.runtime.TextExtraction.Options;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class TextExtractionInjectTest extends WireMockAbstract {
+
+    static String PROCESS_EXTRACTION_ID = "custom-id";
+    static String FILE_NAME = "test.pdf";
+    static String OUTPUT_FILE_NAME = "test.md";
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", URL_WATSONX_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", URL_IAM_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", PROJECT_ID)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.text-extraction.base-url", URL_COS_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.text-extraction.document-reference.connection",
+                    "document-connection")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.text-extraction.document-reference.bucket-name",
+                    "document-bucket-name")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.text-extraction.results-reference.connection",
+                    "results-connection")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.text-extraction.results-reference.bucket-name",
+                    "results-bucket-name")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.text-extraction.log-requests",
+                    "false")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.text-extraction.log-responses",
+                    "false")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.custom.iam.base-url", URL_IAM_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.custom.text-extraction.base-url", URL_COS_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.custom.text-extraction.document-reference.connection",
+                    "custom-document-connection")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.custom.text-extraction.document-reference.bucket-name",
+                    "custom-document-bucket-name")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.custom.text-extraction.results-reference.connection",
+                    "custom-results-connection")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.custom.text-extraction.results-reference.bucket-name",
+                    "custom-results-bucket-name")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.custom.text-extraction.log-requests",
+                    "true")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.custom.text-extraction.log-responses",
+                    "true")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(WireMockUtil.class)
+                    .addAsResource(FILE_NAME));
+
+    @Override
+    void handlerBeforeEach() {
+        mockIAMBuilder(200)
+                .grantType(langchain4jWatsonConfig.defaultConfig().iam().grantType())
+                .response(BEARER_TOKEN, new Date())
+                .build();
+    }
+
+    @Inject
+    TextExtraction textExtraction;
+
+    @Inject
+    @ModelName("custom")
+    TextExtraction customTextExtraction;
+
+    @Test
+    void textExtractionPropertiesTest() {
+        var textExtractionConfig = langchain4jWatsonConfig.defaultConfig().textExtraction().orElseThrow();
+        assertEquals(false, textExtractionConfig.logRequests().orElse(false));
+        assertEquals(false, textExtractionConfig.logResponses().orElse(false));
+    }
+
+    @Test
+    void customTextExtractionPropertiesTest() {
+        var textExtractionConfig = langchain4jWatsonConfig.namedConfig().get("custom").textExtraction().orElseThrow();
+        assertEquals(true, textExtractionConfig.logRequests().orElse(false));
+        assertEquals(true, textExtractionConfig.logResponses().orElse(false));
+    }
+
+    @Test
+    void textExtractionTest() throws Exception {
+
+        File file = new File(TextExtractionInjectTest.class.getClassLoader().getResource(FILE_NAME).toURI());
+
+        var documentReference = TextExtractionDataReference.of("document-connection", FILE_NAME,
+                "document-bucket-name");
+        var resultsReference = TextExtractionDataReference.of("results-connection", OUTPUT_FILE_NAME,
+                "results-bucket-name");
+
+        var request = TextExtractionRequest.builder()
+                .documentReference(documentReference)
+                .resultsReference(resultsReference)
+                .steps(TextExtractionSteps.of(List.of("en"), true))
+                .type(ASSEMBLY_MD)
+                .projectId(PROJECT_ID)
+                .spaceId(null)
+                .build();
+
+        var options = Options.create(List.of(ENGLISH))
+                .removeOutputFile(true)
+                .removeUploadedFile(true);
+
+        mockServers(request, "document-bucket-name", "results-bucket-name", true, true);
+
+        var extractedText = textExtraction.uploadExtractAndFetch(file, options);
+        assertEquals("Hello", extractedText);
+        Thread.sleep(200); // Wait for the async calls.
+        watsonxServer.verify(1, postRequestedFor(urlPathEqualTo("/ml/v1/text/extractions")));
+        watsonxServer.verify(1, getRequestedFor(urlPathEqualTo("/ml/v1/text/extractions/" + PROCESS_EXTRACTION_ID)));
+        cosServer.verify(1, putRequestedFor(urlEqualTo("/%s/%s".formatted("document-bucket-name", FILE_NAME))));
+        cosServer.verify(1, getRequestedFor(urlEqualTo("/%s/%s".formatted("results-bucket-name", OUTPUT_FILE_NAME))));
+        cosServer.verify(1, deleteRequestedFor(urlEqualTo("/%s/%s".formatted("document-bucket-name", FILE_NAME))));
+        cosServer.verify(1, deleteRequestedFor(urlEqualTo("/%s/%s".formatted("results-bucket-name", OUTPUT_FILE_NAME))));
+    }
+
+    @Test
+    void customTextExtractionTest() throws Exception {
+
+        File file = new File(TextExtractionInjectTest.class.getClassLoader().getResource(FILE_NAME).toURI());
+
+        var documentReference = TextExtractionDataReference.of("custom-document-connection", FILE_NAME,
+                "custom-document-bucket-name");
+        var resultsReference = TextExtractionDataReference.of("custom-results-connection", OUTPUT_FILE_NAME,
+                "custom-results-bucket-name");
+
+        var request = TextExtractionRequest.builder()
+                .documentReference(documentReference)
+                .resultsReference(resultsReference)
+                .steps(TextExtractionSteps.of(List.of("en"), true))
+                .type(ASSEMBLY_MD)
+                .projectId(PROJECT_ID)
+                .spaceId(null)
+                .build();
+
+        var options = Options.create(List.of(ENGLISH))
+                .removeOutputFile(true)
+                .removeUploadedFile(true);
+
+        mockServers(request, "custom-document-bucket-name", "custom-results-bucket-name", true, true);
+
+        var extractedText = customTextExtraction.uploadExtractAndFetch(file, options);
+        assertEquals("Hello", extractedText);
+        Thread.sleep(200); // Wait for the async calls.
+        watsonxServer.verify(1, postRequestedFor(urlPathEqualTo("/ml/v1/text/extractions")));
+        watsonxServer.verify(1, getRequestedFor(urlPathEqualTo("/ml/v1/text/extractions/" + PROCESS_EXTRACTION_ID)));
+        cosServer.verify(1, putRequestedFor(urlEqualTo("/%s/%s".formatted("custom-document-bucket-name", FILE_NAME))));
+        cosServer.verify(1, getRequestedFor(urlEqualTo("/%s/%s".formatted("custom-results-bucket-name", OUTPUT_FILE_NAME))));
+        cosServer.verify(1, deleteRequestedFor(urlEqualTo("/%s/%s".formatted("custom-document-bucket-name", FILE_NAME))));
+        cosServer.verify(1, deleteRequestedFor(urlEqualTo("/%s/%s".formatted("custom-results-bucket-name", OUTPUT_FILE_NAME))));
+    }
+
+    private void mockServers(TextExtractionRequest body, String documentBucketName, String resultsBucketName,
+            boolean deleteUploadedFile,
+            boolean deleteOutputFile) {
+        // Mock the upload local file operation.
+        mockCosBuilder(PUT, documentBucketName, FILE_NAME, 200).build();
+
+        // Mock extracted file result.
+        mockCosBuilder(GET, resultsBucketName, OUTPUT_FILE_NAME, 200)
+                .response("Hello")
+                .build();
+
+        if (deleteUploadedFile) {
+            mockCosBuilder(DELETE, documentBucketName, FILE_NAME, 200).build();
+        }
+
+        if (deleteOutputFile) {
+            mockCosBuilder(DELETE, resultsBucketName, OUTPUT_FILE_NAME, 200).build();
+        }
+
+        // Mock start extraction.
+        mockTextExtractionBuilder(POST, URL_WATSONX_TEXT_EXTRACTION_START_API, 200)
+                .body(body)
+                .response(body, PROCESS_EXTRACTION_ID, "submitted")
+                .build();
+
+        // Mock result extraction.
+        mockTextExtractionBuilder(GET,
+                URL_WATSONX_TEXT_EXTRACTION_RESULT_API.formatted(PROCESS_EXTRACTION_ID, PROJECT_ID, VERSION), 200)
+                .response(body, PROCESS_EXTRACTION_ID, "completed")
+                .build();
+    }
+}

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/TextExtractionTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/TextExtractionTest.java
@@ -1,0 +1,883 @@
+package io.quarkiverse.langchain4j.watsonx.deployment;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.http.RequestMethod.DELETE;
+import static com.github.tomakehurst.wiremock.http.RequestMethod.GET;
+import static com.github.tomakehurst.wiremock.http.RequestMethod.POST;
+import static com.github.tomakehurst.wiremock.http.RequestMethod.PUT;
+import static io.quarkiverse.langchain4j.watsonx.bean.TextExtractionRequest.TextExtractionType.ASSEMBLY_JSON;
+import static io.quarkiverse.langchain4j.watsonx.bean.TextExtractionRequest.TextExtractionType.ASSEMBLY_MD;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.API_KEY;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.BEARER_TOKEN;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.GRANT_TYPE;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.PROJECT_ID;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_COS_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_IAM_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_TEXT_EXTRACTION_RESULT_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_TEXT_EXTRACTION_START_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.VERSION;
+import static io.quarkiverse.langchain4j.watsonx.runtime.TextExtraction.Language.ENGLISH;
+import static io.quarkiverse.langchain4j.watsonx.runtime.TextExtraction.Language.ITALIAN;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.resteasy.reactive.client.api.LoggingScope;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+
+import io.quarkiverse.langchain4j.watsonx.bean.CosError;
+import io.quarkiverse.langchain4j.watsonx.bean.CosError.Code;
+import io.quarkiverse.langchain4j.watsonx.bean.TextExtractionRequest;
+import io.quarkiverse.langchain4j.watsonx.bean.TextExtractionRequest.TextExtractionDataReference;
+import io.quarkiverse.langchain4j.watsonx.bean.TextExtractionRequest.TextExtractionSteps;
+import io.quarkiverse.langchain4j.watsonx.bean.TextExtractionResponse;
+import io.quarkiverse.langchain4j.watsonx.bean.TextExtractionResponse.Status;
+import io.quarkiverse.langchain4j.watsonx.bean.WatsonxError;
+import io.quarkiverse.langchain4j.watsonx.client.COSRestApi;
+import io.quarkiverse.langchain4j.watsonx.client.WatsonxRestApi;
+import io.quarkiverse.langchain4j.watsonx.client.filter.BearerTokenHeaderFactory;
+import io.quarkiverse.langchain4j.watsonx.exception.COSException;
+import io.quarkiverse.langchain4j.watsonx.exception.TextExtractionException;
+import io.quarkiverse.langchain4j.watsonx.exception.WatsonxException;
+import io.quarkiverse.langchain4j.watsonx.runtime.TextExtraction;
+import io.quarkiverse.langchain4j.watsonx.runtime.TextExtraction.Language;
+import io.quarkiverse.langchain4j.watsonx.runtime.TextExtraction.Options;
+import io.quarkiverse.langchain4j.watsonx.runtime.TokenGenerationCache;
+import io.quarkiverse.langchain4j.watsonx.runtime.TokenGenerator;
+import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class TextExtractionTest extends WireMockAbstract {
+
+    static String CONNECTION_ID = "my-connection-id";
+    static String BUCKET_NAME = "my-bucket-name";
+    static String FILE_NAME = "test.pdf";
+    static String PROCESS_EXTRACTION_ID = "my-id";
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(WireMockUtil.class)
+                    .addAsResource(FILE_NAME));
+
+    @Override
+    void handlerBeforeEach() {
+        mockIAMBuilder(200)
+                .grantType(langchain4jWatsonConfig.defaultConfig().iam().grantType())
+                .response(BEARER_TOKEN, new Date())
+                .build();
+    }
+
+    static TokenGenerator tokenGenerator;
+    static WatsonxRestApi watsonxRestApi;
+    static COSRestApi cosRestApi;
+    static TextExtraction textExtraction;
+
+    @BeforeAll
+    static void init() throws MalformedURLException {
+        tokenGenerator = TokenGenerationCache.getOrCreateTokenGenerator(
+                API_KEY,
+                URI.create(URL_IAM_SERVER).toURL(),
+                GRANT_TYPE,
+                Duration.ofSeconds(10));
+
+        watsonxRestApi = QuarkusRestClientBuilder.newBuilder()
+                .baseUrl(URI.create(URL_WATSONX_SERVER).toURL())
+                .clientHeadersFactory(new BearerTokenHeaderFactory(tokenGenerator))
+                .connectTimeout(10, TimeUnit.SECONDS)
+                .readTimeout(10, TimeUnit.SECONDS)
+                .loggingScope(LoggingScope.REQUEST_RESPONSE)
+                .build(WatsonxRestApi.class);
+
+        cosRestApi = QuarkusRestClientBuilder.newBuilder()
+                .baseUrl(URI.create(URL_COS_SERVER).toURL())
+                .clientHeadersFactory(new BearerTokenHeaderFactory(tokenGenerator))
+                .connectTimeout(10, TimeUnit.SECONDS)
+                .readTimeout(10, TimeUnit.SECONDS)
+                .build(COSRestApi.class);
+
+        textExtraction = new TextExtraction(
+                new TextExtraction.Reference(CONNECTION_ID, BUCKET_NAME),
+                new TextExtraction.Reference(CONNECTION_ID, BUCKET_NAME),
+                PROJECT_ID,
+                null,
+                VERSION,
+                cosRestApi, watsonxRestApi);
+    }
+
+    @Test
+    void extractAndFetchTest() throws Exception {
+
+        String fileAlreadyUploaded = "test.pdf";
+        String outputFileName = fileAlreadyUploaded.replace(".pdf", ".md");
+
+        TextExtractionRequest body = createDefaultRequest();
+
+        mockServers(body, outputFileName, false, false);
+
+        String textExtracted = textExtraction.extractAndFetch(fileAlreadyUploaded, List.of(ENGLISH));
+        assertEquals("Hello", textExtracted);
+
+        textExtracted = textExtraction.extractAndFetch(fileAlreadyUploaded, Options.create(List.of(ENGLISH)));
+        assertEquals("Hello", textExtracted);
+
+        watsonxServer.verify(2, postRequestedFor(urlPathEqualTo("/ml/v1/text/extractions")));
+        watsonxServer.verify(2, getRequestedFor(urlPathEqualTo("/ml/v1/text/extractions/" + PROCESS_EXTRACTION_ID)));
+        cosServer.verify(0, putRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(2, getRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+    }
+
+    @Test
+    void uploadExtractAndFetchInputStreamTest() throws Exception {
+
+        String fileName = "test.pdf";
+        InputStream inputStream = TextExtractionTest.class.getClassLoader().getResourceAsStream(FILE_NAME);
+        String outputFileName = fileName.replace(".pdf", ".md");
+
+        TextExtractionRequest body = createDefaultRequest();
+
+        mockServers(body, outputFileName, false, false);
+
+        String textExtracted = textExtraction.uploadExtractAndFetch(inputStream, fileName, List.of(ENGLISH));
+        assertEquals("Hello", textExtracted);
+
+        textExtracted = textExtraction.uploadExtractAndFetch(inputStream, fileName, Options.create(List.of(ENGLISH)));
+        assertEquals("Hello", textExtracted);
+
+        watsonxServer.verify(2, postRequestedFor(urlPathEqualTo("/ml/v1/text/extractions")));
+        watsonxServer.verify(2, getRequestedFor(urlPathEqualTo("/ml/v1/text/extractions/" + PROCESS_EXTRACTION_ID)));
+        cosServer.verify(2, putRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(2, getRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+    }
+
+    @Test
+    void uploadExtractAndFetchTest() throws Exception {
+
+        File file = new File(TextExtractionTest.class.getClassLoader().getResource(FILE_NAME).toURI());
+        String outputFileName = file.getName().replace(".pdf", ".md");
+
+        TextExtractionRequest body = createDefaultRequest();
+
+        mockServers(body, outputFileName, false, false);
+
+        String textExtracted = textExtraction.uploadExtractAndFetch(file, List.of(ENGLISH));
+        assertEquals("Hello", textExtracted);
+
+        textExtracted = textExtraction.uploadExtractAndFetch(file, Options.create(List.of(ENGLISH)));
+        assertEquals("Hello", textExtracted);
+
+        watsonxServer.verify(2, postRequestedFor(urlPathEqualTo("/ml/v1/text/extractions")));
+        watsonxServer.verify(2, getRequestedFor(urlPathEqualTo("/ml/v1/text/extractions/" + PROCESS_EXTRACTION_ID)));
+        cosServer.verify(2, putRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(2, getRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+    }
+
+    @Test
+    void uploadExtractAndFetchFileNotFoundTest() throws Exception {
+        File file = new File("doesnotexist.pdf");
+        String outputFileName = file.getName().replace(".pdf", ".md");
+
+        TextExtractionRequest body = createDefaultRequest();
+
+        mockServers(body, outputFileName, false, false);
+
+        TextExtractionException ex = assertThrows(TextExtractionException.class,
+                () -> textExtraction.uploadExtractAndFetch(file, List.of(ENGLISH)));
+        assertEquals(ex.getCode(), "file_not_found");
+        assertTrue(ex.getCause() instanceof FileNotFoundException);
+
+        watsonxServer.verify(0, postRequestedFor(urlPathEqualTo("/ml/v1/text/extractions")));
+        watsonxServer.verify(0, getRequestedFor(urlPathEqualTo("/ml/v1/text/extractions/" + PROCESS_EXTRACTION_ID)));
+        cosServer.verify(0, putRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(0, getRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+    }
+
+    @Test
+    void startExtractionTest() throws Exception {
+
+        String fileAlreadyUploaded = "test.pdf";
+        String outputFileName = fileAlreadyUploaded.replace(".pdf", ".md");
+
+        TextExtractionRequest body = createDefaultRequest();
+
+        mockServers(body, outputFileName, false, false);
+
+        String processId = textExtraction.startExtraction(fileAlreadyUploaded, List.of(ENGLISH));
+        assertEquals(PROCESS_EXTRACTION_ID, processId);
+
+        processId = textExtraction.startExtraction(fileAlreadyUploaded, Options.create(List.of(ENGLISH)));
+        assertEquals(PROCESS_EXTRACTION_ID, processId);
+
+        watsonxServer.verify(2, postRequestedFor(urlPathEqualTo("/ml/v1/text/extractions")));
+        watsonxServer.verify(0, getRequestedFor(urlPathEqualTo("/ml/v1/text/extractions/" + PROCESS_EXTRACTION_ID)));
+        cosServer.verify(0, putRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(0, getRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+    }
+
+    @Test
+    void uploadAndStartExtractionTest() throws Exception {
+
+        File file = new File(TextExtractionTest.class.getClassLoader().getResource(FILE_NAME).toURI());
+        String outputFileName = file.getName().replace(".pdf", ".md");
+
+        TextExtractionRequest body = createDefaultRequest();
+
+        mockServers(body, outputFileName, false, false);
+
+        String processId = textExtraction.uploadAndStartExtraction(file, List.of(ENGLISH));
+        assertEquals(PROCESS_EXTRACTION_ID, processId);
+
+        processId = textExtraction.uploadAndStartExtraction(file, Options.create(List.of(ENGLISH)));
+        assertEquals(PROCESS_EXTRACTION_ID, processId);
+
+        watsonxServer.verify(2, postRequestedFor(urlPathEqualTo("/ml/v1/text/extractions")));
+        watsonxServer.verify(0, getRequestedFor(urlPathEqualTo("/ml/v1/text/extractions/" + PROCESS_EXTRACTION_ID)));
+        cosServer.verify(2, putRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(0, getRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+    }
+
+    @Test
+    void uploadAndStartExtractionFileNotFoundTest() throws Exception {
+
+        File file = new File("doesnotexist.pdf");
+        String outputFileName = file.getName().replace(".pdf", ".md");
+
+        TextExtractionRequest body = createDefaultRequest();
+
+        mockServers(body, outputFileName, false, false);
+
+        TextExtractionException ex = assertThrows(TextExtractionException.class,
+                () -> textExtraction.uploadAndStartExtraction(file, List.of(ENGLISH)));
+        assertEquals(ex.getCode(), "file_not_found");
+        assertTrue(ex.getCause() instanceof FileNotFoundException);
+
+        watsonxServer.verify(0, postRequestedFor(urlPathEqualTo("/ml/v1/text/extractions")));
+        watsonxServer.verify(0, getRequestedFor(urlPathEqualTo("/ml/v1/text/extractions/" + PROCESS_EXTRACTION_ID)));
+        cosServer.verify(0, putRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(0, getRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+    }
+
+    @Test
+    void uploadAndStartExtractionInputStreamTest() throws Exception {
+
+        String fileName = "test.pdf";
+        InputStream inputStream = TextExtractionTest.class.getClassLoader().getResourceAsStream(FILE_NAME);
+        String outputFileName = fileName.replace(".pdf", ".md");
+
+        TextExtractionRequest body = createDefaultRequest();
+
+        mockServers(body, outputFileName, false, false);
+
+        String processId = textExtraction.uploadAndStartExtraction(inputStream, fileName, List.of(ENGLISH));
+        assertEquals(PROCESS_EXTRACTION_ID, processId);
+
+        processId = textExtraction.uploadAndStartExtraction(inputStream, fileName, Options.create(List.of(ENGLISH)));
+        assertEquals(PROCESS_EXTRACTION_ID, processId);
+
+        watsonxServer.verify(2, postRequestedFor(urlPathEqualTo("/ml/v1/text/extractions")));
+        watsonxServer.verify(0, getRequestedFor(urlPathEqualTo("/ml/v1/text/extractions/" + PROCESS_EXTRACTION_ID)));
+        cosServer.verify(2, putRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(0, getRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+    }
+
+    @Test
+    void forceRemoveOutputAndUploadedFiles() throws Exception {
+
+        String outputFileName = "myNewOutput.json";
+        File file = new File(TextExtractionTest.class.getClassLoader().getResource(FILE_NAME).toURI());
+
+        TextExtractionRequest body = TextExtractionRequest.builder()
+                .documentReference(TextExtractionDataReference.of(CONNECTION_ID, FILE_NAME, BUCKET_NAME))
+                .resultsReference(TextExtractionDataReference.of(CONNECTION_ID, outputFileName, BUCKET_NAME))
+                .steps(TextExtractionSteps.of(List.of("en", "it"), false))
+                .type(ASSEMBLY_JSON)
+                .projectId(PROJECT_ID)
+                .spaceId(null)
+                .build();
+
+        mockServers(body, outputFileName, true, true);
+
+        Options options = Options.create(List.of(ENGLISH, ITALIAN))
+                .outputFileName(outputFileName)
+                .removeOutputFile(true)
+                .removeUploadedFile(true)
+                .tableProcessing(false)
+                .type(ASSEMBLY_JSON);
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> textExtraction.startExtraction(FILE_NAME, options),
+                "The asynchronous version of startExtraction doesn't allow the use of the \"removeOutputFile\" and \"removeUploadedFile\" options");
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> textExtraction.uploadAndStartExtraction(file, options),
+                "The asynchronous version of startExtraction doesn't allow the use of the \"removeOutputFile\" and \"removeUploadedFile\" options");
+
+        watsonxServer.verify(0, postRequestedFor(urlPathEqualTo("/ml/v1/text/extractions")));
+        watsonxServer.verify(0, getRequestedFor(urlPathEqualTo("/ml/v1/text/extractions/" + PROCESS_EXTRACTION_ID)));
+        cosServer.verify(0, putRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(0, getRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+
+        String extractedText = textExtraction.extractAndFetch(FILE_NAME, options);
+        assertEquals("Hello", extractedText);
+        Thread.sleep(200); // Wait for the async calls.
+        watsonxServer.verify(1, postRequestedFor(urlPathEqualTo("/ml/v1/text/extractions")));
+        watsonxServer.verify(1, getRequestedFor(urlPathEqualTo("/ml/v1/text/extractions/" + PROCESS_EXTRACTION_ID)));
+        cosServer.verify(0, putRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(1, getRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+        cosServer.verify(1, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(1, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+
+        watsonxServer.resetAll();
+        cosServer.resetAll();
+
+        mockServers(body, outputFileName, true, true);
+
+        extractedText = textExtraction.uploadExtractAndFetch(file, options);
+        assertEquals("Hello", extractedText);
+        Thread.sleep(200); // Wait for the async calls.
+        watsonxServer.verify(1, postRequestedFor(urlPathEqualTo("/ml/v1/text/extractions")));
+        watsonxServer.verify(1, getRequestedFor(urlPathEqualTo("/ml/v1/text/extractions/" + PROCESS_EXTRACTION_ID)));
+        cosServer.verify(1, putRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(1, getRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+        cosServer.verify(1, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(1, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+    }
+
+    @Test
+    void mdOutputFileNameTest() throws Exception {
+        String outputFileName = "test.md";
+
+        TextExtractionRequest body = TextExtractionRequest.builder()
+                .documentReference(TextExtractionDataReference.of(CONNECTION_ID, "test", BUCKET_NAME))
+                .resultsReference(TextExtractionDataReference.of(CONNECTION_ID, outputFileName, BUCKET_NAME))
+                .steps(TextExtractionSteps.of(List.of("en"), true))
+                .type(ASSEMBLY_MD)
+                .projectId(PROJECT_ID)
+                .spaceId(null)
+                .build();
+
+        mockServers(body, outputFileName, false, false);
+
+        textExtraction.startExtraction("test", List.of(ENGLISH));
+        watsonxServer.verify(1, postRequestedFor(urlPathEqualTo("/ml/v1/text/extractions")));
+        watsonxServer.verify(0, getRequestedFor(urlPathEqualTo("/ml/v1/text/extractions/" + PROCESS_EXTRACTION_ID)));
+        cosServer.verify(0, putRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(0, getRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+    }
+
+    @Test
+    void jsonOutputFileNameTest() throws Exception {
+        String outputFileName = "test.json";
+
+        TextExtractionRequest body = TextExtractionRequest.builder()
+                .documentReference(TextExtractionDataReference.of(CONNECTION_ID, FILE_NAME, BUCKET_NAME))
+                .resultsReference(TextExtractionDataReference.of(CONNECTION_ID, outputFileName, BUCKET_NAME))
+                .steps(TextExtractionSteps.of(List.of("en"), true))
+                .type(ASSEMBLY_JSON)
+                .projectId(PROJECT_ID)
+                .spaceId(null)
+                .build();
+
+        mockServers(body, outputFileName, false, false);
+
+        textExtraction.startExtraction(FILE_NAME, Options.create(List.of(ENGLISH)).type(ASSEMBLY_JSON));
+        watsonxServer.verify(1, postRequestedFor(urlPathEqualTo("/ml/v1/text/extractions")));
+        watsonxServer.verify(0, getRequestedFor(urlPathEqualTo("/ml/v1/text/extractions/" + PROCESS_EXTRACTION_ID)));
+        cosServer.verify(0, putRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(0, getRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+    }
+
+    @Test
+    void simulateLongResponseTest() throws Exception {
+
+        String outputFileName = FILE_NAME.replace(".pdf", ".md");
+
+        TextExtractionRequest body = createDefaultRequest();
+
+        mockTextExtractionBuilder(POST, URL_WATSONX_TEXT_EXTRACTION_START_API, 200)
+                .body(body)
+                .response(body, PROCESS_EXTRACTION_ID, "submitted")
+                .scenario(Scenario.STARTED, "firstIteration")
+                .build();
+
+        mockTextExtractionBuilder(GET,
+                URL_WATSONX_TEXT_EXTRACTION_RESULT_API.formatted(PROCESS_EXTRACTION_ID, PROJECT_ID, VERSION), 200)
+                .response(body, PROCESS_EXTRACTION_ID, "running")
+                .scenario("firstIteration", "secondIteration")
+                .build();
+
+        mockTextExtractionBuilder(GET,
+                URL_WATSONX_TEXT_EXTRACTION_RESULT_API.formatted(PROCESS_EXTRACTION_ID, PROJECT_ID, VERSION), 200)
+                .response(body, PROCESS_EXTRACTION_ID, "completed")
+                .scenario("secondIteration", Scenario.STARTED)
+                .build();
+
+        mockCosBuilder(GET, BUCKET_NAME, outputFileName, 200)
+                .response("Hello")
+                .build();
+
+        String extractedValue = textExtraction.extractAndFetch(FILE_NAME, List.of(ENGLISH));
+        assertEquals("Hello", extractedValue);
+        watsonxServer.verify(1, postRequestedFor(urlPathEqualTo("/ml/v1/text/extractions")));
+        watsonxServer.verify(2, getRequestedFor(urlPathEqualTo("/ml/v1/text/extractions/" + PROCESS_EXTRACTION_ID)));
+    }
+
+    @Test
+    void simulateTimeoutResponseTest() {
+
+        String outputFileName = FILE_NAME.replace(".pdf", ".md");
+
+        TextExtractionRequest body = createDefaultRequest();
+
+        mockTextExtractionBuilder(POST, URL_WATSONX_TEXT_EXTRACTION_START_API, 200)
+                .body(body)
+                .response(body, PROCESS_EXTRACTION_ID, "submitted")
+                .scenario(Scenario.STARTED, "firstIteration")
+                .build();
+
+        mockTextExtractionBuilder(GET,
+                URL_WATSONX_TEXT_EXTRACTION_RESULT_API.formatted(PROCESS_EXTRACTION_ID, PROJECT_ID, VERSION), 200)
+                .response(body, PROCESS_EXTRACTION_ID, "running")
+                .scenario("firstIteration", "secondIteration")
+                .build();
+
+        mockTextExtractionBuilder(GET,
+                URL_WATSONX_TEXT_EXTRACTION_RESULT_API.formatted(PROCESS_EXTRACTION_ID, PROJECT_ID, VERSION), 200)
+                .response(body, PROCESS_EXTRACTION_ID, "completed")
+                .scenario("secondIteration", Scenario.STARTED)
+                .build();
+
+        mockCosBuilder(GET, BUCKET_NAME, outputFileName, 200)
+                .response("Hello")
+                .build();
+
+        Options options = Options.create(List.of(ENGLISH))
+                .timeout(Duration.ofMillis(100));
+
+        var ex = assertThrows(
+                TextExtractionException.class,
+                () -> textExtraction.extractAndFetch(FILE_NAME, options));
+
+        assertEquals("Execution to extract test.pdf file took longer than the timeout set by 100 milliseconds",
+                ex.getMessage());
+
+        watsonxServer.verify(1, postRequestedFor(urlPathEqualTo("/ml/v1/text/extractions")));
+        watsonxServer.verify(1, getRequestedFor(urlPathEqualTo("/ml/v1/text/extractions/" + PROCESS_EXTRACTION_ID)));
+    }
+
+    @Test
+    void simulateFailedStatusOnResponseTest() throws Exception {
+
+        String outputFileName = FILE_NAME.replace(".pdf", ".md");
+        File file = new File(TextExtractionTest.class.getClassLoader().getResource(FILE_NAME).toURI());
+
+        TextExtractionRequest request = createDefaultRequest();
+
+        List<Language> languages = List.of(ENGLISH);
+        Options options = Options.create(languages)
+                .removeOutputFile(true)
+                .removeUploadedFile(true);
+
+        mockCosBuilder(PUT, BUCKET_NAME, FILE_NAME, 200).build();
+        mockCosBuilder(DELETE, BUCKET_NAME, FILE_NAME, 200).build();
+
+        mockTextExtractionBuilder(POST, URL_WATSONX_TEXT_EXTRACTION_START_API, 200)
+                .body(request)
+                .response(request, PROCESS_EXTRACTION_ID, "submitted")
+                .build();
+
+        mockTextExtractionBuilder(GET,
+                URL_WATSONX_TEXT_EXTRACTION_RESULT_API.formatted(PROCESS_EXTRACTION_ID, PROJECT_ID, VERSION), 200)
+                .response(request, PROCESS_EXTRACTION_ID, "running")
+                .scenario(Scenario.STARTED, "failed")
+                .build();
+
+        mockTextExtractionBuilder(GET,
+                URL_WATSONX_TEXT_EXTRACTION_RESULT_API.formatted(PROCESS_EXTRACTION_ID, PROJECT_ID, VERSION), 200)
+                .failResponse(request, PROCESS_EXTRACTION_ID)
+                .scenario("failed", Scenario.STARTED)
+                .build();
+
+        var ex = assertThrows(
+                TextExtractionException.class,
+                () -> textExtraction.extractAndFetch(FILE_NAME, options));
+
+        assertEquals(ex.getCode(), "file_download_error");
+        assertEquals(ex.getMessage(), "error message");
+
+        ex = assertThrows(
+                TextExtractionException.class,
+                () -> textExtraction.uploadExtractAndFetch(file, options));
+
+        assertEquals(ex.getCode(), "file_download_error");
+        assertEquals(ex.getMessage(), "error message");
+
+        Thread.sleep(200); // Wait for the async calls.
+        watsonxServer.verify(2, postRequestedFor(urlPathEqualTo("/ml/v1/text/extractions")));
+        watsonxServer.verify(4, getRequestedFor(urlPathEqualTo("/ml/v1/text/extractions/" + PROCESS_EXTRACTION_ID)));
+        cosServer.verify(1, putRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(0, getRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+        cosServer.verify(2, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+    }
+
+    @Test
+    void noSuchBucketTest() throws Exception {
+
+        String outputFileName = FILE_NAME.replace(".pdf", ".md");
+        File file = new File(TextExtractionTest.class.getClassLoader().getResource(FILE_NAME).toURI());
+
+        List<Language> languages = List.of(ENGLISH);
+
+        mockCosBuilder(PUT, BUCKET_NAME, FILE_NAME, 404)
+                .response("""
+                        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                        <Error>
+                            <Code>NoSuchBucket</Code>
+                            <Message>The specified bucket does not exist.</Message>
+                            <Resource>/my-bucket-name/test.pdf</Resource>
+                            <RequestId>my-request-id</RequestId>
+                            <httpStatusCode>404</httpStatusCode>
+                        </Error>
+                        """.trim())
+                .build();
+
+        CosError cosError = new CosError();
+        cosError.setCode(Code.NO_SUCH_BUCKET);
+        cosError.setHttpStatusCode(404);
+        cosError.setMessage("The specified bucket does not exist.");
+        cosError.setRequestId("my-request-id");
+        cosError.setResource("/my-bucket-name/test.pdf");
+
+        var ex = assertThrows(
+                COSException.class,
+                () -> textExtraction.uploadAndStartExtraction(file, languages),
+                "The specified bucket does not exist.");
+
+        assertEquals(cosError, ex.details());
+
+        ex = assertThrows(
+                COSException.class,
+                () -> textExtraction.uploadExtractAndFetch(file, languages),
+                "The specified bucket does not exist.");
+
+        assertEquals(cosError, ex.details());
+
+        watsonxServer.verify(0, postRequestedFor(urlPathEqualTo("/ml/v1/text/extractions")));
+        watsonxServer.verify(0, getRequestedFor(urlPathEqualTo("/ml/v1/text/extractions/" + PROCESS_EXTRACTION_ID)));
+        cosServer.verify(2, putRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(0, getRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+    }
+
+    @Test
+    void noSuchKeyTest() throws Exception {
+
+        String outputFileName = FILE_NAME.replace(".pdf", ".md");
+        File file = new File(TextExtractionTest.class.getClassLoader().getResource(FILE_NAME).toURI());
+
+        TextExtractionRequest body = createDefaultRequest();
+
+        List<Language> languages = List.of(ENGLISH);
+
+        mockCosBuilder(PUT, BUCKET_NAME, FILE_NAME, 200).build();
+        mockCosBuilder(GET, BUCKET_NAME, outputFileName, 404)
+                .response("""
+                        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                        <Error>
+                            <Code>NoSuchKey</Code>
+                            <Message>The specified key does not exist.</Message>
+                            <Resource>/my-bucket-name/test.pdf</Resource>
+                            <RequestId>my-request-id</RequestId>
+                            <httpStatusCode>404</httpStatusCode>
+                        </Error>
+                        """.trim())
+                .build();
+
+        mockTextExtractionBuilder(POST, URL_WATSONX_TEXT_EXTRACTION_START_API, 200)
+                .body(body)
+                .response(body, PROCESS_EXTRACTION_ID, "submitted")
+                .build();
+
+        mockTextExtractionBuilder(GET,
+                URL_WATSONX_TEXT_EXTRACTION_RESULT_API.formatted(PROCESS_EXTRACTION_ID, PROJECT_ID, VERSION), 200)
+                .response(body, PROCESS_EXTRACTION_ID, "completed")
+                .build();
+
+        CosError cosError = new CosError();
+        cosError.setCode(Code.NO_SUCH_KEY);
+        cosError.setHttpStatusCode(404);
+        cosError.setMessage("The specified key does not exist.");
+        cosError.setRequestId("my-request-id");
+        cosError.setResource("/my-bucket-name/test.pdf");
+
+        var ex = assertThrows(
+                COSException.class,
+                () -> textExtraction.extractAndFetch(FILE_NAME, languages),
+                "The specified key does not exist.");
+
+        assertEquals(cosError, ex.details());
+
+        ex = assertThrows(
+                COSException.class,
+                () -> textExtraction.uploadExtractAndFetch(file, languages),
+                "The specified key does not exist.");
+
+        assertEquals(cosError, ex.details());
+
+        watsonxServer.verify(2, postRequestedFor(urlPathEqualTo("/ml/v1/text/extractions")));
+        watsonxServer.verify(2, getRequestedFor(urlPathEqualTo("/ml/v1/text/extractions/" + PROCESS_EXTRACTION_ID)));
+        cosServer.verify(1, putRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(2, getRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, FILE_NAME))));
+        cosServer.verify(0, deleteRequestedFor(urlEqualTo("/%s/%s".formatted(BUCKET_NAME, outputFileName))));
+    }
+
+    @Test
+    void textExtractionEventDoesntExistTest() {
+
+        mockTextExtractionBuilder(GET,
+                URL_WATSONX_TEXT_EXTRACTION_RESULT_API.formatted(PROCESS_EXTRACTION_ID, PROJECT_ID, VERSION), 404)
+                .response("""
+                            {
+                                "trace": "9ddfccd50f6649d9913810df36578d38",
+                                "errors": [
+                                    {
+                                        "code": "text_extraction_event_does_not_exist",
+                                        "message": "Text extraction request does not exist."
+                                    }
+                                ]
+                            }
+                        """)
+                .build();
+
+        var ex = assertThrows(WatsonxException.class,
+                () -> textExtraction.checkExtractionStatus(PROCESS_EXTRACTION_ID));
+        assertEquals(WatsonxError.Code.TEXT_EXTRACTION_EVENT_DOES_NOT_EXIST,
+                ex.details().errors().get(0).codeToEnum().get());
+    }
+
+    @Test
+    void checkExtractionStatusTest() throws TextExtractionException {
+
+        TextExtractionRequest request = createDefaultRequest();
+
+        mockTextExtractionBuilder(GET,
+                URL_WATSONX_TEXT_EXTRACTION_RESULT_API.formatted(PROCESS_EXTRACTION_ID, PROJECT_ID, VERSION), 200)
+                .response(request, PROCESS_EXTRACTION_ID, "completed")
+                .build();
+
+        TextExtractionResponse response = textExtraction.checkExtractionStatus(PROCESS_EXTRACTION_ID);
+        assertEquals(request.documentReference(), response.entity().documentReference());
+        assertEquals(request.resultsReference(), response.entity().resultsReference());
+        assertEquals(PROCESS_EXTRACTION_ID, response.metadata().id());
+        assertEquals(PROJECT_ID, response.metadata().projectId());
+        assertNotNull(response.metadata().createdAt());
+        assertEquals(Status.COMPLETED, response.entity().results().status());
+        assertNotNull(response.entity().results().completedAt());
+        assertNull(response.entity().results().error());
+        assertEquals(1, response.entity().results().numberPagesProcessed());
+        assertNotNull(response.entity().results().runningAt());
+    }
+
+    @Test
+    void overrideConnectionIdAndBucket() throws Exception {
+
+        String outputFileName = FILE_NAME.replace(".pdf", ".md");
+        File file = new File(TextExtractionTest.class.getClassLoader().getResource(FILE_NAME).toURI());
+
+        String NEW_CONNECTION_ID = "my-new-connection-id";
+        String NEW_BUCKET_NAME = "my-new-bucket";
+
+        TextExtractionRequest request = TextExtractionRequest.builder()
+                .documentReference(TextExtractionDataReference.of(NEW_CONNECTION_ID, FILE_NAME, NEW_BUCKET_NAME))
+                .resultsReference(TextExtractionDataReference.of(NEW_CONNECTION_ID, outputFileName, NEW_BUCKET_NAME))
+                .steps(TextExtractionSteps.of(List.of("en"), true))
+                .type(ASSEMBLY_MD)
+                .projectId(PROJECT_ID)
+                .spaceId(null)
+                .build();
+
+        // Mock the upload local file operation.
+        mockCosBuilder(PUT, NEW_BUCKET_NAME, FILE_NAME, 200).build();
+
+        // Mock extracted file result.
+        mockCosBuilder(GET, NEW_BUCKET_NAME, outputFileName, 200)
+                .response("Hello")
+                .build();
+
+        // Mock start extraction.
+        mockTextExtractionBuilder(POST, URL_WATSONX_TEXT_EXTRACTION_START_API, 200)
+                .body(request)
+                .response(request, PROCESS_EXTRACTION_ID, "submitted")
+                .build();
+
+        // Mock result extraction.
+        mockTextExtractionBuilder(GET,
+                URL_WATSONX_TEXT_EXTRACTION_RESULT_API.formatted(PROCESS_EXTRACTION_ID, PROJECT_ID, VERSION), 200)
+                .response(request, PROCESS_EXTRACTION_ID, "completed")
+                .build();
+
+        Options options = Options.create(List.of(ENGLISH))
+                .documentReference(new TextExtraction.Reference(NEW_CONNECTION_ID, NEW_BUCKET_NAME))
+                .outputFileName(outputFileName)
+                .removeOutputFile(false)
+                .removeUploadedFile(false)
+                .resultsReference(new TextExtraction.Reference(NEW_CONNECTION_ID, NEW_BUCKET_NAME))
+                .tableProcessing(true)
+                .type(ASSEMBLY_MD);
+
+        assertDoesNotThrow(() -> textExtraction.extractAndFetch(FILE_NAME, options));
+        assertDoesNotThrow(() -> textExtraction.startExtraction(FILE_NAME, options));
+        assertDoesNotThrow(() -> textExtraction.uploadAndStartExtraction(file, options));
+        assertDoesNotThrow(() -> textExtraction.uploadExtractAndFetch(file, options));
+    }
+
+    @Test
+    void deleteFileTest() {
+
+        mockCosBuilder(DELETE, BUCKET_NAME, FILE_NAME, 200).build();
+        assertDoesNotThrow(() -> textExtraction.deleteFile(BUCKET_NAME, FILE_NAME));
+
+        mockCosBuilder(DELETE, BUCKET_NAME, FILE_NAME, 404)
+                .response("""
+                        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                        <Error>
+                        <Code>NoSuchBucket</Code>
+                        <Message>The specified bucket does not exist.</Message>
+                        <Resource>/andreaproject-donotdelete-pr-xnran4g4ptd1wos/ciao.pdf</Resource>
+                        <RequestId>27482371-17d6-47c7-a526-5a655074bed2</RequestId>
+                        <httpStatusCode>404</httpStatusCode>
+                        </Error>""".trim()).build();
+        var ex = assertThrows(COSException.class, () -> textExtraction.deleteFile(BUCKET_NAME, FILE_NAME));
+        assertEquals(ex.details().getCode(), Code.NO_SUCH_BUCKET);
+
+        // Return an expired token.
+        mockIAMBuilder(200)
+                .scenario(Scenario.STARTED, "retry")
+                .response("expired_token", Date.from(Instant.now().minusSeconds(3)))
+                .build();
+
+        // Second call (retryOn) returns 200
+        mockIAMBuilder(200)
+                .scenario("retry", Scenario.STARTED)
+                .response("my_super_token", Date.from(Instant.now().plusMillis(2000)))
+                .build();
+
+        mockCosBuilder(DELETE, BUCKET_NAME, FILE_NAME, 403)
+                .response("""
+                        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                        <Error>
+                            <Code>AccessDenied</Code>
+                            <Message>Access Denied</Message>
+                            <Resource>/andreaproject-donotdelete-pr-xnran4g4ptd1wo/ciao.pdf</Resource>
+                            <RequestId>df887c2b-43c3-4933-a3a1-b0e19e7c2231</RequestId>
+                            <httpStatusCode>403</httpStatusCode>
+                        </Error>""".trim())
+                .token("expired_token")
+                .scenario(Scenario.STARTED, "retry")
+                .build();
+
+        mockCosBuilder(DELETE, BUCKET_NAME, FILE_NAME, 200)
+                .scenario("retry", Scenario.STARTED)
+                .build();
+
+        assertDoesNotThrow(() -> textExtraction.deleteFile(BUCKET_NAME, FILE_NAME));
+    }
+
+    private void mockServers(TextExtractionRequest body, String outputFileName, boolean deleteUploadedFile,
+            boolean deleteOutputFile) {
+        // Mock the upload local file operation.
+        mockCosBuilder(PUT, BUCKET_NAME, FILE_NAME, 200).build();
+
+        // Mock extracted file result.
+        mockCosBuilder(GET, BUCKET_NAME, outputFileName, 200)
+                .response("Hello")
+                .build();
+
+        if (deleteUploadedFile) {
+            // Mock delete uploaded file.
+            mockCosBuilder(DELETE, BUCKET_NAME, FILE_NAME, 200).build();
+        }
+
+        if (deleteOutputFile) {
+            // Mock delete extracted file.
+            mockCosBuilder(DELETE, BUCKET_NAME, outputFileName, 200).build();
+        }
+
+        // Mock start extraction.
+        mockTextExtractionBuilder(POST, URL_WATSONX_TEXT_EXTRACTION_START_API, 200)
+                .body(body)
+                .response(body, PROCESS_EXTRACTION_ID, "submitted")
+                .build();
+
+        // Mock result extraction.
+        mockTextExtractionBuilder(GET,
+                URL_WATSONX_TEXT_EXTRACTION_RESULT_API.formatted(PROCESS_EXTRACTION_ID, PROJECT_ID, VERSION), 200)
+                .response(body, PROCESS_EXTRACTION_ID, "completed")
+                .build();
+    }
+
+    private TextExtractionRequest createDefaultRequest() {
+        return TextExtractionRequest.builder()
+                .documentReference(TextExtractionDataReference.of(CONNECTION_ID, FILE_NAME, BUCKET_NAME))
+                .resultsReference(
+                        TextExtractionDataReference.of(CONNECTION_ID, FILE_NAME.replace(".pdf", ".md"), BUCKET_NAME))
+                .steps(TextExtractionSteps.of(List.of("en"), true))
+                .type(ASSEMBLY_MD)
+                .projectId(PROJECT_ID)
+                .spaceId(null)
+                .build();
+    }
+}

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/TokenCountEstimatorTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/TokenCountEstimatorTest.java
@@ -1,5 +1,12 @@
 package io.quarkiverse.langchain4j.watsonx.deployment;
 
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.API_KEY;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.BEARER_TOKEN;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.PROJECT_ID;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.RESPONSE_WATSONX_TOKENIZER_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_IAM_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_TOKENIZER_API;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Date;
@@ -24,17 +31,17 @@ public class TokenCountEstimatorTest extends WireMockAbstract {
 
     @RegisterExtension
     static QuarkusUnitTest unitTest = new QuarkusUnitTest()
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", WireMockUtil.URL_WATSONX_SERVER)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", WireMockUtil.URL_IAM_SERVER)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", WireMockUtil.API_KEY)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", WireMockUtil.PROJECT_ID)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", URL_WATSONX_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", URL_IAM_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", PROJECT_ID)
             .overrideConfigKey("quarkus.langchain4j.watsonx.mode", "generation")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
 
     @Override
     void handlerBeforeEach() {
-        mockServers.mockIAMBuilder(200)
-                .response(WireMockUtil.BEARER_TOKEN, new Date())
+        mockIAMBuilder(200)
+                .response(BEARER_TOKEN, new Date())
                 .build();
     }
 
@@ -74,9 +81,9 @@ public class TokenCountEstimatorTest extends WireMockAbstract {
         var projectId = langchain4jWatsonConfig.defaultConfig().projectId().orElse(null);
         var body = new TokenizationRequest(modelId, input, spaceId, projectId);
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_TOKENIZER_API, 200)
+        mockWatsonxBuilder(URL_WATSONX_TOKENIZER_API, 200)
                 .body(mapper.writeValueAsString(body))
-                .response(WireMockUtil.RESPONSE_WATSONX_TOKENIZER_API.formatted(modelId))
+                .response(RESPONSE_WATSONX_TOKENIZER_API.formatted(modelId))
                 .build();
 
         assertEquals(11, tokenization.estimateTokenCount(
@@ -91,9 +98,9 @@ public class TokenCountEstimatorTest extends WireMockAbstract {
         var projectId = langchain4jWatsonConfig.defaultConfig().projectId().orElse(null);
         var body = new TokenizationRequest(modelId, input, spaceId, projectId);
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_TOKENIZER_API, 200)
+        mockWatsonxBuilder(URL_WATSONX_TOKENIZER_API, 200)
                 .body(mapper.writeValueAsString(body))
-                .response(WireMockUtil.RESPONSE_WATSONX_TOKENIZER_API.formatted(modelId))
+                .response(RESPONSE_WATSONX_TOKENIZER_API.formatted(modelId))
                 .build();
 
         return input;

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ToolNotFoundTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ToolNotFoundTest.java
@@ -1,5 +1,12 @@
 package io.quarkiverse.langchain4j.watsonx.deployment;
 
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.API_KEY;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.BEARER_TOKEN;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.PROJECT_ID;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.RESPONSE_WATSONX_CHAT_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_IAM_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_CHAT_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_SERVER;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Date;
@@ -22,18 +29,18 @@ public class ToolNotFoundTest extends WireMockAbstract {
 
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", WireMockUtil.URL_WATSONX_SERVER)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", WireMockUtil.URL_IAM_SERVER)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", WireMockUtil.API_KEY)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", WireMockUtil.PROJECT_ID)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", URL_WATSONX_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", URL_IAM_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", PROJECT_ID)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.tool-choice", "mytool")
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(WireMockUtil.class));
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
 
     @Override
     void handlerBeforeEach() {
-        mockServers.mockIAMBuilder(200)
+        mockIAMBuilder(200)
                 .grantType(langchain4jWatsonConfig.defaultConfig().iam().grantType())
-                .response(WireMockUtil.BEARER_TOKEN, new Date())
+                .response(BEARER_TOKEN, new Date())
                 .build();
     }
 
@@ -43,8 +50,8 @@ public class ToolNotFoundTest extends WireMockAbstract {
     @Test
     void test() {
 
-        mockServers.mockWatsonxBuilder(WireMockUtil.URL_WATSONX_CHAT_API, 200)
-                .response(WireMockUtil.RESPONSE_WATSONX_CHAT_API)
+        mockWatsonxBuilder(URL_WATSONX_CHAT_API, 200)
+                .response(RESPONSE_WATSONX_CHAT_API)
                 .build();
 
         assertThrows(IllegalArgumentException.class,

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/UnsupportedResponseFormatTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/UnsupportedResponseFormatTest.java
@@ -1,5 +1,8 @@
 package io.quarkiverse.langchain4j.watsonx.deployment;
 
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.API_KEY;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.PROJECT_ID;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_SERVER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -17,9 +20,9 @@ public class UnsupportedResponseFormatTest {
 
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", WireMockUtil.URL_WATSONX_SERVER)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", WireMockUtil.API_KEY)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", WireMockUtil.PROJECT_ID)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", URL_WATSONX_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", PROJECT_ID)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.response-format", "not_supported")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
             .assertException(t -> assertThat(t).isInstanceOf(IllegalArgumentException.class));

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/WireMockAbstract.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/WireMockAbstract.java
@@ -17,6 +17,7 @@ import io.quarkiverse.langchain4j.watsonx.runtime.config.LangChain4jWatsonxConfi
 public abstract class WireMockAbstract {
 
     static WireMockServer watsonxServer;
+    static WireMockServer wxServer;
     static WireMockServer iamServer;
     static WireMockUtil mockServers;
     static ObjectMapper mapper;
@@ -31,21 +32,26 @@ public abstract class WireMockAbstract {
         watsonxServer = new WireMockServer(options().port(WireMockUtil.PORT_WATSONX_SERVER));
         watsonxServer.start();
 
+        wxServer = new WireMockServer(options().port(WireMockUtil.PORT_WX_SERVER));
+        wxServer.start();
+
         iamServer = new WireMockServer(options().port(WireMockUtil.PORT_IAM_SERVER));
         iamServer.start();
 
-        mockServers = new WireMockUtil(watsonxServer, iamServer);
+        mockServers = new WireMockUtil(watsonxServer, wxServer, iamServer);
     }
 
     @AfterAll
     static void afterAll() {
         watsonxServer.stop();
+        wxServer.stop();
         iamServer.stop();
     }
 
     @BeforeEach
     void beforeEach() throws Exception {
         watsonxServer.resetAll();
+        wxServer.resetAll();
         iamServer.resetAll();
         handlerBeforeEach();
     }

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/WireMockAbstract.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/WireMockAbstract.java
@@ -1,8 +1,33 @@
 package io.quarkiverse.langchain4j.watsonx.deployment;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.delete;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.head;
+import static com.github.tomakehurst.wiremock.client.WireMock.options;
+import static com.github.tomakehurst.wiremock.client.WireMock.patch;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.trace;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.API_KEY;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.BEARER_TOKEN;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.GRANT_TYPE;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.IAM_200_RESPONSE;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.PORT_IAM_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.PORT_WATSONX_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.PORT_WX_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_IAM_GENERATE_TOKEN;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.VERSION;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 import jakarta.inject.Inject;
+import jakarta.ws.rs.core.MediaType;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -10,6 +35,10 @@ import org.junit.jupiter.api.BeforeEach;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.MappingBuilder;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.matching.StringValuePattern;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 
 import io.quarkiverse.langchain4j.watsonx.client.WatsonxRestApi;
 import io.quarkiverse.langchain4j.watsonx.runtime.config.LangChain4jWatsonxConfig;
@@ -19,7 +48,6 @@ public abstract class WireMockAbstract {
     static WireMockServer watsonxServer;
     static WireMockServer wxServer;
     static WireMockServer iamServer;
-    static WireMockUtil mockServers;
     static ObjectMapper mapper;
 
     @Inject
@@ -29,16 +57,14 @@ public abstract class WireMockAbstract {
     static void beforeAll() {
         mapper = WatsonxRestApi.objectMapper(new ObjectMapper());
 
-        watsonxServer = new WireMockServer(options().port(WireMockUtil.PORT_WATSONX_SERVER));
+        watsonxServer = new WireMockServer(options().port(PORT_WATSONX_SERVER));
         watsonxServer.start();
 
-        wxServer = new WireMockServer(options().port(WireMockUtil.PORT_WX_SERVER));
+        wxServer = new WireMockServer(options().port(PORT_WX_SERVER));
         wxServer.start();
 
-        iamServer = new WireMockServer(options().port(WireMockUtil.PORT_IAM_SERVER));
+        iamServer = new WireMockServer(options().port(PORT_IAM_SERVER));
         iamServer.start();
-
-        mockServers = new WireMockUtil(watsonxServer, wxServer, iamServer);
     }
 
     @AfterAll
@@ -58,4 +84,240 @@ public abstract class WireMockAbstract {
 
     void handlerBeforeEach() throws Exception {
     };
+
+    /**
+     * Builder to mock the IAM server.
+     */
+    public IAMBuilder mockIAMBuilder(int status) {
+        return new IAMBuilder(status);
+    }
+
+    /**
+     *
+     * Builder to mock the wx server.
+     */
+    public WxBuilder mockWxBuilder(String apiURL, int status) {
+        return new WxBuilder(apiURL, status);
+    }
+
+    /**
+     *
+     * Builder to mock the wx server.
+     */
+    public WxBuilder mockWxBuilder(String apiURL, int status, String version) {
+        return new WxBuilder(apiURL, status, version);
+    }
+
+    /**
+     *
+     * Builder to mock the wx server.
+     */
+    public WxBuilder mockWxBuilder(RequestMethod method, String apiURL, int status, String version) {
+        return new WxBuilder(method, apiURL, status, version);
+    }
+
+    /**
+     *
+     * Builder to mock the Watsonx.ai server.
+     */
+    public WatsonxBuilder mockWatsonxBuilder(String apiURL, int status) {
+        return new WatsonxBuilder(apiURL, status);
+    }
+
+    /**
+     *
+     * Builder to mock the Watsonx.ai server.
+     */
+    public WatsonxBuilder mockWatsonxBuilder(String apiURL, int status, String version) {
+        return new WatsonxBuilder(apiURL, status, version);
+    }
+
+    /**
+     *
+     * Builder to mock the Watsonx.ai server.
+     */
+    public WatsonxBuilder mockWatsonxBuilder(RequestMethod method, String apiURL, int status, String version) {
+        return new WatsonxBuilder(method, apiURL, status, version);
+    }
+
+    public static class IAMBuilder {
+
+        private MappingBuilder builder;
+        private String apikey = API_KEY;
+        private String grantType = GRANT_TYPE;
+        private String responseMediaType = MediaType.APPLICATION_JSON;
+        private String response = "";
+        private int status;
+
+        protected IAMBuilder(int status) {
+            this.status = status;
+            this.builder = post(urlEqualTo(URL_IAM_GENERATE_TOKEN));
+        }
+
+        public IAMBuilder scenario(String currentState, String nextState) {
+            builder = builder.inScenario("")
+                    .whenScenarioStateIs(currentState)
+                    .willSetStateTo(nextState);
+            return this;
+        }
+
+        public IAMBuilder apikey(String apikey) {
+            this.apikey = apikey;
+            return this;
+        }
+
+        public IAMBuilder grantType(String grantType) {
+            this.grantType = grantType;
+            return this;
+        }
+
+        public IAMBuilder responseMediaType(String mediaType) {
+            this.responseMediaType = mediaType;
+            return this;
+        }
+
+        public IAMBuilder response(String response) {
+            this.response = response;
+            return this;
+        }
+
+        public IAMBuilder response(String token, Date expiration) {
+            this.response = IAM_200_RESPONSE.formatted(token, TimeUnit.MILLISECONDS.toSeconds(expiration.getTime()));
+            return this;
+        }
+
+        public void build() {
+            iamServer.stubFor(
+                    builder.withHeader("Content-Type", equalTo(MediaType.APPLICATION_FORM_URLENCODED))
+                            .withFormParam("apikey", equalTo(apikey))
+                            .withFormParam("grant_type", equalTo(grantType))
+                            .willReturn(aResponse()
+                                    .withStatus(status)
+                                    .withHeader("Content-Type", responseMediaType)
+                                    .withBody(response)));
+        }
+    }
+
+    public static abstract class ServerBuilder {
+
+        private MappingBuilder builder;
+        private String token = BEARER_TOKEN;
+        private String responseMediaType = MediaType.APPLICATION_JSON;
+        private String response;
+        private int status;
+
+        protected ServerBuilder(RequestMethod method, String apiURL, int status, String version) {
+            this.builder = switch (method.getName()) {
+                case "GET" -> get(urlEqualTo(apiURL.formatted(version)));
+                case "POST" -> post(urlEqualTo(apiURL.formatted(version)));
+                case "PUT" -> put(urlEqualTo(apiURL.formatted(version)));
+                case "DELETE" -> delete(urlEqualTo(apiURL.formatted(version)));
+                case "PATCH" -> patch(urlEqualTo(apiURL.formatted(version)));
+                case "OPTIONS" -> options(urlEqualTo(apiURL.formatted(version)));
+                case "HEAD" -> head(urlEqualTo(apiURL.formatted(version)));
+                case "TRACE" -> trace(urlEqualTo(apiURL.formatted(version)));
+                default -> throw new IllegalArgumentException("Unknown request method: " + method);
+            };
+            this.status = status;
+        }
+
+        protected ServerBuilder(String apiURL, int status, String version) {
+            this(RequestMethod.POST, apiURL, status, version);
+        }
+
+        protected ServerBuilder(String apiURL, int status) {
+            this(RequestMethod.POST, apiURL, status, VERSION);
+        }
+
+        public ServerBuilder scenario(String currentState, String nextState) {
+            builder = builder.inScenario("")
+                    .whenScenarioStateIs(currentState)
+                    .willSetStateTo(nextState);
+            return this;
+        }
+
+        public ServerBuilder bodyIgnoreOrder(String body) {
+            builder.withRequestBody(equalToJson(body, true, false));
+            return this;
+        }
+
+        public ServerBuilder body(String body) {
+            builder.withRequestBody(equalToJson(body));
+            return this;
+        }
+
+        public ServerBuilder body(StringValuePattern stringValuePattern) {
+            builder.withRequestBody(stringValuePattern);
+            return this;
+        }
+
+        public ServerBuilder token(String token) {
+            this.token = token;
+            return this;
+        }
+
+        public ServerBuilder responseMediaType(String mediaType) {
+            this.responseMediaType = mediaType;
+            return this;
+        }
+
+        public ServerBuilder response(String response) {
+            this.response = response;
+            return this;
+        }
+
+        public abstract StubMapping build();
+    }
+
+    public static class WatsonxBuilder extends ServerBuilder {
+
+        protected WatsonxBuilder(RequestMethod method, String apiURL, int status, String version) {
+            super(method, apiURL, status, version);
+        }
+
+        protected WatsonxBuilder(String apiURL, int status, String version) {
+            super(RequestMethod.POST, apiURL, status, version);
+        }
+
+        protected WatsonxBuilder(String apiURL, int status) {
+            super(RequestMethod.POST, apiURL, status, VERSION);
+        }
+
+        @Override
+        public StubMapping build() {
+            return watsonxServer.stubFor(
+                    super.builder
+                            .withHeader("Authorization", equalTo("Bearer %s".formatted(super.token)))
+                            .willReturn(aResponse()
+                                    .withStatus(super.status)
+                                    .withHeader("Content-Type", super.responseMediaType)
+                                    .withBody(super.response)));
+        }
+    }
+
+    public static class WxBuilder extends ServerBuilder {
+
+        protected WxBuilder(RequestMethod method, String apiURL, int status, String version) {
+            super(method, apiURL, status, version);
+        }
+
+        protected WxBuilder(String apiURL, int status, String version) {
+            super(RequestMethod.POST, apiURL, status, version);
+        }
+
+        protected WxBuilder(String apiURL, int status) {
+            super(RequestMethod.POST, apiURL, status, VERSION);
+        }
+
+        @Override
+        public StubMapping build() {
+            return wxServer.stubFor(
+                    super.builder
+                            .withHeader("Authorization", equalTo("Bearer %s".formatted(super.token)))
+                            .willReturn(aResponse()
+                                    .withStatus(super.status)
+                                    .withHeader("Content-Type", super.responseMediaType)
+                                    .withBody(super.response)));
+        }
+    }
 }

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/WireMockUtil.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/WireMockUtil.java
@@ -20,14 +20,19 @@ public class WireMockUtil {
     public static final String URL_WATSONX_SCORING_API = "/ml/v1/text/rerank?version=%s";
     public static final String URL_WATSONX_EMBEDDING_API = "/ml/v1/text/embeddings?version=%s";
     public static final String URL_WATSONX_TOKENIZER_API = "/ml/v1/text/tokenization?version=%s";
+    public static final String URL_WATSONX_TEXT_EXTRACTION_START_API = "/ml/v1/text/extractions?version=%s";
+    public static final String URL_WATSONX_TEXT_EXTRACTION_RESULT_API = "/ml/v1/text/extractions/%s?project_id=%s&version=%s";
+
+    public static final int PORT_IAM_SERVER = 8090;
+    public static final String URL_IAM_SERVER = "http://localhost:8090";
+    public static final String URL_IAM_GENERATE_TOKEN = "/identity/token";
 
     public static final int PORT_WX_SERVER = 8091;
     public static final String URL_WX_SERVER = "http://localhost:8091";
     public static final String URL_WX_AGENT_TOOL_RUN = "/v1-beta/utility_agent_tools/run";
 
-    public static final int PORT_IAM_SERVER = 8090;
-    public static final String URL_IAM_SERVER = "http://localhost:8090";
-    public static final String URL_IAM_GENERATE_TOKEN = "/identity/token";
+    public static final int PORT_COS_SERVER = 8092;
+    public static final String URL_COS_SERVER = "http://localhost:8092";
 
     public static final String API_KEY = "my_super_api_key";
     public static final String BEARER_TOKEN = "my_super_token";

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/WireMockUtil.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/WireMockUtil.java
@@ -35,6 +35,10 @@ public class WireMockUtil {
     public static final String URL_WATSONX_EMBEDDING_API = "/ml/v1/text/embeddings?version=%s";
     public static final String URL_WATSONX_TOKENIZER_API = "/ml/v1/text/tokenization?version=%s";
 
+    public static final int PORT_WX_SERVER = 8091;
+    public static final String URL_WX_SERVER = "http://localhost:8091";
+    public static final String URL_WX_AGENT_TOOL_RUN = "/v1-beta/utility_agent_tools/run";
+
     public static final int PORT_IAM_SERVER = 8090;
     public static final String URL_IAM_SERVER = "http://localhost:8090";
     public static final String URL_IAM_GENERATE_TOKEN = "/identity/token";
@@ -214,9 +218,11 @@ public class WireMockUtil {
 
     WireMockServer iamServer;
     WireMockServer watsonServer;
+    WireMockServer wxServer;
 
-    public WireMockUtil(WireMockServer watsonServer, WireMockServer iamServer) {
-        this.watsonServer = watsonServer;
+    public WireMockUtil(WireMockServer watsonxServer, WireMockServer wxServer, WireMockServer iamServer) {
+        this.watsonServer = watsonxServer;
+        this.wxServer = wxServer;
         this.iamServer = iamServer;
     }
 
@@ -226,6 +232,10 @@ public class WireMockUtil {
 
     public WatsonxBuilder mockWatsonxBuilder(String apiURL, int status) {
         return new WatsonxBuilder(watsonServer, apiURL, status);
+    }
+
+    public WatsonxBuilder mockWxBuilder(String apiURL, int status) {
+        return new WatsonxBuilder(wxServer, apiURL, status);
     }
 
     public WatsonxBuilder mockWatsonxBuilder(String apiURL, int status, String version) {
@@ -276,6 +286,11 @@ public class WireMockUtil {
             builder = builder.inScenario("")
                     .whenScenarioStateIs(currentState)
                     .willSetStateTo(nextState);
+            return this;
+        }
+
+        public WatsonxBuilder bodyIgnoreOrder(String body) {
+            builder.withRequestBody(equalToJson(body, true, false));
             return this;
         }
 

--- a/model-providers/watsonx/runtime/pom.xml
+++ b/model-providers/watsonx/runtime/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.quarkiverse.langchain4j</groupId>
@@ -16,6 +18,10 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-client-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jaxb</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.langchain4j</groupId>
@@ -52,7 +58,8 @@
                             <goal>extension-descriptor</goal>
                         </goals>
                         <configuration>
-                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+                            <deployment>
+                                ${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
                         </configuration>
                     </execution>
                 </executions>

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/Watsonx.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/Watsonx.java
@@ -9,8 +9,10 @@ import java.util.concurrent.TimeUnit;
 import org.jboss.resteasy.reactive.client.api.LoggingScope;
 
 import dev.langchain4j.model.chat.listener.ChatModelListener;
+import io.quarkiverse.langchain4j.watsonx.client.WatsonxClientLogger;
 import io.quarkiverse.langchain4j.watsonx.client.WatsonxRestApi;
 import io.quarkiverse.langchain4j.watsonx.client.filter.BearerTokenHeaderFactory;
+import io.quarkiverse.langchain4j.watsonx.runtime.TokenGenerator;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 
 public abstract class Watsonx {
@@ -28,7 +30,7 @@ public abstract class Watsonx {
 
         if (builder.logRequests || builder.logResponses) {
             restClientBuilder.loggingScope(LoggingScope.REQUEST_RESPONSE);
-            restClientBuilder.clientLogger(new WatsonxRestApi.WatsonClientLogger(
+            restClientBuilder.clientLogger(new WatsonxClientLogger(
                     builder.logRequests,
                     builder.logResponses));
         }
@@ -72,7 +74,7 @@ public abstract class Watsonx {
         protected URL url;
         protected boolean logResponses;
         protected boolean logRequests;
-        protected WatsonxTokenGenerator tokenGenerator;
+        protected TokenGenerator tokenGenerator;
         private List<ChatModelListener> listeners = Collections.emptyList();
 
         public T modelId(String modelId) {
@@ -110,7 +112,7 @@ public abstract class Watsonx {
             return (T) this;
         }
 
-        public T tokenGenerator(WatsonxTokenGenerator tokenGenerator) {
+        public T tokenGenerator(TokenGenerator tokenGenerator) {
             this.tokenGenerator = tokenGenerator;
             return (T) this;
         }

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxUtils.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxUtils.java
@@ -10,8 +10,10 @@ import jakarta.ws.rs.core.Response.Status;
 
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.internal.Utils;
+import io.quarkiverse.langchain4j.watsonx.bean.CosError;
 import io.quarkiverse.langchain4j.watsonx.bean.WatsonxError;
 import io.quarkiverse.langchain4j.watsonx.exception.BuiltinServiceException;
+import io.quarkiverse.langchain4j.watsonx.exception.COSException;
 import io.quarkiverse.langchain4j.watsonx.exception.WatsonxException;
 
 public class WatsonxUtils {
@@ -22,7 +24,7 @@ public class WatsonxUtils {
 
             try {
                 return action.call();
-            } catch (WatsonxException | BuiltinServiceException e) {
+            } catch (WatsonxException | BuiltinServiceException | COSException e) {
 
                 if (!isTokenExpired(e))
                     throw e;
@@ -62,7 +64,13 @@ public class WatsonxUtils {
 
             if (e.statusCode() == Status.UNAUTHORIZED.getStatusCode() &&
                     e.details().equalsIgnoreCase("jwt expired")) {
-                // Jwt expired, retry.
+                return true;
+            }
+
+        } else if (exception instanceof COSException e) {
+
+            if (e.statusCode() == Status.FORBIDDEN.getStatusCode()
+                    && e.details().getCode().equals(CosError.Code.ACCESS_DENIED)) {
                 return true;
             }
         }

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/bean/CosError.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/bean/CosError.java
@@ -1,0 +1,266 @@
+package io.quarkiverse.langchain4j.watsonx.bean;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "Error")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class CosError {
+    @XmlElement(name = "Code")
+    private Code code;
+    @XmlElement(name = "Message")
+    private String message;
+    @XmlElement(name = "Resource")
+    private String resource;
+    @XmlElement(name = "RequestId")
+    private String requestId;
+    @XmlElement(name = "httpStatusCode")
+    private int httpStatusCode;
+
+    public Code getCode() {
+        return code;
+    }
+
+    public void setCode(Code code) {
+        this.code = code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getResource() {
+        return resource;
+    }
+
+    public void setResource(String resource) {
+        this.resource = resource;
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public void setRequestId(String requestId) {
+        this.requestId = requestId;
+    }
+
+    public int getHttpStatusCode() {
+        return httpStatusCode;
+    }
+
+    public void setHttpStatusCode(int httpStatusCode) {
+        this.httpStatusCode = httpStatusCode;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((code == null) ? 0 : code.hashCode());
+        result = prime * result + ((message == null) ? 0 : message.hashCode());
+        result = prime * result + ((resource == null) ? 0 : resource.hashCode());
+        result = prime * result + ((requestId == null) ? 0 : requestId.hashCode());
+        result = prime * result + httpStatusCode;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        CosError other = (CosError) obj;
+        if (code != other.code)
+            return false;
+        if (message == null) {
+            if (other.message != null)
+                return false;
+        } else if (!message.equals(other.message))
+            return false;
+        if (resource == null) {
+            if (other.resource != null)
+                return false;
+        } else if (!resource.equals(other.resource))
+            return false;
+        if (requestId == null) {
+            if (other.requestId != null)
+                return false;
+        } else if (!requestId.equals(other.requestId))
+            return false;
+        if (httpStatusCode != other.httpStatusCode)
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "CosError [code=" + code + ", message=" + message + ", resource=" + resource + ", requestId=" + requestId
+                + ", httpStatusCode=" + httpStatusCode + "]";
+    }
+
+    @XmlEnum
+    public static enum Code {
+
+        @XmlEnumValue("AccessDenied")
+        ACCESS_DENIED,
+
+        @XmlEnumValue("BadDigest")
+        BAD_DIGEST,
+
+        @XmlEnumValue("BucketAlreadyExists")
+        BUCKET_ALREADY_EXISTS,
+
+        @XmlEnumValue("BucketAlreadyOwnedByYou")
+        BUCKET_ALREADY_OWNED_BY_YOU,
+
+        @XmlEnumValue("BucketNotEmpty")
+        BUCKET_NOT_EMPTY,
+
+        @XmlEnumValue("CredentialsNotSupported")
+        CREDENTIALS_NOT_SUPPORTED,
+
+        @XmlEnumValue("EntityTooSmall")
+        ENTITY_TOO_SMALL,
+
+        @XmlEnumValue("EntityTooLarge")
+        ENTITY_TOO_LARGE,
+
+        @XmlEnumValue("IncompleteBody")
+        INCOMPLETE_BODY,
+
+        @XmlEnumValue("IncorrectNumberOfFilesInPostRequest")
+        INCORRECT_NUMBER_OF_FILES_IN_POST_REQUEST,
+
+        @XmlEnumValue("InlineDataTooLarge")
+        INLINE_DATA_TOO_LARGE,
+
+        @XmlEnumValue("InternalError")
+        INTERNAL_ERROR,
+
+        @XmlEnumValue("InvalidAccessKeyId")
+        INVALID_ACCESS_KEY_ID,
+
+        @XmlEnumValue("InvalidArgument")
+        INVALID_ARGUMENT,
+
+        @XmlEnumValue("InvalidBucketName")
+        INVALID_BUCKET_NAME,
+
+        @XmlEnumValue("InvalidBucketState")
+        INVALID_BUCKET_STATE,
+
+        @XmlEnumValue("InvalidDigest")
+        INVALID_DIGEST,
+
+        @XmlEnumValue("InvalidLocationConstraint")
+        INVALID_LOCATION_CONSTRAINT,
+
+        @XmlEnumValue("InvalidObjectState")
+        INVALID_OBJECT_STATE,
+
+        @XmlEnumValue("InvalidPart")
+        INVALID_PART,
+
+        @XmlEnumValue("InvalidPartOrder")
+        INVALID_PART_ORDER,
+
+        @XmlEnumValue("InvalidRange")
+        INVALID_RANGE,
+
+        @XmlEnumValue("InvalidRequest")
+        INVALID_REQUEST,
+
+        @XmlEnumValue("InvalidSecurity")
+        INVALID_SECURITY,
+
+        @XmlEnumValue("InvalidURI")
+        INVALID_URI,
+
+        @XmlEnumValue("KeyTooLong")
+        KEY_TOO_LONG,
+
+        @XmlEnumValue("MalformedPOSTRequest")
+        MALFORMED_POST_REQUEST,
+
+        @XmlEnumValue("MalformedXML")
+        MALFORMED_XML,
+
+        @XmlEnumValue("MaxMessageLengthExceeded")
+        MAX_MESSAGE_LENGTH_EXCEEDED,
+
+        @XmlEnumValue("MaxPostPreDataLengthExceededError")
+        MAX_POST_PRE_DATA_LENGTH_EXCEEDED_ERROR,
+
+        @XmlEnumValue("MetadataTooLarge")
+        METADATA_TOO_LARGE,
+
+        @XmlEnumValue("MethodNotAllowed")
+        METHOD_NOT_ALLOWED,
+
+        @XmlEnumValue("MissingContentLength")
+        MISSING_CONTENT_LENGTH,
+
+        @XmlEnumValue("MissingRequestBodyError")
+        MISSING_REQUEST_BODY_ERROR,
+
+        @XmlEnumValue("NoSuchBucket")
+        NO_SUCH_BUCKET,
+
+        @XmlEnumValue("NoSuchKey")
+        NO_SUCH_KEY,
+
+        @XmlEnumValue("NoSuchUpload")
+        NO_SUCH_UPLOAD,
+
+        @XmlEnumValue("NotImplemented")
+        NOT_IMPLEMENTED,
+
+        @XmlEnumValue("OperationAborted")
+        OPERATION_ABORTED,
+
+        @XmlEnumValue("PreconditionFailed")
+        PRECONDITION_FAILED,
+
+        @XmlEnumValue("Redirect")
+        REDIRECT,
+
+        @XmlEnumValue("RequestIsNotMultiPartContent")
+        REQUEST_IS_NOT_MULTIPART_CONTENT,
+
+        @XmlEnumValue("RequestTimeout")
+        REQUEST_TIMEOUT,
+
+        @XmlEnumValue("RequestTimeTooSkewed")
+        REQUEST_TIME_TOO_SKEWED,
+
+        @XmlEnumValue("ServiceUnavailable")
+        SERVICE_UNAVAILABLE,
+
+        @XmlEnumValue("SlowDown")
+        SLOW_DOWN,
+
+        @XmlEnumValue("TemporaryRedirect")
+        TEMPORARY_REDIRECT,
+
+        @XmlEnumValue("TooManyBuckets")
+        TOO_MANY_BUCKETS,
+
+        @XmlEnumValue("UnexpectedContent")
+        UNEXPECTED_CONTENT,
+
+        @XmlEnumValue("UserKeyMustBeSpecified")
+        USER_KEY_MUST_BE_SPECIFIED;
+    }
+}

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/bean/GoogleSearchResult.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/bean/GoogleSearchResult.java
@@ -1,0 +1,7 @@
+package io.quarkiverse.langchain4j.watsonx.bean;
+
+import dev.langchain4j.Experimental;
+
+@Experimental
+public record GoogleSearchResult(String title, String description, String url) {
+}

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/bean/TextExtractionRequest.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/bean/TextExtractionRequest.java
@@ -38,7 +38,7 @@ public record TextExtractionRequest(String spaceId, String projectId, TextExtrac
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public record TextExtractionSteps(TextExtractionStepOcr ocr, TextExtractionStepTablesProcessing tablesProcessing) {
         public static TextExtractionSteps of(List<String> languages, boolean tableProcessing) {
-            var obj = tableProcessing ? new TextExtractionStepTablesProcessing(true) : null;
+            var obj = new TextExtractionStepTablesProcessing(tableProcessing);
             return new TextExtractionSteps(new TextExtractionStepOcr(languages), obj);
         }
     }

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/bean/TextExtractionResponse.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/bean/TextExtractionResponse.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import io.quarkiverse.langchain4j.watsonx.bean.TextExtractionRequest.TextExtractionDataReference;
+
 public record TextExtractionResponse(TextExtractionMetadata metadata, Entity entity) {
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public record TextExtractionMetadata(String id, Instant createdAt, String projectId) {
@@ -15,7 +17,8 @@ public record TextExtractionResponse(TextExtractionMetadata metadata, Entity ent
     public record ServiceError(String code, String message, String moreInfo) {
     }
 
-    public record Entity(TextExtractionResults results) {
+    public record Entity(TextExtractionDataReference documentReference, TextExtractionDataReference resultsReference,
+            TextExtractionResults results) {
     }
 
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
@@ -36,6 +39,9 @@ public record TextExtractionResponse(TextExtractionMetadata metadata, Entity ent
 
         @JsonProperty("downloading")
         DOWNLOADING,
+
+        @JsonProperty("downloaded")
+        DOWNLOADED,
 
         @JsonProperty("completed")
         COMPLETED,

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/bean/UtilityAgentToolsRequest.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/bean/UtilityAgentToolsRequest.java
@@ -1,0 +1,52 @@
+package io.quarkiverse.langchain4j.watsonx.bean;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import dev.langchain4j.Experimental;
+
+@Experimental
+public record UtilityAgentToolsRequest(ToolName toolName, UtilityAgentToolInput input, Map<String, Object> config) {
+    public sealed interface UtilityAgentToolInput permits StringInput, WebCrawlerInput, WeatherInput {
+    }
+
+    public record StringInput(@JsonValue String input) implements UtilityAgentToolInput {
+    }
+
+    public record WebCrawlerInput(String url) implements UtilityAgentToolInput {
+    }
+
+    public record WeatherInput(String name, String country) implements UtilityAgentToolInput {
+    }
+
+    public UtilityAgentToolsRequest(ToolName toolName, UtilityAgentToolInput input) {
+        this(toolName, input, null);
+    }
+
+    public enum ToolName {
+
+        @JsonProperty("GoogleSearch")
+        GOOGLE_SEARCH("GoogleSearch"),
+
+        @JsonProperty("WebCrawler")
+        WEB_CRAWLER("WebCrawler"),
+
+        @JsonProperty("Weather")
+        WEATHER("Weather"),
+
+        @JsonProperty("PythonInterpreter")
+        PYTHON_INTERPRETER("PythonInterpreter");
+
+        private String value;
+
+        ToolName(String value) {
+            this.value = value;
+        }
+
+        public String value() {
+            return this.value;
+        }
+    }
+}

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/bean/UtilityAgentToolsResponse.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/bean/UtilityAgentToolsResponse.java
@@ -1,0 +1,7 @@
+package io.quarkiverse.langchain4j.watsonx.bean;
+
+import dev.langchain4j.Experimental;
+
+@Experimental
+public record UtilityAgentToolsResponse(String output) {
+}

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/bean/WatsonxError.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/bean/WatsonxError.java
@@ -47,6 +47,9 @@ public record WatsonxError(Integer statusCode, String trace, List<Error> errors)
         TOKEN_QUOTA_REACHED,
 
         @JsonProperty("authentication_token_expired")
-        AUTHENTICATION_TOKEN_EXPIRED;
+        AUTHENTICATION_TOKEN_EXPIRED,
+
+        @JsonProperty("text_extraction_event_does_not_exist")
+        TEXT_EXTRACTION_EVENT_DOES_NOT_EXIST;
     }
 }

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/bean/WebCrawlerResult.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/bean/WebCrawlerResult.java
@@ -1,0 +1,7 @@
+package io.quarkiverse.langchain4j.watsonx.bean;
+
+import dev.langchain4j.Experimental;
+
+@Experimental
+public record WebCrawlerResult(String url, String contentType, String content) {
+}

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/client/COSRestApi.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/client/COSRestApi.java
@@ -1,0 +1,49 @@
+package io.quarkiverse.langchain4j.watsonx.client;
+
+import java.io.InputStream;
+
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HEAD;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import io.quarkiverse.langchain4j.watsonx.bean.CosError;
+import io.quarkiverse.langchain4j.watsonx.exception.COSException;
+import io.quarkus.rest.client.reactive.ClientExceptionMapper;
+import io.smallrye.mutiny.Uni;
+
+public interface COSRestApi {
+
+    @PUT
+    @Path("{bucketName}/{fileName}")
+    public Response createFile(@PathParam("bucketName") String bucketName,
+            @PathParam("fileName") String fileName, InputStream is);
+
+    @GET
+    @Path("{bucketName}/{fileName}")
+    public String getFileContent(@PathParam("bucketName") String bucketName,
+            @PathParam("fileName") String fileName);
+
+    @DELETE
+    @Path("{bucketName}/{fileName}")
+    Uni<Response> deleteFile(@PathParam("bucketName") String bucketName,
+            @PathParam("fileName") String fileName);
+
+    @HEAD
+    @Path("{bucketName}/{fileName}")
+    public void getFileMetadata(@PathParam("bucketName") String bucketName,
+            @PathParam("fileName") String fileName);
+
+    @ClientExceptionMapper
+    static COSException toException(jakarta.ws.rs.core.Response response) {
+        if (MediaType.APPLICATION_XML.equals(response.getHeaderString("Content-Type"))) {
+            CosError error = response.readEntity(CosError.class);
+            return new COSException(error.getMessage(), error, response.getStatus());
+        }
+        return new COSException(response.readEntity(String.class), response.getStatus());
+    }
+}

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/client/UtilityAgentToolsRestApi.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/client/UtilityAgentToolsRestApi.java
@@ -1,0 +1,59 @@
+package io.quarkiverse.langchain4j.watsonx.client;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response.Status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import dev.langchain4j.Experimental;
+import io.quarkiverse.langchain4j.QuarkusJsonCodecFactory;
+import io.quarkiverse.langchain4j.watsonx.bean.UtilityAgentToolsRequest;
+import io.quarkiverse.langchain4j.watsonx.bean.UtilityAgentToolsResponse;
+import io.quarkiverse.langchain4j.watsonx.exception.BuiltinServiceException;
+import io.quarkus.rest.client.reactive.ClientExceptionMapper;
+import io.quarkus.rest.client.reactive.jackson.ClientObjectMapper;
+
+@Experimental
+@Path("/v1-beta/utility_agent_tools")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public interface UtilityAgentToolsRestApi {
+
+    @POST
+    @Path("run")
+    public UtilityAgentToolsResponse run(UtilityAgentToolsRequest request);
+
+    @ClientObjectMapper
+    static ObjectMapper objectMapper(ObjectMapper defaultObjectMapper) {
+        return QuarkusJsonCodecFactory.SnakeCaseObjectMapperHolder.MAPPER;
+    }
+
+    @ClientExceptionMapper
+    static BuiltinServiceException toException(jakarta.ws.rs.core.Response response) {
+        MediaType mediaType = response.getMediaType();
+        if ((mediaType != null) && mediaType.isCompatible(MediaType.APPLICATION_JSON_TYPE)) {
+
+            // In the beta version, the web server does not specify all possible exceptions.
+            // Review and update the exception handling in the release version to ensure all cases are covered.
+
+            if (response.getStatus() == Status.UNAUTHORIZED.getStatusCode()) {
+                ObjectNode jsonObject = response.readEntity(ObjectNode.class);
+
+                try {
+
+                    String description = jsonObject.get("description").asText();
+                    return new BuiltinServiceException(description, response.getStatus());
+
+                } catch (Exception e) {
+                    return new BuiltinServiceException(response.readEntity(String.class), response.getStatus());
+                }
+            }
+        }
+        return new BuiltinServiceException(response.readEntity(String.class), response.getStatus());
+    }
+}

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/client/WatsonxClientLogger.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/client/WatsonxClientLogger.java
@@ -1,0 +1,161 @@
+package io.quarkiverse.langchain4j.watsonx.client;
+
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.StreamSupport.stream;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.client.api.ClientLogger;
+
+import io.quarkiverse.langchain4j.QuarkusJsonCodecFactory.ObjectMapperHolder;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+
+public class WatsonxClientLogger implements ClientLogger {
+
+    private static final Logger log = Logger.getLogger(WatsonxClientLogger.class);
+    private static final Pattern BEARER_PATTERN = Pattern.compile("(Bearer\\s*)(\\w{4})(\\w+)(\\w{4})");
+    private static final Pattern BASE64_IMAGE_PATTERN = Pattern.compile("(data:.+;base64,)(.{15})(.+)(.{15})([\\s\\S]*)");
+
+    private final boolean logRequests;
+    private final boolean logResponses;
+
+    public WatsonxClientLogger(boolean logRequests, boolean logResponses) {
+        this.logRequests = logRequests;
+        this.logResponses = logResponses;
+    }
+
+    public WatsonxClientLogger(Optional<Boolean> logRequests, Optional<Boolean> logResponses) {
+        this.logRequests = logRequests.orElse(false);
+        this.logResponses = logResponses.orElse(false);
+    }
+
+    @Override
+    public void setBodySize(int bodySize) {
+        // ignore
+    }
+
+    @Override
+    public void logRequest(HttpClientRequest request, Buffer body, boolean omitBody) {
+        if (!logRequests || !log.isInfoEnabled()) {
+            return;
+        }
+        try {
+            log.infof(
+                    "Request:\n- method: %s\n- url: %s\n- headers: %s\n- body: %s",
+                    request.getMethod(),
+                    request.absoluteURI(),
+                    inOneLine(request.headers()),
+                    bodyToString(body));
+        } catch (Exception e) {
+            log.warn("Failed to log request", e);
+        }
+    }
+
+    @Override
+    public void logResponse(HttpClientResponse response, boolean redirect) {
+        if (!logResponses || !log.isInfoEnabled()) {
+            return;
+        }
+        response.bodyHandler(new Handler<>() {
+            @Override
+            public void handle(Buffer body) {
+                String prettyBody;
+                try {
+                    prettyBody = ObjectMapperHolder.WRITER
+                            .writeValueAsString(ObjectMapperHolder.MAPPER.readTree(bodyToString(body)));
+                } catch (Exception e) {
+                    prettyBody = bodyToString(body);
+                }
+                try {
+
+                    log.infof(
+                            "Response:\n- status code: %s\n- headers: %s\n- body: %s",
+                            response.statusCode(),
+                            inOneLine(response.headers()),
+                            prettyBody);
+                } catch (Exception e) {
+                    log.warn("Failed to log response", e);
+                }
+            }
+        });
+    }
+
+    private String bodyToString(Buffer body) {
+        if (body == null) {
+            return "";
+        }
+        return formatBase64ImageForLogging(body.toString());
+    }
+
+    private String inOneLine(MultiMap headers) {
+
+        return stream(headers.spliterator(), false)
+                .map(header -> {
+                    String headerKey = header.getKey();
+                    String headerValue = header.getValue();
+                    if ("Authorization".equals(headerKey)) {
+                        headerValue = maskAuthorizationHeaderValue(headerValue);
+                    } else if ("api-key".equals(headerKey)) {
+                        headerValue = maskApiKeyHeaderValue(headerValue);
+                    }
+                    return String.format("[%s: %s]", headerKey, headerValue);
+                })
+                .collect(joining(", "));
+    }
+
+    private static String maskAuthorizationHeaderValue(String authorizationHeaderValue) {
+        try {
+
+            Matcher matcher = BEARER_PATTERN.matcher(authorizationHeaderValue);
+
+            StringBuilder sb = new StringBuilder();
+            while (matcher.find()) {
+                matcher.appendReplacement(sb, matcher.group(1) + matcher.group(2) + "..." + matcher.group(4));
+            }
+
+            return sb.toString();
+        } catch (Exception e) {
+            return "Failed to mask the API key.";
+        }
+    }
+
+    private static String formatBase64ImageForLogging(String body) {
+        try {
+
+            if (body == null || body.isBlank())
+                return body;
+
+            Matcher matcher = BASE64_IMAGE_PATTERN.matcher(body);
+
+            StringBuilder sb = new StringBuilder();
+            while (matcher.find()) {
+                matcher.appendReplacement(sb,
+                        matcher.group(1) + matcher.group(2) + "..." + matcher.group(4) + matcher.group(5));
+            }
+
+            return sb.isEmpty() ? body : sb.toString();
+        } catch (Exception e) {
+            return "Failed to format the base64 image value.";
+        }
+    }
+
+    private static String maskApiKeyHeaderValue(String apiKeyHeaderValue) {
+        try {
+            if (apiKeyHeaderValue.length() <= 4) {
+                return apiKeyHeaderValue;
+            }
+            return apiKeyHeaderValue.substring(0, 2)
+                    + "..."
+                    + apiKeyHeaderValue.substring(apiKeyHeaderValue.length() - 2);
+        } catch (Exception e) {
+            return "Failed to mask the API key.";
+        }
+    }
+}

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/client/WatsonxRestApi.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/client/WatsonxRestApi.java
@@ -1,11 +1,6 @@
 package io.quarkiverse.langchain4j.watsonx.client;
 
-import static java.util.stream.Collectors.joining;
-import static java.util.stream.StreamSupport.stream;
-
 import java.util.StringJoiner;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
@@ -16,14 +11,11 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
-import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.RestStreamElementType;
-import org.jboss.resteasy.reactive.client.api.ClientLogger;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkiverse.langchain4j.QuarkusJsonCodecFactory;
-import io.quarkiverse.langchain4j.QuarkusJsonCodecFactory.ObjectMapperHolder;
 import io.quarkiverse.langchain4j.watsonx.bean.EmbeddingRequest;
 import io.quarkiverse.langchain4j.watsonx.bean.EmbeddingResponse;
 import io.quarkiverse.langchain4j.watsonx.bean.ScoringRequest;
@@ -42,11 +34,6 @@ import io.quarkiverse.langchain4j.watsonx.exception.WatsonxException;
 import io.quarkus.rest.client.reactive.ClientExceptionMapper;
 import io.quarkus.rest.client.reactive.jackson.ClientObjectMapper;
 import io.smallrye.mutiny.Multi;
-import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
 
 /**
  * This Microprofile REST client is used as the building block of all the API calls to watsonx. The implementation is provided
@@ -133,146 +120,5 @@ public interface WatsonxRestApi {
     @ClientObjectMapper
     static ObjectMapper objectMapper(ObjectMapper defaultObjectMapper) {
         return QuarkusJsonCodecFactory.SnakeCaseObjectMapperHolder.MAPPER;
-    }
-
-    /**
-     * Introduce a custom logger as the stock one logs at the DEBUG level by default...
-     */
-    class WatsonClientLogger implements ClientLogger {
-
-        private static final Logger log = Logger.getLogger(WatsonClientLogger.class);
-        private static final Pattern BEARER_PATTERN = Pattern.compile("(Bearer\\s*)(\\w{4})(\\w+)(\\w{4})");
-        private static final Pattern BASE64_IMAGE_PATTERN = Pattern.compile("(data:.+;base64,)(.{15})(.+)(.{15})([\\s\\S]*)");
-
-        private final boolean logRequests;
-        private final boolean logResponses;
-
-        public WatsonClientLogger(boolean logRequests, boolean logResponses) {
-            this.logRequests = logRequests;
-            this.logResponses = logResponses;
-        }
-
-        @Override
-        public void setBodySize(int bodySize) {
-            // ignore
-        }
-
-        @Override
-        public void logRequest(HttpClientRequest request, Buffer body, boolean omitBody) {
-            if (!logRequests || !log.isInfoEnabled()) {
-                return;
-            }
-            try {
-                log.infof(
-                        "Request:\n- method: %s\n- url: %s\n- headers: %s\n- body: %s",
-                        request.getMethod(),
-                        request.absoluteURI(),
-                        inOneLine(request.headers()),
-                        bodyToString(body));
-            } catch (Exception e) {
-                log.warn("Failed to log request", e);
-            }
-        }
-
-        @Override
-        public void logResponse(HttpClientResponse response, boolean redirect) {
-            if (!logResponses || !log.isInfoEnabled()) {
-                return;
-            }
-            response.bodyHandler(new Handler<>() {
-                @Override
-                public void handle(Buffer body) {
-                    String prettyBody;
-                    try {
-                        prettyBody = ObjectMapperHolder.WRITER
-                                .writeValueAsString(ObjectMapperHolder.MAPPER.readTree(bodyToString(body)));
-                    } catch (Exception e) {
-                        prettyBody = bodyToString(body);
-                    }
-                    try {
-
-                        log.infof(
-                                "Response:\n- status code: %s\n- headers: %s\n- body: %s",
-                                response.statusCode(),
-                                inOneLine(response.headers()),
-                                prettyBody);
-                    } catch (Exception e) {
-                        log.warn("Failed to log response", e);
-                    }
-                }
-            });
-        }
-
-        private String bodyToString(Buffer body) {
-            if (body == null) {
-                return "";
-            }
-            return formatBase64ImageForLogging(body.toString());
-        }
-
-        private String inOneLine(MultiMap headers) {
-
-            return stream(headers.spliterator(), false)
-                    .map(header -> {
-                        String headerKey = header.getKey();
-                        String headerValue = header.getValue();
-                        if ("Authorization".equals(headerKey)) {
-                            headerValue = maskAuthorizationHeaderValue(headerValue);
-                        } else if ("api-key".equals(headerKey)) {
-                            headerValue = maskApiKeyHeaderValue(headerValue);
-                        }
-                        return String.format("[%s: %s]", headerKey, headerValue);
-                    })
-                    .collect(joining(", "));
-        }
-
-        private static String maskAuthorizationHeaderValue(String authorizationHeaderValue) {
-            try {
-
-                Matcher matcher = BEARER_PATTERN.matcher(authorizationHeaderValue);
-
-                StringBuilder sb = new StringBuilder();
-                while (matcher.find()) {
-                    matcher.appendReplacement(sb, matcher.group(1) + matcher.group(2) + "..." + matcher.group(4));
-                }
-
-                return sb.toString();
-            } catch (Exception e) {
-                return "Failed to mask the API key.";
-            }
-        }
-
-        private static String formatBase64ImageForLogging(String body) {
-            try {
-
-                if (body == null || body.isBlank())
-                    return body;
-
-                Matcher matcher = BASE64_IMAGE_PATTERN.matcher(body);
-
-                StringBuilder sb = new StringBuilder();
-                while (matcher.find()) {
-                    matcher.appendReplacement(sb,
-                            matcher.group(1) + matcher.group(2) + "..." + matcher.group(4) + matcher.group(5));
-                }
-
-                return sb.isEmpty() ? body : sb.toString();
-            } catch (Exception e) {
-                return "Failed to format the base64 image value.";
-            }
-        }
-
-        private static String maskApiKeyHeaderValue(String apiKeyHeaderValue) {
-            try {
-                if (apiKeyHeaderValue.length() <= 4) {
-                    return apiKeyHeaderValue;
-                }
-                return apiKeyHeaderValue.substring(0, 2)
-                        + "..."
-                        + apiKeyHeaderValue.substring(apiKeyHeaderValue.length() - 2);
-            } catch (Exception e) {
-                return "Failed to mask the API key.";
-            }
-        }
     }
 }

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/client/filter/BearerTokenHeaderFactory.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/client/filter/BearerTokenHeaderFactory.java
@@ -4,7 +4,7 @@ import java.util.function.Function;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
-import io.quarkiverse.langchain4j.watsonx.WatsonxTokenGenerator;
+import io.quarkiverse.langchain4j.watsonx.runtime.TokenGenerator;
 import io.quarkus.rest.client.reactive.ReactiveClientHeadersFactory;
 import io.smallrye.mutiny.Uni;
 
@@ -13,9 +13,9 @@ import io.smallrye.mutiny.Uni;
  */
 public class BearerTokenHeaderFactory extends ReactiveClientHeadersFactory {
 
-    private final WatsonxTokenGenerator tokenGenerator;
+    private final TokenGenerator tokenGenerator;
 
-    public BearerTokenHeaderFactory(WatsonxTokenGenerator tokenGenerator) {
+    public BearerTokenHeaderFactory(TokenGenerator tokenGenerator) {
         this.tokenGenerator = tokenGenerator;
     }
 

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/exception/BuiltinServiceException.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/exception/BuiltinServiceException.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.langchain4j.watsonx.exception;
+
+public class BuiltinServiceException extends RuntimeException {
+
+    final Integer statusCode;
+    final String details;
+
+    public BuiltinServiceException(String message, Integer statusCode) {
+        super(message);
+        this.statusCode = statusCode;
+        this.details = message;
+    }
+
+    public Integer statusCode() {
+        return statusCode;
+    }
+
+    public String details() {
+        return details;
+    }
+
+    @Override
+    public String toString() {
+        return "BuiltinToolException [statusCode=" + statusCode + ", details=" + details + "]";
+    }
+}

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/exception/COSException.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/exception/COSException.java
@@ -1,0 +1,34 @@
+package io.quarkiverse.langchain4j.watsonx.exception;
+
+import io.quarkiverse.langchain4j.watsonx.bean.CosError;
+
+public class COSException extends RuntimeException {
+
+    final Integer statusCode;
+    final CosError details;
+
+    public COSException(String message, Integer statusCode) {
+        super(message);
+        this.statusCode = statusCode;
+        this.details = null;
+    }
+
+    public COSException(String message, CosError details, Integer statusCode) {
+        super(message);
+        this.statusCode = statusCode;
+        this.details = details;
+    }
+
+    public Integer statusCode() {
+        return statusCode;
+    }
+
+    public CosError details() {
+        return details;
+    }
+
+    @Override
+    public String toString() {
+        return "COSException [statusCode=" + statusCode + ", details=" + details + ", message=" + getMessage() + "]";
+    }
+}

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/exception/TextExtractionException.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/exception/TextExtractionException.java
@@ -1,0 +1,25 @@
+package io.quarkiverse.langchain4j.watsonx.exception;
+
+public class TextExtractionException extends Exception {
+
+    final String code;
+
+    public TextExtractionException(String code, String message, Throwable cause) {
+        super(message, cause);
+        this.code = code;
+    }
+
+    public TextExtractionException(String code, String message) {
+        super(message);
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String toString() {
+        return "TextExtractionException [code=" + code + ", message=" + getMessage() + "]";
+    }
+}

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/BuiltinServiceRecorder.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/BuiltinServiceRecorder.java
@@ -1,0 +1,212 @@
+package io.quarkiverse.langchain4j.watsonx.runtime;
+
+import static io.quarkiverse.langchain4j.runtime.OptionalUtil.firstOrDefault;
+import static io.quarkiverse.langchain4j.watsonx.runtime.TokenGenerationCache.getOrCreateTokenGenerator;
+import static java.util.Objects.isNull;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.jboss.resteasy.reactive.client.api.LoggingScope;
+
+import io.quarkiverse.langchain4j.watsonx.client.UtilityAgentToolsRestApi;
+import io.quarkiverse.langchain4j.watsonx.client.WatsonxClientLogger;
+import io.quarkiverse.langchain4j.watsonx.client.filter.BearerTokenHeaderFactory;
+import io.quarkiverse.langchain4j.watsonx.runtime.config.BuiltinServiceConfig;
+import io.quarkiverse.langchain4j.watsonx.runtime.config.IAMConfig;
+import io.quarkiverse.langchain4j.watsonx.runtime.config.LangChain4jWatsonxConfig;
+import io.quarkiverse.langchain4j.watsonx.services.GoogleSearchService;
+import io.quarkiverse.langchain4j.watsonx.services.WeatherService;
+import io.quarkiverse.langchain4j.watsonx.services.WebCrawlerService;
+import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
+import io.quarkus.runtime.annotations.Recorder;
+import io.smallrye.config.ConfigValidationException;
+
+@Recorder
+public class BuiltinServiceRecorder {
+
+    private static final ConfigValidationException.Problem[] EMPTY_PROBLEMS = new ConfigValidationException.Problem[0];
+    private static final String MISSING_BUILTIN_SERVICE_PROPERTY_ERROR = "To use the built-in service classes, you must set the property 'quarkus.langchain4j.watsonx.built-in.%s'";
+    private static final String INVALID_BASE_URL_ERROR = "The property 'quarkus.langchain4j.watsonx.base-url' does not have a correct url. Use one of the urls given in the documentation or use the property 'quarkus.langchain4j.watsonx.built-in-service.base-url' to set a custom url.";
+
+    public Supplier<WebCrawlerService> webCrawler(LangChain4jWatsonxConfig runtimeConfig) {
+
+        IAMConfig iamConfig = runtimeConfig.defaultConfig().iam();
+        BuiltinServiceConfig builtinToolConfig = runtimeConfig.builtInService();
+
+        String baseUrl = firstOrDefault(
+                getWxBaseUrl(runtimeConfig.defaultConfig().baseUrl()),
+                builtinToolConfig.baseUrl());
+
+        if (isNull(baseUrl) && runtimeConfig.defaultConfig().baseUrl().isPresent())
+            throw new RuntimeException(INVALID_BASE_URL_ERROR);
+
+        String apiKey = firstOrDefault(
+                runtimeConfig.defaultConfig().apiKey().orElse(null),
+                builtinToolConfig.apiKey());
+
+        var configProblems = checkConfigurations(baseUrl, apiKey);
+        if (!configProblems.isEmpty()) {
+            throw new ConfigValidationException(configProblems.toArray(EMPTY_PROBLEMS));
+        }
+
+        Duration timeout = firstOrDefault(Duration.ofSeconds(10),
+                builtinToolConfig.timeout(),
+                runtimeConfig.defaultConfig().timeout());
+
+        boolean logRequests = firstOrDefault(
+                runtimeConfig.defaultConfig().logRequests().orElse(false),
+                builtinToolConfig.logRequests());
+
+        boolean logResponses = firstOrDefault(
+                runtimeConfig.defaultConfig().logResponses().orElse(false),
+                builtinToolConfig.logResponses());
+
+        return new Supplier<WebCrawlerService>() {
+            @Override
+            public WebCrawlerService get() {
+                return new WebCrawlerService(
+                        createRestClient(baseUrl, apiKey, iamConfig, timeout, logRequests, logResponses));
+            }
+        };
+    }
+
+    public Supplier<GoogleSearchService> googleSearch(LangChain4jWatsonxConfig runtimeConfig) {
+
+        IAMConfig iamConfig = runtimeConfig.defaultConfig().iam();
+        BuiltinServiceConfig builtinToolConfig = runtimeConfig.builtInService();
+
+        String baseUrl = firstOrDefault(
+                getWxBaseUrl(runtimeConfig.defaultConfig().baseUrl()),
+                builtinToolConfig.baseUrl());
+
+        if (isNull(baseUrl) && runtimeConfig.defaultConfig().baseUrl().isPresent())
+            throw new RuntimeException(INVALID_BASE_URL_ERROR);
+
+        String apiKey = firstOrDefault(
+                runtimeConfig.defaultConfig().apiKey().orElse(null),
+                builtinToolConfig.apiKey());
+
+        var configProblems = checkConfigurations(baseUrl, apiKey);
+        if (!configProblems.isEmpty()) {
+            throw new ConfigValidationException(configProblems.toArray(EMPTY_PROBLEMS));
+        }
+
+        Duration timeout = firstOrDefault(Duration.ofSeconds(10),
+                builtinToolConfig.timeout(),
+                runtimeConfig.defaultConfig().timeout());
+
+        boolean logRequests = firstOrDefault(
+                runtimeConfig.defaultConfig().logRequests().orElse(false),
+                builtinToolConfig.logRequests());
+
+        boolean logResponses = firstOrDefault(
+                runtimeConfig.defaultConfig().logResponses().orElse(false),
+                builtinToolConfig.logResponses());
+
+        return new Supplier<GoogleSearchService>() {
+            @Override
+            public GoogleSearchService get() {
+                return new GoogleSearchService(
+                        createRestClient(baseUrl, apiKey, iamConfig, timeout, logRequests, logResponses),
+                        builtinToolConfig.googleSearch());
+            }
+        };
+    }
+
+    public Supplier<WeatherService> weather(LangChain4jWatsonxConfig runtimeConfig) {
+
+        IAMConfig iamConfig = runtimeConfig.defaultConfig().iam();
+        BuiltinServiceConfig builtinToolConfig = runtimeConfig.builtInService();
+
+        String baseUrl = firstOrDefault(
+                getWxBaseUrl(runtimeConfig.defaultConfig().baseUrl()),
+                builtinToolConfig.baseUrl());
+
+        if (isNull(baseUrl) && runtimeConfig.defaultConfig().baseUrl().isPresent())
+            throw new RuntimeException(INVALID_BASE_URL_ERROR);
+
+        String apiKey = firstOrDefault(
+                runtimeConfig.defaultConfig().apiKey().orElse(null),
+                builtinToolConfig.apiKey());
+
+        var configProblems = checkConfigurations(baseUrl, apiKey);
+        if (!configProblems.isEmpty()) {
+            throw new ConfigValidationException(configProblems.toArray(EMPTY_PROBLEMS));
+        }
+
+        Duration timeout = firstOrDefault(Duration.ofSeconds(10),
+                builtinToolConfig.timeout(),
+                runtimeConfig.defaultConfig().timeout());
+
+        boolean logRequests = firstOrDefault(
+                runtimeConfig.defaultConfig().logRequests().orElse(false),
+                builtinToolConfig.logRequests());
+
+        boolean logResponses = firstOrDefault(
+                runtimeConfig.defaultConfig().logResponses().orElse(false),
+                builtinToolConfig.logResponses());
+
+        return new Supplier<WeatherService>() {
+            @Override
+            public WeatherService get() {
+                return new WeatherService(
+                        createRestClient(baseUrl, apiKey, iamConfig, timeout, logRequests, logResponses));
+            }
+        };
+    }
+
+    private UtilityAgentToolsRestApi createRestClient(
+            String baseUrl, String apiKey, IAMConfig iamConfig,
+            Duration timeout, boolean logRequests, boolean logResponses) {
+        var builder = QuarkusRestClientBuilder.newBuilder()
+                .baseUri(URI.create(baseUrl))
+                .clientHeadersFactory(
+                        new BearerTokenHeaderFactory(getOrCreateTokenGenerator(
+                                apiKey,
+                                iamConfig.baseUrl(),
+                                iamConfig.grantType(),
+                                iamConfig.timeout().orElse(Duration.ofSeconds(10)))))
+                .readTimeout(timeout.toMillis(), TimeUnit.MILLISECONDS)
+                .connectTimeout(timeout.toMillis(), TimeUnit.MILLISECONDS);
+
+        if (logRequests || logResponses) {
+            builder.loggingScope(LoggingScope.REQUEST_RESPONSE)
+                    .clientLogger(new WatsonxClientLogger(logRequests, logResponses));
+        }
+
+        return builder.build(UtilityAgentToolsRestApi.class);
+    }
+
+    private String getWxBaseUrl(Optional<String> baseUrl) {
+        if (baseUrl.isEmpty())
+            return null;
+        return switch (baseUrl.get()) {
+            case "https://us-south.ml.cloud.ibm.com" -> "https://api.dataplatform.cloud.ibm.com/wx";
+            case "https://eu-de.ml.cloud.ibm.com" -> "https://api.eu-de.dataplatform.cloud.ibm.com/wx";
+            case "https://eu-gb.ml.cloud.ibm.com" -> "https://api.eu-gb.dataplatform.cloud.ibm.com/wx";
+            case "https://jp-tok.ml.cloud.ibm.com" -> "https://api.jp-tok.dataplatform.cloud.ibm.com/wx";
+            case "https://au-syd.ml.cloud.ibm.com" -> "https://api.au-syd.dai.cloud.ibm.com/wx";
+            case "https://ca-tor.ml.cloud.ibm.com" -> "https://api.ca-tor.dai.cloud.ibm.com/wx";
+            default -> null;
+        };
+    }
+
+    private List<ConfigValidationException.Problem> checkConfigurations(String baseUrl, String apiKey) {
+        List<ConfigValidationException.Problem> configProblems = new ArrayList<>();
+        if (isNull(baseUrl))
+            configProblems
+                    .add(new ConfigValidationException.Problem(MISSING_BUILTIN_SERVICE_PROPERTY_ERROR.formatted("base-url")));
+
+        if (isNull(apiKey))
+            configProblems
+                    .add(new ConfigValidationException.Problem(MISSING_BUILTIN_SERVICE_PROPERTY_ERROR.formatted("api-key")));
+
+        return configProblems;
+    }
+}

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/TextExtraction.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/TextExtraction.java
@@ -1,0 +1,768 @@
+package io.quarkiverse.langchain4j.watsonx.runtime;
+
+import static io.quarkiverse.langchain4j.runtime.OptionalUtil.firstOrDefault;
+import static io.quarkiverse.langchain4j.watsonx.WatsonxUtils.retryOn;
+import static io.quarkiverse.langchain4j.watsonx.bean.TextExtractionRequest.TextExtractionType.ASSEMBLY_MD;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+import static java.util.Objects.requireNonNull;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.time.Duration;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.function.Consumer;
+
+import jakarta.ws.rs.core.Response;
+
+import org.jboss.logging.Logger;
+
+import io.quarkiverse.langchain4j.watsonx.WatsonxUtils;
+import io.quarkiverse.langchain4j.watsonx.bean.TextExtractionRequest;
+import io.quarkiverse.langchain4j.watsonx.bean.TextExtractionRequest.TextExtractionDataReference;
+import io.quarkiverse.langchain4j.watsonx.bean.TextExtractionRequest.TextExtractionSteps;
+import io.quarkiverse.langchain4j.watsonx.bean.TextExtractionRequest.TextExtractionType;
+import io.quarkiverse.langchain4j.watsonx.bean.TextExtractionResponse;
+import io.quarkiverse.langchain4j.watsonx.bean.TextExtractionResponse.ServiceError;
+import io.quarkiverse.langchain4j.watsonx.bean.TextExtractionResponse.Status;
+import io.quarkiverse.langchain4j.watsonx.client.COSRestApi;
+import io.quarkiverse.langchain4j.watsonx.client.WatsonxRestApi;
+import io.quarkiverse.langchain4j.watsonx.exception.COSException;
+import io.quarkiverse.langchain4j.watsonx.exception.TextExtractionException;
+
+/**
+ * This class provides methods for extracting text from high-value business documents, making them
+ * more accessible to AI models or enabling the identification of key information.
+ * <p>
+ * The API supports text extraction from the following file types:
+ * </p>
+ * <ul>
+ * <li>PDF</li>
+ * <li>GIF</li>
+ * <li>JPG</li>
+ * <li>PNG</li>
+ * <li>TIFF</li>
+ * </ul>
+ * <p>
+ * The extracted text can be output in the following formats:
+ * </p>
+ * <ul>
+ * <li>JSON</li>
+ * <li>Markdown</li>
+ * </ul>
+ */
+public class TextExtraction {
+
+    private static final Logger logger = Logger.getLogger(TextExtraction.class);
+
+    public record Reference(String connection, String bucket) {
+        public Reference {
+            requireNonNull(connection);
+        }
+
+        public Reference(String connection) {
+            this(connection, null);
+        }
+    };
+
+    final private WatsonxRestApi watsonxClient;
+    final private COSRestApi cosClient;
+    final private Reference documentReference;
+    final private Reference resultReference;
+    final private String projectId, spaceId, version;
+
+    /**
+     * Constructs a {@code TextExtraction} instance with the required parameters to perform text
+     * extraction from documents stored in IBM Cloud Object Storage (COS). This constructor initializes
+     * the necessary references, project details, and client instances for interacting with IBM COS and
+     * Watsonx AI services.
+     * <p>
+     * <strong>Default Bucket:</strong>
+     * <p>
+     * The {@code documentReference.bucket} and {@code resultReference.bucket} fields are used as the
+     * default buckets for uploading documents to COS and they will serve as the target location for the
+     * following:
+     * <ul>
+     * <li>{@code documentReference.bucket}: The default bucket for uploading local documents to
+     * COS.</li>
+     * <li>{@code resultReference.bucket}: The default bucket for uploading extracted documents to
+     * COS.</li>
+     * </ul>
+     */
+    public TextExtraction(
+            Reference documentReference, Reference resultReference,
+            String projectId, String spaceId, String version,
+            COSRestApi cosClient, WatsonxRestApi watsonxClient) {
+
+        requireNonNull(cosClient);
+        requireNonNull(documentReference);
+        requireNonNull(resultReference);
+        requireNonNull(watsonxClient);
+
+        if (nonNull(documentReference) && (isNull(documentReference.bucket) || documentReference.bucket.isBlank()))
+            throw new IllegalArgumentException(
+                    "The TextExtraction constructor needs a non-empty or null value for \"documentReference.bucket\", this value will be the default bucket used to upload the local documents to the Cloud Object Storage.");
+
+        if (nonNull(resultReference) && (isNull(resultReference.bucket) || resultReference.bucket.isBlank()))
+            throw new IllegalArgumentException(
+                    "The TextExtraction constructor needs a non-empty or null value for \"resultReference.bucket\", this value will be the default bucket used to upload the extracted documents to the Cloud Object Storage.");
+
+        this.documentReference = documentReference;
+        this.resultReference = resultReference;
+        this.projectId = projectId;
+        this.spaceId = spaceId;
+        this.version = version;
+        this.cosClient = cosClient;
+        this.watsonxClient = watsonxClient;
+    }
+
+    /**
+     * Starts the asynchronous text extraction process for a document stored in IBM Cloud Object Storage
+     * (COS). The extracted text is saved as a new <b>Markdown</b> file in COS, preserving the original
+     * filename but using the {@code .md } extension. To customize the output behavior, use the method
+     * with the {@link Options} parameter.
+     *
+     * <pre>
+     * {@code
+     * String startExtraction(String absolutePath, Options options)
+     * }
+     * </pre>
+     *
+     * <b>Note:</b> This method does not return the extracted value. Use {@code extractAndFetch} to
+     * extract the text immediately.
+     *
+     * @param absolutePath The COS path of the document to extract text from.
+     * @param languages Language codes to guide the text extraction process.
+     * @return The unique identifier of the text extraction process.
+     */
+    public String startExtraction(String absolutePath, List<Language> languages) throws TextExtractionException {
+        requireNonNull(languages);
+        return startExtraction(absolutePath, Options.create(languages));
+    }
+
+    /**
+     * Starts the asynchronous text extraction process for a document stored in IBM Cloud Object Storage
+     * (COS). The extracted text is saved as a new <b>Markdown</b> file in COS, preserving the original
+     * filename but using the {@code .md} extension by default. Output behavior can be customized using
+     * the {@link Options} parameter.
+     * <p>
+     * <b>Note:</b> This method does not return the extracted text. Use {@code extractAndFetch} to
+     * extract the text immediately.
+     *
+     * @param absolutePath The COS path of the document to extract text from.
+     * @param options The configuration options for text extraction.
+     * @return The unique identifier of the text extraction process.
+     */
+    public String startExtraction(String absolutePath, Options options) throws TextExtractionException {
+        requireNonNull(options);
+        return startExtraction(absolutePath, options, false).metadata().id();
+    }
+
+    /**
+     * Uploads a local file to IBM Cloud Object Storage (COS) and starts the asynchronous text
+     * extraction process. The extracted text is saved as a new <b>Markdown</b> file in COS, preserving
+     * the original filename but using the {@code .md} extension by default. To customize the output
+     * behavior you can use the {@link Options} parameter.
+     *
+     * <pre>
+     * {@code
+     * String uploadAndStartExtraction(File file, Options options);
+     * }
+     * </pre>
+     *
+     * <b>Note:</b> This method does not return the extracted text. Use {@code uploadExtractAndFetch} to
+     * extract the text immediately.
+     *
+     * @param file The local file to be uploaded and processed.
+     * @param languages Language codes to guide the text extraction process.
+     * @return The unique identifier of the text extraction process.
+     */
+    public String uploadAndStartExtraction(File file, List<Language> languages) throws TextExtractionException {
+        requireNonNull(languages);
+        return uploadAndStartExtraction(file, Options.create(languages));
+    }
+
+    /**
+     * Uploads a local file to IBM Cloud Object Storage (COS) and starts the asynchronous text
+     * extraction process. The extracted text is saved as a new <b>Markdown</b> file in COS, preserving
+     * the original filename but using the {@code .md} extension by default. Output behavior can be
+     * customized using the {@link Options} parameter.
+     *
+     * <p>
+     * <b>Note:</b> This method does not return the extracted text. Use {@code uploadExtractAndFetch} to
+     * extract the text immediately.
+     *
+     * @param file The local file to be uploaded and processed.
+     * @param options The configuration options for text extraction.
+     * @return The unique identifier of the text extraction process.
+     */
+    public String uploadAndStartExtraction(File file, Options options) throws TextExtractionException {
+        requireNonNull(options);
+        requireNonNull(file);
+
+        if (file.isDirectory())
+            throw new TextExtractionException("directory_not_allowed", "The file can not be a directory");
+
+        try {
+            upload(new BufferedInputStream(new FileInputStream(file)), file.getName(), options, false);
+            return startExtraction(file.getName(), options);
+        } catch (FileNotFoundException e) {
+            throw new TextExtractionException("file_not_found", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Uploads an InputStream to IBM Cloud Object Storage (COS) and starts the asynchronous text
+     * extraction process. The extracted text is saved as a new <b>Markdown</b> file in COS, preserving
+     * the original filename but using the {@code .md} extension by default. To customize the output
+     * behavior you can use the {@link Options} parameter.
+     *
+     * <pre>
+     * {@code
+     * String uploadAndStartExtraction(InputStream is, String fileName, Options options);
+     * }
+     * </pre>
+     *
+     * <b>Note:</b> This method does not return the extracted text. Use {@code uploadExtractAndFetch} to
+     * extract the text immediately.
+     *
+     * @param is The input stream of the file to be uploaded and processed.
+     * @param fileName The name of the file to be uploaded and processed.
+     * @param languages Language codes to guide the text extraction process.
+     * @return The unique identifier of the text extraction process.
+     */
+    public String uploadAndStartExtraction(InputStream is, String fileName, List<Language> languages)
+            throws TextExtractionException {
+        requireNonNull(languages);
+        return uploadAndStartExtraction(is, fileName, Options.create(languages));
+    }
+
+    /**
+     * Uploads an InputStream to IBM Cloud Object Storage (COS) and starts the asynchronous text
+     * extraction process. The extracted text is saved as a new <b>Markdown</b> file in COS, preserving
+     * the original filename but using the {@code .md} extension by default. Output behavior can be
+     * customized using the {@link Options} parameter.
+     *
+     * <p>
+     * <b>Note:</b> This method does not return the extracted text. Use {@code uploadExtractAndFetch} to
+     * extract the text immediately.
+     *
+     * @param is The input stream of the file to be uploaded and processed.
+     * @param fileName The name of the file to be uploaded and processed.
+     * @param options The configuration options for text extraction.
+     * @return The unique identifier of the text extraction process.
+     */
+    public String uploadAndStartExtraction(InputStream is, String fileName, Options options)
+            throws TextExtractionException {
+        requireNonNull(options);
+        upload(is, fileName, options, false);
+        return startExtraction(fileName, options);
+    }
+
+    /**
+     * Starts the text extraction process for a file that is already present in Cloud Object Storage
+     * (COS) and returns the extracted text value. The extracted text is saved as a new <b>Markdown</b>
+     * file in COS, preserving the original filename but using the {@code .md} extension by default. To
+     * customize the output behavior, use the method with the {@link Options} parameter.
+     *
+     * <pre>
+     * {@code
+     * String extractAndFetch(String absolutePath, Options options);
+     * }
+     * </pre>
+     *
+     * <b>Note:</b> The default timeout value is set to 60 seconds.
+     *
+     * @param absolutePath The absolute path of the file in Cloud Object Storage.
+     * @param languages Language codes to guide the text extraction process.
+     * @return The text extracted.
+     */
+    public String extractAndFetch(String absolutePath, List<Language> languages) throws TextExtractionException {
+        requireNonNull(languages);
+        return extractAndFetch(absolutePath, Options.create(languages));
+    }
+
+    /**
+     * Starts the text extraction process for a file that is already present in Cloud Object Storage
+     * (COS) and returns the extracted text value. The extracted text is saved as a new <b>Markdown</b>
+     * file in COS, preserving the original filename but using the {@code .md} extension by default.
+     * Output behavior can be customized using the {@link Options} parameter.
+     *
+     * <p>
+     * <li><b>Note:</b> This method waits until the extraction process is complete and returns the
+     * extracted value. The default timeout value is set to 60 seconds.
+     *
+     * @param absolutePath The COS path of the document to extract text from.
+     * @param options Configuration options, including cleanup behavior.
+     * @return The text extracted.
+     */
+    public String extractAndFetch(String absolutePath, Options options) throws TextExtractionException {
+        requireNonNull(options);
+        var textExtractionResponse = startExtraction(absolutePath, options, true);
+        return getExtractedText(textExtractionResponse, options);
+    }
+
+    /**
+     * Uploads a local file to IBM Cloud Object Storage (COS), starts text extraction process and
+     * returns the extracted text value. The extracted text is saved as a new <b>Markdown</b> file in
+     * COS, preserving the original filename but using the {@code .md} extension by default. To
+     * customize the output behavior, use the method with the {@link Options} parameter.
+     *
+     * <pre>
+     * {@code
+     * String uploadExtractAndFetch(File file, Options options);
+     * }
+     * </pre>
+     *
+     * <li><b>Note:</b> This method waits until the extraction process is complete and returns the
+     * extracted value. The default timeout value is set to 60 seconds.
+     *
+     * @param file The local file to be uploaded and processed.
+     * @param languages Language codes to guide the text extraction process.
+     * @return The text extracted.
+     */
+    public String uploadExtractAndFetch(File file, List<Language> languages) throws TextExtractionException {
+        requireNonNull(languages);
+        return uploadExtractAndFetch(file, Options.create(languages));
+    }
+
+    /**
+     * Uploads a local file to IBM Cloud Object Storage (COS) and starts the asynchronous text
+     * extraction process. The extracted text is saved as a new <b>Markdown</b> file in COS, preserving
+     * the original filename but using the {@code .md} extension by default. Output behavior can be
+     * customized using the {@link Options} parameter.
+     *
+     * <p>
+     * <li><b>Notes:</b> This method waits until the extraction process is complete and returns the
+     * extracted value. The default timeout value is set to 60 seconds.
+     *
+     * @param file The local file to be uploaded and processed.
+     * @param options Configuration options, including cleanup behavior.
+     * @return The text extracted.
+     */
+    public String uploadExtractAndFetch(File file, Options options) throws TextExtractionException {
+        requireNonNull(options);
+        try {
+            upload(new BufferedInputStream(new FileInputStream(file)), file.getName(), options, true);
+        } catch (FileNotFoundException e) {
+            throw new TextExtractionException("file_not_found", e.getMessage(), e);
+        }
+        return extractAndFetch(file.getName(), options);
+    }
+
+    /**
+     * Uploads an InputStream to IBM Cloud Object Storage (COS), starts text extraction process and
+     * returns the extracted text value. The extracted text is saved as a new <b>Markdown</b> file in
+     * COS, preserving the original filename but using the {@code .md} extension by default. To
+     * customize the output behavior, use the method with the {@link Options} parameter.
+     *
+     * <pre>
+     * {@code
+     * String uploadExtractAndFetch(InputStream is, String fileName, Options options);
+     * }
+     * </pre>
+     *
+     * <li><b>Note:</b> This method waits until the extraction process is complete and returns the
+     * extracted value. The default timeout value is set to 60 seconds.
+     *
+     * @param is The input stream of the file to be uploaded and processed.
+     * @param fileName The name of the file to be uploaded and processed.
+     * @param languages Language codes to guide the text extraction process.
+     * @return The text extracted.
+     */
+    public String uploadExtractAndFetch(InputStream is, String fileName, List<Language> languages)
+            throws TextExtractionException {
+        requireNonNull(languages);
+        return uploadExtractAndFetch(is, fileName, Options.create(languages));
+    }
+
+    /**
+     * Uploads an InputStream to IBM Cloud Object Storage (COS) and starts the asynchronous text
+     * extraction process. The extracted text is saved as a new <b>Markdown</b> file in COS, preserving
+     * the original filename but using the {@code .md} extension by default. Output behavior can be
+     * customized using the {@link Options} parameter.
+     *
+     * <p>
+     * <li><b>Note:</b> This method waits until the extraction process is complete and returns the
+     * extracted value. The default timeout value is set to 60 seconds.
+     *
+     * @param is The input stream of the file to be uploaded and processed.
+     * @param fileName The name of the file to be uploaded and processed.
+     * @param options Configuration options, including cleanup behavior.
+     * @return The text extracted.
+     */
+    public String uploadExtractAndFetch(InputStream is, String fileName, Options options)
+            throws TextExtractionException {
+        requireNonNull(options);
+        upload(is, fileName, options, true);
+        return extractAndFetch(fileName, options);
+    }
+
+    /**
+     * Retrieves the current status of a text extraction process.
+     *
+     * @param id The unique identifier of the extraction process.
+     * @return A {@link TextExtractionResponse} containing the status and details of the extraction job.
+     */
+    public TextExtractionResponse checkExtractionStatus(String id) throws TextExtractionException {
+        return retryOn(new Callable<TextExtractionResponse>() {
+            @Override
+            public TextExtractionResponse call() throws Exception {
+                return watsonxClient.getTextExtractionDetails(id, spaceId, projectId, version);
+            }
+        });
+    }
+
+    /**
+     * Deletes a file from the specified bucket.
+     *
+     * @param bucketName the name of the storage bucket from which the file should be deleted.
+     * @param path the path of the file to be deleted within the bucket.
+     * @throws COSException if an error occurs while attempting to delete the file.
+     */
+    public void deleteFile(String bucketName, String path) throws COSException {
+        deleteFile(bucketName, path, Duration.ofMinutes(1));
+    }
+
+    /**
+     * Deletes a file from the specified bucket.
+     *
+     * @param bucketName the name of the storage bucket from which the file should be deleted.
+     * @param path the path of the file to be deleted within the bucket.
+     * @param timeout the maximum duration to wait for the deletion operation to complete.
+     * @throws COSException if an error occurs while attempting to delete the file.
+     */
+    public void deleteFile(String bucketName, String path, Duration timeout) throws COSException {
+        requireNonNull(bucketName);
+        requireNonNull(path);
+        timeout = isNull(timeout) ? Duration.ofMinutes(1) : timeout;
+        cosClient.deleteFile(bucketName, path)
+                .onFailure(WatsonxUtils::isTokenExpired).retry().atMost(1)
+                .await().atMost(timeout);
+    }
+
+    //
+    // Upload a stream to the Cloud Object Storage.
+    //
+    private void upload(InputStream is, String fileName, Options options, boolean waitForExtraction) {
+        requireNonNull(is);
+        if (isNull(fileName) || fileName.isBlank())
+            throw new IllegalArgumentException("The file name can not be null or empty");
+
+        boolean removeOutputFile = options.removeOutputFile.orElse(false);
+        boolean removeUploadedFile = options.removeUploadedFile.orElse(false);
+
+        if (!waitForExtraction && (removeOutputFile || removeUploadedFile))
+            throw new IllegalArgumentException(
+                    "The asynchronous version of startExtraction doesn't allow the use of the \"removeOutputFile\" and \"removeUploadedFile\" options");
+
+        Reference documentReference = firstOrDefault(this.documentReference, options.documentReference);
+        retryOn(new Callable<Response>() {
+            @Override
+            public Response call() throws Exception {
+                return cosClient.createFile(documentReference.bucket, fileName, is);
+            }
+        });
+    }
+
+    private TextExtractionResponse startExtraction(String absolutePath, Options options, boolean waitUntilJobIsDone)
+            throws TextExtractionException {
+        requireNonNull(absolutePath);
+        requireNonNull(options);
+
+        if (options.languages.isEmpty())
+            throw new IllegalArgumentException(
+                    "To start the extraction process, you must specify at least one language");
+
+        boolean removeOutputFile = options.removeOutputFile.orElse(false);
+        boolean removeUploadedFile = options.removeUploadedFile.orElse(false);
+
+        if (!waitUntilJobIsDone && (removeOutputFile || removeUploadedFile))
+            throw new IllegalArgumentException(
+                    "The asynchronous version of startExtraction doesn't allow the use of the \"removeOutputFile\" and \"removeUploadedFile\" options");
+
+        if (isNull(options.outputFileName) || options.outputFileName.isBlank()) {
+
+            String extension = switch (options.type) {
+                case ASSEMBLY_JSON -> ".json";
+                case ASSEMBLY_MD -> ".md";
+            };
+
+            var index = absolutePath.lastIndexOf(".");
+            if (index > 0) {
+                options.outputFileName = absolutePath.substring(0, index) + extension;
+            } else {
+                options.outputFileName = absolutePath + extension;
+            }
+        }
+
+        Reference documentReference = firstOrDefault(this.documentReference, options.documentReference);
+        Reference resultsReference = firstOrDefault(this.resultReference, options.resultsReference);
+
+        var request = TextExtractionRequest.builder()
+                .documentReference(
+                        TextExtractionDataReference.of(documentReference.connection, absolutePath,
+                                documentReference.bucket))
+                .resultsReference(TextExtractionDataReference.of(resultsReference.connection, options.outputFileName,
+                        resultsReference.bucket))
+                .steps(TextExtractionSteps.of(options.languages, options.tableProcessing))
+                .type(options.type)
+                .projectId(projectId)
+                .spaceId(spaceId)
+                .build();
+
+        TextExtractionResponse response = retryOn(new Callable<TextExtractionResponse>() {
+            @Override
+            public TextExtractionResponse call() throws Exception {
+                return watsonxClient.startTextExtractionJob(request, version);
+            }
+        });
+
+        if (!waitUntilJobIsDone)
+            return response;
+
+        Status status;
+        long sleepTime = 100;
+        LocalTime endTime = LocalTime.now().plus(options.timeout);
+
+        do {
+
+            if (LocalTime.now().isAfter(endTime))
+                throw new TextExtractionException("timeout",
+                        "Execution to extract %s file took longer than the timeout set by %s milliseconds"
+                                .formatted(absolutePath, options.timeout.toMillis()));
+
+            try {
+
+                Thread.sleep(sleepTime);
+                sleepTime *= 2;
+                sleepTime = Math.min(sleepTime, 3000);
+
+            } catch (Exception e) {
+                throw new TextExtractionException("interrupted", e.getMessage());
+            }
+
+            var processId = response.metadata().id();
+            response = retryOn(new Callable<TextExtractionResponse>() {
+                @Override
+                public TextExtractionResponse call() throws Exception {
+                    return watsonxClient.getTextExtractionDetails(processId, spaceId, projectId, version);
+                }
+            });
+
+            status = response.entity().results().status();
+
+        } while (status != Status.FAILED && status != Status.COMPLETED);
+
+        return response;
+    }
+
+    private String getExtractedText(TextExtractionResponse textExtractionResponse, Options options)
+            throws TextExtractionException {
+        requireNonNull(textExtractionResponse);
+        requireNonNull(options);
+
+        String uploadedPath = textExtractionResponse.entity().documentReference().location().fileName();
+        String outputPath = textExtractionResponse.entity().resultsReference().location().fileName();
+        Status status = textExtractionResponse.entity().results().status();
+        boolean removeUploadedFile = options.removeUploadedFile.orElse(false);
+        boolean removeOutputFile = options.removeOutputFile.orElse(false);
+
+        Reference documentReference = firstOrDefault(this.documentReference, options.documentReference);
+        String documentBucketName = documentReference.bucket;
+
+        Reference resultsReference = firstOrDefault(this.resultReference, options.resultsReference);
+        String resultsBucketName = resultsReference.bucket;
+
+        try {
+
+            String extractedFile = switch (status) {
+                case COMPLETED -> retryOn(new Callable<String>() {
+                    @Override
+                    public String call() throws Exception {
+                        return cosClient.getFileContent(resultsBucketName, options.outputFileName);
+                    }
+                });
+                case FAILED -> {
+                    ServiceError error = textExtractionResponse.entity().results().error();
+                    throw new TextExtractionException(error.code(), error.message());
+                }
+                default -> throw new TextExtractionException("generic_error", "Status %s not managed".formatted(status));
+            };
+
+            if (removeOutputFile) {
+                cosClient.deleteFile(resultsBucketName, outputPath)
+                        .onFailure(WatsonxUtils::isTokenExpired).retry().atMost(1)
+                        .subscribe()
+                        .with(new Consumer<Response>() {
+                            @Override
+                            public void accept(Response response) {
+                                if (response.getStatus() >= 200 || response.getStatus() < 300)
+                                    logger.debug("File %s deleted from the Cloud Object Storage".formatted(outputPath));
+                                else
+                                    logger.error("Error during the execution of the delete operation for the file %s"
+                                            .formatted(outputPath));
+                            }
+                        });
+            }
+
+            return extractedFile;
+
+        } finally {
+
+            if (removeUploadedFile) {
+                cosClient.deleteFile(documentBucketName, uploadedPath)
+                        .onFailure(WatsonxUtils::isTokenExpired).retry().atMost(1)
+                        .subscribe()
+                        .with(new Consumer<Response>() {
+                            @Override
+                            public void accept(Response response) {
+                                if (response.getStatus() >= 200 || response.getStatus() < 300)
+                                    logger.debug(
+                                            "File %s deleted from the Cloud Object Storage".formatted(uploadedPath));
+                                else
+                                    logger.error("Error during the execution of the delete operation for the file %s"
+                                            .formatted(uploadedPath));
+                            }
+                        });
+            }
+        }
+    }
+
+    /**
+     * Options to configure the behavior of the @{link TextExtraction} methods.
+     */
+    public static class Options {
+
+        Duration timeout;
+        String outputFileName;
+        List<String> languages;
+        TextExtractionType type;
+        boolean tableProcessing;
+        Optional<Reference> documentReference;
+        Optional<Reference> resultsReference;
+        Optional<Boolean> removeUploadedFile;
+        Optional<Boolean> removeOutputFile;
+
+        protected Options(Duration timeout, String outputFileName, List<String> languages, TextExtractionType type,
+                boolean tableProcessing, Optional<Reference> documentReference, Optional<Reference> resultsReference,
+                Optional<Boolean> removeUploadedFile, Optional<Boolean> removeOutputFile) {
+            this.timeout = timeout;
+            this.outputFileName = outputFileName;
+            this.languages = languages;
+            this.type = type;
+            this.tableProcessing = tableProcessing;
+            this.documentReference = documentReference;
+            this.resultsReference = resultsReference;
+            this.removeUploadedFile = removeUploadedFile;
+            this.removeOutputFile = removeOutputFile;
+        }
+
+        protected Options(Options options) {
+            this(options.timeout, options.outputFileName, options.languages, options.type, options.tableProcessing,
+                    options.documentReference, options.resultsReference, options.removeUploadedFile,
+                    options.removeOutputFile);
+        }
+
+        public Options(List<Language> languages) {
+            this.type = ASSEMBLY_MD;
+            this.tableProcessing = true;
+            this.removeUploadedFile = Optional.empty();
+            this.removeOutputFile = Optional.empty();
+            this.languages = convertList(languages);
+            this.timeout = Duration.ofSeconds(60);
+        }
+
+        public static Options create(List<Language> languages) {
+            return new Options(languages);
+        }
+
+        public Options outputFileName(String outputFileName) {
+            this.outputFileName = outputFileName;
+            return this;
+        }
+
+        public Options languages(List<Language> languages) {
+            this.languages = convertList(languages);
+            return this;
+        }
+
+        public Options type(TextExtractionType type) {
+            this.type = type;
+            return this;
+        }
+
+        public Options tableProcessing(boolean tableProcessing) {
+            this.tableProcessing = tableProcessing;
+            return this;
+        }
+
+        public Options timeout(Duration timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        public Options documentReference(Reference documentReference) {
+            this.documentReference = Optional.of(documentReference);
+            return this;
+        }
+
+        public Options resultsReference(Reference resultsReference) {
+            this.resultsReference = Optional.of(resultsReference);
+            return this;
+        }
+
+        public Options removeUploadedFile(boolean removeUploadedFile) {
+            this.removeUploadedFile = Optional.of(removeUploadedFile);
+            return this;
+        }
+
+        public Options removeOutputFile(boolean removeOutputFile) {
+            this.removeOutputFile = Optional.of(removeOutputFile);
+            return this;
+        }
+
+        private List<String> convertList(List<Language> languages) {
+            return isNull(languages) ? List.of() : languages.stream().map(Language::code).toList();
+        }
+    }
+
+    public static enum Language {
+        CHINESE_SIMPLIFIED("zh-CN"),
+        CHINESE_TRADITIONAL("zh-TW"),
+        DANISH("da"),
+        DUTCH("nl"),
+        ENGLISH("en"),
+        ENGLISH_HANDWRITING("en_hw"),
+        FINNISH("fi"),
+        FRENCH("fr"),
+        GERMAN("de"),
+        GREEK("el"),
+        HEBREW("he"),
+        ITALIAN("it"),
+        JAPANESE("ja"),
+        KOREAN("ko"),
+        NORWEGIAN_BOKMAL("nb"),
+        NORWEGIAN_NYNORSK("nn"),
+        POLISH("pl"),
+        PORTUGUESE("pt"),
+        SPANISH("es"),
+        SWEDISH("sv");
+
+        private final String code;
+
+        Language(String code) {
+            this.code = code;
+        }
+
+        public String code() {
+            return code;
+        }
+    }
+}

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/TokenGenerationCache.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/TokenGenerationCache.java
@@ -1,0 +1,28 @@
+package io.quarkiverse.langchain4j.watsonx.runtime;
+
+import java.net.URL;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+public class TokenGenerationCache {
+
+    private static final Map<String, TokenGenerator> cache = new ConcurrentHashMap<>();
+
+    public static Optional<TokenGenerator> get(String apiKey) {
+        return Optional.ofNullable(cache.get(apiKey));
+    }
+
+    public static TokenGenerator getOrCreateTokenGenerator(String apiKey, URL iamBaseUrl, String grantType,
+            Duration timeout) {
+        return cache.computeIfAbsent(apiKey,
+                new Function<String, TokenGenerator>() {
+                    @Override
+                    public TokenGenerator apply(String apiKey) {
+                        return new TokenGenerator(iamBaseUrl, timeout, grantType, apiKey);
+                    }
+                });
+    }
+}

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/TokenGenerator.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/TokenGenerator.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.langchain4j.watsonx;
+package io.quarkiverse.langchain4j.watsonx.runtime;
 
 import java.net.URL;
 import java.time.Duration;
@@ -13,7 +13,7 @@ import io.quarkiverse.langchain4j.watsonx.client.IAMRestApi;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import io.smallrye.mutiny.Uni;
 
-public class WatsonxTokenGenerator {
+public class TokenGenerator {
 
     private final Semaphore lock = new Semaphore(1);
     private final IAMRestApi client;
@@ -21,7 +21,7 @@ public class WatsonxTokenGenerator {
     private final String grantType;
     private IdentityTokenResponse token;
 
-    public WatsonxTokenGenerator(URL url, Duration timeout, String grantType, String apiKey) {
+    public TokenGenerator(URL url, Duration timeout, String grantType, String apiKey) {
 
         this.client = QuarkusRestClientBuilder.newBuilder()
                 .baseUrl(url)

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/BuiltinServiceConfig.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/BuiltinServiceConfig.java
@@ -1,0 +1,69 @@
+package io.quarkiverse.langchain4j.watsonx.runtime.config;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigDocDefault;
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+
+@ConfigGroup
+public interface BuiltinServiceConfig {
+
+    /**
+     * Base URL for the built-in service.
+     * <p>
+     * All available URLs are listed in the IBM Watsonx.ai documentation at the
+     * <a href="https://cloud.ibm.com/apidocs/watsonx-ai#endpoint-url">following
+     * link</a>.
+     * <p>
+     * <b>Note:</b> If empty, the URL is automatically calculated based on the {@code watsonx.base-url} value.
+     */
+    Optional<String> baseUrl();
+
+    /**
+     * IBM Cloud API key.
+     * <p>
+     * If empty, the api key inherits the value from the {@code watsonx.api-key} property.
+     */
+    Optional<String> apiKey();
+
+    /**
+     * Timeout for built-in tools APIs.
+     * <p>
+     * If empty, the api key inherits the value from the {@code watsonx.timeout} property.
+     */
+    @ConfigDocDefault("10s")
+    Optional<Duration> timeout();
+
+    /**
+     * Whether the built-in rest client should log requests.
+     */
+    @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.log-requests}")
+    Optional<Boolean> logRequests();
+
+    /**
+     * Whether the built-in rest client should log responses.
+     */
+    @ConfigDocDefault("false")
+    @WithDefault("${quarkus.langchain4j.log-requests}")
+    Optional<Boolean> logResponses();
+
+    /**
+     * Google search service configuration.
+     */
+    GoogleSearchConfig googleSearch();
+
+    @ConfigGroup
+    public interface GoogleSearchConfig {
+
+        /**
+         * Maximum number of search results.
+         * <p>
+         * <strong>Possible values:</strong> <code>1 < value < 20</code>
+         */
+        @WithDefault("10")
+        int maxResults();
+    }
+}

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/LangChain4jWatsonxConfig.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/LangChain4jWatsonxConfig.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
@@ -28,6 +29,7 @@ public interface LangChain4jWatsonxConfig {
     /**
      * Named model config.
      */
+    @ConfigDocSection
     @ConfigDocMapKey("model-name")
     @WithParentName
     @WithDefaults
@@ -106,6 +108,13 @@ public interface LangChain4jWatsonxConfig {
          * IAM authentication related settings.
          */
         IAMConfig iam();
+
+        /**
+         * Cloud Object Storage related settings.
+         * <p>
+         * This configuration is only required when using the {@code TextExtraction} class.
+         */
+        Optional<TextExtractionConfig> textExtraction();
 
         /**
          * Chat model related settings.

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/LangChain4jWatsonxConfig.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/LangChain4jWatsonxConfig.java
@@ -33,10 +33,18 @@ public interface LangChain4jWatsonxConfig {
     @WithDefaults
     Map<String, WatsonConfig> namedConfig();
 
+    /**
+     * Configuration for built-in services.
+     */
+    BuiltinServiceConfig builtInService();
+
     @ConfigGroup
     interface WatsonConfig {
         /**
          * Base URL of the watsonx.ai API.
+         * <p>
+         * All available URLs are listed in the IBM Watsonx.ai documentation at the
+         * <a href="https://cloud.ibm.com/apidocs/watsonx-ai#endpoint-url">following link</a>.
          */
         Optional<String> baseUrl();
 
@@ -88,8 +96,8 @@ public interface LangChain4jWatsonxConfig {
 
         /**
          * Whether to enable the integration. Defaults to {@code true}, which means requests are made to the watsonx.ai
-         * provider. Set to
-         * {@code false} to disable all requests.
+         * provider. Set to {@code false} to
+         * disable all requests.
          */
         @WithDefault("true")
         Boolean enableIntegration();

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/TextExtractionConfig.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/TextExtractionConfig.java
@@ -1,0 +1,51 @@
+package io.quarkiverse.langchain4j.watsonx.runtime.config;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigDocDefault;
+import io.quarkus.runtime.annotations.ConfigGroup;
+
+@ConfigGroup
+public interface TextExtractionConfig {
+
+    /**
+     * Base URL of the Cloud Object Storage API.
+     */
+    String baseUrl();
+
+    /**
+     * The reference to the document that needs to be processed.
+     */
+    Reference documentReference();
+
+    /**
+     * The reference where the extracted text results will be stored.
+     */
+    Reference resultsReference();
+
+    /**
+     * Whether the Cloud Object Storage client should log requests.
+     */
+    @ConfigDocDefault("false")
+    Optional<Boolean> logRequests();
+
+    /**
+     * Whether the Cloud Object Storage client should log responses.
+     */
+    @ConfigDocDefault("false")
+    Optional<Boolean> logResponses();
+
+    @ConfigGroup
+    interface Reference {
+
+        /**
+         * The id of the connection asset that contains the credentials required to access the data.
+         */
+        String connection();
+
+        /**
+         * The default bucket for uploading/extracting documents.
+         */
+        String bucketName();
+    }
+}

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/services/GoogleSearchService.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/services/GoogleSearchService.java
@@ -1,0 +1,88 @@
+package io.quarkiverse.langchain4j.watsonx.services;
+
+import static io.quarkiverse.langchain4j.watsonx.WatsonxUtils.retryOn;
+import static io.quarkiverse.langchain4j.watsonx.bean.UtilityAgentToolsRequest.ToolName.GOOGLE_SEARCH;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+
+import org.jboss.logging.Logger;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import dev.langchain4j.Experimental;
+import io.quarkiverse.langchain4j.QuarkusJsonCodecFactory;
+import io.quarkiverse.langchain4j.watsonx.bean.GoogleSearchResult;
+import io.quarkiverse.langchain4j.watsonx.bean.UtilityAgentToolsRequest;
+import io.quarkiverse.langchain4j.watsonx.bean.UtilityAgentToolsRequest.StringInput;
+import io.quarkiverse.langchain4j.watsonx.bean.UtilityAgentToolsResponse;
+import io.quarkiverse.langchain4j.watsonx.client.UtilityAgentToolsRestApi;
+import io.quarkiverse.langchain4j.watsonx.exception.BuiltinServiceException;
+import io.quarkiverse.langchain4j.watsonx.runtime.config.BuiltinServiceConfig.GoogleSearchConfig;
+
+/**
+ * Built-in service to search for online trends, news, current events, real-time information or research topics.
+ */
+@Experimental
+public class GoogleSearchService {
+
+    private static final Logger logger = Logger.getLogger(GoogleSearchService.class);
+    private static final ObjectMapper objectMapper = QuarkusJsonCodecFactory.ObjectMapperHolder.MAPPER;
+    private UtilityAgentToolsRestApi client;
+    private int maxResults;
+
+    public GoogleSearchService(UtilityAgentToolsRestApi utilityAgentToolRestApi, GoogleSearchConfig config) {
+        this.client = utilityAgentToolRestApi;
+        this.maxResults = config.maxResults();
+    }
+
+    /**
+     * Search for online trends, news, current events, real-time information, or research topics.
+     *
+     * @param url The URL of the web page to fetch.
+     * @return {@link List} of {@link GoogleSearchResult} that contain the retrieved web page content.
+     */
+    public List<GoogleSearchResult> search(String input) throws BuiltinServiceException {
+        return search(input, this.maxResults);
+    }
+
+    /**
+     * Search for online trends, news, current events, real-time information, or research topics.
+     *
+     * @param url The URL of the web page to fetch.
+     * @param maxResults Max number of results.
+     * @return {@link List} of {@link GoogleSearchResult} that contain the retrieved web page content.
+     */
+    public List<GoogleSearchResult> search(String input, Integer maxResults) throws BuiltinServiceException {
+
+        if (Objects.isNull(input) || input.isBlank())
+            throw new IllegalArgumentException("The field \"input\" cannot be null or empty");
+
+        if (maxResults == null || maxResults < 0) {
+            maxResults = this.maxResults;
+        }
+
+        if (maxResults > 20) {
+            logger.info("The tool cannot return more than 20 elements, set maxResults to 20");
+            maxResults = 20;
+        }
+
+        var request = new UtilityAgentToolsRequest(GOOGLE_SEARCH, new StringInput(input), Map.of("maxResults", maxResults));
+        var response = retryOn(new Callable<UtilityAgentToolsResponse>() {
+            @Override
+            public UtilityAgentToolsResponse call() throws Exception {
+                return client.run(request);
+            }
+        });
+
+        try {
+            return objectMapper.readValue(response.output(), new TypeReference<List<GoogleSearchResult>>() {
+            });
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/services/WeatherService.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/services/WeatherService.java
@@ -1,0 +1,69 @@
+package io.quarkiverse.langchain4j.watsonx.services;
+
+import static io.quarkiverse.langchain4j.watsonx.WatsonxUtils.retryOn;
+import static io.quarkiverse.langchain4j.watsonx.bean.UtilityAgentToolsRequest.ToolName.WEATHER;
+import static java.util.Objects.isNull;
+
+import java.util.concurrent.Callable;
+
+import dev.langchain4j.Experimental;
+import io.quarkiverse.langchain4j.watsonx.bean.UtilityAgentToolsRequest;
+import io.quarkiverse.langchain4j.watsonx.bean.UtilityAgentToolsRequest.WeatherInput;
+import io.quarkiverse.langchain4j.watsonx.bean.UtilityAgentToolsResponse;
+import io.quarkiverse.langchain4j.watsonx.client.UtilityAgentToolsRestApi;
+import io.quarkiverse.langchain4j.watsonx.exception.BuiltinServiceException;
+
+/**
+ * Built-in service to find the weather of a city.
+ */
+@Experimental
+public class WeatherService {
+
+    private static final String NO_CITY_FOUND = "Unable to find coordinates of the location:";
+    private UtilityAgentToolsRestApi client;
+
+    public WeatherService(UtilityAgentToolsRestApi utilityAgentToolRestApi) {
+        this.client = utilityAgentToolRestApi;
+    }
+
+    public String find(String name, String country)
+            throws WeatherServiceException, NoCityFoundException {
+
+        if (isNull(name) || name.isBlank())
+            throw new IllegalArgumentException("The field \"name\" cannot be null or empty");
+
+        var request = new UtilityAgentToolsRequest(WEATHER, new WeatherInput(name, country));
+
+        try {
+            var response = retryOn(new Callable<UtilityAgentToolsResponse>() {
+                @Override
+                public UtilityAgentToolsResponse call() throws Exception {
+                    return client.run(request);
+                }
+            });
+
+            return response.output();
+
+        } catch (BuiltinServiceException exception) {
+            if (isNull(exception.details()))
+                throw new WeatherServiceException(exception.getMessage(), exception);
+
+            if (exception.details().startsWith(NO_CITY_FOUND))
+                throw new NoCityFoundException(name, country, exception);
+
+            throw new WeatherServiceException(exception.getMessage(), exception);
+        }
+    }
+
+    public static class WeatherServiceException extends Exception {
+        public WeatherServiceException(String message, Throwable e) {
+            super(message);
+        }
+    }
+
+    public static class NoCityFoundException extends WeatherServiceException {
+        public NoCityFoundException(String city, String country, Throwable e) {
+            super("%s %s%s".formatted(NO_CITY_FOUND, city, isNull(country) ? "" : "," + country), e);
+        }
+    }
+}

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/services/WebCrawlerService.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/services/WebCrawlerService.java
@@ -1,0 +1,61 @@
+package io.quarkiverse.langchain4j.watsonx.services;
+
+import static io.quarkiverse.langchain4j.watsonx.WatsonxUtils.retryOn;
+import static io.quarkiverse.langchain4j.watsonx.bean.UtilityAgentToolsRequest.ToolName.WEB_CRAWLER;
+
+import java.util.Objects;
+import java.util.concurrent.Callable;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import dev.langchain4j.Experimental;
+import io.quarkiverse.langchain4j.QuarkusJsonCodecFactory;
+import io.quarkiverse.langchain4j.watsonx.bean.UtilityAgentToolsRequest;
+import io.quarkiverse.langchain4j.watsonx.bean.UtilityAgentToolsRequest.WebCrawlerInput;
+import io.quarkiverse.langchain4j.watsonx.bean.UtilityAgentToolsResponse;
+import io.quarkiverse.langchain4j.watsonx.bean.WebCrawlerResult;
+import io.quarkiverse.langchain4j.watsonx.client.UtilityAgentToolsRestApi;
+import io.quarkiverse.langchain4j.watsonx.exception.BuiltinServiceException;
+
+/**
+ * Built-in service for fetching the content of a single web page.
+ */
+@Experimental
+public class WebCrawlerService {
+
+    private static final ObjectMapper objectMapper = QuarkusJsonCodecFactory.ObjectMapperHolder.MAPPER;
+    private UtilityAgentToolsRestApi client;
+
+    public WebCrawlerService(UtilityAgentToolsRestApi utilityAgentToolRestApi) {
+        this.client = utilityAgentToolRestApi;
+    }
+
+    /**
+     * Fetches the content of a single web page.
+     *
+     * @param url The URL of the web page to fetch.
+     * @return A {@code WebCrawlerToolResult} containing the retrieved web page content.
+     */
+    public WebCrawlerResult process(String url) throws BuiltinServiceException {
+
+        if (Objects.isNull(url) || url.isBlank())
+            throw new IllegalArgumentException("The field \"url\" cannot be null or empty");
+
+        var request = new UtilityAgentToolsRequest(WEB_CRAWLER, new WebCrawlerInput(url));
+        var response = retryOn(new Callable<UtilityAgentToolsResponse>() {
+            @Override
+            public UtilityAgentToolsResponse call() throws Exception {
+                return client.run(request);
+            }
+        });
+        try {
+            return objectMapper.readValue(
+                    // Convert the double-escaped JSON string into a properly formatted JSON string.
+                    objectMapper.readValue(response.output(), String.class),
+                    // Deserialize into WebCrawlerToolResult record
+                    WebCrawlerResult.class);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
These commits enable two new features available in watsonx.ai

**Built-in services:** 
This is an experimental feature that allows the developer to use different built-in services in watsonx.ai. Currently the built-in services are:
- WebCrawlerService: Fetches the content of a single web page.
- GoogleSearchService: Searches for online trends, news, current events, real-time information, or research topics.
- WeatherService: Finds the weather for a city.

These services can be used with the `@Inject` annotation.

**TextExtraction:**
Bean responsible for handling the interaction between watsonx.ai APIs and IBM Cloud Object Storage for document text extraction.