### PR TITLE
Add DeepWiki badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Quarkus LangChain4j
 
 [![Version](https://img.shields.io/maven-central/v/io.quarkiverse.langchain4j/quarkus-langchain4j-parent?logo=apache-maven&style=flat-square)](https://search.maven.org/artifact/io.quarkiverse.langchain4j/quarkus-langchain4j)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/quarkiverse/quarkus-langchain4j)
 
 This repository contains Quarkus extensions that facilitate seamless integration between Quarkus and [LangChain4j](https://github.com/langchain4j/langchain4j), enabling easy incorporation of Large Language Models (LLMs) into your Quarkus applications.
 


### PR DESCRIPTION
DeepWiki will update the [repo wiki](https://deepwiki.com/quarkiverse/quarkus-langchain4j) weekly if it sees a badge in the readme file.