### PR TITLE
Prevent infinite loop when using tool-choice in watsonx.ai

### DIFF
--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/AiChatServiceTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/AiChatServiceTest.java
@@ -6,6 +6,7 @@ import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.DEFAULT
 import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.PROJECT_ID;
 import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.RESPONSE_WATSONX_CHAT_API;
 import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.RESPONSE_WATSONX_CHAT_STREAMING_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.RESPONSE_WATSONX_CHAT_STREAMING_TOOLS_API;
 import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_IAM_SERVER;
 import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_CHAT_API;
 import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_CHAT_STREAMING_API;
@@ -322,67 +323,7 @@ public class AiChatServiceTest extends WireMockAbstract {
                 .body(mapper.writeValueAsString(generateChatRequest(STARTED, tools)))
                 .responseMediaType(MediaType.SERVER_SENT_EVENTS)
                 .scenario(Scenario.STARTED, "TOOL_CALL")
-                .response(
-                        """
-                                id: 1
-                                event: message
-                                data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[{"index":0,"finish_reason":null,"delta":{"role":"assistant"}}],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.490Z","usage":{"prompt_tokens":84,"total_tokens":84},"system":{"warnings":[{"message":"This model is a Non-IBM Product governed by a third-party license that may impose use restrictions and other obligations. By using this model you agree to its terms as identified in the following URL.","id":"disclaimer_warning","more_info":"https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models.html?context=wx"},{"message":"The value of 'max_tokens' for this model was set to value 1024","id":"unspecified_max_token","additional_properties":{"limit":0,"new_value":1024,"parameter":"max_tokens","value":0}}]}}
-
-                                id: 2
-                                event: message
-                                data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[{"index":0,"finish_reason":null,"delta":{"tool_calls":[{"index":0,"id":"chatcmpl-tool-7cf5dfd7c52441e59a7585243b22a86a","type":"function","function":{"name":"","arguments":""}}]}}],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.546Z","usage":{"completion_tokens":4,"prompt_tokens":84,"total_tokens":88}}
-
-                                id: 3
-                                event: message
-                                data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[{"index":0,"finish_reason":null,"delta":{"tool_calls":[{"index":0,"function":{"name":"sum","arguments":""}}]}}],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.620Z","usage":{"completion_tokens":8,"prompt_tokens":84,"total_tokens":92}}
-
-                                id: 4
-                                event: message
-                                data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[{"index":0,"finish_reason":null,"delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":"{\\\"first\\\": 1"}}]}}],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.768Z","usage":{"completion_tokens":16,"prompt_tokens":84,"total_tokens":100}}
-
-                                id: 5
-                                event: message
-                                data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[{"index":0,"finish_reason":null,"delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":""}}]}}],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.786Z","usage":{"completion_tokens":17,"prompt_tokens":84,"total_tokens":101}}
-
-                                id: 6
-                                event: message
-                                data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[{"index":0,"finish_reason":null,"delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":""}}]}}],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.805Z","usage":{"completion_tokens":18,"prompt_tokens":84,"total_tokens":102}}
-
-                                id: 7
-                                event: message
-                                data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[{"index":0,"finish_reason":null,"delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":""}}]}}],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.823Z","usage":{"completion_tokens":19,"prompt_tokens":84,"total_tokens":103}}
-
-                                id: 8
-                                event: message
-                                data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[{"index":0,"finish_reason":null,"delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":""}}]}}],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.842Z","usage":{"completion_tokens":20,"prompt_tokens":84,"total_tokens":104}}
-
-                                id: 9
-                                event: message
-                                data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[{"index":0,"finish_reason":null,"delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":""}}]}}],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.861Z","usage":{"completion_tokens":21,"prompt_tokens":84,"total_tokens":105}}
-
-                                id: 10
-                                event: message
-                                data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[{"index":0,"finish_reason":null,"delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":", \\\"second\\\": 1"}}]}}],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.879Z","usage":{"completion_tokens":22,"prompt_tokens":84,"total_tokens":106}}
-
-                                id: 11
-                                event: message
-                                data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[{"index":0,"finish_reason":null,"delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":""}}]}}],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.897Z","usage":{"completion_tokens":23,"prompt_tokens":84,"total_tokens":107}}
-
-                                id: 12
-                                event: message
-                                data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[{"index":0,"finish_reason":null,"delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":""}}]}}],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.916Z","usage":{"completion_tokens":24,"prompt_tokens":84,"total_tokens":108}}
-
-                                id: 13
-                                event: message
-                                data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[{"index":0,"finish_reason":"tool_calls","delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":"}"}}]}}],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.934Z","usage":{"completion_tokens":25,"prompt_tokens":84,"total_tokens":109}}
-
-                                id: 14
-                                event: message
-                                data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.935Z","usage":{"completion_tokens":25,"prompt_tokens":84,"total_tokens":109}}
-
-                                id: 15
-                                event: close
-                                """)
+                .response(RESPONSE_WATSONX_CHAT_STREAMING_TOOLS_API)
                 .build();
 
         var TOOL_CALL = List.<TextChatMessage> of(

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ToolChoiceTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ToolChoiceTest.java
@@ -1,0 +1,210 @@
+package io.quarkiverse.langchain4j.watsonx.deployment;
+
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.API_KEY;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.BEARER_TOKEN;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.DEFAULT_TIME_LIMIT;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.PROJECT_ID;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_IAM_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_CHAT_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_SERVER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Date;
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.watsonx.bean.TextChatMessage;
+import io.quarkiverse.langchain4j.watsonx.bean.TextChatMessage.TextChatMessageAssistant;
+import io.quarkiverse.langchain4j.watsonx.bean.TextChatMessage.TextChatMessageSystem;
+import io.quarkiverse.langchain4j.watsonx.bean.TextChatMessage.TextChatMessageTool;
+import io.quarkiverse.langchain4j.watsonx.bean.TextChatMessage.TextChatMessageUser;
+import io.quarkiverse.langchain4j.watsonx.bean.TextChatMessage.TextChatParameterTool;
+import io.quarkiverse.langchain4j.watsonx.bean.TextChatMessage.TextChatToolCall;
+import io.quarkiverse.langchain4j.watsonx.bean.TextChatParameters;
+import io.quarkiverse.langchain4j.watsonx.bean.TextChatRequest;
+import io.quarkiverse.langchain4j.watsonx.runtime.config.ChatModelConfig;
+import io.quarkiverse.langchain4j.watsonx.runtime.config.LangChain4jWatsonxConfig;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.common.annotation.Blocking;
+
+public class ToolChoiceTest extends WireMockAbstract {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", URL_WATSONX_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", URL_IAM_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", PROJECT_ID)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.tool-choice", "sum")
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class).addClasses(WireMockUtil.class, Calculator.class));
+
+    @Override
+    void handlerBeforeEach() {
+        mockIAMBuilder(200)
+                .grantType(langchain4jWatsonConfig.defaultConfig().iam().grantType())
+                .response(BEARER_TOKEN, new Date())
+                .build();
+    }
+
+    static ToolSpecification tool = ToolSpecification.builder()
+            .description("Execute the sum of two numbers")
+            .name("sum")
+            .parameters(
+                    JsonObjectSchema.builder()
+                            .addIntegerProperty("first")
+                            .addIntegerProperty("second")
+                            .required("first", "second")
+                            .build())
+            .build();
+
+    @Singleton
+    @RegisterAiService(tools = Calculator.class)
+    @SystemMessage("This is a systemMessage")
+    interface AIService {
+        String chat(@MemoryId String memoryId, @UserMessage String text);
+    }
+
+    @Singleton
+    static class Calculator {
+        @Tool("Execute the sum of two numbers")
+        @Blocking
+        public int sum(int first, int second) {
+            return first + second;
+        }
+    }
+
+    @Inject
+    AIService aiService;
+
+    @Test
+    void chat() throws Exception {
+
+        var toolExecutionRequest = ToolExecutionRequest.builder()
+                .name("sum")
+                .id("chatcmpl-tool-3f621ce6ad9240da963d661215621711")
+                .arguments("{\"first\":1, \"second\":1}")
+                .build();
+
+        var firstCallChatMessages = List.<TextChatMessage> of(
+                TextChatMessageSystem.of("This is a systemMessage"),
+                TextChatMessageUser.of("Execute the sum of 1 + 1"));
+
+        var firstCallParameters = generateChatRequest(firstCallChatMessages, List.of(TextChatParameterTool.of(tool)), true);
+
+        mockWatsonxBuilder(URL_WATSONX_CHAT_API, 200)
+                .body(mapper.writeValueAsString(firstCallParameters))
+                .scenario(Scenario.STARTED, "TOOL_CALL")
+                .response("""
+                            {
+                                "id": "chat-2e8d342d8ced41d89c0ff4efd32b3f9d",
+                                "model_id": "mistralai/mistral-large",
+                                "choices": [{
+                                    "index": 0,
+                                    "message": {
+                                        "role": "assistant",
+                                        "tool_calls": [
+                                            {
+                                                "id": "chatcmpl-tool-3f621ce6ad9240da963d661215621711",
+                                                "type": "function",
+                                                "function": {
+                                                    "name": "sum",
+                                                    "arguments": "{\\\"first\\\":1, \\\"second\\\":1}"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "finish_reason": "tool_calls"
+                                }],
+                                "created": 1728808696,
+                                "model_version": "2.0.0",
+                                "created_at": "2024-10-13T08:38:16.960Z",
+                                "usage": {
+                                    "completion_tokens": 25,
+                                    "prompt_tokens": 84,
+                                    "total_tokens": 109
+                                }
+                        }""")
+                .build();
+
+        var toolExecutionResultMessage = ToolExecutionResultMessage.from(toolExecutionRequest, "2");
+
+        var secondCallChatMessages = List.<TextChatMessage> of(
+                TextChatMessageSystem.of("This is a systemMessage"),
+                TextChatMessageUser.of("Execute the sum of 1 + 1"),
+                TextChatMessageAssistant.of(List.of(TextChatToolCall.of(toolExecutionRequest))),
+                TextChatMessageTool.of(toolExecutionResultMessage));
+
+        var secondCallParameters = generateChatRequest(secondCallChatMessages, null, false);
+
+        mockWatsonxBuilder(URL_WATSONX_CHAT_API, 200)
+                .body(mapper.writeValueAsString(secondCallParameters))
+                .scenario("TOOL_CALL", "AI_RESPONSE")
+                .response("""
+                        {
+                            "id": "cmpl-15475d0dea9b4429a55843c77997f8a9",
+                            "model_id": "mistralai/mistral-large",
+                            "created": 1728806666,
+                            "created_at": "2024-10-13T08:04:26.200Z",
+                            "choices": [{
+                                "index": 0,
+                                "message": {
+                                    "role": "assistant",
+                                    "content": "The result is 2"
+                                },
+                                "finish_reason": "stop"
+                            }],
+                            "usage": {
+                                "completion_tokens": 47,
+                                "prompt_tokens": 59,
+                                "total_tokens": 106
+                            }
+                        }""")
+                .build();
+
+        var result = aiService.chat("myId", "Execute the sum of 1 + 1");
+        assertEquals("The result is 2", result);
+    }
+
+    private TextChatRequest generateChatRequest(List<TextChatMessage> messages, List<TextChatParameterTool> tools,
+            boolean withToolChoice) {
+        LangChain4jWatsonxConfig.WatsonConfig watsonConfig = langchain4jWatsonConfig.defaultConfig();
+        ChatModelConfig chatModelConfig = watsonConfig.chatModel();
+        String modelId = chatModelConfig.modelId();
+        String spaceId = watsonConfig.spaceId().orElse(null);
+        String projectId = watsonConfig.projectId().orElse(null);
+
+        TextChatParameters.Builder builder = TextChatParameters.builder()
+                .frequencyPenalty(0.0)
+                .logprobs(false)
+                .maxTokens(1024)
+                .n(1)
+                .presencePenalty(0.0)
+                .temperature(1.0)
+                .topP(1.0)
+                .timeLimit(DEFAULT_TIME_LIMIT);
+
+        if (withToolChoice)
+            builder.toolChoice("sum");
+
+        return new TextChatRequest(modelId, spaceId, projectId, messages, tools, builder.build());
+    }
+}

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/WireMockUtil.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/WireMockUtil.java
@@ -206,6 +206,66 @@ public class WireMockUtil {
               }
             }
             """;
+    public static final String RESPONSE_WATSONX_CHAT_STREAMING_TOOLS_API = """
+            id: 1
+            event: message
+            data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[{"index":0,"finish_reason":null,"delta":{"role":"assistant"}}],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.490Z","usage":{"prompt_tokens":84,"total_tokens":84},"system":{"warnings":[{"message":"This model is a Non-IBM Product governed by a third-party license that may impose use restrictions and other obligations. By using this model you agree to its terms as identified in the following URL.","id":"disclaimer_warning","more_info":"https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models.html?context=wx"},{"message":"The value of 'max_tokens' for this model was set to value 1024","id":"unspecified_max_token","additional_properties":{"limit":0,"new_value":1024,"parameter":"max_tokens","value":0}}]}}
+
+            id: 2
+            event: message
+            data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[{"index":0,"finish_reason":null,"delta":{"tool_calls":[{"index":0,"id":"chatcmpl-tool-7cf5dfd7c52441e59a7585243b22a86a","type":"function","function":{"name":"","arguments":""}}]}}],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.546Z","usage":{"completion_tokens":4,"prompt_tokens":84,"total_tokens":88}}
+
+            id: 3
+            event: message
+            data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[{"index":0,"finish_reason":null,"delta":{"tool_calls":[{"index":0,"function":{"name":"sum","arguments":""}}]}}],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.620Z","usage":{"completion_tokens":8,"prompt_tokens":84,"total_tokens":92}}
+
+            id: 4
+            event: message
+            data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[{"index":0,"finish_reason":null,"delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":"{\\\"first\\\": 1"}}]}}],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.768Z","usage":{"completion_tokens":16,"prompt_tokens":84,"total_tokens":100}}
+
+            id: 5
+            event: message
+            data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[{"index":0,"finish_reason":null,"delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":""}}]}}],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.786Z","usage":{"completion_tokens":17,"prompt_tokens":84,"total_tokens":101}}
+
+            id: 6
+            event: message
+            data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[{"index":0,"finish_reason":null,"delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":""}}]}}],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.805Z","usage":{"completion_tokens":18,"prompt_tokens":84,"total_tokens":102}}
+
+            id: 7
+            event: message
+            data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[{"index":0,"finish_reason":null,"delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":""}}]}}],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.823Z","usage":{"completion_tokens":19,"prompt_tokens":84,"total_tokens":103}}
+
+            id: 8
+            event: message
+            data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[{"index":0,"finish_reason":null,"delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":""}}]}}],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.842Z","usage":{"completion_tokens":20,"prompt_tokens":84,"total_tokens":104}}
+
+            id: 9
+            event: message
+            data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[{"index":0,"finish_reason":null,"delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":""}}]}}],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.861Z","usage":{"completion_tokens":21,"prompt_tokens":84,"total_tokens":105}}
+
+            id: 10
+            event: message
+            data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[{"index":0,"finish_reason":null,"delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":", \\\"second\\\": 1"}}]}}],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.879Z","usage":{"completion_tokens":22,"prompt_tokens":84,"total_tokens":106}}
+
+            id: 11
+            event: message
+            data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[{"index":0,"finish_reason":null,"delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":""}}]}}],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.897Z","usage":{"completion_tokens":23,"prompt_tokens":84,"total_tokens":107}}
+
+            id: 12
+            event: message
+            data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[{"index":0,"finish_reason":null,"delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":""}}]}}],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.916Z","usage":{"completion_tokens":24,"prompt_tokens":84,"total_tokens":108}}
+
+            id: 13
+            event: message
+            data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[{"index":0,"finish_reason":"tool_calls","delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":"}"}}]}}],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.934Z","usage":{"completion_tokens":25,"prompt_tokens":84,"total_tokens":109}}
+
+            id: 14
+            event: message
+            data: {"id":"chat-188595e69470446fb1740c98acfdfe12","model_id":"mistralai/mistral-large","choices":[],"created":1728811250,"model_version":"2.0.0","created_at":"2024-10-13T09:20:50.935Z","usage":{"completion_tokens":25,"prompt_tokens":84,"total_tokens":109}}
+
+            id: 15
+            event: close
+            """;
 
     public static StreamingChatResponseHandler streamingChatResponseHandler(AtomicReference<ChatResponse> streamingResponse) {
         return new StreamingChatResponseHandler() {

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxChatModel.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxChatModel.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.langchain4j.watsonx;
 
 import static io.quarkiverse.langchain4j.watsonx.WatsonxUtils.retryOn;
+import static java.util.Objects.nonNull;
 
 import java.util.List;
 import java.util.Set;
@@ -8,6 +9,8 @@ import java.util.concurrent.Callable;
 
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.model.chat.Capability;
 import dev.langchain4j.model.chat.ChatLanguageModel;
@@ -83,8 +86,29 @@ public class WatsonxChatModel extends Watsonx implements ChatLanguageModel {
                 ? toolSpecifications.stream().map(TextChatParameterTool::of).toList()
                 : null;
 
-        TextChatRequest request = new TextChatRequest(modelId, spaceId, projectId, messages, tools,
-                TextChatParameters.convert(parameters));
+        TextChatParameters textChatParameters = TextChatParameters.convert(parameters);
+
+        if (nonNull(parameters.toolChoice()) && parameters.toolChoice().equals(ToolChoice.REQUIRED) && messages.size() > 0) {
+            // This code is needed to avoid a infinite-loop when using the AiService
+            // in combination with the tool-choice option.
+            // If the tool-choice option is not removed after calling the tool,
+            // the model may continuously reselect the same tool in subsequent responses,
+            // even though the tool has already been invoked. This leads to an infinite loop
+            // where the assistant keeps generating tool calls without progressing the conversation.
+            // By explicitly removing the tool-choice field after the tool has been executed,
+            // we allow the assistant to resume normal message generation and provide a response
+            // based on the tool output instead of redundantly triggering it again.
+
+            int LAST_MESSAGE = chatRequest.messages().size() - 1;
+            ChatMessage lastMessage = chatRequest.messages().get(LAST_MESSAGE);
+            if (lastMessage instanceof ToolExecutionResultMessage) {
+                tools = null;
+                textChatParameters.cleanToolChoice();
+            }
+        }
+
+        TextChatRequest request = new TextChatRequest(modelId, spaceId, projectId, messages, tools, textChatParameters);
+
         TextChatResponse response = retryOn(new Callable<TextChatResponse>() {
             @Override
             public TextChatResponse call() throws Exception {

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/bean/TextChatMessage.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/bean/TextChatMessage.java
@@ -6,6 +6,7 @@ import static java.util.Objects.isNull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
@@ -272,6 +273,10 @@ public sealed interface TextChatMessage
         }
 
         public TextChatToolCall build() {
+            // Watsonx doesn't return "id" if the option tool-choice is set to REQUIRED.
+            if (isNull(id)) {
+                this.id = UUID.randomUUID().toString();
+            }
             return new TextChatToolCall(index, id, type, new TextChatFunctionCall(name, arguments.toString()));
         }
     }

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/bean/TextChatParameters.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/bean/TextChatParameters.java
@@ -26,8 +26,8 @@ public class TextChatParameters {
         }
     };
 
-    private final String toolChoiceOption;
-    private final TextChatToolChoiceTool toolChoice;
+    private String toolChoiceOption;
+    private TextChatToolChoiceTool toolChoice;
     private final Double frequencyPenalty;
     private final Map<String, Integer> logitBias;
     private final Boolean logprobs;
@@ -126,6 +126,11 @@ public class TextChatParameters {
         }
 
         return builder.build();
+    }
+
+    public void cleanToolChoice() {
+        this.toolChoiceOption = null;
+        this.toolChoice = null;
     }
 
     public String getToolChoiceOption() {


### PR DESCRIPTION
This commit avoids an infinite loop when a developer uses the `tool-choice` option.  The fix is for the `watsonx.ai` module, but maybe this can also affect other models in `quarkus-langchain4j` and could be something to move in the core part.

I've done a quick fix in `watsonx.ai` because I'm working on a project and I need to use the `tool-choice` in the next few days.
Let's understand if this is something that can be moved to the core or if it is a problem specific to the watsonx.ai module.