### PR TITLE
Update to new Ollama api/embed endpoint

### DIFF
--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/EmbeddingRequest.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/EmbeddingRequest.java
@@ -3,11 +3,11 @@ package io.quarkiverse.langchain4j.ollama;
 public class EmbeddingRequest {
 
     private final String model;
-    private final String prompt;
+    private final String input;
 
     private EmbeddingRequest(Builder builder) {
         model = builder.model;
-        prompt = builder.prompt;
+        input = builder.input;
     }
 
     public static Builder builder() {
@@ -18,13 +18,13 @@ public class EmbeddingRequest {
         return model;
     }
 
-    public String getPrompt() {
-        return prompt;
+    public String getInput() {
+        return input;
     }
 
     public static final class Builder {
         private String model = "llama2";
-        private String prompt;
+        private String input;
 
         private Builder() {
         }
@@ -34,8 +34,8 @@ public class EmbeddingRequest {
             return this;
         }
 
-        public Builder prompt(String val) {
-            prompt = val;
+        public Builder input(String val) {
+            input = val;
             return this;
         }
 

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/EmbeddingResponse.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/EmbeddingResponse.java
@@ -6,29 +6,29 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 @JsonDeserialize(builder = EmbeddingResponse.Builder.class)
 public class EmbeddingResponse {
 
-    private float[] embedding;
+    private float[][] embeddings;
 
     private EmbeddingResponse(Builder builder) {
-        embedding = builder.embedding;
+        embeddings = builder.embeddings;
     }
 
-    public float[] getEmbedding() {
-        return embedding;
+    public float[][] getEmbeddings() {
+        return embeddings;
     }
 
-    public void setEmbedding(float[] embedding) {
-        this.embedding = embedding;
+    public void setEmbeddings(float[][] embeddings) {
+        this.embeddings = embeddings;
     }
 
     @JsonPOJOBuilder(withPrefix = "")
     public static final class Builder {
-        private float[] embedding;
+        private float[][] embeddings;
 
         private Builder() {
         }
 
-        public Builder embedding(float[] val) {
-            embedding = val;
+        public Builder embeddings(float[][] val) {
+            embeddings = val;
             return this;
         }
 

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/OllamaEmbeddingModel.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/OllamaEmbeddingModel.java
@@ -31,12 +31,14 @@ public class OllamaEmbeddingModel implements EmbeddingModel {
         textSegments.forEach(textSegment -> {
             EmbeddingRequest request = EmbeddingRequest.builder()
                     .model(model)
-                    .prompt(textSegment.text())
+                    .input(textSegment.text())
                     .build();
 
             EmbeddingResponse response = client.embedding(request);
 
-            embeddings.add(Embedding.from(response.getEmbedding()));
+            for (float[] embedding : response.getEmbeddings()) {
+                embeddings.add(Embedding.from(embedding));
+            }
         });
 
         return Response.from(embeddings);

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/OllamaRestApi.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/OllamaRestApi.java
@@ -63,7 +63,7 @@ public interface OllamaRestApi {
     @RestStreamElementType(MediaType.APPLICATION_JSON)
     Multi<ChatResponse> streamingChat(ChatRequest request);
 
-    @Path("/api/embeddings")
+    @Path("/api/embed")
     @POST
     EmbeddingResponse embeddings(EmbeddingRequest request);
 


### PR DESCRIPTION
Old `api/embeddings` endpoint is deprecated and undocumented.
Update to new `api/embed` endpoint described in:
https://github.com/ollama/ollama/blob/main/docs/api.md#generate-embeddings