### PR TITLE
Port "Properly construct ChatRequest in Azure OpenAI module" to AzureOpenAiStreamingChatModel.

### DIFF
--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/AzureOpenAiStreamingChatModel.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/AzureOpenAiStreamingChatModel.java
@@ -245,12 +245,12 @@ public class AzureOpenAiStreamingChatModel implements StreamingChatModel {
             List<ToolSpecification> toolSpecifications) {
         return ChatRequest.builder()
                 .messages(messages)
-                .toolSpecifications(toolSpecifications)
                 .parameters(ChatRequestParameters.builder()
                         .modelName(request.model())
                         .temperature(request.temperature())
                         .topP(request.topP())
                         .maxOutputTokens(request.maxTokens())
+                        .toolSpecifications(toolSpecifications)
                         .build())
                 .build();
     }


### PR DESCRIPTION
Fixes #1508 for AzureOpenAiStreamingChatModel.

Ports the fix #1510 for the non-streaming models to streaming models. 