### PR TITLE
Update watsonx.ai defaults and add tool choice configuration

### DIFF
--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ChatAllPropertiesTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ChatAllPropertiesTest.java
@@ -86,7 +86,8 @@ public class ChatAllPropertiesTest extends WireMockAbstract {
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.temperature", "1.5")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.top-p", "0.5")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.response-format", "json_object")
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.tool-choice", "myfunction")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.tool-choice", "required")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.tool-choice-name", "myfunction")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.built-in-service.log-requests", "true")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.built-in-service.log-responses", "true")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
@@ -149,7 +150,8 @@ public class ChatAllPropertiesTest extends WireMockAbstract {
         assertEquals(1.5, runtimeConfig.chatModel().temperature());
         assertEquals(0.5, runtimeConfig.chatModel().topP());
         assertEquals("json_object", runtimeConfig.chatModel().responseFormat().orElse(null));
-        assertEquals("myfunction", runtimeConfig.chatModel().toolChoice().orElse(null));
+        assertEquals(ToolChoice.REQUIRED, runtimeConfig.chatModel().toolChoice().orElse(null));
+        assertEquals("myfunction", runtimeConfig.chatModel().toolChoiceName().orElse(null));
         assertEquals(true, langchain4jWatsonConfig.builtInService().logRequests().orElse(false));
         assertEquals(true, langchain4jWatsonConfig.builtInService().logResponses().orElse(false));
     }

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ToolChoiceNameTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ToolChoiceNameTest.java
@@ -45,7 +45,7 @@ import io.quarkiverse.langchain4j.watsonx.runtime.config.LangChain4jWatsonxConfi
 import io.quarkus.test.QuarkusUnitTest;
 import io.smallrye.common.annotation.Blocking;
 
-public class ToolChoiceTest extends WireMockAbstract {
+public class ToolChoiceNameTest extends WireMockAbstract {
 
     @RegisterExtension
     static QuarkusUnitTest unitTest = new QuarkusUnitTest()
@@ -53,7 +53,7 @@ public class ToolChoiceTest extends WireMockAbstract {
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", URL_IAM_SERVER)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", API_KEY)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", PROJECT_ID)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.tool-choice", "required")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.tool-choice-name", "sum")
             .setArchiveProducer(
                     () -> ShrinkWrap.create(JavaArchive.class).addClasses(WireMockUtil.class, Calculator.class));
 
@@ -185,7 +185,7 @@ public class ToolChoiceTest extends WireMockAbstract {
     }
 
     private TextChatRequest generateChatRequest(List<TextChatMessage> messages, List<TextChatParameterTool> tools,
-            boolean toolChoiceOptionIsRequired) {
+            boolean withToolChoice) {
         LangChain4jWatsonxConfig.WatsonConfig watsonConfig = langchain4jWatsonConfig.defaultConfig();
         ChatModelConfig chatModelConfig = watsonConfig.chatModel();
         String modelId = chatModelConfig.modelId();
@@ -202,8 +202,8 @@ public class ToolChoiceTest extends WireMockAbstract {
                 .topP(1.0)
                 .timeLimit(DEFAULT_TIME_LIMIT);
 
-        if (toolChoiceOptionIsRequired)
-            builder.toolChoiceOption("required");
+        if (withToolChoice)
+            builder.toolChoice("sum");
 
         return new TextChatRequest(modelId, spaceId, projectId, messages, tools, builder.build());
     }

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ToolChoiceNameToolNotFoundTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ToolChoiceNameToolNotFoundTest.java
@@ -1,0 +1,73 @@
+package io.quarkiverse.langchain4j.watsonx.deployment;
+
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.API_KEY;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.BEARER_TOKEN;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.PROJECT_ID;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.RESPONSE_WATSONX_CHAT_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_IAM_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_CHAT_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_SERVER;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Date;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ToolChoiceNameToolNotFoundTest extends WireMockAbstract {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", URL_WATSONX_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", URL_IAM_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", PROJECT_ID)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.tool-choice-name", "mytool")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
+
+    @Override
+    void handlerBeforeEach() {
+        mockIAMBuilder(200)
+                .grantType(langchain4jWatsonConfig.defaultConfig().iam().grantType())
+                .response(BEARER_TOKEN, new Date())
+                .build();
+    }
+
+    @Inject
+    ChatLanguageModel model;
+
+    @Test
+    void test() {
+
+        mockWatsonxBuilder(URL_WATSONX_CHAT_API, 200)
+                .response(RESPONSE_WATSONX_CHAT_API)
+                .build();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> model.chat(ChatRequest.builder().messages(UserMessage.from("test")).build()),
+                "If tool-choice-name is set, at least one tool must be specified.");
+
+        assertThrows(IllegalArgumentException.class,
+                () -> model.chat(ChatRequest
+                        .builder()
+                        .messages(UserMessage.from("test"))
+                        .parameters(
+                                ChatRequestParameters.builder()
+                                        .toolSpecifications(ToolSpecification.builder().name("sum").build())
+                                        .build())
+                        .build()),
+                "The tool with name 'mytool' is not available in the list of tools sent to the model. Tool lists: [sum]");
+    }
+
+}

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ToolChoiceToolNotFoundTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ToolChoiceToolNotFoundTest.java
@@ -18,14 +18,12 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
-import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import io.quarkus.test.QuarkusUnitTest;
 
