### PR TITLE
Avoid NPE for methods without @McpToolBox

### DIFF
--- a/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/QuarkusMcpToolProvider.java
+++ b/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/QuarkusMcpToolProvider.java
@@ -37,7 +37,10 @@ public class QuarkusMcpToolProvider extends McpToolProvider {
 
         @Override
         public boolean test(McpClient mcpClient, ToolSpecification tool) {
-            return keys.isEmpty() || keys.stream().anyMatch(name -> name.equals(mcpClient.key()));
+            // keys == null means no McpToolBox annotation, so no MCP clients, whereas
+            // keys.size() == 0 means all MCP clients
+            return keys != null
+                    && (keys.isEmpty() || keys.stream().anyMatch(name -> name.equals(mcpClient.key())));
         }
     }
 }


### PR DESCRIPTION
Fixes #1504 