### PR TITLE
Use ClientWebApplicationException in Bedrock

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-mcp.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-mcp.adoc
@@ -28,6 +28,29 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`true`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-mcp_quarkus-langchain4j-mcp-config-file]] [.property-path]##link:#quarkus-langchain4j-mcp_quarkus-langchain4j-mcp-config-file[`quarkus.langchain4j.mcp.config-file`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.mcp.config-file+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+File containing the MCP servers configuration in the Claude Desktop format. This configuration can only be used to configure `stdio` transport type MCP servers.
+
+This file is read at *build time* which means that which MCP servers the client will use, is determined at build time. However, specific configuration of each MCP server can be overridden at runtime.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MCP_CONFIG_FILE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MCP_CONFIG_FILE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
 h|[[quarkus-langchain4j-mcp_section_quarkus-langchain4j-mcp]] [.section-name.section-level0]##link:#quarkus-langchain4j-mcp_section_quarkus-langchain4j-mcp[Configured MCP clients]##
 h|Type
 h|Default

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-mcp_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-mcp_quarkus.langchain4j.adoc
@@ -28,6 +28,29 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`true`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-mcp_quarkus-langchain4j-mcp-config-file]] [.property-path]##link:#quarkus-langchain4j-mcp_quarkus-langchain4j-mcp-config-file[`quarkus.langchain4j.mcp.config-file`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.mcp.config-file+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+File containing the MCP servers configuration in the Claude Desktop format. This configuration can only be used to configure `stdio` transport type MCP servers.
+
+This file is read at *build time* which means that which MCP servers the client will use, is determined at build time. However, specific configuration of each MCP server can be overridden at runtime.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MCP_CONFIG_FILE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MCP_CONFIG_FILE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
 h|[[quarkus-langchain4j-mcp_section_quarkus-langchain4j-mcp]] [.section-name.section-level0]##link:#quarkus-langchain4j-mcp_section_quarkus-langchain4j-mcp[Configured MCP clients]##
 h|Type
 h|Default

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-milvus.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-milvus.adoc
@@ -330,7 +330,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-TODO
+Name of the field that contains the ID of the vector.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -342,6 +342,48 @@ endif::add-copy-button-to-env-var[]
 --
 |string
 |`id`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-text-field]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-text-field[`quarkus.langchain4j.milvus.text-field`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus.text-field+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the field that contains the text from which the vector was calculated.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS_TEXT_FIELD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS_TEXT_FIELD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`text`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-metadata-field]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-metadata-field[`quarkus.langchain4j.milvus.metadata-field`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus.metadata-field+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the field that contains JSON metadata associated with the text.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS_METADATA_FIELD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS_METADATA_FIELD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`metadata`
 
 a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-vector-field]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-vector-field[`quarkus.langchain4j.milvus.vector-field`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-milvus_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-milvus_quarkus.langchain4j.adoc
@@ -330,7 +330,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-TODO
+Name of the field that contains the ID of the vector.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -342,6 +342,48 @@ endif::add-copy-button-to-env-var[]
 --
 |string
 |`id`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-text-field]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-text-field[`quarkus.langchain4j.milvus.text-field`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus.text-field+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the field that contains the text from which the vector was calculated.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS_TEXT_FIELD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS_TEXT_FIELD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`text`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-metadata-field]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-metadata-field[`quarkus.langchain4j.milvus.metadata-field`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus.metadata-field+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the field that contains JSON metadata associated with the text.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS_METADATA_FIELD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS_METADATA_FIELD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`metadata`
 
 a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-vector-field]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-vector-field[`quarkus.langchain4j.milvus.vector-field`]##
 ifdef::add-copy-button-to-config-props[]

--- a/model-providers/bedrock/runtime/src/main/java/io/quarkiverse/langchain4j/bedrock/runtime/jaxrsclient/JaxRsSdkHttpClientExecutable.java
+++ b/model-providers/bedrock/runtime/src/main/java/io/quarkiverse/langchain4j/bedrock/runtime/jaxrsclient/JaxRsSdkHttpClientExecutable.java
@@ -9,7 +9,7 @@ import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.core.Response;
 
-import org.jboss.resteasy.reactive.client.api.WebClientApplicationException;
+import org.jboss.resteasy.reactive.ClientWebApplicationException;
 
 import software.amazon.awssdk.http.AbortableInputStream;
 import software.amazon.awssdk.http.ContentStreamProvider;
@@ -44,7 +44,7 @@ public class JaxRsSdkHttpClientExecutable implements ExecutableHttpRequest {
         }
 
         if (response.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
-            throw new WebClientApplicationException(response.getStatus(), response.getStatusInfo().getReasonPhrase());
+            throw new ClientWebApplicationException(response.getStatus());
         }
 
         return createSdkResponse(response);


### PR DESCRIPTION
This is done because `WebClientApplicationException`
that was used before has since been removed
from Quarkus `main`