### PR TITLE
Allow to mix static and dynamic tools

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolresolution/ExplicitToolBoxAndProviderSupplierTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolresolution/ExplicitToolBoxAndProviderSupplierTest.java
@@ -13,12 +13,13 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import dev.langchain4j.service.MemoryId;
 import dev.langchain4j.service.UserMessage;
 import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.ToolBox;
 import io.quarkus.test.QuarkusUnitTest;
 
 /**
  *
  */
-public class ExplicitToolsAndProviderSupplierTest {
+public class ExplicitToolBoxAndProviderSupplierTest {
 
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
@@ -30,9 +31,10 @@ public class ExplicitToolsAndProviderSupplierTest {
                             MyCustomToolProvider.class,
                             ToolsClass.class));
 
-    @RegisterAiService(toolProviderSupplier = MyCustomToolProviderSupplier.class, tools = ToolsClass.class, chatLanguageModelSupplier = TestAiSupplier.class)
+    @RegisterAiService(toolProviderSupplier = MyCustomToolProviderSupplier.class, chatLanguageModelSupplier = TestAiSupplier.class)
     interface ServiceWithToolClash {
 
+        @ToolBox(ToolsClass.class)
         String chat(@UserMessage String msg, @MemoryId Object id);
 
     }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/RegisterAiService.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/RegisterAiService.java
@@ -134,7 +134,7 @@ public @interface RegisterAiService {
     Class<? extends Supplier<ModerationModel>> moderationModelSupplier() default BeanIfExistsModerationModelSupplier.class;
 
     /**
-     * Configures a toolProviderSupplier. Either a toolProviderSupplier or "normal" tools can be used, but not both
+     * Configures a toolProviderSupplier. It is possible to use together toolProviderSupplier and "normal" tools.
      */
     Class<? extends Supplier<ToolProvider>> toolProviderSupplier() default BeanIfExistsToolProviderSupplier.class;
 

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/AiServicesRecorder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/AiServicesRecorder.java
@@ -197,11 +197,6 @@ public class AiServicesRecorder {
                         if (!RegisterAiService.BeanIfExistsToolProviderSupplier.class.getName()
                                 .equals(info.toolProviderSupplier())) {
                             // specific provider
-                            if (hasExplicitTools) {
-                                // if the service has both explicit tools and a specific tool provider,
-                                // this is an error
-                                throw new IllegalStateException("Cannot use a tool provider when explicit tools are provided");
-                            }
                             Class<?> toolProviderClass = Thread.currentThread().getContextClassLoader()
                                     .loadClass(info.toolProviderSupplier());
                             Supplier<? extends ToolProvider> toolProvider = (Supplier<? extends ToolProvider>) creationalContext

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
@@ -190,8 +190,8 @@ public class AiServiceMethodImplementationSupport {
                 : context.toolService.toolExecutors();
 
         if (context.toolService.toolProvider() != null) {
-            toolSpecifications = new ArrayList<>();
-            toolExecutors = new HashMap<>();
+            toolSpecifications = toolSpecifications != null ? new ArrayList<>(toolSpecifications) : new ArrayList<>();
+            toolExecutors = toolExecutors != null ? new HashMap<>(toolExecutors) : new HashMap<>();
             ToolProviderRequest request = new ToolProviderRequest(memoryId, userMessage);
             ToolProviderResult result = context.toolService.toolProvider().provideTools(request);
             for (ToolSpecification specification : result.tools().keySet()) {


### PR DESCRIPTION
This change follows a [similar improvement](https://github.com/langchain4j/langchain4j/pull/2819), made on LangChain4j, intended to allow an AI service to use both statically defined and dynamically loaded tools (possibly from one or more MCP servers) at the same time. 

/cc @jmartisk @geoand 