-public class ToolNotFoundTest extends WireMockAbstract {
+public class ToolChoiceToolNotFoundTest extends WireMockAbstract {
 
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
@@ -33,7 +31,7 @@ public class ToolNotFoundTest extends WireMockAbstract {
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", URL_IAM_SERVER)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", API_KEY)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", PROJECT_ID)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.tool-choice", "mytool")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.tool-choice", "required")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
 
     @Override
@@ -57,17 +55,5 @@ public class ToolNotFoundTest extends WireMockAbstract {
         assertThrows(IllegalArgumentException.class,
                 () -> model.chat(ChatRequest.builder().messages(UserMessage.from("test")).build()),
                 "If tool-choice is 'REQUIRED', at least one tool must be specified.");
-
-        assertThrows(IllegalArgumentException.class,
-                () -> model.chat(ChatRequest
-                        .builder()
-                        .messages(UserMessage.from("test"))
-                        .parameters(
-                                ChatRequestParameters.builder()
-                                        .toolSpecifications(ToolSpecification.builder().name("sum").build())
-                                        .build())
-                        .build()),
-                "The tool with name 'mytool' is not available in the list of tools sent to the model. Tool lists: [sum]");
     }
-
 }

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/WireMockUtil.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/WireMockUtil.java
@@ -38,9 +38,9 @@ public class WireMockUtil {
     public static final String BEARER_TOKEN = "my_super_token";
     public static final String PROJECT_ID = "123123321321";
     public static final String GRANT_TYPE = "urn:ibm:params:oauth:grant-type:apikey";
-    public static final String VERSION = "2024-03-14";
-    public static final String DEFAULT_CHAT_MODEL = "mistralai/mistral-large";
-    public static final String DEFAULT_EMBEDDING_MODEL = "ibm/slate-125m-english-rtrvr";
+    public static final String VERSION = "2025-04-23";
+    public static final String DEFAULT_CHAT_MODEL = "meta-llama/llama-4-maverick-17b-128e-instruct-fp8";
+    public static final String DEFAULT_EMBEDDING_MODEL = "ibm/granite-embedding-278m-multilingual";
     public static final String DEFAULT_SCORING_MODEL = "cross-encoder/ms-marco-minilm-l-12-v2";
     public static final String IAM_200_RESPONSE = """
             {

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxChatModel.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/WatsonxChatModel.java
@@ -35,14 +35,6 @@ import io.quarkiverse.langchain4j.watsonx.bean.TextChatResponse.TextChatUsage;
 
 public class WatsonxChatModel extends Watsonx implements ChatLanguageModel {
 
-    private static final String ID_CONTEXT = "ID";
-    private static final String MODEL_ID_CONTEXT = "MODEL_ID";
-    private static final String USAGE_CONTEXT = "USAGE";
-    private static final String FINISH_REASON_CONTEXT = "FINISH_REASON";
-    private static final String ROLE_CONTEXT = "ROLE";
-    private static final String TOOLS_CONTEXT = "TOOLS";
-    private static final String COMPLETE_MESSAGE_CONTEXT = "COMPLETE_MESSAGE";
-
     private final WatsonxChatRequestParameters defaultRequestParameters;
 
     public WatsonxChatModel(Builder builder) {
@@ -88,7 +80,8 @@ public class WatsonxChatModel extends Watsonx implements ChatLanguageModel {
 
         TextChatParameters textChatParameters = TextChatParameters.convert(parameters);
 
-        if (nonNull(parameters.toolChoice()) && parameters.toolChoice().equals(ToolChoice.REQUIRED) && messages.size() > 0) {
+        if (nonNull(parameters.toolChoice()) && parameters.toolChoice().equals(ToolChoice.REQUIRED)
+                && messages.size() > 0) {
             // This code is needed to avoid a infinite-loop when using the AiService
             // in combination with the tool-choice option.
             // If the tool-choice option is not removed after calling the tool,

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/EmbeddingModelConfig.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/EmbeddingModelConfig.java
@@ -10,25 +10,28 @@ import io.smallrye.config.WithDefault;
 public interface EmbeddingModelConfig {
 
     /**
-     * The id of the model to be used.
+     * Specifies the ID of the model to be used.
      * <p>
-     * All available models are listed in the IBM Watsonx.ai documentation at the <a href="
-     * https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models-embed.html?context=wx&audience=wdp#ibm-provided">following
+     * A list of all available models is provided in the IBM watsonx.ai documentation at the
+     * <a href=
+     * "https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models-embed.html?context=wx&audience=wdp#ibm-provided">this
      * link</a>.
      * <p>
-     * To use a model, locate the <code>API model_id</code> column in the table and copy the corresponding model ID.
+     * To use a model, locate the <code>API model ID</code> column in the table and copy the corresponding model ID.
      */
-    @WithDefault("ibm/slate-125m-english-rtrvr")
+    @WithDefault("ibm/granite-embedding-278m-multilingual")
     String modelId();
 
     /**
-     * Represents the maximum number of input tokens accepted. This can be used to avoid requests failing due to input being
-     * longer
-     * than configured limits. If the text is truncated, then it truncates the end of the input (on the right), so the start of
-     * the
-     * input will remain the same. If this value exceeds the maximum sequence length (refer to the documentation to find this
-     * value
-     * for the model) then the call will fail if the total number of tokens exceeds the maximum sequence length.
+     * Specifies the maximum number of input tokens accepted. This can be used to prevent requests from failing due to input
+     * exceeding the configured
+     * token limits.
+     * <p>
+     * If the input exceeds the specified token limit, the input will be truncated from the end (right side), ensuring that the
+     * start of the input remains
+     * intact. If the provided value exceeds the model's maximum sequence length (refer to the documentation for the model's
+     * maximum sequence length), the
+     * request will fail if the total number of tokens exceeds the maximum limit.
      */
     Optional<Integer> truncateInputTokens();
 

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/GenerationModelConfig.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/GenerationModelConfig.java
@@ -19,7 +19,7 @@ public interface GenerationModelConfig {
      * <p>
      * To use a model, locate the <code>API model_id</code> column in the table and copy the corresponding model ID.
      */
-    @WithDefault("mistralai/mistral-large")
+    @WithDefault("meta-llama/llama-4-maverick-17b-128e-instruct-fp8")
     String modelId();
 
     /**
@@ -145,14 +145,12 @@ public interface GenerationModelConfig {
      * Whether chat model requests should be logged.
      */
     @ConfigDocDefault("false")
-    @WithDefault("${quarkus.langchain4j.watsonx.log-requests}")
     Optional<Boolean> logRequests();
 
     /**
      * Whether chat model responses should be logged.
      */
     @ConfigDocDefault("false")
-    @WithDefault("${quarkus.langchain4j.watsonx.log-responses}")
     Optional<Boolean> logResponses();
 
     /**

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/LangChain4jWatsonxConfig.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/LangChain4jWatsonxConfig.java
@@ -42,11 +42,12 @@ public interface LangChain4jWatsonxConfig {
 
     @ConfigGroup
     interface WatsonConfig {
+
         /**
-         * Base URL of the watsonx.ai API.
+         * Specifies the base URL of the watsonx.ai API.
          * <p>
-         * All available URLs are listed in the IBM Watsonx.ai documentation at the
-         * <a href="https://cloud.ibm.com/apidocs/watsonx-ai#endpoint-url">following link</a>.
+         * A list of all available URLs is provided in the IBM Watsonx.ai documentation at the
+         * <a href="https://cloud.ibm.com/apidocs/watsonx-ai#endpoint-url">this link</a>.
          */
         Optional<String> baseUrl();
 
@@ -65,7 +66,7 @@ public interface LangChain4jWatsonxConfig {
         /**
          * The version date for the API of the form YYYY-MM-DD.
          */
-        @WithDefault("2024-03-14")
+        @WithDefault("2025-04-23")
         String version();
 
         /**

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/ScoringModelConfig.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/ScoringModelConfig.java
@@ -22,13 +22,14 @@ public interface ScoringModelConfig {
     String modelId();
 
     /**
-     * Represents the maximum number of input tokens accepted. This can be used to avoid requests failing due to input being
-     * longer
-     * than configured limits. If the text is truncated, then it truncates the end of the input (on the right), so the start of
-     * the
-     * input will remain the same. If this value exceeds the maximum sequence length (refer to the documentation to find this
-     * value
-     * for the model) then the call will fail if the total number of tokens exceeds the maximum sequence length.
+     * Specifies the maximum number of input tokens accepted. This helps to avoid requests failing due to input exceeding the
+     * configured token limits.
+     * <p>
+     * If the input exceeds the specified token limit, the text will be truncated from the end (right side), ensuring that the
+     * start of the input remains
+     * intact. If the provided value exceeds the model's maximum sequence length (refer to the documentation for the model's
+     * maximum sequence length), the
+     * request will fail if the total number of tokens exceeds the maximum limit.
      */
     Optional<Integer> truncateInputTokens();
 


### PR DESCRIPTION
This commit updates default configurations:
- **chat-model.model-id** from `mistralai/mistral-large` to `meta-llama/llama-4-maverick-17b-128e-instruct-fp8`
- **embedding-model.model-id** from `ibm/slate-125m-english-rtrvr` to `ibm/granite-embedding-278m-multilingual`
- **api version** from `2024-03-14` to `2025-04-23`

It also adds support for:
- Tool invocation control via `tool-choice` (auto or required) and `tool-choice-name` (forces a specific tool, overriding `tool-choice`)
- Inheritable fields: `timeout`, `log-requests`, and `log-responses`