### PR TITLE
Polish the secure-mcp-sse-client-server a bit

### DIFF
--- a/samples/mcp-sse-client-server/mcp-client/src/main/resources/application.properties
+++ b/samples/mcp-sse-client-server/mcp-client/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 quarkus.langchain4j.log-requests=true
 
-quarkus.langchain4j.mcp.generate-tool-provider.transport-type=http
-quarkus.langchain4j.mcp.generate-tool-provider.url=http://localhost:8081/mcp/sse/
+quarkus.langchain4j.mcp.weather.transport-type=http
+quarkus.langchain4j.mcp.weather.url=http://localhost:8081/mcp/sse/
 
 quarkus.http.port=8080
 


### PR DESCRIPTION
- `quarkus.langchain4j.mcp.generate-tool-provider.*` (naming a MCP client `generate-tool-provider`) is confusing  because it "clashes" with the property `quarkus.langchain4j.mcp.generate-tool-provider` that is not tied to any particular client
- `@McpToolBox` annotation without a value is only bloating the code and doesn't change anything