### PR TITLE
Update quickstart-rag.adoc fixing the dependency to langchain4j-embeddings

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,3 +1,4 @@
 :project-version: 1.1.0.CR1
 :langchain4j-version: 1.1.0
+:langchain4j-embeddings-version: 1.1.0-beta7
 :examples-dir: ./../examples/

--- a/docs/modules/ROOT/pages/quickstart-rag.adoc
+++ b/docs/modules/ROOT/pages/quickstart-rag.adoc
@@ -70,7 +70,7 @@ Add these dependencies to your pom.xml:
 <dependency>
     <groupId>dev.langchain4j</groupId>
     <artifactId>langchain4j-embeddings</artifactId>
-    <version>{langchain4j-version}</version>
+    <version>{langchain4j-embeddings-version}</version>
 </dependency>
 <dependency>
     <groupId>io.quarkiverse.langchain4j</groupId>

--- a/docs/templates/includes/attributes.adoc
+++ b/docs/templates/includes/attributes.adoc
@@ -1,3 +1,4 @@
 :project-version: ${release.current-version}
 :langchain4j-version: ${langchain4j.version}
+:langchain4j-embeddings-version: ${langchain4j-embeddings.version}
 :examples-dir: ./../examples/

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <langchain4j.version>1.1.0</langchain4j.version>
     <langchain4j-rc.version>1.1.0-rc1</langchain4j-rc.version>
     <langchain4j-beta.version>1.1.0-beta7</langchain4j-beta.version>
-    <langchain4j-embeddings.version>1.0.0-beta5</langchain4j-embeddings.version>
+    <langchain4j-embeddings.version>1.1.0-beta7</langchain4j-embeddings.version>
     <quarkus-antora.version>2.2.0</quarkus-antora.version>
     <quarkus-poi.version>2.0.4</quarkus-poi.version> <!-- we need to use this version because langchain4j uses POI 5.2.3 instead of 5.2.5 and the substitution needed is different in the two versions -->
     <assertj.version>3.27.3</assertj.version>


### PR DESCRIPTION
Version 1.1.0.CR1 is currently not available in the repository.