### PR TITLE
fix: use quarkiverse bundle

### DIFF
--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -8,7 +8,7 @@ content:
     start_path: docs
 ui: 
   bundle:
-    url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/HEAD/raw/build/ui-bundle.zip?job=bundle-stable
+    url: https://github.com/quarkiverse/antora-ui-quarkiverse/releases/latest/download/ui-bundle.zip
     snapshot: true
 
 asciidoc:


### PR DESCRIPTION
noticed that the antora bundle used in the for dev only was not the actual quarkiverse bundle.

so this just make it use the same as the quarkiverse doc site build so it looks the same