### PR TITLE
Kotlin sample: Optimizations

### DIFF
--- a/samples/chatbot-easy-rag-kotlin/pom.xml
+++ b/samples/chatbot-easy-rag-kotlin/pom.xml
@@ -10,15 +10,15 @@
   <packaging>jar</packaging>
 
   <properties>
-    <compiler-plugin.version>3.13.0</compiler-plugin.version>
     <java.version>17</java.version>
     <skipITs>true</skipITs>
+    <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
     <kotlin.version>2.1.21</kotlin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.22.2</quarkus.platform.version>
+    <quarkus.platform.version>3.22.3</quarkus.platform.version>
     <kotest.version>5.9.1</kotest.version>
     <kotlinx-datetime.version>0.6.2</kotlinx-datetime.version>
     <quarkus-langchain4j.version>1.0.0.CR1</quarkus-langchain4j.version>
@@ -119,6 +119,11 @@
       <artifactId>kotlinx-datetime-jvm</artifactId>
       <version>${kotlinx-datetime.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-opentelemetry</artifactId>
+      <scope>runtime</scope>
+    </dependency>
 
     <!-- UI -->
     <dependency>
@@ -154,7 +159,7 @@
     <dependency>
       <groupId>me.kpavlov.aimocks</groupId>
       <artifactId>ai-mocks-openai-jvm</artifactId>
-      <version>0.3.5</version>
+      <version>0.4.0</version>
       <scope>test</scope>
     </dependency>
 
@@ -196,21 +201,10 @@
       <version>${kotest.version}</version>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
   <build>
     <sourceDirectory>src/main/kotlin</sourceDirectory>
     <testSourceDirectory>src/test/kotlin</testSourceDirectory>
-
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.14.0</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
 
     <plugins>
 
@@ -265,6 +259,16 @@
             <version>${kotlin.version}</version>
           </dependency>
         </dependencies>
+        <executions>
+          <execution>
+            <id>default-kapt</id>
+            <phase>none</phase>
+          </execution>
+          <execution>
+            <id>default-test-kapt</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
@@ -279,7 +283,7 @@
       <plugin>
         <groupId>io.smallrye</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.3.1</version>
         <executions>
           <execution>
             <id>make-index</id>

--- a/samples/chatbot-easy-rag-kotlin/src/main/resources/application-dev.properties
+++ b/samples/chatbot-easy-rag-kotlin/src/main/resources/application-dev.properties
@@ -3,8 +3,8 @@
 ## Debugging properties, should enver be set on production
 quarkus.langchain4j.openai.chat-model.log-responses=true
 quarkus.langchain4j.openai.chat-model.log-requests=true
-quarkus.langchain4j.mcp.*.log-requests=true
-quarkus.langchain4j.mcp.*.log-responses=true
+quarkus.langchain4j.mcp.time.log-requests=true
+quarkus.langchain4j.mcp.time.log-responses=true
 #quarkus.langchain4j.openai.moderation-model.log-requests=true
 #quarkus.langchain4j.openai.moderation-model.log-responses=true
 #quarkus.langchain4j.easy-rag.reuse-embeddings.enabled=true

--- a/samples/chatbot-easy-rag-kotlin/src/main/resources/application.properties
+++ b/samples/chatbot-easy-rag-kotlin/src/main/resources/application.properties
@@ -16,6 +16,7 @@ quarkus.langchain4j.openai.chat-model.max-tokens=2500
 quarkus.langchain4j.openai.chat-model.temperature=0.1
 quarkus.langchain4j.openai.chat-model.response-format=json_schema
 quarkus.langchain4j.openai.chat-model.strict-json-schema=true
+quarkus.langchain4j.openai.embedding-model.model-name=text-embedding-3-small
 
 #quarkus.langchain4j.openai.moderation-model.model-name=text-moderation-latest
 quarkus.langchain4j.openai.moderation-model.model-name=omni-moderation-latest


### PR DESCRIPTION
# Kotlin sample: Optimizations

- Disable `default-kapt` and `default-test-kapt` executions in kotlin-maven-plugin.
- Enable Kotlin incremental compilation
- Upgrade Quarkus Platform to 3.22.3
- Upgrade ai-mocks-openai to 0.4.0
- Remove traces of maven-compiler-plugin
- Upgrade jandex-maven-plugin
- Add opentelemetry dependency
- Use new embedding model `text-embedding-3-small`