### PR TITLE
Dev UI page for MCP clients

### DIFF
--- a/mcp/deployment/src/main/java/io/quarkiverse/langchain4j/mcp/deployment/devui/McpDevUiProcessor.java
+++ b/mcp/deployment/src/main/java/io/quarkiverse/langchain4j/mcp/deployment/devui/McpDevUiProcessor.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.langchain4j.mcp.deployment.devui;
+
+import io.quarkiverse.langchain4j.mcp.runtime.devui.McpClientsJsonRpcService;
+import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
+import io.quarkus.devui.spi.page.CardPageBuildItem;
+import io.quarkus.devui.spi.page.Page;
+
+public class McpDevUiProcessor {
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    CardPageBuildItem cardPage() {
+        CardPageBuildItem card = new CardPageBuildItem();
+        card.addPage(Page.webComponentPageBuilder().title("MCP clients")
+                .componentLink("qwc-mcp-clients.js")
+                .icon("font-awesome-solid:robot"));
+        return card;
+    }
+
+    @BuildStep
+    void jsonRpcService(BuildProducer<JsonRPCProvidersBuildItem> producers) {
+        producers.produce(new JsonRPCProvidersBuildItem(McpClientsJsonRpcService.class));
+    }
+}

--- a/mcp/deployment/src/main/resources/dev-ui/qwc-mcp-clients.js
+++ b/mcp/deployment/src/main/resources/dev-ui/qwc-mcp-clients.js
@@ -1,0 +1,91 @@
+import {LitElement, html, css} from 'lit';
+import '@vaadin/text-area';
+import '@vaadin/button';
+import '@vaadin/checkbox';
+import '@vaadin/details';
+import '@vaadin/vertical-layout';
+import '@vaadin/message-input';
+import '@vaadin/message-list';
+import '@vaadin/progress-bar';
+import '@vaadin/text-field';
+import '@vaadin/icon';
+import '@vaadin/icons';
+import 'qui-alert';
+import { JsonRpc } from 'jsonrpc';
+import { columnBodyRenderer } from '@vaadin/grid/lit.js';
+
+export class QwcMcpClients extends LitElement {
+
+    jsonRpc = new JsonRpc(this);
+
+    static styles = css`
+        :host {
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+            margin-left: 15px;
+            margin-right: 15px;
+        }
+    `;
+
+    static properties = {
+        _clientInfos: {state: true},
+    }
+
+    constructor() {
+        super();
+        this._clientInfos = [];
+        this.jsonRpc.clientInfos().then(jsonRpcResponse => {
+            this._clientInfos = jsonRpcResponse.result;
+        });
+    }
+
+    render() {
+        if(this._clientInfos === []) {
+            return html`Loading...`;
+         } else return html`
+            ${this._clientInfos.map(clientInfo => html`
+                
+              <h2>MCP client: ${clientInfo.cdiName}</h2>  
+              <h3>Tools</h3>
+              <vaadin-grid .items="${clientInfo.tools}" theme="wrap-cell-content">
+                  <vaadin-grid-sort-column resizable
+                                           path="name"
+                                           header="Name">
+                  </vaadin-grid-sort-column>
+                  <vaadin-grid-sort-column resizable
+                                           path="description"
+                                           header="Description">
+                  </vaadin-grid-sort-column>
+                  <vaadin-grid-sort-column resizable
+                                           header="Execute"
+                                           ${columnBodyRenderer((tool => this._toolExecuteColumnRenderer(tool, clientInfo)), [])}>
+                  </vaadin-grid-sort-column>
+              </vaadin-grid>
+            `)}            
+        `;
+    }
+
+    _toolExecuteColumnRenderer(tool, clientInfo) {
+        var actualArguments = tool.exampleInput;
+        const textAreaId = `output-${clientInfo.cdiName}-${tool.name}`
+        return html`
+            <vaadin-vertical-layout>
+                <vaadin-text-area label="Arguments" value=${tool.exampleInput} style="width: 100%;" 
+                                   @change=${(e) => actualArguments = e.detail.sourceEvent.currentTarget.value}></vaadin-text-area>
+                <vaadin-button @click=${() => {
+                    this.jsonRpc.executeTool({clientName: clientInfo.cdiName, toolName: tool.name, arguments: actualArguments})
+                                .then(jsonRpcResponse => {
+                                    let outputElement = this.shadowRoot.getElementById(textAreaId);
+                                    outputElement.style = "width: 100%; display: block;";
+                                    outputElement.value = JSON.stringify(jsonRpcResponse.result);
+                                });}
+                }>Execute</vaadin-button>
+                <vaadin-text-area label="Output" id=${textAreaId} disabled style="width: 100%; display: none;"></vaadin-text-area>
+            </vaadin-vertical-layout>
+        `
+    }
+
+}
+
+customElements.define('qwc-mcp-clients', QwcMcpClients);

