### PR TITLE
Fix NPE in MetricsChatModelListener.java

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/listeners/MetricsChatModelListener.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/listeners/MetricsChatModelListener.java
@@ -76,7 +76,10 @@ public class MetricsChatModelListener implements ChatModelListener {
 
         ChatRequest request = responseContext.chatRequest();
         ChatResponse response = responseContext.chatResponse();
-        Tags tags = Tags.of("gen_ai.request.model", request.parameters().modelName());
+        Tags tags = Tags.empty();
+        if (request.parameters().modelName() != null) {
+            tags = tags.and("gen_ai.request.model", request.parameters().modelName());
+        }
         if (response.metadata().modelName() != null) {
             tags = tags.and("gen_ai.response.model", response.metadata().modelName());
         }


### PR DESCRIPTION
When using Azure OpenAI there is no model name so we get in the logs the following error:

>     2025-05-28 07:41:30,789 WARN [io.qua.lan.azu.ope.AzureOpenAiChatModel] (executor-thread-1) 52093f841912115693757cf41ecec505 Exception while calling model listener: java.lang.NullPointerException
>     at java.base/java.util.Objects.requireNonNull(Objects.java:233)
>     at io.micrometer.core.instrument.ImmutableTag.(ImmutableTag.java:37)
>     at io.micrometer.core.instrument.Tag.of(Tag.java:31)
>     at io.micrometer.core.instrument.Tags.of(Tags.java:349)
>     at io.quarkiverse.langchain4j.runtime.listeners.MetricsChatModelListener.onResponse(MetricsChatModelListener.java:79)
>     at io.quarkiverse.langchain4j.azure.openai.AzureOpenAiChatModel.lambda$doChat$2(AzureOpenAiChatModel.java:182)
>     at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
>     at io.quarkiverse.langchain4j.azure.openai.AzureOpenAiChatModel.doChat(AzureOpenAiChatModel.java:180)

