### PR TITLE
Make MCP Client Health check actually optional

### DIFF
--- a/mcp/deployment/src/main/java/io/quarkiverse/langchain4j/mcp/deployment/McpProcessor.java
+++ b/mcp/deployment/src/main/java/io/quarkiverse/langchain4j/mcp/deployment/McpProcessor.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.service.tool.ToolProvider;
+import io.quarkiverse.langchain4j.mcp.runtime.McpClientHealthCheck;
 import io.quarkiverse.langchain4j.mcp.runtime.McpClientName;
 import io.quarkiverse.langchain4j.mcp.runtime.McpRecorder;
 import io.quarkiverse.langchain4j.mcp.runtime.config.LocalLaunchParams;
@@ -159,7 +160,7 @@ public class McpProcessor {
             }
             // generate a health check
             if (mcpBuildTimeConfiguration.mpHealthEnabled()) {
-                healthBuildItems.produce(new HealthBuildItem("io.quarkiverse.langchain4j.mcp.runtime.McpClientHealthCheck",
+                healthBuildItems.produce(new HealthBuildItem(McpClientHealthCheck.class.getName(),
                         true));
             }
         }

--- a/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/McpClientHealthCheck.java
+++ b/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/McpClientHealthCheck.java
@@ -4,7 +4,6 @@ import java.lang.annotation.Annotation;
 import java.util.HashMap;
 import java.util.Map;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Any;
 
 import org.eclipse.microprofile.health.HealthCheck;
@@ -17,11 +16,10 @@ import io.quarkus.arc.Arc;
 import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.InstanceHandle;
 
-@ApplicationScoped
 @Readiness
 public class McpClientHealthCheck implements HealthCheck {
 
-    private Map<String, McpClient> clientMap;
+    private final Map<String, McpClient> clientMap;
 
     public McpClientHealthCheck() {
         clientMap = getClientMap();


### PR DESCRIPTION
This is needed to avoid warnings at both build time and runtime which stemmed from the fact that the
health check was previously always a bean.

The build time warnings were like:

```
2025-05-12 16:07:09,173 WARN  [io.qua.arc.pro.BeanArchives] (build-40) Failed to index org.eclipse.microprofile.health.HealthCheck: Class does not exist in ClassLoader QuarkusClassLoader:Deployment Class Loader: DEV for quarkus-langchain4j-sample-mcp-client-1.0-SNAPSHOT@5be49b60
2025-05-12 16:07:50,576 INFO  [io.qua.arc.pro.IndexClassLookupUtils] (build-40) Class for name: org.eclipse.microprofile.health.HealthCheck was not found in Jandex index. Please ensure the class is part of the index.
```

and the runtime ones:

```
2025-05-12 16:07:51,180 WARN  [io.qua.arc.ComponentsProvider] (Quarkus Main Thread) Unable to load removed bean type [io.quarkiverse.langchain4j.mcp.runtime.McpClientHealthCheck]: java.lang.NoClassDefFoundError: org/eclipse/microprofile/health/HealthCheck
```

FWIW, in a lot of core extensions in Quarkus this is not an issue because those extensions do **not** include an empty `beans.xml` file.