--- a/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/devui/McpClientsJsonRpcService.java
+++ b/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/devui/McpClientsJsonRpcService.java
@@ -1,0 +1,75 @@
+package io.quarkiverse.langchain4j.mcp.runtime.devui;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.enterprise.inject.Any;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.mcp.client.McpClient;
+import io.quarkiverse.langchain4j.mcp.runtime.McpClientName;
+import io.quarkiverse.langchain4j.mcp.runtime.devui.json.JsonSchemaToExampleStringHelper;
+import io.quarkiverse.langchain4j.mcp.runtime.devui.json.McpClientInfo;
+import io.quarkiverse.langchain4j.mcp.runtime.devui.json.McpToolInfo;
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.InstanceHandle;
+
+public class McpClientsJsonRpcService {
+
+    // The key here is the logical (CDI) name of the client
+    private final Map<String, McpClient> clients = new HashMap<>();
+
+    public McpClientsJsonRpcService() {
+        // initialize the client map
+        for (InstanceHandle<McpClient> handle : Arc.container().select(McpClient.class, Any.Literal.INSTANCE).handles()) {
+            InjectableBean<McpClient> bean = handle.getBean();
+            String key = null;
+            for (Annotation qualifier : bean.getQualifiers()) {
+                if (qualifier instanceof McpClientName mcpClientName) {
+                    key = mcpClientName.value();
+                    break;
+                }
+            }
+            // TODO: if no CDI key exists, generate one ad-hoc for the purpose of having the client uniquely identifiable in the UI?
+            clients.put(key == null ? "null" : key, handle.get());
+        }
+    }
+
+    public List<McpClientInfo> clientInfos() {
+        List<McpClientInfo> infos = new ArrayList<>();
+        for (String key : clients.keySet()) {
+            McpClient client = clients.get(key);
+            McpClientInfo info = buildClientInfo(client);
+            info.setCdiName(key);
+            infos.add(info);
+        }
+        return infos;
+    }
+
+    public String executeTool(String clientName, String toolName, String arguments) {
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                .name(toolName)
+                .arguments(arguments)
+                .build();
+        return clients.get(clientName).executeTool(request);
+    }
+
+    private McpClientInfo buildClientInfo(McpClient client) {
+        McpClientInfo info = new McpClientInfo();
+        info.setTools(client.listTools().stream().map(this::buildToolInfo).toList());
+        return info;
+    }
+
+    private McpToolInfo buildToolInfo(ToolSpecification toolSpec) {
+        McpToolInfo info = new McpToolInfo();
+        info.setName(toolSpec.name());
+        info.setDescription(toolSpec.description());
+        info.setExampleInput(JsonSchemaToExampleStringHelper.generateExampleStringFromSchema(toolSpec.parameters()));
+        return info;
+    }
+}

--- a/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/devui/json/JsonSchemaToExampleStringHelper.java
+++ b/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/devui/json/JsonSchemaToExampleStringHelper.java
@@ -1,0 +1,40 @@
+package io.quarkiverse.langchain4j.mcp.runtime.devui.json;
+
+import java.util.stream.Collectors;
+
+import dev.langchain4j.model.chat.request.json.*;
+
+public class JsonSchemaToExampleStringHelper {
+
+    public static String generateExampleStringFromSchema(JsonSchemaElement element) {
+        if (element instanceof JsonBooleanSchema) {
+            return "true";
+        } else if (element instanceof JsonNumberSchema) {
+            return "1.0";
+        } else if (element instanceof JsonStringSchema) {
+            return "\"example\"";
+        } else if (element instanceof JsonIntegerSchema) {
+            return "1";
+        } else if (element instanceof JsonNullSchema) {
+            return "null";
+        } else if (element instanceof JsonObjectSchema schema) {
+            StringBuilder builder = new StringBuilder();
+            builder.append("{");
+            String example = schema.properties().entrySet().stream()
+                    .map((entry) -> "\"" + entry.getKey() + "\": " + generateExampleStringFromSchema(entry.getValue()))
+                    .collect(Collectors.joining(", "));
+            builder.append(example);
+            builder.append("}");
+            return builder.toString();
+        } else if (element instanceof JsonArraySchema schema) {
+            StringBuilder builder = new StringBuilder();
+            builder.append("[");
+            builder.append(generateExampleStringFromSchema(schema.items()));
+            builder.append("]");
+            return builder.toString();
+        } else if (element instanceof JsonAnyOfSchema schema) {
+            return generateExampleStringFromSchema(schema.anyOf().get(0));
+        }
+        throw new UnsupportedOperationException("Unsupported schema type: " + element.getClass());
+    }
+}

--- a/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/devui/json/McpClientInfo.java
+++ b/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/devui/json/McpClientInfo.java
@@ -1,0 +1,25 @@
+package io.quarkiverse.langchain4j.mcp.runtime.devui.json;
+
+import java.util.List;
+
+public class McpClientInfo {
+
+    private String cdiName;
+    private List<McpToolInfo> tools;
+
+    public String getCdiName() {
+        return cdiName;
+    }
+
+    public void setCdiName(String cdiName) {
+        this.cdiName = cdiName;
+    }
+
+    public List<McpToolInfo> getTools() {
+        return tools;
+    }
+
+    public void setTools(List<McpToolInfo> tools) {
+        this.tools = tools;
+    }
+}

--- a/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/devui/json/McpToolInfo.java
+++ b/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/devui/json/McpToolInfo.java
@@ -1,0 +1,32 @@
+package io.quarkiverse.langchain4j.mcp.runtime.devui.json;
+
+public class McpToolInfo {
+
+    private String name;
+    private String description;
+    private String exampleInput;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getExampleInput() {
+        return exampleInput;
+    }
+
+    public void setExampleInput(String exampleInput) {
+        this.exampleInput = exampleInput;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}


### PR DESCRIPTION
Allows the user to list available tools from all configured MCP clients and execute them from the Dev UI. I attempted to automatically provide an appropriate JSON document that captures the arguments of the tool that is being invoked (but of course, the user will have to change the actual values...).

Video sample that uses the `samples/mcp-tools` sample from this repo:
[simplescreenrecorder-2025-07-08_15.16.54.webm](https://github.com/user-attachments/assets/7da2109a-62f4-496a-ab94-f6d6c4ccda12)
