### PR TITLE
Use the Any qualifier when injecting tools for the Dev UI

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/devui/ChatJsonRPCService.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/devui/ChatJsonRPCService.java
@@ -11,6 +11,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.enterprise.inject.Any;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
@@ -104,7 +105,8 @@ public class ChatJsonRPCService {
                     Object objectWithTool = null;
                     try {
                         objectWithTool = Arc.container().select(
-                                Thread.currentThread().getContextClassLoader().loadClass(entry.getKey())).get();
+                                Thread.currentThread().getContextClassLoader().loadClass(entry.getKey()),
+                                new Any.Literal()).get();
                     } catch (ClassNotFoundException e) {
                         throw new RuntimeException(e);
                     }


### PR DESCRIPTION
Fixes https://github.com/quarkiverse/quarkus-langchain4j/issues/1359 (the problem was that a REST client gets a  `@RestClient` qualifier and we look up without specifying any qualifiers)

This is not optimal, but we don't know what qualifiers the beans with tools might have, so let's try to just inject `any` bean...