### PR TITLE
Add fine-grained control for MCP server(s) provided tools

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
@@ -1375,6 +1375,8 @@ public class AiServicesProcessor {
                 toolQualifierProviders.stream().map(
                         ToolQualifierProvider.BuildItem::getProvider).toList());
 
+        List<String> methodMcpClientNames = gatherMethodMcpClientNames(method);
+
         List<String> outputGuardrails = AiServicesMethodBuildItem.gatherGuardrails(method, OUTPUT_GUARDRAILS);
         List<String> inputGuardrails = AiServicesMethodBuildItem.gatherGuardrails(method, INPUT_GUARDRAILS);
 
@@ -1390,8 +1392,8 @@ public class AiServicesProcessor {
                 userMessageInfo, memoryIdParamPosition, requiresModeration,
                 returnTypeSignature(method.returnType(), new TypeArgMapper(method.declaringClass(), index)),
                 overrideChatModelParamPosition, metricsTimedInfo, metricsCountedInfo, spanInfo, responseSchemaInfo,
-                methodToolClassInfo, switchToWorkerThreadForToolExecution, inputGuardrails, outputGuardrails,
-                accumulatorClassName, responseAugmenterClassName);
+                methodToolClassInfo, methodMcpClientNames, switchToWorkerThreadForToolExecution, inputGuardrails,
+                outputGuardrails, accumulatorClassName, responseAugmenterClassName);
     }
 
     private Optional<JsonSchema> jsonSchemaFrom(java.lang.reflect.Type returnType) {
@@ -1837,6 +1839,26 @@ public class AiServicesProcessor {
         }
 
         return Arrays.stream(toolClasses).map(t -> t.name().toString()).collect(Collectors.toList());
+    }
+
+    private List<String> gatherMethodMcpClientNames(MethodInfo method) {
+        // Using the class name to keep the McpToolBox annotation in the mcp module
+        AnnotationInstance mcpToolBoxInstance = method.declaredAnnotation("io.quarkiverse.langchain4j.mcp.runtime.McpToolBox");
+        if (mcpToolBoxInstance == null) {
+            return null;
+        }
+
+        AnnotationValue mcpToolBoxValue = mcpToolBoxInstance.value();
+        if (mcpToolBoxValue == null) {
+            return Collections.emptyList();
+        }
+
+        String[] mcpClientNames = mcpToolBoxValue.asStringArray();
+        if (mcpClientNames.length == 0) {
+            return Collections.emptyList();
+        }
+
+        return Arrays.asList(mcpClientNames);
     }
 
     private DotName determineChatMemorySeeder(ClassInfo iface, ClassOutput classOutput) {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodCreateInfo.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodCreateInfo.java
@@ -41,6 +41,7 @@ public final class AiServiceMethodCreateInfo {
     private final Optional<SpanInfo> spanInfo;
     // support @Toolbox
     private final Map<String, AnnotationLiteral<?>> toolClassInfo;
+    private final List<String> mcpClientNames;
     private final ResponseSchemaInfo responseSchemaInfo;
 
     // support for guardrails
@@ -78,6 +79,7 @@ public final class AiServiceMethodCreateInfo {
             Optional<SpanInfo> spanInfo,
             ResponseSchemaInfo responseSchemaInfo,
             Map<String, AnnotationLiteral<?>> toolClassInfo,
+            List<String> mcpClientNames,
             boolean switchToWorkerThreadForToolExecution,
             List<String> inputGuardrailsClassNames,
             List<String> outputGuardrailsClassNames,
@@ -102,6 +104,7 @@ public final class AiServiceMethodCreateInfo {
         this.spanInfo = spanInfo;
         this.responseSchemaInfo = responseSchemaInfo;
         this.toolClassInfo = toolClassInfo;
+        this.mcpClientNames = mcpClientNames;
         this.inputGuardrailsClassNames = inputGuardrailsClassNames;
         this.outputGuardrailsClassNames = outputGuardrailsClassNames;
         this.outputTokenAccumulatorClassName = outputTokenAccumulatorClassName;
@@ -171,6 +174,10 @@ public final class AiServiceMethodCreateInfo {
 
     public Map<String, AnnotationLiteral<?>> getToolClassInfo() {
         return toolClassInfo;
+    }
+
+    public List<String> getMcpClientNames() {
+        return mcpClientNames;
     }
 
     public List<ToolSpecification> getToolSpecifications() {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
@@ -192,7 +192,8 @@ public class AiServiceMethodImplementationSupport {
         if (context.toolService.toolProvider() != null) {
             toolSpecifications = toolSpecifications != null ? new ArrayList<>(toolSpecifications) : new ArrayList<>();
             toolExecutors = toolExecutors != null ? new HashMap<>(toolExecutors) : new HashMap<>();
-            ToolProviderRequest request = new ToolProviderRequest(memoryId, userMessage);
+            ToolProviderRequest request = new QuarkusToolProviderRequest(memoryId, userMessage,
+                    methodCreateInfo.getMcpClientNames());
             ToolProviderResult result = context.toolService.toolProvider().provideTools(request);
             for (ToolSpecification specification : result.tools().keySet()) {
                 toolSpecifications.add(specification);

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusToolProviderRequest.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusToolProviderRequest.java
@@ -1,0 +1,20 @@
+package io.quarkiverse.langchain4j.runtime.aiservice;
+
+import java.util.List;
+
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.service.tool.ToolProviderRequest;
+
+public class QuarkusToolProviderRequest extends ToolProviderRequest {
+
+    private final List<String> mcpClientNames;
+
+    public QuarkusToolProviderRequest(Object chatMemoryId, UserMessage userMessage, List<String> mcpClientNames) {
+        super(chatMemoryId, userMessage);
+        this.mcpClientNames = mcpClientNames;
+    }
+
+    public List<String> getMcpClientNames() {
+        return mcpClientNames;
+    }
+}

--- a/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/AbstractMockHttpMcpServer.java
+++ b/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/AbstractMockHttpMcpServer.java
@@ -1,0 +1,242 @@
+package io.quarkiverse.langchain4j.mcp.test;
+
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.sse.Sse;
+import jakarta.ws.rs.sse.SseEventSink;
+
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.RestStreamElementType;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public abstract class AbstractMockHttpMcpServer {
+
+    private final AtomicLong ID_GENERATOR = new AtomicLong(new Random().nextLong(1000, 5000));
+
+    private static Logger logger = Logger.getLogger(MockHttpMcpServer.class);
+
+    private volatile boolean shouldRespondToPing = true;
+
+    // key = operation ID of the ping
+    // value = future that will be completed when the ping response for that ID is received
+    final Map<Long, CompletableFuture<Void>> pendingPings = new ConcurrentHashMap<>();
+
+    private volatile SseEventSink sink;
+    private volatile Sse sse;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private volatile boolean initializationNotificationReceived = false;
+
+    @Inject
+    ScheduledExecutorService scheduledExecutorService;
+
+    @Path("/sse")
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    @RestStreamElementType(MediaType.TEXT_PLAIN)
+    public void sse(@Context SseEventSink sink, @Context Sse sse) {
+        this.sink = sink;
+        this.sse = sse;
+        sink.send(sse.newEventBuilder()
+                .id("id")
+                .name("endpoint")
+                .mediaType(MediaType.TEXT_PLAIN_TYPE)
+                .data("/" + getEndpoint() + "/post")
+                .build());
+    }
+
+    protected abstract String getEndpoint();
+
+    @Path("/post")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @POST
+    public Response post(JsonNode message) {
+        if (message.get("method") != null) {
+            String method = message.get("method").asText();
+            if (method.equals("notifications/cancelled")) {
+                return Response.ok().build();
+            }
+            if (method.equals("notifications/initialized")) {
+                if (initializationNotificationReceived) {
+                    return Response.serverError().entity("Duplicate 'notifications/initialized' message").build();
+                }
+                initializationNotificationReceived = true;
+                return Response.ok().build();
+            }
+            String operationId = message.get("id").asText();
+            if (method.equals("initialize")) {
+                initialize(operationId);
+            } else if (method.equals("tools/list")) {
+                ensureInitialized();
+                listTools(operationId);
+            } else if (method.equals("tools/call")) {
+                ensureInitialized();
+                if (message.get("params").get("name").asText().equals("add")) {
+                    executeAddOperation(message, operationId);
+                } else if (message.get("params").get("name").asText().equals("logging")) {
+                    executeLoggingOperation(message, operationId);
+                } else if (message.get("params").get("name").asText().equals("longRunningOperation")) {
+                    executeLongRunningOperation(message, operationId);
+                } else {
+                    return Response.serverError().entity("Unknown operation").build();
+                }
+
+            } else if (method.equals("ping")) {
+                if (shouldRespondToPing) {
+                    ObjectNode result = buildPongMessage(operationId);
+                    sink.send(sse.newEventBuilder()
+                            .name("message")
+                            .data(result)
+                            .build());
+                } else {
+                    logger.info("Ignoring ping request");
+                }
+                return Response.accepted().build();
+            }
+        } else {
+            // if 'method' is null, the message is probably a ping response
+            long id = message.get("id").asLong();
+            CompletableFuture<Void> future = pendingPings.remove(id);
+            if (future != null) {
+                future.complete(null);
+            } else {
+                return Response.serverError().entity("Received a ping response with unknown ID " + id).build();
+            }
+        }
+        return Response.accepted().build();
+    }
+
+    private ObjectNode buildPongMessage(String operationId) {
+        ObjectNode pong = objectMapper.createObjectNode();
+        pong.put("jsonrpc", "2.0");
+        pong.put("id", operationId);
+        pong.put("result", objectMapper.createObjectNode());
+        return pong;
+    }
+
+    private void executeLoggingOperation(JsonNode message, String operationId) {
+        ObjectNode logData = objectMapper.createObjectNode();
+        logData.put("message", "This is a log message");
+        ObjectNode log = buildLoggingMessage(logData);
+        sink.send(sse.newEventBuilder()
+                .name("message")
+                .data(log)
+                .build());
+        ObjectNode result = buildToolResult(operationId, "OK");
+        sink.send(sse.newEventBuilder()
+                .name("message")
+                .data(result)
+                .build());
+    }
+
+    private ObjectNode buildLoggingMessage(JsonNode message) {
+        ObjectNode log = objectMapper.createObjectNode();
+        log.put("jsonrpc", "2.0");
+        log.put("method", "notifications/message");
+        ObjectNode params = objectMapper.createObjectNode();
+        log.set("params", params);
+        params.put("level", "info");
+        params.put("logger", getEndpoint());
+        params.set("data", message);
+        return log;
+    }
+
+    private ObjectNode buildToolResult(String operationId, String result) {
+        ObjectNode resultNode = objectMapper.createObjectNode();
+        resultNode.put("id", operationId);
+        resultNode.put("jsonrpc", "2.0");
+        ObjectNode resultContent = objectMapper.createObjectNode();
+        resultNode.set("result", resultContent);
+        resultContent.putArray("content")
+                .addObject()
+                .put("type", "text")
+                .put("text", result);
+        return resultNode;
+    }
+
+    // throw an exception if we haven't received the 'notifications/initialized' message yet
+    private void ensureInitialized() {
+        if (!initializationNotificationReceived) {
+            throw new IllegalStateException("The client has not sent the 'notifications/initialized' message yet");
+        }
+    }
+
+    private void listTools(String operationId) {
+        String response = getToolsListResponse().formatted(operationId);
+        sink.send(sse.newEventBuilder()
+                .name("message")
+                .data(response)
+                .build());
+    }
+
+    protected abstract String getToolsListResponse();
+
+    private void initialize(String operationId) {
+        ObjectNode initializeResponse = objectMapper.createObjectNode();
+        initializeResponse
+                .put("id", operationId)
+                .put("jsonrpc", "2.0")
+                .putObject("result")
+                .put("protocolVersion", "2024-11-05");
+        sink.send(sse.newEventBuilder()
+                .name("message")
+                .data(initializeResponse)
+                .build());
+    }
+
+    private void executeAddOperation(JsonNode message, String operationId) {
+        int a = message.get("params").get("arguments").get("a").asInt();
+        int b = message.get("params").get("arguments").get("b").asInt();
+        int additionResult = a + b;
+        ObjectNode result = buildToolResult(operationId, "The sum of " + a + " and " + b + " is " + additionResult + ".");
+        sink.send(sse.newEventBuilder()
+                .name("message")
+                .data(result)
+                .build());
+    }
+
+    private void executeLongRunningOperation(JsonNode message, String operationId) {
+        int duration = message.get("params").get("arguments").get("duration").asInt();
+        scheduledExecutorService.schedule(() -> {
+            ObjectNode result = buildToolResult(operationId, "Operation completed.");
+            sink.send(sse.newEventBuilder()
+                    .name("message")
+                    .data(result)
+                    .build());
+        }, duration, TimeUnit.SECONDS);
+    }
+
+    long sendPing() {
+        ObjectNode initializeResponse = objectMapper.createObjectNode();
+        long id = ID_GENERATOR.incrementAndGet();
+        initializeResponse
+                .put("id", id)
+                .put("jsonrpc", "2.0")
+                .put("method", "ping");
+        sink.send(sse.newEventBuilder()
+                .name("message")
+                .data(initializeResponse)
+                .build());
+        pendingPings.put(id, new CompletableFuture<>());
+        return id;
+    }
+
+    void stopRespondingToPings() {
+        shouldRespondToPing = false;
+    }
+}

--- a/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/McpClaudeConfigTest.java
+++ b/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/McpClaudeConfigTest.java
@@ -27,7 +27,7 @@ public class McpClaudeConfigTest {
     @RegisterExtension
     static QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClass(MockHttpMcpServer.class)
+                    .addClasses(AbstractMockHttpMcpServer.class, MockHttpMcpServer.class)
                     .addAsResource(new StringAsset("""
                             {
                               "mcpServers": {

--- a/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/McpClientAndToolProviderCDITest.java
+++ b/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/McpClientAndToolProviderCDITest.java
@@ -11,11 +11,11 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import dev.langchain4j.mcp.McpToolProvider;
 import dev.langchain4j.mcp.client.DefaultMcpClient;
 import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.service.tool.ToolProvider;
 import io.quarkiverse.langchain4j.mcp.runtime.McpClientName;
+import io.quarkiverse.langchain4j.mcp.runtime.QuarkusMcpToolProvider;
 import io.quarkus.arc.ClientProxy;
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -24,7 +24,7 @@ public class McpClientAndToolProviderCDITest {
     @RegisterExtension
     static QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClass(MockHttpMcpServer.class)
+                    .addClasses(AbstractMockHttpMcpServer.class, MockHttpMcpServer.class)
                     .addAsResource(new StringAsset("""
                             quarkus.langchain4j.mcp.client1.transport-type=http
                             quarkus.langchain4j.mcp.client1.url=http://localhost:8081/mock-mcp/sse
@@ -50,7 +50,7 @@ public class McpClientAndToolProviderCDITest {
 
         ToolProvider provider = toolProviderCDIInstance.get();
         assertThat(provider).isNotNull();
-        assertThat(ClientProxy.unwrap(provider)).isInstanceOf(McpToolProvider.class);
+        assertThat(ClientProxy.unwrap(provider)).isInstanceOf(QuarkusMcpToolProvider.class);
     }
 
 }

--- a/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/McpHealthCheckTest.java
+++ b/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/McpHealthCheckTest.java
@@ -20,7 +20,7 @@ public class McpHealthCheckTest {
     @RegisterExtension
     static QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClass(MockHttpMcpServer.class)
+                    .addClasses(AbstractMockHttpMcpServer.class, MockHttpMcpServer.class)
                     .addAsResource(
                             new StringAsset(
                                     """

--- a/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/McpOverHttpTransportTest.java
+++ b/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/McpOverHttpTransportTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
-import dev.langchain4j.mcp.McpToolProvider;
 import dev.langchain4j.mcp.client.logging.McpLogLevel;
 import dev.langchain4j.mcp.client.logging.McpLogMessage;
 import dev.langchain4j.model.chat.request.json.JsonNumberSchema;
@@ -30,6 +29,7 @@ import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.service.tool.ToolProviderResult;
 import io.quarkiverse.langchain4j.mcp.runtime.McpClientName;
+import io.quarkiverse.langchain4j.mcp.runtime.QuarkusMcpToolProvider;
 import io.quarkus.arc.ClientProxy;
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -43,7 +43,7 @@ public class McpOverHttpTransportTest {
     @RegisterExtension
     static QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClass(MockHttpMcpServer.class)
+                    .addClasses(AbstractMockHttpMcpServer.class, MockHttpMcpServer.class)
                     .addAsResource(new StringAsset("""
                             quarkus.langchain4j.mcp.client1.transport-type=http
                             quarkus.langchain4j.mcp.client1.url=http://localhost:8081/mock-mcp/sse
@@ -60,7 +60,7 @@ public class McpOverHttpTransportTest {
 
     @Test
     public void toolProviderShouldBeMcpBased() {
-        assertThat(ClientProxy.unwrap(toolProvider)).isInstanceOf(McpToolProvider.class);
+        assertThat(ClientProxy.unwrap(toolProvider)).isInstanceOf(QuarkusMcpToolProvider.class);
     }
 
     @Test

--- a/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/Mock2HttpMcpServer.java
+++ b/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/Mock2HttpMcpServer.java
@@ -1,0 +1,54 @@
+package io.quarkiverse.langchain4j.mcp.test;
+
+import jakarta.ws.rs.Path;
+
+/**
+ * A very basic mock MCP server using the HTTP transport.
+ */
+@Path("/mock2-mcp")
+public class Mock2HttpMcpServer extends AbstractMockHttpMcpServer {
+
+    // language=JSON
+    public static final String TOOLS_LIST_RESPONSE = """
+            {
+              "result": {
+                "tools": [
+                  {
+                    "name": "subtract",
+                    "description": "Subtracts two numbers",
+                    "inputSchema": {
+                      "type": "object",
+                      "properties": {
+                        "a": {
+                          "type": "number",
+                          "description": "First number"
+                        },
+                        "b": {
+                          "type": "number",
+                          "description": "Second number"
+                        }
+                      },
+                      "required": [
+                        "a",
+                        "b"
+                      ],
+                      "additionalProperties": false,
+                      "$schema": "http://json-schema.org/draft-07/schema#"
+                    }
+                  }
+                ]
+              },
+              "jsonrpc": "2.0",
+              "id": "%s"
+            }
+            """;
+
+    protected String getToolsListResponse() {
+        return TOOLS_LIST_RESPONSE;
+    }
+
+    @Override
+    protected String getEndpoint() {
+        return "mock2-mcp";
+    }
+}

--- a/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/Mock3HttpMcpServer.java
+++ b/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/Mock3HttpMcpServer.java
@@ -1,0 +1,54 @@
+package io.quarkiverse.langchain4j.mcp.test;
+
+import jakarta.ws.rs.Path;
+
+/**
+ * A very basic mock MCP server using the HTTP transport.
+ */
+@Path("/mock3-mcp")
+public class Mock3HttpMcpServer extends AbstractMockHttpMcpServer {
+
+    // language=JSON
+    public static final String TOOLS_LIST_RESPONSE = """
+            {
+              "result": {
+                "tools": [
+                  {
+                    "name": "multiply",
+                    "description": "Multiplies two numbers",
+                    "inputSchema": {
+                      "type": "object",
+                      "properties": {
+                        "a": {
+                          "type": "number",
+                          "description": "First number"
+                        },
+                        "b": {
+                          "type": "number",
+                          "description": "Second number"
+                        }
+                      },
+                      "required": [
+                        "a",
+                        "b"
+                      ],
+                      "additionalProperties": false,
+                      "$schema": "http://json-schema.org/draft-07/schema#"
+                    }
+                  }
+                ]
+              },
+              "jsonrpc": "2.0",
+              "id": "%s"
+            }
+            """;
+
+    protected String getToolsListResponse() {
+        return TOOLS_LIST_RESPONSE;
+    }
+
+    @Override
+    protected String getEndpoint() {
+        return "mock3-mcp";
+    }
+}

--- a/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/MockHttpMcpServer.java
+++ b/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/MockHttpMcpServer.java
@@ -1,46 +1,12 @@
 package io.quarkiverse.langchain4j.mcp.test;
 
-import java.util.Map;
-import java.util.Random;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-
-import jakarta.inject.Inject;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.Context;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.sse.Sse;
-import jakarta.ws.rs.sse.SseEventSink;
-
-import org.jboss.logging.Logger;
-import org.jboss.resteasy.reactive.RestStreamElementType;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * A very basic mock MCP server using the HTTP transport.
  */
 @Path("/mock-mcp")
-public class MockHttpMcpServer {
-
-    private final AtomicLong ID_GENERATOR = new AtomicLong(new Random().nextLong(1000, 5000));
-
-    private static Logger logger = Logger.getLogger(MockHttpMcpServer.class);
-
-    private volatile boolean shouldRespondToPing = true;
-
-    // key = operation ID of the ping
-    // value = future that will be completed when the ping response for that ID is received
-    final Map<Long, CompletableFuture<Void>> pendingPings = new ConcurrentHashMap<>();
+public class MockHttpMcpServer extends AbstractMockHttpMcpServer {
 
     // language=JSON
     public static final String TOOLS_LIST_RESPONSE = """
@@ -109,201 +75,13 @@ public class MockHttpMcpServer {
             }
             """;
 
-    private volatile SseEventSink sink;
-    private volatile Sse sse;
-    private final ObjectMapper objectMapper = new ObjectMapper();
-    private volatile boolean initializationNotificationReceived = false;
-
-    @Inject
-    ScheduledExecutorService scheduledExecutorService;
-
-    @Path("/sse")
-    @Produces(MediaType.SERVER_SENT_EVENTS)
-    @RestStreamElementType(MediaType.TEXT_PLAIN)
-    public void sse(@Context SseEventSink sink, @Context Sse sse) {
-        this.sink = sink;
-        this.sse = sse;
-        sink.send(sse.newEventBuilder()
-                .id("id")
-                .name("endpoint")
-                .mediaType(MediaType.TEXT_PLAIN_TYPE)
-                .data("/mock-mcp/post")
-                .build());
+    @Override
+    protected String getToolsListResponse() {
+        return TOOLS_LIST_RESPONSE;
     }
 
-    @Path("/post")
-    @Consumes(MediaType.APPLICATION_JSON)
-    @POST
-    public Response post(JsonNode message) {
-        if (message.get("method") != null) {
-            String method = message.get("method").asText();
-            if (method.equals("notifications/cancelled")) {
-                return Response.ok().build();
-            }
-            if (method.equals("notifications/initialized")) {
-                if (initializationNotificationReceived) {
-                    return Response.serverError().entity("Duplicate 'notifications/initialized' message").build();
-                }
-                initializationNotificationReceived = true;
-                return Response.ok().build();
-            }
-            String operationId = message.get("id").asText();
-            if (method.equals("initialize")) {
-                initialize(operationId);
-            } else if (method.equals("tools/list")) {
-                ensureInitialized();
-                listTools(operationId);
-            } else if (method.equals("tools/call")) {
-                ensureInitialized();
-                if (message.get("params").get("name").asText().equals("add")) {
-                    executeAddOperation(message, operationId);
-                } else if (message.get("params").get("name").asText().equals("logging")) {
-                    executeLoggingOperation(message, operationId);
-                } else if (message.get("params").get("name").asText().equals("longRunningOperation")) {
-                    executeLongRunningOperation(message, operationId);
-                } else {
-                    return Response.serverError().entity("Unknown operation").build();
-                }
-            } else if (method.equals("ping")) {
-                if (shouldRespondToPing) {
-                    ObjectNode result = buildPongMessage(operationId);
-                    sink.send(sse.newEventBuilder()
-                            .name("message")
-                            .data(result)
-                            .build());
-                } else {
-                    logger.info("Ignoring ping request");
-                }
-                return Response.accepted().build();
-            }
-        } else {
-            // if 'method' is null, the message is probably a ping response
-            long id = message.get("id").asLong();
-            CompletableFuture<Void> future = pendingPings.remove(id);
-            if (future != null) {
-                future.complete(null);
-            } else {
-                return Response.serverError().entity("Received a ping response with unknown ID " + id).build();
-            }
-        }
-        return Response.accepted().build();
+    @Override
+    protected String getEndpoint() {
+        return "mock-mcp";
     }
-
-    private ObjectNode buildPongMessage(String operationId) {
-        ObjectNode pong = objectMapper.createObjectNode();
-        pong.put("jsonrpc", "2.0");
-        pong.put("id", operationId);
-        pong.put("result", objectMapper.createObjectNode());
-        return pong;
-    }
-
-    private void executeLoggingOperation(JsonNode message, String operationId) {
-        ObjectNode logData = objectMapper.createObjectNode();
-        logData.put("message", "This is a log message");
-        ObjectNode log = buildLoggingMessage(logData);
-        sink.send(sse.newEventBuilder()
-                .name("message")
-                .data(log)
-                .build());
-        ObjectNode result = buildToolResult(operationId, "OK");
-        sink.send(sse.newEventBuilder()
-                .name("message")
-                .data(result)
-                .build());
-    }
-
-    private ObjectNode buildLoggingMessage(JsonNode message) {
-        ObjectNode log = objectMapper.createObjectNode();
-        log.put("jsonrpc", "2.0");
-        log.put("method", "notifications/message");
-        ObjectNode params = objectMapper.createObjectNode();
-        log.set("params", params);
-        params.put("level", "info");
-        params.put("logger", "mock-mcp");
-        params.set("data", message);
-        return log;
-    }
-
-    private ObjectNode buildToolResult(String operationId, String result) {
-        ObjectNode resultNode = objectMapper.createObjectNode();
-        resultNode.put("id", operationId);
-        resultNode.put("jsonrpc", "2.0");
-        ObjectNode resultContent = objectMapper.createObjectNode();
-        resultNode.set("result", resultContent);
-        resultContent.putArray("content")
-                .addObject()
-                .put("type", "text")
-                .put("text", result);
-        return resultNode;
-    }
-
-    // throw an exception if we haven't received the 'notifications/initialized' message yet
-    private void ensureInitialized() {
-        if (!initializationNotificationReceived) {
-            throw new IllegalStateException("The client has not sent the 'notifications/initialized' message yet");
-        }
-    }
-
-    private void listTools(String operationId) {
-        String response = TOOLS_LIST_RESPONSE.formatted(operationId);
-        sink.send(sse.newEventBuilder()
-                .name("message")
-                .data(response)
-                .build());
-    }
-
-    private void initialize(String operationId) {
-        ObjectNode initializeResponse = objectMapper.createObjectNode();
-        initializeResponse
-                .put("id", operationId)
-                .put("jsonrpc", "2.0")
-                .putObject("result")
-                .put("protocolVersion", "2024-11-05");
-        sink.send(sse.newEventBuilder()
-                .name("message")
-                .data(initializeResponse)
-                .build());
-    }
-
-    private void executeAddOperation(JsonNode message, String operationId) {
-        int a = message.get("params").get("arguments").get("a").asInt();
-        int b = message.get("params").get("arguments").get("b").asInt();
-        int additionResult = a + b;
-        ObjectNode result = buildToolResult(operationId, "The sum of " + a + " and " + b + " is " + additionResult + ".");
-        sink.send(sse.newEventBuilder()
-                .name("message")
-                .data(result)
-                .build());
-    }
-
-    private void executeLongRunningOperation(JsonNode message, String operationId) {
-        int duration = message.get("params").get("arguments").get("duration").asInt();
-        scheduledExecutorService.schedule(() -> {
-            ObjectNode result = buildToolResult(operationId, "Operation completed.");
-            sink.send(sse.newEventBuilder()
-                    .name("message")
-                    .data(result)
-                    .build());
-        }, duration, TimeUnit.SECONDS);
-    }
-
-    long sendPing() {
-        ObjectNode initializeResponse = objectMapper.createObjectNode();
-        long id = ID_GENERATOR.incrementAndGet();
-        initializeResponse
-                .put("id", id)
-                .put("jsonrpc", "2.0")
-                .put("method", "ping");
-        sink.send(sse.newEventBuilder()
-                .name("message")
-                .data(initializeResponse)
-                .build());
-        pendingPings.put(id, new CompletableFuture<>());
-        return id;
-    }
-
-    void stopRespondingToPings() {
-        shouldRespondToPing = false;
-    }
-
 }

--- a/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/MultipleMcpClientsTest.java
+++ b/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/MultipleMcpClientsTest.java
@@ -1,0 +1,199 @@
+package io.quarkiverse.langchain4j.mcp.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIterable;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.tool.ToolProvider;
+import dev.langchain4j.service.tool.ToolProviderResult;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.mcp.runtime.McpToolBox;
+import io.quarkiverse.langchain4j.runtime.aiservice.NoopChatMemory;
+import io.quarkiverse.langchain4j.runtime.aiservice.QuarkusToolProviderRequest;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Test MCP clients over an HTTP transport.
+ * This is a very rudimentary test that runs against a mock MCP server. The plan is
+ * to replace it with a more proper MCP server once we have an appropriate Java SDK ready for it.
+ */
+public class MultipleMcpClientsTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(AbstractMockHttpMcpServer.class, MockHttpMcpServer.class, Mock2HttpMcpServer.class,
+                            Mock3HttpMcpServer.class, AllToolsService.class, SelectedToolsService.class,
+                            SingleToolService.class)
+                    .addAsResource(new StringAsset("""
+                            quarkus.langchain4j.mcp.client1.transport-type=http
+                            quarkus.langchain4j.mcp.client1.url=http://localhost:8081/mock-mcp/sse
+                            quarkus.langchain4j.mcp.client2.transport-type=http
+                            quarkus.langchain4j.mcp.client2.url=http://localhost:8081/mock2-mcp/sse
+                            quarkus.langchain4j.mcp.client3.transport-type=http
+                            quarkus.langchain4j.mcp.client3.url=http://localhost:8081/mock3-mcp/sse
+                            quarkus.log.category."dev.langchain4j".level=DEBUG
+                            quarkus.log.category."io.quarkiverse".level=DEBUG
+                            quarkus.langchain4j.mcp.client1.tool-execution-timeout=1s
+                            """),
+                            "application.properties"));
+
+    @Inject
+    ToolProvider toolProvider;
+
+    @Inject
+    AllToolsService allToolsService;
+
+    @Inject
+    SelectedToolsService selectedToolsService;
+
+    @Inject
+    SingleToolService singleToolService;
+
+    @Inject
+    NoToolService noToolService;
+
+    @Test
+    public void providingAllTools() {
+        ToolProviderResult toolProviderResult = toolProvider.provideTools(null);
+
+        assertThat(toolProviderResult.tools()).hasSize(5);
+        Set<String> toolNames = toolProviderResult.tools().keySet().stream()
+                .map(ToolSpecification::name)
+                .collect(Collectors.toSet());
+        assertThatIterable(toolNames)
+                .containsExactlyInAnyOrder("add", "subtract", "multiply", "longRunningOperation", "logging");
+    }
+
+    @Test
+    public void providingSelectedTools() {
+        var request = new QuarkusToolProviderRequest(null, null, List.of("client1", "client3"));
+        ToolProviderResult toolProviderResult = toolProvider.provideTools(request);
+
+        assertThat(toolProviderResult.tools()).hasSize(4);
+        Set<String> toolNames = toolProviderResult.tools().keySet().stream()
+                .map(ToolSpecification::name)
+                .collect(Collectors.toSet());
+        assertThatIterable(toolNames)
+                .containsExactlyInAnyOrder("add", "multiply", "longRunningOperation", "logging");
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = MyMemoryProviderSupplier.class)
+    public interface AllToolsService {
+
+        @McpToolBox
+        String toolsList(@UserMessage String userMessage);
+    }
+
+    @Test
+    @ActivateRequestContext
+    public void serviceHasAllTools() {
+        String[] toolNames = allToolsService.toolsList("test").split(",");
+        assertThat(toolNames)
+                .hasSize(5)
+                .containsExactlyInAnyOrder("add", "subtract", "multiply", "longRunningOperation", "logging");
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = MyMemoryProviderSupplier.class)
+    public interface SelectedToolsService {
+
+        @McpToolBox({ "client1", "client3" })
+        String toolsList(@UserMessage String userMessage);
+    }
+
+    @Test
+    @ActivateRequestContext
+    public void serviceHasOnlySelectedTools() {
+        String[] toolNames = selectedToolsService.toolsList("test").split(",");
+        assertThat(toolNames)
+                .hasSize(4)
+                .containsExactlyInAnyOrder("add", "multiply", "longRunningOperation", "logging");
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = MyMemoryProviderSupplier.class)
+    public interface SingleToolService {
+
+        @McpToolBox("client2")
+        String toolsList(@UserMessage String userMessage);
+    }
+
+    @Test
+    @ActivateRequestContext
+    public void serviceHasOneTool() {
+        String[] toolNames = singleToolService.toolsList("test").split(",");
+        assertThat(toolNames).hasSize(1);
+        assertThat(toolNames[0]).isEqualTo("subtract");
+    }
+
+    public static class MyChatModelSupplier implements Supplier<ChatLanguageModel> {
+
+        @Override
+        public ChatLanguageModel get() {
+            return new MyChatModel();
+        }
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = MyMemoryProviderSupplier.class)
+    public interface NoToolService {
+
+        String toolsList(@UserMessage String userMessage);
+    }
+
+    @Test
+    @ActivateRequestContext
+    public void serviceHasNoTools() {
+        assertThat(noToolService.toolsList("test")).hasSize(0);
+    }
+
+    public static class MyChatModel implements ChatLanguageModel {
+
+        @Override
+        public ChatResponse chat(List<ChatMessage> messages) {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            List<ToolSpecification> toolSpecifications = chatRequest.toolSpecifications();
+            String tools = toolSpecifications == null ? ""
+                    : toolSpecifications.stream()
+                            .map(ToolSpecification::name)
+                            .collect(Collectors.joining(","));
+            return ChatResponse.builder().aiMessage(new AiMessage(tools)).build();
+        }
+    }
+
+    public static class MyMemoryProviderSupplier implements Supplier<ChatMemoryProvider> {
+        @Override
+        public ChatMemoryProvider get() {
+            return new ChatMemoryProvider() {
+                @Override
+                public ChatMemory get(Object memoryId) {
+                    return new NoopChatMemory();
+                }
+            };
+        }
+    }
+}

--- a/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/NoAutomaticToolProviderTest.java
+++ b/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/NoAutomaticToolProviderTest.java
@@ -26,7 +26,7 @@ public class NoAutomaticToolProviderTest {
     @RegisterExtension
     static QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClass(MockHttpMcpServer.class)
+                    .addClasses(AbstractMockHttpMcpServer.class, MockHttpMcpServer.class)
                     .addAsResource(new StringAsset("""
                             quarkus.langchain4j.mcp.client1.transport-type=http
                             quarkus.langchain4j.mcp.client1.url=http://localhost:8081/mock-mcp/sse

--- a/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/McpRecorder.java
+++ b/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/McpRecorder.java
@@ -1,14 +1,13 @@
 package io.quarkiverse.langchain4j.mcp.runtime;
 
-import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import dev.langchain4j.mcp.McpToolProvider;
 import dev.langchain4j.mcp.client.DefaultMcpClient;
 import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.mcp.client.transport.McpTransport;
@@ -79,14 +78,12 @@ public class McpRecorder {
         return new Function<>() {
             @Override
             public ToolProvider apply(SyntheticCreationalContext<ToolProvider> context) {
-                List<McpClient> clients = new ArrayList<>();
+                Map<String, McpClient> clients = new HashMap<>();
                 for (String mcpClientName : mcpClientNames) {
                     McpClientName.Literal qualifier = McpClientName.Literal.of(mcpClientName);
-                    clients.add(context.getInjectedReference(McpClient.class, qualifier));
+                    clients.put(mcpClientName, context.getInjectedReference(McpClient.class, qualifier));
                 }
-                return new McpToolProvider.Builder()
-                        .mcpClients(clients)
-                        .build();
+                return new QuarkusMcpToolProvider(clients);
             }
 
         };

--- a/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/McpToolBox.java
+++ b/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/McpToolBox.java
@@ -1,0 +1,30 @@
+package io.quarkiverse.langchain4j.mcp.runtime;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import dev.langchain4j.service.tool.ToolProvider;
+import io.quarkiverse.langchain4j.RegisterAiService;
+
+/**
+ * When used on a method of an AiService annotated with {@link RegisterAiService}, the method will use the tools
+ * provided by the MCP servers named in {@code value}. If no name is provided than the method will automatically
+ * use all the MCP servers available.
+ * </p>
+ * Note that the filtering of the named MCP servers is possible only if the MCP extension is allowed to automatically
+ * generate a {@link ToolProvider} that is wired up to all the configured MCP clients,
+ * i.e. the {@code quarkus.langchain4j.mcp.generate-tool-provider} property is set to true (which is the default value).
+ * Conversely, if the AI service uses a custom {@link ToolProvider} than this annotation will have no effect and the
+ * wiring of specific MCP clients will have to be encoded in the {@link ToolProvider} itself.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD })
+public @interface McpToolBox {
+
+    /**
+     * MCP servers to use. In case no {@code value} is provided it will use all the MCP servers available.
+     */
+    String[] value() default {};
+}

--- a/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/QuarkusMcpToolProvider.java
+++ b/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/QuarkusMcpToolProvider.java
@@ -1,0 +1,80 @@
+package io.quarkiverse.langchain4j.mcp.runtime;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.service.tool.ToolProvider;
+import dev.langchain4j.service.tool.ToolProviderRequest;
+import dev.langchain4j.service.tool.ToolProviderResult;
+import io.quarkiverse.langchain4j.runtime.aiservice.QuarkusToolProviderRequest;
+
+public class QuarkusMcpToolProvider implements ToolProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(QuarkusMcpToolProvider.class);
+
+    private final Map<String, McpClient> mcpClients;
+    private final boolean failIfOneServerFails;
+
+    QuarkusMcpToolProvider(Map<String, McpClient> mcpClients) {
+        this(mcpClients, false);
+    }
+
+    QuarkusMcpToolProvider(Map<String, McpClient> mcpClients, boolean failIfOneServerFails) {
+        this.mcpClients = mcpClients;
+        this.failIfOneServerFails = failIfOneServerFails;
+    }
+
+    @Override
+    public ToolProviderResult provideTools(ToolProviderRequest request) {
+        ToolProviderResult.Builder builder = ToolProviderResult.builder();
+
+        for (McpClient mcpClient : getMcpClients(request)) {
+            try {
+                for (ToolSpecification toolSpecification : mcpClient.listTools()) {
+                    builder.add(toolSpecification, (executionRequest, memoryId) -> mcpClient.executeTool(executionRequest));
+                }
+            } catch (Exception e) {
+                if (this.failIfOneServerFails) {
+                    throw new RuntimeException("Failed to retrieve tools from MCP server", e);
+                }
+
+                log.warn("Failed to retrieve tools from MCP server", e);
+            }
+        }
+
+        return builder.build();
+
+    }
+
+    private Collection<McpClient> getMcpClients(ToolProviderRequest request) {
+        if (request instanceof QuarkusToolProviderRequest quarkusRequest) {
+            List<String> mcpClientNames = quarkusRequest.getMcpClientNames();
+            if (mcpClientNames == null) {
+                return Collections.emptyList();
+            }
+            if (mcpClientNames.isEmpty()) {
+                return mcpClients.values();
+            }
+            return mcpClientNames.stream()
+                    .map(mcpClientName -> {
+                        McpClient mcpClient = mcpClients.get(mcpClientName);
+                        if (mcpClient == null) {
+                            log.warn("Failed to find MCP client for server {}", mcpClientName);
+                        }
+                        return mcpClient;
+                    })
+                    .filter(Objects::nonNull)
+                    .toList();
+        }
+
+        return mcpClients.values();
+    }
+}


### PR DESCRIPTION
This is an implementation for https://github.com/quarkiverse/quarkus-langchain4j/issues/1409

At the moment the `McpToolBox` annotation is only used to limit the MCP servers that a AI service can use. In other words if you have configured the MCP servers A, B and C, the following service:

```
@RegisterAiService
public interface MyService {

    @McpToolBox({"A", "C"})
    String chat(String query);
}
```

will be provided only for tools in the server A and C, but not B. If the `McpToolBox` annotation is present with no values or is not present at all it will behave in the same way, automatically providing all the tools for all the configured MCP servers. I did this to keep backward compatibility, but in reality what I would like to do is giving access to the MCP provided tools only to method annotated with `McpToolBox`, only the named ones or all if used without values. Any feedback on this is welcome.

I implemented this feature purely on the extension side and for this reason I had add to add a `QuarkusToolProviderRequest` and a `QuarkusMcpToolProvider`, but maybe we may this also in LangChain4j, so I could move the changes that I introduced with those classes directly there? /cc @dliubarskyi 

Finally I'm struggling to find a way to properly test this feature, so any suggestion about this will be also very welcome.

/cc @jmartisk @geoand 