### PR TITLE
Dev UI: always produce JsonRPCProvidersBuildItem

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/devui/LangChain4jDevUIProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/devui/LangChain4jDevUIProcessor.java
@@ -122,7 +122,7 @@ public class LangChain4jDevUIProcessor {
                 .icon("font-awesome-solid:comments"));
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     void jsonRpcProviders(BuildProducer<JsonRPCProvidersBuildItem> producers,
             List<InProcessEmbeddingBuildItem> inProcessEmbeddingModelBuildItems,
             List<EmbeddingModelProviderCandidateBuildItem> embeddingModelCandidateBuildItems,

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/devui/OpenWebUIDevUIProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/devui/OpenWebUIDevUIProcessor.java
@@ -38,12 +38,15 @@ import io.quarkus.devui.spi.buildtime.BuildTimeActionBuildItem;
 public final class OpenWebUIDevUIProcessor {
     private static final String CONTAINER_NAME_PREFIX = "quarkus-open-webui-";
 
+    @BuildStep
+    JsonRPCProvidersBuildItem jsonRpcProviders() {
+        return new JsonRPCProvidersBuildItem(OpenWebUIJsonRPCService.class);
+    }
+
     @BuildStep(onlyIf = IsDevelopment.class)
     void registerOpenWebUiCard(
             BuildProducer<BuildTimeActionBuildItem> buildTimeActionProducer,
-            BuildProducer<JsonRPCProvidersBuildItem> jsonRPCProviders,
             CuratedApplicationShutdownBuildItem closeBuildItem) {
-        jsonRPCProviders.produce(new JsonRPCProvidersBuildItem(OpenWebUIJsonRPCService.class));
 
         closeBuildItem.addCloseTask(() -> {
             stopOpenWebUI();

--- a/model-providers/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/devui/OpenAiDevUIProcessor.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/devui/OpenAiDevUIProcessor.java
@@ -29,7 +29,7 @@ public class OpenAiDevUIProcessor {
         return card;
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     void jsonRpcProviders(BuildProducer<JsonRPCProvidersBuildItem> rpcProviders,
             LangChain4jOpenAiBuildConfig config) {
         if (config.imageModel().enabled().orElse(true)) {


### PR DESCRIPTION
This is due to an upcoming change in Execution Model Validation [1] where we need the `JsonRPCProvidersBuildItem` produced always, not only in dev mode. JSON RPC providers can use execution model affecting annotations, so we need to know about them, otherwise a non-dev build would fail with an incorrect validation error.

[1] https://github.com/quarkusio/quarkus/pull/46965