### PR TITLE
Add description to codestart to avoid inheriting parent description

### DIFF
--- a/codestarts/chatbot/pom.xml
+++ b/codestarts/chatbot/pom.xml
@@ -14,6 +14,8 @@
     <packaging>pom</packaging>
     <name>Quarkus Langchain4j - Codestarts - Chatbot - Parent</name>
 
+    <description>A chatbot, similar to the one used in the in quarkus-langchain4j-workshop.</description>
+
     <modules>
         <module>deployment</module>
         <module>runtime</module>


### PR DESCRIPTION
At the moment the codestart looks silly on http://quarkus.io/extensions and http://code.quarkus.io:

<img width="320" alt="image" src="https://github.com/user-attachments/assets/220192ec-5c08-4c35-89a5-110416c6470c" />

<img width="1312" alt="image" src="https://github.com/user-attachments/assets/6245ea89-458a-43ac-a83b-bde3b5939f37" />


Even with the description, though, I'm a bit confused by this extension. We don't normally create standalone extensions for our codestarts, because the idea is that they'd just be hooked into code.quarkus.io. The other langchain4j codestarts aren't published as extensions (you can see at https://quarkus.io/extensions/?search-regex=codestart this the chatbot codestart is the only codestart published that way). 

I guess maybe we've done it that way because, unlike the EasyRAG codestart, it's a cross-extension codestart? It feels like it's maybe mixing concepts from samples and codestarts, though.