### PR TITLE
Improve styles in Kotlin sample

### DIFF
--- a/samples/chatbot-easy-rag-kotlin/src/main/resources/META-INF/resources/components/demo-title.js
+++ b/samples/chatbot-easy-rag-kotlin/src/main/resources/META-INF/resources/components/demo-title.js
@@ -22,7 +22,7 @@ export class DemoTitle extends LitElement {
       .explanation {
         margin-left: auto;
         margin-right: auto;
-        width: 50%;
+        width: 90%;
         text-align: justify;
         font-size: 20px;
       }

--- a/samples/chatbot-easy-rag-kotlin/src/main/resources/META-INF/resources/index.html
+++ b/samples/chatbot-easy-rag-kotlin/src/main/resources/META-INF/resources/index.html
@@ -26,9 +26,7 @@
         body {
             margin: 0;
             width: 100%;
-            height: 100vh;
             font-family: 'Red Hat Text', sans-serif;
-            overflow: hidden;
             display: flex;
             flex-direction: column;
             justify-content: center;
@@ -44,6 +42,11 @@
             --chatbot-send-button-color: var(--main-highlight-text-color);
             --chatbot-container-width: 90vw;
             --chatbot-container-height: 90vh;
+        }
+
+        chat-bot::part(chat-bubble) {
+          font-size: 1.4em;
+          font-weight: bold;
         }
 
         .middle {


### PR DESCRIPTION
# Improve styles in Kotlin sample

Make it look better on demo screen

- Adjust demo-title explanation width to 90%
- Dropped `height: 100vh` and `overflow: hidden` to fix scrolling
- Increase text size in chat-bubble