### PR TITLE
Produce spans for MCP tool calls

### DIFF
--- a/mcp/deployment/src/main/java/io/quarkiverse/langchain4j/mcp/deployment/McpProcessor.java
+++ b/mcp/deployment/src/main/java/io/quarkiverse/langchain4j/mcp/deployment/McpProcessor.java
@@ -16,6 +16,8 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.ClassType;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -23,6 +25,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.service.tool.ToolProvider;
+import io.opentelemetry.api.trace.Tracer;
+import io.quarkiverse.langchain4j.deployment.DotNames;
 import io.quarkiverse.langchain4j.mcp.auth.McpClientAuthProvider;
 import io.quarkiverse.langchain4j.mcp.runtime.McpClientHealthCheck;
 import io.quarkiverse.langchain4j.mcp.runtime.McpClientName;
@@ -53,6 +57,7 @@ public class McpProcessor {
     private static final DotName MCP_CLIENT = DotName.createSimple(McpClient.class);
     private static final DotName MCP_CLIENT_NAME = DotName.createSimple(McpClientName.class);
     private static final DotName TOOL_PROVIDER = DotName.createSimple(ToolProvider.class);
+    private static final DotName TRACER = DotName.createSimple(Tracer.class);
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @BuildStep
@@ -157,6 +162,8 @@ public class McpProcessor {
                         .defaultBean()
                         .unremovable()
                         .scope(ApplicationScoped.class)
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ClassType.create(TRACER) }, null))
                         .createWith(recorder.toolProviderFunction(clients.keySet()));
                 for (AnnotationInstance qualifier : qualifiers) {
                     configurator.addInjectionPoint(ClassType.create(MCP_CLIENT), qualifier);

--- a/mcp/runtime/pom.xml
+++ b/mcp/runtime/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- we only depend on the API as it's up to the user whether to use the Quarkus OTel extension -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/McpRecorder.java
+++ b/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/McpRecorder.java
@@ -8,11 +8,15 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.util.TypeLiteral;
+
 import dev.langchain4j.mcp.client.DefaultMcpClient;
 import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import dev.langchain4j.mcp.client.transport.stdio.StdioMcpTransport;
 import dev.langchain4j.service.tool.ToolProvider;
+import io.opentelemetry.api.trace.Tracer;
 import io.quarkiverse.langchain4j.mcp.runtime.config.LocalLaunchParams;
 import io.quarkiverse.langchain4j.mcp.runtime.config.McpClientRuntimeConfig;
 import io.quarkiverse.langchain4j.mcp.runtime.config.McpRuntimeConfiguration;
@@ -26,6 +30,9 @@ import io.quarkus.runtime.configuration.ConfigurationException;
 
 @Recorder
 public class McpRecorder {
+
+    private static final TypeLiteral<Instance<Tracer>> TRACER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
 
     public static Map<String, LocalLaunchParams> claudeConfigContents = Collections.emptyMap();
 
@@ -88,7 +95,7 @@ public class McpRecorder {
                     McpClientName.Literal qualifier = McpClientName.Literal.of(mcpClientName);
                     clients.add(context.getInjectedReference(McpClient.class, qualifier));
                 }
-                return new QuarkusMcpToolProvider(clients);
+                return new QuarkusMcpToolProvider(clients, context.getInjectedReference(TRACER_TYPE_LITERAL));
             }
         };
     }

--- a/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/QuarkusMcpToolProvider.java
+++ b/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/QuarkusMcpToolProvider.java
@@ -2,18 +2,35 @@ package io.quarkiverse.langchain4j.mcp.runtime;
 
 import java.util.List;
 import java.util.function.BiPredicate;
+import java.util.function.Function;
 
+import jakarta.enterprise.inject.Instance;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.mcp.McpToolProvider;
 import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.service.tool.ToolProviderRequest;
 import dev.langchain4j.service.tool.ToolProviderResult;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
 import io.quarkiverse.langchain4j.runtime.aiservice.QuarkusToolProviderRequest;
 
 public class QuarkusMcpToolProvider extends McpToolProvider {
 
-    QuarkusMcpToolProvider(List<McpClient> mcpClients) {
-        super(mcpClients, false, (mcp, tool) -> true);
+    QuarkusMcpToolProvider(List<McpClient> mcpClients, Instance<Tracer> tracerInstance) {
+        super(mcpClients, false, AlwaysTrueMcpClientToolSpecificationBiPredicate.INSTANCE,
+                determineToolWrapper(tracerInstance));
+    }
+
+    private static Function<ToolExecutor, ToolExecutor> determineToolWrapper(Instance<Tracer> tracerInstance) {
+        if (tracerInstance.isResolvable()) {
+            return new SpanToolExecutor(tracerInstance);
+        } else {
+            return Function.identity();
+        }
     }
 
     @Override
@@ -25,7 +42,7 @@ public class QuarkusMcpToolProvider extends McpToolProvider {
         if (request instanceof QuarkusToolProviderRequest quarkusRequest) {
             return new McpClientKeyFilter(quarkusRequest.getMcpClientNames());
         }
-        return (mcp, tool) -> true;
+        return AlwaysTrueMcpClientToolSpecificationBiPredicate.INSTANCE;
     }
 
     private static class McpClientKeyFilter implements BiPredicate<McpClient, ToolSpecification> {
@@ -41,6 +58,47 @@ public class QuarkusMcpToolProvider extends McpToolProvider {
             // keys.size() == 0 means all MCP clients
             return keys != null
                     && (keys.isEmpty() || keys.stream().anyMatch(name -> name.equals(mcpClient.key())));
+        }
+    }
+
+    private static class AlwaysTrueMcpClientToolSpecificationBiPredicate
+            implements BiPredicate<McpClient, ToolSpecification> {
+
+        private static final AlwaysTrueMcpClientToolSpecificationBiPredicate INSTANCE = new AlwaysTrueMcpClientToolSpecificationBiPredicate();
+
+        private AlwaysTrueMcpClientToolSpecificationBiPredicate() {
+        }
+
+        @Override
+        public boolean test(McpClient mcpClient, ToolSpecification toolSpecification) {
+            return true;
+        }
+    }
+
+    private static class SpanToolExecutor implements Function<ToolExecutor, ToolExecutor> {
+        private final Instance<Tracer> tracerInstance;
+
+        public SpanToolExecutor(Instance<Tracer> tracerInstance) {
+            this.tracerInstance = tracerInstance;
+        }
+
+        @Override
+        public ToolExecutor apply(ToolExecutor toolExecutor) {
+            return new ToolExecutor() {
+                @Override
+                public String execute(ToolExecutionRequest toolExecutionRequest, Object memoryId) {
+                    Span span = tracerInstance.get().spanBuilder("langchain4j.mcp-tools." + toolExecutionRequest.name())
+                            .startSpan();
+                    try (Scope scope = span.makeCurrent()) {
+                        return toolExecutor.execute(toolExecutionRequest, memoryId);
+                    } catch (Throwable t) {
+                        span.recordException(t);
+                        throw t;
+                    } finally {
+                        span.end();
+                    }
+                }
+            };
         }
     }
 }


### PR DESCRIPTION
When using our weather sample with OTel dependencies, Quarkus LangChain4j now produces the following:

![Screenshot from 2025-06-20 14-50-44](https://github.com/user-attachments/assets/8439762f-9846-489a-9255-103d8c10ad03)


- Closes: #1416