### PR TITLE
Make secure-mcp-server even simpler

### DIFF
--- a/samples/secure-mcp-sse-client-server/secure-mcp-server/src/main/java/io/quarkiverse/langchain4j/sample/SecurityIdentityPermissionAugmentor.java
+++ b/samples/secure-mcp-sse-client-server/secure-mcp-server/src/main/java/io/quarkiverse/langchain4j/sample/SecurityIdentityPermissionAugmentor.java
@@ -1,7 +1,5 @@
 package io.quarkiverse.langchain4j.sample;
 
-import io.quarkus.oidc.UserInfo;
-import io.quarkus.oidc.runtime.OidcUtils;
 import io.quarkus.security.identity.AuthenticationRequestContext;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.identity.SecurityIdentityAugmentor;
@@ -27,9 +25,9 @@ public class SecurityIdentityPermissionAugmentor implements SecurityIdentityAugm
 
         @ActivateRequestContext
         public SecurityIdentity augment(SecurityIdentity securityIdentity) {
+            Identity identity = Identity.findByName(securityIdentity.getPrincipal().getName());
+            
             QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder(securityIdentity);
-            UserInfo userInfo = securityIdentity.getAttribute(OidcUtils.USER_INFO_ATTRIBUTE); 
-            Identity identity = Identity.findByName(userInfo.getName());
             return builder.addPermissionAsString(identity.permission).build();
         }
     }

--- a/samples/secure-mcp-sse-client-server/secure-mcp-server/src/main/java/io/quarkiverse/langchain4j/sample/UserNameProvider.java
+++ b/samples/secure-mcp-sse-client-server/secure-mcp-server/src/main/java/io/quarkiverse/langchain4j/sample/UserNameProvider.java
@@ -2,18 +2,18 @@ package io.quarkiverse.langchain4j.sample;
 
 import io.quarkiverse.mcp.server.TextContent;
 import io.quarkiverse.mcp.server.Tool;
-import io.quarkus.oidc.UserInfo;
 import io.quarkus.security.PermissionsAllowed;
+import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.inject.Inject;
 
 public class UserNameProvider {
 
     @Inject
-    UserInfo userInfo;
+    SecurityIdentity securityIdentity;
     
     @PermissionsAllowed("read:name")
     @Tool(name = "user-name-provider", description = "Provides a name of the currently logged-in user")
     TextContent provideUserName() {
-        return new TextContent(userInfo.getName());
+        return new TextContent(securityIdentity.getPrincipal().getName());
     }
 }


### PR DESCRIPTION
One more secure-mcp-server code simplification PR to make the tool code nearly identical to [the one in the quarkus-mcp-server](https://github.com/quarkiverse/quarkus-mcp-server/blob/main/samples/secure-mcp-sse-server/src/main/java/org/acme/ServerFeatures.java).

The augmentor is also simplified further - I think I had to use UserInfo when I was experimenting with checking emails, which is no longer needed