### PR TITLE
Do not use Runtime configuration during deployment

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/ChatMemoryProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/ChatMemoryProcessor.java
@@ -10,7 +10,6 @@ import dev.langchain4j.memory.chat.ChatMemoryProvider;
 import dev.langchain4j.model.TokenCountEstimator;
 import dev.langchain4j.store.memory.chat.ChatMemoryStore;
 import io.quarkiverse.langchain4j.runtime.ChatMemoryRecorder;
-import io.quarkiverse.langchain4j.runtime.aiservice.ChatMemoryConfig;
 import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
@@ -23,7 +22,7 @@ public class ChatMemoryProcessor {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    void setupBeans(ChatMemoryBuildConfig buildConfig, ChatMemoryConfig runtimeConfig,
+    void setupBeans(ChatMemoryBuildConfig buildConfig,
             ChatMemoryRecorder recorder,
             BuildProducer<UnremovableBeanBuildItem> unremovableProducer,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeanProducer) {
@@ -38,10 +37,10 @@ public class ChatMemoryProcessor {
                 .defaultBean();
 
         if (buildConfig.type() == ChatMemoryBuildConfig.Type.MESSAGE_WINDOW) {
-            fun = recorder.messageWindow(runtimeConfig);
+            fun = recorder.messageWindow();
         } else if (buildConfig.type() == ChatMemoryBuildConfig.Type.TOKEN_WINDOW) {
             configurator.addInjectionPoint(ClassType.create(TokenCountEstimator.class));
-            fun = recorder.tokenWindow(runtimeConfig);
+            fun = recorder.tokenWindow();
         } else {
             throw new IllegalStateException(
                     "Invalid configuration '" + buildConfig.type() + "' used in 'quarkus.langchain4j.chat-memory.type'");

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/ChatMemoryRecorder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/ChatMemoryRecorder.java
@@ -10,17 +10,23 @@ import dev.langchain4j.model.TokenCountEstimator;
 import dev.langchain4j.store.memory.chat.ChatMemoryStore;
 import io.quarkiverse.langchain4j.runtime.aiservice.ChatMemoryConfig;
 import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class ChatMemoryRecorder {
+    private final RuntimeValue<ChatMemoryConfig> config;
 
-    public Function<SyntheticCreationalContext<ChatMemoryProvider>, ChatMemoryProvider> messageWindow(ChatMemoryConfig config) {
+    public ChatMemoryRecorder(RuntimeValue<ChatMemoryConfig> config) {
+        this.config = config;
+    }
+
+    public Function<SyntheticCreationalContext<ChatMemoryProvider>, ChatMemoryProvider> messageWindow() {
         return new Function<>() {
             @Override
             public ChatMemoryProvider apply(SyntheticCreationalContext<ChatMemoryProvider> context) {
                 ChatMemoryStore chatMemoryStore = context.getInjectedReference(ChatMemoryStore.class);
-                int maxMessages = config.memoryWindow().maxMessages();
+                int maxMessages = config.getValue().memoryWindow().maxMessages();
                 return new ChatMemoryProvider() {
                     @Override
                     public ChatMemory get(Object memoryId) {
@@ -35,13 +41,13 @@ public class ChatMemoryRecorder {
         };
     }
 
-    public Function<SyntheticCreationalContext<ChatMemoryProvider>, ChatMemoryProvider> tokenWindow(ChatMemoryConfig config) {
+    public Function<SyntheticCreationalContext<ChatMemoryProvider>, ChatMemoryProvider> tokenWindow() {
         return new Function<>() {
             @Override
             public ChatMemoryProvider apply(SyntheticCreationalContext<ChatMemoryProvider> context) {
                 ChatMemoryStore chatMemoryStore = context.getInjectedReference(ChatMemoryStore.class);
                 TokenCountEstimator tokenizer = context.getInjectedReference(TokenCountEstimator.class);
-                int maxTokens = config.tokenWindow().maxTokens();
+                int maxTokens = config.getValue().tokenWindow().maxTokens();
                 return new ChatMemoryProvider() {
                     @Override
                     public ChatMemory get(Object memoryId) {

--- a/embedding-stores/chroma/deployment/src/main/java/io/quarkiverse/langchain4j/chroma/deployment/ChromaProcessor.java
+++ b/embedding-stores/chroma/deployment/src/main/java/io/quarkiverse/langchain4j/chroma/deployment/ChromaProcessor.java
@@ -9,7 +9,6 @@ import org.jboss.jandex.ParameterizedType;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import io.quarkiverse.langchain4j.chroma.ChromaEmbeddingStore;
-import io.quarkiverse.langchain4j.chroma.runtime.ChromaConfig;
 import io.quarkiverse.langchain4j.chroma.runtime.ChromaRecorder;
 import io.quarkiverse.langchain4j.deployment.EmbeddingStoreBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
@@ -40,7 +39,6 @@ class ChromaProcessor {
     public void createBean(
             BuildProducer<SyntheticBeanBuildItem> beanProducer,
             ChromaRecorder recorder,
-            ChromaConfig config,
             BuildProducer<EmbeddingStoreBuildItem> embeddingStoreProducer) {
         beanProducer.produce(SyntheticBeanBuildItem
                 .configure(CHROMA_EMBEDDING_STORE)
@@ -50,7 +48,7 @@ class ChromaProcessor {
                 .setRuntimeInit()
                 .unremovable()
                 .scope(ApplicationScoped.class)
-                .supplier(recorder.chromaStoreSupplier(config))
+                .supplier(recorder.chromaStoreSupplier())
                 .done());
         embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
     }

--- a/embedding-stores/chroma/runtime/src/main/java/io/quarkiverse/langchain4j/chroma/runtime/ChromaRecorder.java
+++ b/embedding-stores/chroma/runtime/src/main/java/io/quarkiverse/langchain4j/chroma/runtime/ChromaRecorder.java
@@ -4,19 +4,26 @@ import java.time.Duration;
 import java.util.function.Supplier;
 
 import io.quarkiverse.langchain4j.chroma.ChromaEmbeddingStore;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class ChromaRecorder {
-    public Supplier<ChromaEmbeddingStore> chromaStoreSupplier(ChromaConfig config) {
+    private final RuntimeValue<ChromaConfig> runtimeConfig;
+
+    public ChromaRecorder(RuntimeValue<ChromaConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public Supplier<ChromaEmbeddingStore> chromaStoreSupplier() {
         return new Supplier<>() {
             @Override
             public ChromaEmbeddingStore get() {
-                return new ChromaEmbeddingStore(config.url(),
-                        config.collectionName(),
-                        config.timeout().orElse(Duration.ofSeconds(5)),
-                        config.logRequests().orElse(false),
-                        config.logResponses().orElse(false));
+                return new ChromaEmbeddingStore(runtimeConfig.getValue().url(),
+                        runtimeConfig.getValue().collectionName(),
+                        runtimeConfig.getValue().timeout().orElse(Duration.ofSeconds(5)),
+                        runtimeConfig.getValue().logRequests().orElse(false),
+                        runtimeConfig.getValue().logResponses().orElse(false));
             }
         };
     }

--- a/embedding-stores/infinispan/deployment/src/main/java/io/quarkiverse/langchain4j/infinispan/InfinispanEmbeddingStoreProcessor.java
+++ b/embedding-stores/infinispan/deployment/src/main/java/io/quarkiverse/langchain4j/infinispan/InfinispanEmbeddingStoreProcessor.java
@@ -12,7 +12,6 @@ import org.jboss.jandex.ParameterizedType;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import io.quarkiverse.langchain4j.deployment.EmbeddingStoreBuildItem;
-import io.quarkiverse.langchain4j.infinispan.runtime.InfinispanEmbeddingStoreConfig;
 import io.quarkiverse.langchain4j.infinispan.runtime.InfinispanEmbeddingStoreRecorder;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
@@ -48,7 +47,6 @@ public class InfinispanEmbeddingStoreProcessor {
     public void createBean(
             BuildProducer<SyntheticBeanBuildItem> beanProducer,
             InfinispanEmbeddingStoreRecorder recorder,
-            InfinispanEmbeddingStoreConfig config,
             BuildProducer<EmbeddingStoreBuildItem> embeddingStoreProducer,
             InfinispanEmbeddingStoreBuildTimeConfig buildTimeConfig) {
         String clientName = buildTimeConfig.clientName().orElse(null);
@@ -71,7 +69,7 @@ public class InfinispanEmbeddingStoreProcessor {
                 .scope(ApplicationScoped.class)
                 .addInjectionPoint(ClassType.create(DotName.createSimple(RemoteCacheManager.class)),
                         infinispanClientQualifier)
-                .createWith(recorder.embeddingStoreFunction(config, clientName))
+                .createWith(recorder.embeddingStoreFunction(clientName))
                 .done());
         embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
     }

--- a/embedding-stores/infinispan/runtime/src/main/java/io/quarkiverse/langchain4j/infinispan/runtime/InfinispanEmbeddingStoreRecorder.java
+++ b/embedding-stores/infinispan/runtime/src/main/java/io/quarkiverse/langchain4j/infinispan/runtime/InfinispanEmbeddingStoreRecorder.java
@@ -7,13 +7,19 @@ import org.infinispan.client.hotrod.RemoteCacheManager;
 import io.quarkiverse.langchain4j.infinispan.InfinispanEmbeddingStore;
 import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.infinispan.client.InfinispanClientName;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class InfinispanEmbeddingStoreRecorder {
+    private final RuntimeValue<InfinispanEmbeddingStoreConfig> runtimeConfig;
+
+    public InfinispanEmbeddingStoreRecorder(RuntimeValue<InfinispanEmbeddingStoreConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
 
     public Function<SyntheticCreationalContext<InfinispanEmbeddingStore>, InfinispanEmbeddingStore> embeddingStoreFunction(
-            InfinispanEmbeddingStoreConfig config, String clientName) {
+            String clientName) {
         return new Function<>() {
             @Override
             public InfinispanEmbeddingStore apply(SyntheticCreationalContext<InfinispanEmbeddingStore> context) {
@@ -26,7 +32,8 @@ public class InfinispanEmbeddingStoreRecorder {
                             new InfinispanClientName.Literal(clientName));
                 }
                 builder.cacheManager(cacheManager);
-                builder.schema(new InfinispanSchema(config.cacheName(), config.dimension(), config.distance()));
+                builder.schema(new InfinispanSchema(runtimeConfig.getValue().cacheName(), runtimeConfig.getValue().dimension(),
+                        runtimeConfig.getValue().distance()));
                 return builder.build();
             }
         };

--- a/embedding-stores/milvus/deployment/src/main/java/io/quarkiverse/langchain4j/milvus/MilvusProcessor.java
+++ b/embedding-stores/milvus/deployment/src/main/java/io/quarkiverse/langchain4j/milvus/MilvusProcessor.java
@@ -11,7 +11,6 @@ import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.milvus.MilvusEmbeddingStore;
 import io.quarkiverse.langchain4j.deployment.EmbeddingStoreBuildItem;
 import io.quarkiverse.langchain4j.milvus.runtime.MilvusRecorder;
-import io.quarkiverse.langchain4j.milvus.runtime.MilvusRuntimeConfig;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -34,7 +33,6 @@ public class MilvusProcessor {
     public void createBean(
             BuildProducer<SyntheticBeanBuildItem> beanProducer,
             MilvusRecorder recorder,
-            MilvusRuntimeConfig config,
             BuildProducer<EmbeddingStoreBuildItem> embeddingStoreProducer) {
         beanProducer.produce(SyntheticBeanBuildItem
                 .configure(MILVUS_EMBEDDING_STORE)
@@ -44,7 +42,7 @@ public class MilvusProcessor {
                 .setRuntimeInit()
                 .unremovable()
                 .scope(ApplicationScoped.class)
-                .supplier(recorder.milvusStoreSupplier(config))
+                .supplier(recorder.milvusStoreSupplier())
                 .done());
         embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
     }

--- a/embedding-stores/milvus/runtime/src/main/java/io/quarkiverse/langchain4j/milvus/runtime/MilvusRecorder.java
+++ b/embedding-stores/milvus/runtime/src/main/java/io/quarkiverse/langchain4j/milvus/runtime/MilvusRecorder.java
@@ -3,32 +3,38 @@ package io.quarkiverse.langchain4j.milvus.runtime;
 import java.util.function.Supplier;
 
 import dev.langchain4j.store.embedding.milvus.MilvusEmbeddingStore;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class MilvusRecorder {
+    private final RuntimeValue<MilvusRuntimeConfig> runtimeConfig;
 
-    public Supplier<MilvusEmbeddingStore> milvusStoreSupplier(MilvusRuntimeConfig config) {
+    public MilvusRecorder(RuntimeValue<MilvusRuntimeConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public Supplier<MilvusEmbeddingStore> milvusStoreSupplier() {
         return new Supplier<>() {
             @Override
             public MilvusEmbeddingStore get() {
                 return new MilvusEmbeddingStore.Builder()
-                        .host(config.host())
-                        .port(config.port())
-                        .collectionName(config.collectionName())
-                        .idFieldName(config.primaryField())
-                        .textFieldName(config.textField())
-                        .metadataFieldName(config.metadataField())
-                        .vectorFieldName(config.vectorField())
-                        .dimension(config.dimension().orElse(null))
-                        .indexType(config.indexType())
-                        .metricType(config.metricType())
-                        .token(config.token().orElse(null))
-                        .username(config.username().orElse(null))
-                        .password(config.password().orElse(null))
-                        .consistencyLevel(config.consistencyLevel())
+                        .host(runtimeConfig.getValue().host())
+                        .port(runtimeConfig.getValue().port())
+                        .collectionName(runtimeConfig.getValue().collectionName())
+                        .idFieldName(runtimeConfig.getValue().primaryField())
+                        .textFieldName(runtimeConfig.getValue().textField())
+                        .metadataFieldName(runtimeConfig.getValue().metadataField())
+                        .vectorFieldName(runtimeConfig.getValue().vectorField())
+                        .dimension(runtimeConfig.getValue().dimension().orElse(null))
+                        .indexType(runtimeConfig.getValue().indexType())
+                        .metricType(runtimeConfig.getValue().metricType())
+                        .token(runtimeConfig.getValue().token().orElse(null))
+                        .username(runtimeConfig.getValue().username().orElse(null))
+                        .password(runtimeConfig.getValue().password().orElse(null))
+                        .consistencyLevel(runtimeConfig.getValue().consistencyLevel())
                         .retrieveEmbeddingsOnSearch(true)
-                        .databaseName(config.dbName())
+                        .databaseName(runtimeConfig.getValue().dbName())
                         .build();
             }
         };

--- a/embedding-stores/neo4j/deployment/src/main/java/io/quarkiverse/langchain4j/neo4j/Neo4jEmbeddingStoreProcessor.java
+++ b/embedding-stores/neo4j/deployment/src/main/java/io/quarkiverse/langchain4j/neo4j/Neo4jEmbeddingStoreProcessor.java
@@ -12,7 +12,6 @@ import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import io.quarkiverse.langchain4j.deployment.EmbeddingStoreBuildItem;
 import io.quarkiverse.langchain4j.neo4j.runtime.Neo4jEmbeddingStoreRecorder;
-import io.quarkiverse.langchain4j.neo4j.runtime.Neo4jRuntimeConfig;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -36,7 +35,6 @@ public class Neo4jEmbeddingStoreProcessor {
     public void createBean(
             BuildProducer<SyntheticBeanBuildItem> beanProducer,
             Neo4jEmbeddingStoreRecorder recorder,
-            Neo4jRuntimeConfig config,
             BuildProducer<UnremovableBeanBuildItem> unremovableProducer,
             BuildProducer<EmbeddingStoreBuildItem> embeddingStoreProducer) {
         unremovableProducer.produce(UnremovableBeanBuildItem.beanTypes(Driver.class));
@@ -51,7 +49,7 @@ public class Neo4jEmbeddingStoreProcessor {
                 .unremovable()
                 .scope(ApplicationScoped.class)
                 .addInjectionPoint(ClassType.create(DotName.createSimple(Driver.class)))
-                .createWith(recorder.embeddingStoreFunction(config))
+                .createWith(recorder.embeddingStoreFunction())
                 .done());
         embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
     }

--- a/embedding-stores/neo4j/runtime/src/main/java/io/quarkiverse/langchain4j/neo4j/runtime/Neo4jEmbeddingStoreRecorder.java
+++ b/embedding-stores/neo4j/runtime/src/main/java/io/quarkiverse/langchain4j/neo4j/runtime/Neo4jEmbeddingStoreRecorder.java
@@ -9,29 +9,34 @@ import org.neo4j.driver.SessionConfig;
 
 import dev.langchain4j.community.store.embedding.neo4j.Neo4jEmbeddingStore;
 import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class Neo4jEmbeddingStoreRecorder {
+    private final RuntimeValue<Neo4jRuntimeConfig> runtimeConfig;
 
-    public Function<SyntheticCreationalContext<Neo4jEmbeddingStore>, Neo4jEmbeddingStore> embeddingStoreFunction(
-            Neo4jRuntimeConfig config) {
+    public Neo4jEmbeddingStoreRecorder(RuntimeValue<Neo4jRuntimeConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public Function<SyntheticCreationalContext<Neo4jEmbeddingStore>, Neo4jEmbeddingStore> embeddingStoreFunction() {
         return new Function<>() {
             @Override
             public Neo4jEmbeddingStore apply(SyntheticCreationalContext<Neo4jEmbeddingStore> context) {
                 var builder = Neo4jEmbeddingStore.builder();
                 Driver driver = context.getInjectedReference(Driver.class, new Default.Literal());
                 builder.driver(driver);
-                builder.dimension(config.dimension());
-                builder.label(config.label());
-                builder.embeddingProperty(config.embeddingProperty());
-                builder.idProperty(config.idProperty());
-                builder.metadataPrefix(config.metadataPrefix().orElse(""));
-                builder.textProperty(config.textProperty());
-                builder.indexName(config.indexName());
-                builder.databaseName(config.databaseName());
-                builder.retrievalQuery(config.retrievalQuery());
-                builder.config(SessionConfig.forDatabase(config.databaseName()));
+                builder.dimension(runtimeConfig.getValue().dimension());
+                builder.label(runtimeConfig.getValue().label());
+                builder.embeddingProperty(runtimeConfig.getValue().embeddingProperty());
+                builder.idProperty(runtimeConfig.getValue().idProperty());
+                builder.metadataPrefix(runtimeConfig.getValue().metadataPrefix().orElse(""));
+                builder.textProperty(runtimeConfig.getValue().textProperty());
+                builder.indexName(runtimeConfig.getValue().indexName());
+                builder.databaseName(runtimeConfig.getValue().databaseName());
+                builder.retrievalQuery(runtimeConfig.getValue().retrievalQuery());
+                builder.config(SessionConfig.forDatabase(runtimeConfig.getValue().databaseName()));
                 return builder.build();
             }
         };

--- a/embedding-stores/pgvector/deployment/src/main/java/io/quarkiverse/langchain4j/pgvector/deployment/PgVectorEmbeddingStoreProcessor.java
+++ b/embedding-stores/pgvector/deployment/src/main/java/io/quarkiverse/langchain4j/pgvector/deployment/PgVectorEmbeddingStoreProcessor.java
@@ -17,7 +17,6 @@ import io.agroal.api.AgroalPoolInterceptor;
 import io.quarkiverse.langchain4j.deployment.EmbeddingStoreBuildItem;
 import io.quarkiverse.langchain4j.pgvector.PgVectorAgroalPoolInterceptor;
 import io.quarkiverse.langchain4j.pgvector.PgVectorEmbeddingStore;
-import io.quarkiverse.langchain4j.pgvector.runtime.PgVectorEmbeddingStoreConfig;
 import io.quarkiverse.langchain4j.pgvector.runtime.PgVectorEmbeddingStoreRecorder;
 import io.quarkus.agroal.DataSource;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
@@ -53,7 +52,6 @@ class PgVectorEmbeddingStoreProcessor {
     public void createBean(
             BuildProducer<SyntheticBeanBuildItem> beanProducer,
             PgVectorEmbeddingStoreRecorder recorder,
-            PgVectorEmbeddingStoreConfig config,
             PgVectorEmbeddingStoreBuildTimeConfig buildTimeConfig,
             BuildProducer<EmbeddingStoreBuildItem> embeddingStoreProducer) {
 
@@ -70,7 +68,7 @@ class PgVectorEmbeddingStoreProcessor {
                 .defaultBean()
                 .unremovable()
                 .scope(ApplicationScoped.class)
-                .createWith(recorder.embeddingStoreFunction(config, buildTimeConfig.datasource().orElse(null)))
+                .createWith(recorder.embeddingStoreFunction(buildTimeConfig.datasource().orElse(null)))
                 .addInjectionPoint(ClassType.create(DotName.createSimple(AgroalDataSource.class)), datasourceQualifier)
                 .done());
 
@@ -80,7 +78,7 @@ class PgVectorEmbeddingStoreProcessor {
                 .setRuntimeInit()
                 .unremovable()
                 .scope(ApplicationScoped.class)
-                .supplier(recorder.pgVectorAgroalPoolInterceptor(config))
+                .supplier(recorder.pgVectorAgroalPoolInterceptor())
                 .qualifiers(datasourceQualifier)
                 .done());
 

--- a/embedding-stores/pgvector/runtime/src/main/java/io/quarkiverse/langchain4j/pgvector/runtime/PgVectorEmbeddingStoreRecorder.java
+++ b/embedding-stores/pgvector/runtime/src/main/java/io/quarkiverse/langchain4j/pgvector/runtime/PgVectorEmbeddingStoreRecorder.java
@@ -10,13 +10,19 @@ import io.quarkiverse.langchain4j.pgvector.PgVectorAgroalPoolInterceptor;
 import io.quarkiverse.langchain4j.pgvector.PgVectorEmbeddingStore;
 import io.quarkus.agroal.DataSource.DataSourceLiteral;
 import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class PgVectorEmbeddingStoreRecorder {
+    private final RuntimeValue<PgVectorEmbeddingStoreConfig> runtimeConfig;
+
+    public PgVectorEmbeddingStoreRecorder(RuntimeValue<PgVectorEmbeddingStoreConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
 
     public Function<SyntheticCreationalContext<PgVectorEmbeddingStore>, PgVectorEmbeddingStore> embeddingStoreFunction(
-            PgVectorEmbeddingStoreConfig config, String datasourceName) {
+            String datasourceName) {
         return new Function<>() {
             @Override
             public PgVectorEmbeddingStore apply(SyntheticCreationalContext<PgVectorEmbeddingStore> context) {
@@ -29,17 +35,23 @@ public class PgVectorEmbeddingStoreRecorder {
 
                 dataSource.flush(AgroalDataSource.FlushMode.GRACEFUL);
 
-                return new PgVectorEmbeddingStore(dataSource, config.table(), config.dimension(), config.useIndex(),
-                        config.indexListSize(), config.createTable(), config.dropTableFirst(), config.metadata());
+                return new PgVectorEmbeddingStore(dataSource,
+                        runtimeConfig.getValue().table(),
+                        runtimeConfig.getValue().dimension(),
+                        runtimeConfig.getValue().useIndex(),
+                        runtimeConfig.getValue().indexListSize(),
+                        runtimeConfig.getValue().createTable(),
+                        runtimeConfig.getValue().dropTableFirst(),
+                        runtimeConfig.getValue().metadata());
             }
         };
     }
 
-    public Supplier<PgVectorAgroalPoolInterceptor> pgVectorAgroalPoolInterceptor(PgVectorEmbeddingStoreConfig config) {
+    public Supplier<PgVectorAgroalPoolInterceptor> pgVectorAgroalPoolInterceptor() {
         return new Supplier<>() {
             @Override
             public PgVectorAgroalPoolInterceptor get() {
-                return new PgVectorAgroalPoolInterceptor(config);
+                return new PgVectorAgroalPoolInterceptor(runtimeConfig.getValue());
             }
         };
     }

--- a/embedding-stores/pinecone/deployment/src/main/java/io/quarkiverse/langchain4j/pinecone/PineconeProcessor.java
+++ b/embedding-stores/pinecone/deployment/src/main/java/io/quarkiverse/langchain4j/pinecone/PineconeProcessor.java
@@ -9,7 +9,6 @@ import org.jboss.jandex.ParameterizedType;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import io.quarkiverse.langchain4j.deployment.EmbeddingStoreBuildItem;
-import io.quarkiverse.langchain4j.pinecone.runtime.PineconeConfig;
 import io.quarkiverse.langchain4j.pinecone.runtime.PineconeRecorder;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
@@ -38,7 +37,6 @@ public class PineconeProcessor {
     public void createBean(
             BuildProducer<SyntheticBeanBuildItem> beanProducer,
             PineconeRecorder recorder,
-            PineconeConfig config,
             BuildProducer<EmbeddingStoreBuildItem> embeddingStoreProducer) {
         beanProducer.produce(SyntheticBeanBuildItem
                 .configure(PINECONE_EMBEDDING_STORE)
@@ -48,7 +46,7 @@ public class PineconeProcessor {
                 .setRuntimeInit()
                 .unremovable()
                 .scope(ApplicationScoped.class)
-                .supplier(recorder.pineconeStoreSupplier(config))
+                .supplier(recorder.pineconeStoreSupplier())
                 .done());
         embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
     }

--- a/embedding-stores/pinecone/runtime/src/main/java/io/quarkiverse/langchain4j/pinecone/runtime/PineconeRecorder.java
+++ b/embedding-stores/pinecone/runtime/src/main/java/io/quarkiverse/langchain4j/pinecone/runtime/PineconeRecorder.java
@@ -4,25 +4,31 @@ import java.time.Duration;
 import java.util.function.Supplier;
 
 import io.quarkiverse.langchain4j.pinecone.PineconeEmbeddingStore;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class PineconeRecorder {
+    private final RuntimeValue<PineconeConfig> runtimeConfig;
 
-    public Supplier<PineconeEmbeddingStore> pineconeStoreSupplier(PineconeConfig config) {
+    public PineconeRecorder(RuntimeValue<PineconeConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public Supplier<PineconeEmbeddingStore> pineconeStoreSupplier() {
         return new Supplier<>() {
             @Override
             public PineconeEmbeddingStore get() {
-                return new PineconeEmbeddingStore(config.apiKey(),
-                        config.indexName(),
-                        config.projectId(),
-                        config.environment(),
-                        config.namespace().orElse(null),
-                        config.textFieldName(),
-                        config.timeout().orElse(Duration.ofSeconds(5)),
-                        config.dimension().orElse(null),
-                        config.podType(),
-                        config.indexReadinessTimeout().orElse(Duration.ofMinutes(1)));
+                return new PineconeEmbeddingStore(runtimeConfig.getValue().apiKey(),
+                        runtimeConfig.getValue().indexName(),
+                        runtimeConfig.getValue().projectId(),
+                        runtimeConfig.getValue().environment(),
+                        runtimeConfig.getValue().namespace().orElse(null),
+                        runtimeConfig.getValue().textFieldName(),
+                        runtimeConfig.getValue().timeout().orElse(Duration.ofSeconds(5)),
+                        runtimeConfig.getValue().dimension().orElse(null),
+                        runtimeConfig.getValue().podType(),
+                        runtimeConfig.getValue().indexReadinessTimeout().orElse(Duration.ofMinutes(1)));
             }
         };
     }

--- a/embedding-stores/qdrant/deployment/src/main/java/io/quarkiverse/langchain4j/qdrant/QdrantProcessor.java
+++ b/embedding-stores/qdrant/deployment/src/main/java/io/quarkiverse/langchain4j/qdrant/QdrantProcessor.java
@@ -11,7 +11,6 @@ import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.qdrant.QdrantEmbeddingStore;
 import io.quarkiverse.langchain4j.deployment.EmbeddingStoreBuildItem;
 import io.quarkiverse.langchain4j.qdrant.runtime.QdrantRecorder;
-import io.quarkiverse.langchain4j.qdrant.runtime.QdrantRuntimeConfig;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -34,7 +33,6 @@ public class QdrantProcessor {
     public void createBean(
             BuildProducer<SyntheticBeanBuildItem> beanProducer,
             QdrantRecorder recorder,
-            QdrantRuntimeConfig config,
             BuildProducer<EmbeddingStoreBuildItem> embeddingStoreProducer) {
 
         beanProducer.produce(SyntheticBeanBuildItem
@@ -46,7 +44,7 @@ public class QdrantProcessor {
                 .setRuntimeInit()
                 .unremovable()
                 .scope(ApplicationScoped.class)
-                .supplier(recorder.qdrantStoreSupplier(config))
+                .supplier(recorder.qdrantStoreSupplier())
                 .done());
 
         embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());

--- a/embedding-stores/qdrant/runtime/src/main/java/io/quarkiverse/langchain4j/qdrant/runtime/QdrantRecorder.java
+++ b/embedding-stores/qdrant/runtime/src/main/java/io/quarkiverse/langchain4j/qdrant/runtime/QdrantRecorder.java
@@ -3,22 +3,28 @@ package io.quarkiverse.langchain4j.qdrant.runtime;
 import java.util.function.Supplier;
 
 import dev.langchain4j.store.embedding.qdrant.QdrantEmbeddingStore;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class QdrantRecorder {
+    private final RuntimeValue<QdrantRuntimeConfig> runtimeConfig;
 
-    public Supplier<QdrantEmbeddingStore> qdrantStoreSupplier(QdrantRuntimeConfig config) {
+    public QdrantRecorder(RuntimeValue<QdrantRuntimeConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public Supplier<QdrantEmbeddingStore> qdrantStoreSupplier() {
         return new Supplier<>() {
             @Override
             public QdrantEmbeddingStore get() {
                 return new QdrantEmbeddingStore.Builder()
-                        .host(config.host())
-                        .port(config.port())
-                        .apiKey(config.apiKey().orElse(null))
-                        .collectionName(config.collection().name())
-                        .useTls(config.useTls())
-                        .payloadTextKey(config.payloadTextKey())
+                        .host(runtimeConfig.getValue().host())
+                        .port(runtimeConfig.getValue().port())
+                        .apiKey(runtimeConfig.getValue().apiKey().orElse(null))
+                        .collectionName(runtimeConfig.getValue().collection().name())
+                        .useTls(runtimeConfig.getValue().useTls())
+                        .payloadTextKey(runtimeConfig.getValue().payloadTextKey())
                         .build();
             }
         };

--- a/embedding-stores/redis/deployment/src/main/java/io/quarkiverse/langchain4j/redis/RedisEmbeddingStoreProcessor.java
+++ b/embedding-stores/redis/deployment/src/main/java/io/quarkiverse/langchain4j/redis/RedisEmbeddingStoreProcessor.java
@@ -11,7 +11,6 @@ import org.jboss.jandex.ParameterizedType;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import io.quarkiverse.langchain4j.deployment.EmbeddingStoreBuildItem;
-import io.quarkiverse.langchain4j.redis.runtime.RedisEmbeddingStoreConfig;
 import io.quarkiverse.langchain4j.redis.runtime.RedisEmbeddingStoreRecorder;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -45,7 +44,6 @@ public class RedisEmbeddingStoreProcessor {
     public void createBean(
             BuildProducer<SyntheticBeanBuildItem> beanProducer,
             RedisEmbeddingStoreRecorder recorder,
-            RedisEmbeddingStoreConfig config,
             BuildProducer<EmbeddingStoreBuildItem> embeddingStoreProducer,
             RedisEmbeddingStoreBuildTimeConfig buildTimeConfig) {
         String clientName = buildTimeConfig.clientName().orElse(null);
@@ -67,7 +65,7 @@ public class RedisEmbeddingStoreProcessor {
                 .scope(ApplicationScoped.class)
                 .addInjectionPoint(ClassType.create(DotName.createSimple(ReactiveRedisDataSource.class)),
                         redisClientQualifier)
-                .createWith(recorder.embeddingStoreFunction(config, clientName))
+                .createWith(recorder.embeddingStoreFunction(clientName))
                 .done());
         embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
     }

--- a/embedding-stores/redis/runtime/src/main/java/io/quarkiverse/langchain4j/redis/runtime/RedisEmbeddingStoreRecorder.java
+++ b/embedding-stores/redis/runtime/src/main/java/io/quarkiverse/langchain4j/redis/runtime/RedisEmbeddingStoreRecorder.java
@@ -9,13 +9,19 @@ import io.quarkiverse.langchain4j.redis.RedisEmbeddingStore;
 import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.redis.client.RedisClientName;
 import io.quarkus.redis.datasource.ReactiveRedisDataSource;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class RedisEmbeddingStoreRecorder {
+    private final RuntimeValue<RedisEmbeddingStoreConfig> runtimeConfig;
+
+    public RedisEmbeddingStoreRecorder(RuntimeValue<RedisEmbeddingStoreConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
 
     public Function<SyntheticCreationalContext<RedisEmbeddingStore>, RedisEmbeddingStore> embeddingStoreFunction(
-            RedisEmbeddingStoreConfig config, String clientName) {
+            String clientName) {
         return new Function<>() {
             @Override
             public RedisEmbeddingStore apply(SyntheticCreationalContext<RedisEmbeddingStore> context) {
@@ -30,15 +36,15 @@ public class RedisEmbeddingStoreRecorder {
                 builder.dataSource(dataSource);
 
                 RedisSchema schema = new RedisSchema.Builder()
-                        .indexName(config.indexName())
-                        .prefix(config.prefix())
-                        .vectorFieldName(config.vectorFieldName())
-                        .scalarFieldName(config.scalarFieldName())
-                        .numericMetadataFields(config.numericMetadataFields().orElse(Collections.emptyList()))
-                        .textualMetadataFields(config.textualMetadataFields().orElse(Collections.emptyList()))
-                        .vectorAlgorithm(config.vectorAlgorithm())
-                        .dimension(config.dimension())
-                        .metricType(config.distanceMetric())
+                        .indexName(runtimeConfig.getValue().indexName())
+                        .prefix(runtimeConfig.getValue().prefix())
+                        .vectorFieldName(runtimeConfig.getValue().vectorFieldName())
+                        .scalarFieldName(runtimeConfig.getValue().scalarFieldName())
+                        .numericMetadataFields(runtimeConfig.getValue().numericMetadataFields().orElse(Collections.emptyList()))
+                        .textualMetadataFields(runtimeConfig.getValue().textualMetadataFields().orElse(Collections.emptyList()))
+                        .vectorAlgorithm(runtimeConfig.getValue().vectorAlgorithm())
+                        .dimension(runtimeConfig.getValue().dimension())
+                        .metricType(runtimeConfig.getValue().distanceMetric())
                         .build();
                 builder.schema(schema);
 

--- a/embedding-stores/weaviate/deployment/src/main/java/io/quarkiverse/langchain4j/weaviate/deployment/WeaviateProcessor.java
+++ b/embedding-stores/weaviate/deployment/src/main/java/io/quarkiverse/langchain4j/weaviate/deployment/WeaviateProcessor.java
@@ -11,7 +11,6 @@ import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.weaviate.WeaviateEmbeddingStore;
 import io.quarkiverse.langchain4j.deployment.EmbeddingStoreBuildItem;
 import io.quarkiverse.langchain4j.weaviate.runtime.WeaviateRecorder;
-import io.quarkiverse.langchain4j.weaviate.runtime.WeaviateRuntimeConfig;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -37,7 +36,6 @@ class WeaviateProcessor {
     public void createBeans(
             BuildProducer<SyntheticBeanBuildItem> beanProducer,
             WeaviateRecorder recorder,
-            WeaviateRuntimeConfig config,
             BuildProducer<EmbeddingStoreBuildItem> embeddingStoreProducer) {
         beanProducer.produce(SyntheticBeanBuildItem
                 .configure(WEAVIATE_EMBEDDING_STORE)
@@ -47,7 +45,7 @@ class WeaviateProcessor {
                 .setRuntimeInit()
                 .unremovable()
                 .scope(ApplicationScoped.class)
-                .supplier(recorder.weaviateStoreSupplier(config))
+                .supplier(recorder.weaviateStoreSupplier())
                 .done());
 
         beanProducer.produce(SyntheticBeanBuildItem
@@ -57,7 +55,7 @@ class WeaviateProcessor {
                 .setRuntimeInit()
                 .unremovable()
                 .scope(ApplicationScoped.class)
-                .supplier(recorder.weaviateClientSupplier(config))
+                .supplier(recorder.weaviateClientSupplier())
                 .done());
 
         embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());

--- a/embedding-stores/weaviate/runtime/src/main/java/io/quarkiverse/langchain4j/weaviate/runtime/WeaviateRecorder.java
+++ b/embedding-stores/weaviate/runtime/src/main/java/io/quarkiverse/langchain4j/weaviate/runtime/WeaviateRecorder.java
@@ -3,37 +3,44 @@ package io.quarkiverse.langchain4j.weaviate.runtime;
 import java.util.function.Supplier;
 
 import dev.langchain4j.store.embedding.weaviate.WeaviateEmbeddingStore;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.weaviate.client.Config;
 import io.weaviate.client.WeaviateClient;
 
 @Recorder
 public class WeaviateRecorder {
+    private final RuntimeValue<WeaviateRuntimeConfig> runtimeConfig;
 
-    public Supplier<WeaviateClient> weaviateClientSupplier(WeaviateRuntimeConfig config) {
+    public WeaviateRecorder(RuntimeValue<WeaviateRuntimeConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public Supplier<WeaviateClient> weaviateClientSupplier() {
         return new Supplier<>() {
             @Override
             public WeaviateClient get() {
-                return new WeaviateClient(new Config(config.scheme(), config.host() + ":" + config.port()));
+                return new WeaviateClient(new Config(runtimeConfig.getValue().scheme(),
+                        runtimeConfig.getValue().host() + ":" + runtimeConfig.getValue().port()));
             }
         };
     }
 
-    public Supplier<WeaviateEmbeddingStore> weaviateStoreSupplier(WeaviateRuntimeConfig config) {
+    public Supplier<WeaviateEmbeddingStore> weaviateStoreSupplier() {
         return new Supplier<>() {
             @Override
             public WeaviateEmbeddingStore get() {
                 return WeaviateEmbeddingStore.builder()
-                        .apiKey(config.apiKey().orElse(null))
-                        .scheme(config.scheme())
-                        .host(config.host())
-                        .port(config.port())
-                        .objectClass(config.objectClass())
-                        .textFieldName(config.textFieldName())
-                        .avoidDups(config.avoidDups())
-                        .consistencyLevel(config.consistencyLevel().toString())
-                        .metadataKeys(config.metadata().keys())
-                        .metadataFieldName(config.metadata().fieldName())
+                        .apiKey(runtimeConfig.getValue().apiKey().orElse(null))
+                        .scheme(runtimeConfig.getValue().scheme())
+                        .host(runtimeConfig.getValue().host())
+                        .port(runtimeConfig.getValue().port())
+                        .objectClass(runtimeConfig.getValue().objectClass())
+                        .textFieldName(runtimeConfig.getValue().textFieldName())
+                        .avoidDups(runtimeConfig.getValue().avoidDups())
+                        .consistencyLevel(runtimeConfig.getValue().consistencyLevel().toString())
+                        .metadataKeys(runtimeConfig.getValue().metadata().keys())
+                        .metadataFieldName(runtimeConfig.getValue().metadata().fieldName())
                         .build();
             }
         };

--- a/mcp/deployment/src/main/java/io/quarkiverse/langchain4j/mcp/deployment/McpProcessor.java
+++ b/mcp/deployment/src/main/java/io/quarkiverse/langchain4j/mcp/deployment/McpProcessor.java
@@ -35,7 +35,6 @@ import io.quarkiverse.langchain4j.mcp.runtime.McpClientName;
 import io.quarkiverse.langchain4j.mcp.runtime.McpRecorder;
 import io.quarkiverse.langchain4j.mcp.runtime.config.LocalLaunchParams;
 import io.quarkiverse.langchain4j.mcp.runtime.config.McpBuildTimeConfiguration;
-import io.quarkiverse.langchain4j.mcp.runtime.config.McpRuntimeConfiguration;
 import io.quarkiverse.langchain4j.mcp.runtime.config.McpTransportType;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
@@ -120,7 +119,6 @@ public class McpProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     public void registerMcpClients(McpBuildTimeConfiguration mcpBuildTimeConfiguration,
-            McpRuntimeConfiguration mcpRuntimeConfiguration,
             Optional<McpConfigFileContentsBuildItem> maybeMcpConfigFileContents,
             BuildProducer<SyntheticBeanBuildItem> beanProducer,
             BuildProducer<HealthBuildItem> healthBuildItems,

--- a/model-providers/anthropic/deployment/src/main/java/io/quarkiverse/langchain4j/anthropic/deployment/AnthropicProcessor.java
+++ b/model-providers/anthropic/deployment/src/main/java/io/quarkiverse/langchain4j/anthropic/deployment/AnthropicProcessor.java
@@ -11,7 +11,6 @@ import org.jboss.jandex.AnnotationInstance;
 
 import io.quarkiverse.langchain4j.ModelName;
 import io.quarkiverse.langchain4j.anthropic.runtime.AnthropicRecorder;
-import io.quarkiverse.langchain4j.anthropic.runtime.config.LangChain4jAnthropicConfig;
 import io.quarkiverse.langchain4j.deployment.items.ChatModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedChatModelProviderBuildItem;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
@@ -48,7 +47,7 @@ public class AnthropicProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void generateBeans(AnthropicRecorder recorder, List<SelectedChatModelProviderBuildItem> selectedChatItem,
-            LangChain4jAnthropicConfig config, BuildProducer<SyntheticBeanBuildItem> beanProducer) {
+            BuildProducer<SyntheticBeanBuildItem> beanProducer) {
         for (var selected : selectedChatItem) {
             if (PROVIDER.equals(selected.getProvider())) {
                 var configName = selected.getConfigName();
@@ -57,7 +56,7 @@ public class AnthropicProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.chatModel(config, configName));
+                        .supplier(recorder.chatModel(configName));
 
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
@@ -67,7 +66,7 @@ public class AnthropicProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.streamingChatModel(config, configName));
+                        .supplier(recorder.streamingChatModel(configName));
 
                 addQualifierIfNecessary(streamingBuilder, configName);
                 beanProducer.produce(streamingBuilder.done());

--- a/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/AnthropicRecorder.java
+++ b/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/AnthropicRecorder.java
@@ -13,6 +13,7 @@ import dev.langchain4j.model.chat.DisabledStreamingChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import io.quarkiverse.langchain4j.anthropic.runtime.config.LangChain4jAnthropicConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.smallrye.config.ConfigValidationException;
 
@@ -20,8 +21,14 @@ import io.smallrye.config.ConfigValidationException;
 public class AnthropicRecorder {
     private static final String DUMMY_KEY = "dummy";
 
-    public Supplier<ChatModel> chatModel(LangChain4jAnthropicConfig runtimeConfig, String configName) {
-        var anthropicConfig = correspondingAnthropicConfig(runtimeConfig, configName);
+    private final RuntimeValue<LangChain4jAnthropicConfig> runtimeConfig;
+
+    public AnthropicRecorder(RuntimeValue<LangChain4jAnthropicConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public Supplier<ChatModel> chatModel(String configName) {
+        var anthropicConfig = correspondingAnthropicConfig(runtimeConfig.getValue(), configName);
 
         if (anthropicConfig.enableIntegration()) {
             var chatModelConfig = anthropicConfig.chatModel();
@@ -71,9 +78,8 @@ public class AnthropicRecorder {
         }
     }
 
-    public Supplier<StreamingChatModel> streamingChatModel(LangChain4jAnthropicConfig runtimeConfig,
-            String configName) {
-        var anthropicConfig = correspondingAnthropicConfig(runtimeConfig, configName);
+    public Supplier<StreamingChatModel> streamingChatModel(String configName) {
+        var anthropicConfig = correspondingAnthropicConfig(runtimeConfig.getValue(), configName);
 
         if (anthropicConfig.enableIntegration()) {
             var chatModelConfig = anthropicConfig.chatModel();

--- a/model-providers/bedrock/deployment/src/main/java/io/quarkiverse/langchain4j/bedrock/deployment/BedrockProcessor.java
+++ b/model-providers/bedrock/deployment/src/main/java/io/quarkiverse/langchain4j/bedrock/deployment/BedrockProcessor.java
@@ -12,13 +12,11 @@ import org.jboss.jandex.AnnotationInstance;
 
 import io.quarkiverse.langchain4j.ModelName;
 import io.quarkiverse.langchain4j.bedrock.runtime.BedrockRecorder;
-import io.quarkiverse.langchain4j.bedrock.runtime.config.LangChain4jBedrockConfig;
 import io.quarkiverse.langchain4j.deployment.items.ChatModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.EmbeddingModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedChatModelProviderBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedEmbeddingModelCandidateBuildItem;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
-import io.quarkiverse.langchain4j.runtime.config.LangChain4jConfig;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
@@ -66,8 +64,6 @@ public class BedrockProcessor {
     void generateBeans(BedrockRecorder recorder,
             List<SelectedChatModelProviderBuildItem> selectedChatItem,
             List<SelectedEmbeddingModelCandidateBuildItem> selectedEmbedding,
-            LangChain4jBedrockConfig config,
-            LangChain4jConfig rootConfig,
             BuildProducer<SyntheticBeanBuildItem> beanProducer) {
 
         for (var selected : selectedChatItem) {
@@ -78,7 +74,7 @@ public class BedrockProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.chatModel(config, configName, rootConfig));
+                        .supplier(recorder.chatModel(configName));
 
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
@@ -88,7 +84,7 @@ public class BedrockProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.streamingChatModel(config, configName, rootConfig));
+                        .supplier(recorder.streamingChatModel(configName));
                 addQualifierIfNecessary(streamingBuilder, configName);
                 beanProducer.produce(streamingBuilder.done());
             }
@@ -103,7 +99,7 @@ public class BedrockProcessor {
                         .defaultBean()
                         .unremovable()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.embeddingModel(config, configName, rootConfig));
+                        .supplier(recorder.embeddingModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }

--- a/model-providers/bedrock/runtime/src/main/java/io/quarkiverse/langchain4j/bedrock/runtime/BedrockRecorder.java
+++ b/model-providers/bedrock/runtime/src/main/java/io/quarkiverse/langchain4j/bedrock/runtime/BedrockRecorder.java
@@ -24,6 +24,7 @@ import io.quarkiverse.langchain4j.bedrock.runtime.config.LangChain4jBedrockConfi
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkiverse.langchain4j.runtime.config.LangChain4jConfig;
 import io.quarkus.arc.Arc;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
@@ -35,10 +36,17 @@ import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 
 @Recorder
 public class BedrockRecorder {
+    private final RuntimeValue<LangChain4jConfig> rootRuntimeConfig;
+    private final RuntimeValue<LangChain4jBedrockConfig> runtimeConfig;
 
-    public Supplier<ChatModel> chatModel(LangChain4jBedrockConfig runtimeConfig, String configName,
-            final LangChain4jConfig rootConfig) {
-        LangChain4jBedrockConfig.BedrockConfig config = correspondingBedrockConfig(runtimeConfig, configName);
+    public BedrockRecorder(RuntimeValue<LangChain4jConfig> rootRuntimeConfig,
+            RuntimeValue<LangChain4jBedrockConfig> runtimeConfig) {
+        this.rootRuntimeConfig = rootRuntimeConfig;
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public Supplier<ChatModel> chatModel(String configName) {
+        LangChain4jBedrockConfig.BedrockConfig config = correspondingBedrockConfig(configName);
 
         if (config.enableIntegration()) {
             var modelConfig = config.chatModel();
@@ -64,7 +72,8 @@ public class BedrockRecorder {
 
             var clientBuilder = BedrockRuntimeClient.builder();
 
-            clientBuilder.httpClient(JaxRsSdkHttpClientFactory.createSync(modelConfig.client(), config.client(), rootConfig));
+            clientBuilder.httpClient(
+                    JaxRsSdkHttpClientFactory.createSync(modelConfig.client(), config.client(), rootRuntimeConfig.getValue()));
 
             configureClient(clientBuilder, modelConfig, config);
 
@@ -105,16 +114,16 @@ public class BedrockRecorder {
                         cp.getClass().getName()));
     }
 
-    public Supplier<StreamingChatModel> streamingChatModel(final LangChain4jBedrockConfig runtimeConfig,
-            final String configName, final LangChain4jConfig rootConfig) {
-        LangChain4jBedrockConfig.BedrockConfig config = correspondingBedrockConfig(runtimeConfig, configName);
+    public Supplier<StreamingChatModel> streamingChatModel(final String configName) {
+        LangChain4jBedrockConfig.BedrockConfig config = correspondingBedrockConfig(configName);
 
         if (config.enableIntegration()) {
             var modelConfig = config.chatModel();
 
             var clientBuilder = BedrockRuntimeAsyncClient.builder();
 
-            clientBuilder.httpClient(JaxRsSdkHttpClientFactory.createAsync(modelConfig.client(), config.client(), rootConfig));
+            clientBuilder.httpClient(
+                    JaxRsSdkHttpClientFactory.createAsync(modelConfig.client(), config.client(), rootRuntimeConfig.getValue()));
 
             configureClient(clientBuilder, modelConfig, config);
 
@@ -174,16 +183,16 @@ public class BedrockRecorder {
         }
     }
 
-    public Supplier<EmbeddingModel> embeddingModel(final LangChain4jBedrockConfig runtimeConfig,
-            final String configName, final LangChain4jConfig rootConfig) {
-        LangChain4jBedrockConfig.BedrockConfig config = correspondingBedrockConfig(runtimeConfig, configName);
+    public Supplier<EmbeddingModel> embeddingModel(final String configName) {
+        LangChain4jBedrockConfig.BedrockConfig config = correspondingBedrockConfig(configName);
 
         if (config.enableIntegration()) {
             var modelConfig = config.embeddingModel();
 
             var clientBuilder = BedrockRuntimeClient.builder(); //NOSONAR creds can be specified later
 
-            clientBuilder.httpClient(JaxRsSdkHttpClientFactory.createSync(modelConfig.client(), config.client(), rootConfig));
+            clientBuilder.httpClient(
+                    JaxRsSdkHttpClientFactory.createSync(modelConfig.client(), config.client(), rootRuntimeConfig.getValue()));
 
             configureClient(clientBuilder, modelConfig, config);
 
@@ -241,13 +250,12 @@ public class BedrockRecorder {
         }
     }
 
-    private LangChain4jBedrockConfig.BedrockConfig correspondingBedrockConfig(LangChain4jBedrockConfig runtimeConfig,
-            String configName) {
+    private LangChain4jBedrockConfig.BedrockConfig correspondingBedrockConfig(String configName) {
         LangChain4jBedrockConfig.BedrockConfig config;
         if (NamedConfigUtil.isDefault(configName)) {
-            config = runtimeConfig.defaultConfig();
+            config = runtimeConfig.getValue().defaultConfig();
         } else {
-            config = runtimeConfig.namedConfig().get(configName);
+            config = runtimeConfig.getValue().namedConfig().get(configName);
         }
         return config;
     }

--- a/model-providers/cohere/deployment/src/main/java/io/quarkiverse/langchain4j/cohere/CohereProcessor.java
+++ b/model-providers/cohere/deployment/src/main/java/io/quarkiverse/langchain4j/cohere/CohereProcessor.java
@@ -13,7 +13,6 @@ import dev.langchain4j.model.scoring.ScoringModel;
 import io.quarkiverse.langchain4j.ModelName;
 import io.quarkiverse.langchain4j.cohere.runtime.CohereRecorder;
 import io.quarkiverse.langchain4j.cohere.runtime.QuarkusCohereScoringModel;
-import io.quarkiverse.langchain4j.cohere.runtime.config.Langchain4jCohereConfig;
 import io.quarkiverse.langchain4j.deployment.items.ScoringModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedScoringModelProviderBuildItem;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
@@ -53,8 +52,7 @@ public class CohereProcessor {
     public void createScoringModelBean(
             BuildProducer<SyntheticBeanBuildItem> beanProducer,
             List<SelectedScoringModelProviderBuildItem> selectedScoring,
-            CohereRecorder recorder,
-            Langchain4jCohereConfig config) {
+            CohereRecorder recorder) {
 
         for (var selected : selectedScoring) {
             if (PROVIDER.equals(selected.getProvider())) {
@@ -67,7 +65,7 @@ public class CohereProcessor {
                         .defaultBean()
                         .unremovable()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.cohereScoringModelSupplier(config, configName));
+                        .supplier(recorder.cohereScoringModelSupplier(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }

--- a/model-providers/cohere/runtime/src/main/java/io/quarkiverse/langchain4j/cohere/runtime/CohereRecorder.java
+++ b/model-providers/cohere/runtime/src/main/java/io/quarkiverse/langchain4j/cohere/runtime/CohereRecorder.java
@@ -7,6 +7,7 @@ import java.util.function.Supplier;
 import dev.langchain4j.model.scoring.ScoringModel;
 import io.quarkiverse.langchain4j.cohere.runtime.config.Langchain4jCohereConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.smallrye.config.ConfigValidationException;
 
@@ -16,8 +17,14 @@ public class CohereRecorder {
     private static final String DUMMY_API_KEY = "dummy";
     private static final ConfigValidationException.Problem[] EMPTY_PROBLEMS = new ConfigValidationException.Problem[0];
 
-    public Supplier<ScoringModel> cohereScoringModelSupplier(Langchain4jCohereConfig runtimeConfig, String configName) {
-        Langchain4jCohereConfig.CohereConfig cohereConfig = correspondingCohereConfig(runtimeConfig, configName);
+    private final RuntimeValue<Langchain4jCohereConfig> runtimeConfig;
+
+    public CohereRecorder(RuntimeValue<Langchain4jCohereConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public Supplier<ScoringModel> cohereScoringModelSupplier(String configName) {
+        Langchain4jCohereConfig.CohereConfig cohereConfig = correspondingCohereConfig(configName);
 
         var configProblems = checkConfigurations(cohereConfig, configName);
 
@@ -60,14 +67,12 @@ public class CohereRecorder {
                 NamedConfigUtil.isDefault(configName) ? "." : ("." + configName + "."), key));
     }
 
-    private Langchain4jCohereConfig.CohereConfig correspondingCohereConfig(
-            Langchain4jCohereConfig runtimeConfig,
-            String configName) {
+    private Langchain4jCohereConfig.CohereConfig correspondingCohereConfig(String configName) {
         Langchain4jCohereConfig.CohereConfig cohereConfig;
         if (NamedConfigUtil.isDefault(configName)) {
-            cohereConfig = runtimeConfig.defaultConfig();
+            cohereConfig = runtimeConfig.getValue().defaultConfig();
         } else {
-            cohereConfig = runtimeConfig.namedConfig().get(configName);
+            cohereConfig = runtimeConfig.getValue().namedConfig().get(configName);
         }
         return cohereConfig;
     }

--- a/model-providers/google/gemini/ai-gemini/deployment/src/main/java/io/quarkiverse/langchain4j/ai/gemini/deployment/AiGeminiProcessor.java
+++ b/model-providers/google/gemini/ai-gemini/deployment/src/main/java/io/quarkiverse/langchain4j/ai/gemini/deployment/AiGeminiProcessor.java
@@ -15,7 +15,6 @@ import org.jboss.jandex.Type;
 
 import io.quarkiverse.langchain4j.ModelName;
 import io.quarkiverse.langchain4j.ai.runtime.gemini.AiGeminiRecorder;
-import io.quarkiverse.langchain4j.ai.runtime.gemini.config.LangChain4jAiGeminiConfig;
 import io.quarkiverse.langchain4j.deployment.DotNames;
 import io.quarkiverse.langchain4j.deployment.items.ChatModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.EmbeddingModelProviderCandidateBuildItem;
@@ -62,11 +61,11 @@ public class AiGeminiProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     void generateBeans(AiGeminiRecorder recorder, List<SelectedChatModelProviderBuildItem> selectedChatItem,
             List<SelectedEmbeddingModelCandidateBuildItem> selectedEmbedding,
-            LangChain4jAiGeminiConfig config, BuildProducer<SyntheticBeanBuildItem> beanProducer) {
+            BuildProducer<SyntheticBeanBuildItem> beanProducer) {
         for (var selected : selectedChatItem) {
             if (PROVIDER.equals(selected.getProvider())) {
                 var configName = selected.getConfigName();
-                var chatModel = recorder.chatModel(config, configName);
+                var chatModel = recorder.chatModel(configName);
                 var builder = SyntheticBeanBuildItem
                         .configure(CHAT_MODEL)
                         .setRuntimeInit()
@@ -81,7 +80,7 @@ public class AiGeminiProcessor {
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
 
-                var streamingChatModel = recorder.streamingChatModel(config, configName);
+                var streamingChatModel = recorder.streamingChatModel(configName);
                 var streamingBuilder = SyntheticBeanBuildItem
                         .configure(STREAMING_CHAT_MODEL)
                         .setRuntimeInit()
@@ -101,7 +100,7 @@ public class AiGeminiProcessor {
         for (var selected : selectedEmbedding) {
             if (PROVIDER.equals(selected.getProvider())) {
                 var configName = selected.getConfigName();
-                var embeddingModel = recorder.embeddingModel(config, configName);
+                var embeddingModel = recorder.embeddingModel(configName);
                 var builder = SyntheticBeanBuildItem
                         .configure(EMBEDDING_MODEL)
                         .setRuntimeInit()

--- a/model-providers/google/gemini/ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/ai/runtime/gemini/AiGeminiRecorder.java
+++ b/model-providers/google/gemini/ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/ai/runtime/gemini/AiGeminiRecorder.java
@@ -20,6 +20,7 @@ import io.quarkiverse.langchain4j.ai.runtime.gemini.config.LangChain4jAiGeminiCo
 import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.smallrye.config.ConfigValidationException;
 
@@ -30,9 +31,14 @@ public class AiGeminiRecorder {
     private static final TypeLiteral<Instance<ModelAuthProvider>> MODEL_AUTH_PROVIDER_TYPE_LITERAL = new TypeLiteral<>() {
     };
 
-    public Function<SyntheticCreationalContext<EmbeddingModel>, EmbeddingModel> embeddingModel(LangChain4jAiGeminiConfig config,
-            String configName) {
-        var aiConfig = correspondingAiConfig(config, configName);
+    private final RuntimeValue<LangChain4jAiGeminiConfig> runtimeConfig;
+
+    public AiGeminiRecorder(RuntimeValue<LangChain4jAiGeminiConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public Function<SyntheticCreationalContext<EmbeddingModel>, EmbeddingModel> embeddingModel(String configName) {
+        var aiConfig = correspondingAiConfig(configName);
 
         if (aiConfig.enableIntegration()) {
             var embeddingModelConfig = aiConfig.embeddingModel();
@@ -75,9 +81,8 @@ public class AiGeminiRecorder {
         }
     }
 
-    public Function<SyntheticCreationalContext<ChatModel>, ChatModel> chatModel(
-            LangChain4jAiGeminiConfig config, String configName) {
-        var aiConfig = correspondingAiConfig(config, configName);
+    public Function<SyntheticCreationalContext<ChatModel>, ChatModel> chatModel(String configName) {
+        var aiConfig = correspondingAiConfig(configName);
 
         if (aiConfig.enableIntegration()) {
             var chatModelConfig = aiConfig.chatModel();
@@ -129,9 +134,8 @@ public class AiGeminiRecorder {
 
     }
 
-    public Function<SyntheticCreationalContext<StreamingChatModel>, StreamingChatModel> streamingChatModel(
-            LangChain4jAiGeminiConfig config, String configName) {
-        var aiConfig = correspondingAiConfig(config, configName);
+    public Function<SyntheticCreationalContext<StreamingChatModel>, StreamingChatModel> streamingChatModel(String configName) {
+        var aiConfig = correspondingAiConfig(configName);
 
         if (aiConfig.enableIntegration()) {
             var chatModelConfig = aiConfig.chatModel();
@@ -192,11 +196,10 @@ public class AiGeminiRecorder {
         return context.getInjectedReference(MODEL_AUTH_PROVIDER_TYPE_LITERAL).isResolvable();
     }
 
-    private LangChain4jAiGeminiConfig.AiGeminiConfig correspondingAiConfig(
-            LangChain4jAiGeminiConfig runtimeConfig, String configName) {
+    private LangChain4jAiGeminiConfig.AiGeminiConfig correspondingAiConfig(String configName) {
 
-        return NamedConfigUtil.isDefault(configName) ? runtimeConfig.defaultConfig()
-                : runtimeConfig.namedConfig().get(configName);
+        return NamedConfigUtil.isDefault(configName) ? runtimeConfig.getValue().defaultConfig()
+                : runtimeConfig.getValue().namedConfig().get(configName);
     }
 
     private static ConfigValidationException.Problem[] createConfigProblems(String key, String configName) {

--- a/model-providers/google/vertex-ai-gemini/deployment/src/main/java/io/quarkiverse/langchain4j/vertexai/gemini/deployment/VertexAiGeminiProcessor.java
+++ b/model-providers/google/vertex-ai-gemini/deployment/src/main/java/io/quarkiverse/langchain4j/vertexai/gemini/deployment/VertexAiGeminiProcessor.java
@@ -21,7 +21,6 @@ import io.quarkiverse.langchain4j.deployment.items.SelectedChatModelProviderBuil
 import io.quarkiverse.langchain4j.deployment.items.SelectedEmbeddingModelCandidateBuildItem;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkiverse.langchain4j.vertexai.runtime.gemini.VertexAiGeminiRecorder;
-import io.quarkiverse.langchain4j.vertexai.runtime.gemini.config.LangChain4jVertexAiGeminiConfig;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
@@ -61,11 +60,11 @@ public class VertexAiGeminiProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     void generateBeans(VertexAiGeminiRecorder recorder, List<SelectedChatModelProviderBuildItem> selectedChatItem,
             List<SelectedEmbeddingModelCandidateBuildItem> selectedEmbedding,
-            LangChain4jVertexAiGeminiConfig config, BuildProducer<SyntheticBeanBuildItem> beanProducer) {
+            BuildProducer<SyntheticBeanBuildItem> beanProducer) {
         for (var selected : selectedChatItem) {
             if (PROVIDER.equals(selected.getProvider())) {
                 var configName = selected.getConfigName();
-                var chatModel = recorder.chatModel(config, configName);
+                var chatModel = recorder.chatModel(configName);
                 var builder = SyntheticBeanBuildItem
                         .configure(CHAT_MODEL)
                         .setRuntimeInit()
@@ -78,7 +77,7 @@ public class VertexAiGeminiProcessor {
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
 
-                var streamingChatModel = recorder.streamingChatModel(config, configName);
+                var streamingChatModel = recorder.streamingChatModel(configName);
                 var streamingBuilder = SyntheticBeanBuildItem
                         .configure(STREAMING_CHAT_MODEL)
                         .setRuntimeInit()
@@ -103,7 +102,7 @@ public class VertexAiGeminiProcessor {
                         .defaultBean()
                         .unremovable()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.embeddingModel(config, configName));
+                        .supplier(recorder.embeddingModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }

--- a/model-providers/google/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/VertexAiGeminiRecorder.java
+++ b/model-providers/google/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/VertexAiGeminiRecorder.java
@@ -20,6 +20,7 @@ import dev.langchain4j.model.embedding.EmbeddingModel;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkiverse.langchain4j.vertexai.runtime.gemini.config.LangChain4jVertexAiGeminiConfig;
 import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.smallrye.config.ConfigValidationException;
 
@@ -30,8 +31,14 @@ public class VertexAiGeminiRecorder {
     private static final TypeLiteral<Instance<ChatModelListener>> CHAT_MODEL_LISTENER_TYPE_LITERAL = new TypeLiteral<>() {
     };
 
-    public Supplier<EmbeddingModel> embeddingModel(LangChain4jVertexAiGeminiConfig config, String configName) {
-        var vertexAiConfig = correspondingVertexAiConfig(config, configName);
+    private final RuntimeValue<LangChain4jVertexAiGeminiConfig> runtimeConfig;
+
+    public VertexAiGeminiRecorder(RuntimeValue<LangChain4jVertexAiGeminiConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public Supplier<EmbeddingModel> embeddingModel(String configName) {
+        var vertexAiConfig = correspondingVertexAiConfig(configName);
 
         if (vertexAiConfig.enableIntegration()) {
             var embeddingModelConfig = vertexAiConfig.embeddingModel();
@@ -68,9 +75,8 @@ public class VertexAiGeminiRecorder {
         }
     }
 
-    public Function<SyntheticCreationalContext<ChatModel>, ChatModel> chatModel(
-            LangChain4jVertexAiGeminiConfig config, String configName) {
-        var vertexAiConfig = correspondingVertexAiConfig(config, configName);
+    public Function<SyntheticCreationalContext<ChatModel>, ChatModel> chatModel(String configName) {
+        var vertexAiConfig = correspondingVertexAiConfig(configName);
 
         if (vertexAiConfig.enableIntegration()) {
             var chatModelConfig = vertexAiConfig.chatModel();
@@ -127,9 +133,8 @@ public class VertexAiGeminiRecorder {
 
     }
 
-    public Function<SyntheticCreationalContext<StreamingChatModel>, StreamingChatModel> streamingChatModel(
-            LangChain4jVertexAiGeminiConfig config, String configName) {
-        var vertexAiConfig = correspondingVertexAiConfig(config, configName);
+    public Function<SyntheticCreationalContext<StreamingChatModel>, StreamingChatModel> streamingChatModel(String configName) {
+        var vertexAiConfig = correspondingVertexAiConfig(configName);
 
         if (vertexAiConfig.enableIntegration()) {
             var chatModelConfig = vertexAiConfig.chatModel();
@@ -186,11 +191,10 @@ public class VertexAiGeminiRecorder {
         }
     }
 
-    private LangChain4jVertexAiGeminiConfig.VertexAiGeminiConfig correspondingVertexAiConfig(
-            LangChain4jVertexAiGeminiConfig runtimeConfig, String configName) {
+    private LangChain4jVertexAiGeminiConfig.VertexAiGeminiConfig correspondingVertexAiConfig(String configName) {
 
-        return NamedConfigUtil.isDefault(configName) ? runtimeConfig.defaultConfig()
-                : runtimeConfig.namedConfig().get(configName);
+        return NamedConfigUtil.isDefault(configName) ? runtimeConfig.getValue().defaultConfig()
+                : runtimeConfig.getValue().namedConfig().get(configName);
     }
 
     private static ConfigValidationException.Problem[] createConfigProblems(String key, String configName) {

--- a/model-providers/google/vertex-ai/deployment/src/main/java/io/quarkiverse/langchain4j/vertexai/deployment/VertexAiProcessor.java
+++ b/model-providers/google/vertex-ai/deployment/src/main/java/io/quarkiverse/langchain4j/vertexai/deployment/VertexAiProcessor.java
@@ -13,7 +13,6 @@ import io.quarkiverse.langchain4j.deployment.items.ChatModelProviderCandidateBui
 import io.quarkiverse.langchain4j.deployment.items.SelectedChatModelProviderBuildItem;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkiverse.langchain4j.vertexai.runtime.VertexAiRecorder;
-import io.quarkiverse.langchain4j.vertexai.runtime.config.LangChain4jVertexAiConfig;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
@@ -48,7 +47,7 @@ public class VertexAiProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void generateBeans(VertexAiRecorder recorder, List<SelectedChatModelProviderBuildItem> selectedChatItem,
-            LangChain4jVertexAiConfig config, BuildProducer<SyntheticBeanBuildItem> beanProducer) {
+            BuildProducer<SyntheticBeanBuildItem> beanProducer) {
         for (var selected : selectedChatItem) {
             if (PROVIDER.equals(selected.getProvider())) {
                 var configName = selected.getConfigName();
@@ -57,7 +56,7 @@ public class VertexAiProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.chatModel(config, configName));
+                        .supplier(recorder.chatModel(configName));
 
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());

--- a/model-providers/google/vertex-ai/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/VertexAiRecorder.java
+++ b/model-providers/google/vertex-ai/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/VertexAiRecorder.java
@@ -9,6 +9,7 @@ import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.DisabledChatModel;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkiverse.langchain4j.vertexai.runtime.config.LangChain4jVertexAiConfig;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.smallrye.config.ConfigValidationException;
 
@@ -16,8 +17,14 @@ import io.smallrye.config.ConfigValidationException;
 public class VertexAiRecorder {
     private static final String DUMMY_KEY = "dummy";
 
-    public Supplier<ChatModel> chatModel(LangChain4jVertexAiConfig config, String configName) {
-        var vertexAiConfig = correspondingVertexAiConfig(config, configName);
+    private final RuntimeValue<LangChain4jVertexAiConfig> runtimeConfig;
+
+    public VertexAiRecorder(RuntimeValue<LangChain4jVertexAiConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public Supplier<ChatModel> chatModel(String configName) {
+        var vertexAiConfig = correspondingVertexAiConfig(configName);
 
         if (vertexAiConfig.enableIntegration()) {
             var chatModelConfig = vertexAiConfig.chatModel();
@@ -63,11 +70,10 @@ public class VertexAiRecorder {
 
     }
 
-    private LangChain4jVertexAiConfig.VertexAiConfig correspondingVertexAiConfig(
-            LangChain4jVertexAiConfig runtimeConfig, String configName) {
+    private LangChain4jVertexAiConfig.VertexAiConfig correspondingVertexAiConfig(String configName) {
 
-        return NamedConfigUtil.isDefault(configName) ? runtimeConfig.defaultConfig()
-                : runtimeConfig.namedConfig().get(configName);
+        return NamedConfigUtil.isDefault(configName) ? runtimeConfig.getValue().defaultConfig()
+                : runtimeConfig.getValue().namedConfig().get(configName);
     }
 
     private static ConfigValidationException.Problem[] createConfigProblems(String key, String configName) {

--- a/model-providers/hugging-face/deployment/src/main/java/io/quarkiverse/langchain4j/huggingface/deployment/HuggingFaceProcessor.java
+++ b/model-providers/hugging-face/deployment/src/main/java/io/quarkiverse/langchain4j/huggingface/deployment/HuggingFaceProcessor.java
@@ -15,7 +15,6 @@ import io.quarkiverse.langchain4j.deployment.items.EmbeddingModelProviderCandida
 import io.quarkiverse.langchain4j.deployment.items.SelectedChatModelProviderBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedEmbeddingModelCandidateBuildItem;
 import io.quarkiverse.langchain4j.huggingface.runtime.HuggingFaceRecorder;
-import io.quarkiverse.langchain4j.huggingface.runtime.config.LangChain4jHuggingFaceConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
@@ -57,7 +56,6 @@ public class HuggingFaceProcessor {
     void generateBeans(HuggingFaceRecorder recorder,
             List<SelectedChatModelProviderBuildItem> selectedChatItem,
             List<SelectedEmbeddingModelCandidateBuildItem> selectedEmbedding,
-            LangChain4jHuggingFaceConfig config,
             BuildProducer<SyntheticBeanBuildItem> beanProducer) {
 
         for (var selected : selectedChatItem) {
@@ -68,7 +66,7 @@ public class HuggingFaceProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.chatModel(config, configName));
+                        .supplier(recorder.chatModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }
@@ -83,7 +81,7 @@ public class HuggingFaceProcessor {
                         .defaultBean()
                         .unremovable()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.embeddingModel(config, configName));
+                        .supplier(recorder.embeddingModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }

--- a/model-providers/hugging-face/runtime/src/main/java/io/quarkiverse/langchain4j/huggingface/runtime/HuggingFaceRecorder.java
+++ b/model-providers/hugging-face/runtime/src/main/java/io/quarkiverse/langchain4j/huggingface/runtime/HuggingFaceRecorder.java
@@ -16,6 +16,7 @@ import io.quarkiverse.langchain4j.huggingface.runtime.config.ChatModelConfig;
 import io.quarkiverse.langchain4j.huggingface.runtime.config.EmbeddingModelConfig;
 import io.quarkiverse.langchain4j.huggingface.runtime.config.LangChain4jHuggingFaceConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.smallrye.config.ConfigValidationException;
 
@@ -25,9 +26,15 @@ public class HuggingFaceRecorder {
     private static final String DUMMY_KEY = "dummy";
     private static final String HUGGING_FACE_URL_MARKER = "api-inference.huggingface.co";
 
-    public Supplier<ChatModel> chatModel(LangChain4jHuggingFaceConfig runtimeConfig, String configName) {
-        LangChain4jHuggingFaceConfig.HuggingFaceConfig huggingFaceConfig = correspondingHuggingFaceConfig(runtimeConfig,
-                configName);
+    private final RuntimeValue<LangChain4jHuggingFaceConfig> runtimeConfig;
+
+    public HuggingFaceRecorder(RuntimeValue<LangChain4jHuggingFaceConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public Supplier<ChatModel> chatModel(String configName) {
+        LangChain4jHuggingFaceConfig.HuggingFaceConfig huggingFaceConfig = correspondingHuggingFaceConfig(
+                runtimeConfig.getValue(), configName);
 
         if (huggingFaceConfig.enableIntegration()) {
             String apiKey = huggingFaceConfig.apiKey();
@@ -75,9 +82,9 @@ public class HuggingFaceRecorder {
         }
     }
 
-    public Supplier<EmbeddingModel> embeddingModel(LangChain4jHuggingFaceConfig runtimeConfig, String configName) {
-        LangChain4jHuggingFaceConfig.HuggingFaceConfig huggingFaceConfig = correspondingHuggingFaceConfig(runtimeConfig,
-                configName);
+    public Supplier<EmbeddingModel> embeddingModel(String configName) {
+        LangChain4jHuggingFaceConfig.HuggingFaceConfig huggingFaceConfig = correspondingHuggingFaceConfig(
+                runtimeConfig.getValue(), configName);
 
         if (huggingFaceConfig.enableIntegration()) {
             String apiKey = huggingFaceConfig.apiKey();

--- a/model-providers/hugging-face/runtime/src/test/java/io/quarkiverse/langchain4j/huggingface/runtime/DisabledModelsHuggingFaceRecorderTest.java
+++ b/model-providers/hugging-face/runtime/src/test/java/io/quarkiverse/langchain4j/huggingface/runtime/DisabledModelsHuggingFaceRecorderTest.java
@@ -11,11 +11,12 @@ import dev.langchain4j.model.embedding.DisabledEmbeddingModel;
 import io.quarkiverse.langchain4j.huggingface.runtime.config.LangChain4jHuggingFaceConfig;
 import io.quarkiverse.langchain4j.huggingface.runtime.config.LangChain4jHuggingFaceConfig.HuggingFaceConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
+import io.quarkus.runtime.RuntimeValue;
 
 class DisabledModelsHuggingFaceRecorderTest {
     LangChain4jHuggingFaceConfig config = mock(LangChain4jHuggingFaceConfig.class);
     HuggingFaceConfig defaultConfig = mock(HuggingFaceConfig.class);
-    HuggingFaceRecorder recorder = new HuggingFaceRecorder();
+    HuggingFaceRecorder recorder = new HuggingFaceRecorder(new RuntimeValue<>(config));
 
     @BeforeEach
     void setupMocks() {
@@ -28,14 +29,14 @@ class DisabledModelsHuggingFaceRecorderTest {
 
     @Test
     void disabledChatModel() {
-        assertThat(recorder.chatModel(config, NamedConfigUtil.DEFAULT_NAME).get())
+        assertThat(recorder.chatModel(NamedConfigUtil.DEFAULT_NAME).get())
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledChatModel.class);
     }
 
     @Test
     void disabledEmbeddingModel() {
-        assertThat(recorder.embeddingModel(config, NamedConfigUtil.DEFAULT_NAME).get())
+        assertThat(recorder.embeddingModel(NamedConfigUtil.DEFAULT_NAME).get())
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledEmbeddingModel.class);
     }

--- a/model-providers/mistral/deployment/src/main/java/io/quarkiverse/langchain4j/mistralai/deployment/MistralAiProcessor.java
+++ b/model-providers/mistral/deployment/src/main/java/io/quarkiverse/langchain4j/mistralai/deployment/MistralAiProcessor.java
@@ -21,7 +21,6 @@ import io.quarkiverse.langchain4j.deployment.items.SelectedChatModelProviderBuil
 import io.quarkiverse.langchain4j.deployment.items.SelectedEmbeddingModelCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedModerationModelProviderBuildItem;
 import io.quarkiverse.langchain4j.mistralai.runtime.MistralAiRecorder;
-import io.quarkiverse.langchain4j.mistralai.runtime.config.LangChain4jMistralAiConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
@@ -82,7 +81,6 @@ public class MistralAiProcessor {
             List<SelectedChatModelProviderBuildItem> selectedChatItem,
             List<SelectedEmbeddingModelCandidateBuildItem> selectedEmbedding,
             List<SelectedModerationModelProviderBuildItem> selectedModeration,
-            LangChain4jMistralAiConfig config,
             BuildProducer<SyntheticBeanBuildItem> beanProducer) {
 
         for (var selected : selectedChatItem) {
@@ -93,7 +91,7 @@ public class MistralAiProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.chatModel(config, configName));
+                        .supplier(recorder.chatModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
 
@@ -102,7 +100,7 @@ public class MistralAiProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.streamingChatModel(config, configName));
+                        .supplier(recorder.streamingChatModel(configName));
                 addQualifierIfNecessary(streamingBuilder, configName);
                 beanProducer.produce(streamingBuilder.done());
             }
@@ -117,7 +115,7 @@ public class MistralAiProcessor {
                         .defaultBean()
                         .unremovable()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.embeddingModel(config, configName));
+                        .supplier(recorder.embeddingModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }
@@ -131,7 +129,7 @@ public class MistralAiProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.moderationModel(config, configName));
+                        .supplier(recorder.moderationModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }

--- a/model-providers/mistral/runtime/src/main/java/io/quarkiverse/langchain4j/mistralai/runtime/MistralAiRecorder.java
+++ b/model-providers/mistral/runtime/src/main/java/io/quarkiverse/langchain4j/mistralai/runtime/MistralAiRecorder.java
@@ -24,15 +24,20 @@ import io.quarkiverse.langchain4j.mistralai.runtime.config.EmbeddingModelConfig;
 import io.quarkiverse.langchain4j.mistralai.runtime.config.LangChain4jMistralAiConfig;
 import io.quarkiverse.langchain4j.mistralai.runtime.config.ModerationModelConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.smallrye.config.ConfigValidationException;
 
 @Recorder
 public class MistralAiRecorder {
+    private final RuntimeValue<LangChain4jMistralAiConfig> runtimeConfig;
 
-    public Supplier<ChatModel> chatModel(LangChain4jMistralAiConfig runtimeConfig, String configName) {
-        LangChain4jMistralAiConfig.MistralAiConfig mistralAiConfig = correspondingMistralAiConfig(runtimeConfig,
-                configName);
+    public MistralAiRecorder(RuntimeValue<LangChain4jMistralAiConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public Supplier<ChatModel> chatModel(String configName) {
+        LangChain4jMistralAiConfig.MistralAiConfig mistralAiConfig = correspondingMistralAiConfig(configName);
 
         if (mistralAiConfig.enableIntegration()) {
             ChatModelConfig chatModelConfig = mistralAiConfig.chatModel();
@@ -83,10 +88,8 @@ public class MistralAiRecorder {
         }
     }
 
-    public Supplier<StreamingChatModel> streamingChatModel(LangChain4jMistralAiConfig runtimeConfig,
-            String configName) {
-        LangChain4jMistralAiConfig.MistralAiConfig mistralAiConfig = correspondingMistralAiConfig(runtimeConfig,
-                configName);
+    public Supplier<StreamingChatModel> streamingChatModel(String configName) {
+        LangChain4jMistralAiConfig.MistralAiConfig mistralAiConfig = correspondingMistralAiConfig(configName);
 
         if (mistralAiConfig.enableIntegration()) {
             ChatModelConfig chatModelConfig = mistralAiConfig.chatModel();
@@ -137,9 +140,8 @@ public class MistralAiRecorder {
         }
     }
 
-    public Supplier<EmbeddingModel> embeddingModel(LangChain4jMistralAiConfig runtimeConfig, String configName) {
-        LangChain4jMistralAiConfig.MistralAiConfig mistralAiConfig = correspondingMistralAiConfig(runtimeConfig,
-                configName);
+    public Supplier<EmbeddingModel> embeddingModel(String configName) {
+        LangChain4jMistralAiConfig.MistralAiConfig mistralAiConfig = correspondingMistralAiConfig(configName);
 
         if (mistralAiConfig.enableIntegration()) {
             EmbeddingModelConfig embeddingModelConfig = mistralAiConfig.embeddingModel();
@@ -174,9 +176,8 @@ public class MistralAiRecorder {
         }
     }
 
-    public Supplier<ModerationModel> moderationModel(LangChain4jMistralAiConfig runtimeConfig, String configName) {
-        LangChain4jMistralAiConfig.MistralAiConfig mistralAiConfig = correspondingMistralAiConfig(runtimeConfig,
-                configName);
+    public Supplier<ModerationModel> moderationModel(String configName) {
+        LangChain4jMistralAiConfig.MistralAiConfig mistralAiConfig = correspondingMistralAiConfig(configName);
 
         if (mistralAiConfig.enableIntegration()) {
             ModerationModelConfig moderationModelConfig = mistralAiConfig.moderationModel();
@@ -211,13 +212,12 @@ public class MistralAiRecorder {
         }
     }
 
-    private LangChain4jMistralAiConfig.MistralAiConfig correspondingMistralAiConfig(
-            LangChain4jMistralAiConfig runtimeConfig, String configName) {
+    private LangChain4jMistralAiConfig.MistralAiConfig correspondingMistralAiConfig(String configName) {
         LangChain4jMistralAiConfig.MistralAiConfig config;
         if (NamedConfigUtil.isDefault(configName)) {
-            config = runtimeConfig.defaultConfig();
+            config = runtimeConfig.getValue().defaultConfig();
         } else {
-            config = runtimeConfig.namedConfig().get(configName);
+            config = runtimeConfig.getValue().namedConfig().get(configName);
         }
         return config;
     }

--- a/model-providers/ollama/deployment/src/main/java/io/quarkiverse/langchain4j/ollama/deployment/OllamaProcessor.java
+++ b/model-providers/ollama/deployment/src/main/java/io/quarkiverse/langchain4j/ollama/deployment/OllamaProcessor.java
@@ -25,7 +25,6 @@ import io.quarkiverse.langchain4j.deployment.items.ImplicitlyUserConfiguredChatP
 import io.quarkiverse.langchain4j.deployment.items.SelectedChatModelProviderBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedEmbeddingModelCandidateBuildItem;
 import io.quarkiverse.langchain4j.ollama.runtime.OllamaRecorder;
-import io.quarkiverse.langchain4j.ollama.runtime.config.LangChain4jOllamaConfig;
 import io.quarkiverse.langchain4j.ollama.runtime.config.LangChain4jOllamaFixedRuntimeConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
@@ -138,8 +137,6 @@ public class OllamaProcessor {
     void generateBeans(OllamaRecorder recorder,
             List<SelectedChatModelProviderBuildItem> selectedChatItem,
             List<SelectedEmbeddingModelCandidateBuildItem> selectedEmbedding,
-            LangChain4jOllamaConfig config,
-            LangChain4jOllamaFixedRuntimeConfig fixedRuntimeConfig,
             BuildProducer<SyntheticBeanBuildItem> beanProducer) {
 
         for (var selected : selectedChatItem) {
@@ -152,7 +149,7 @@ public class OllamaProcessor {
                         .scope(ApplicationScoped.class)
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
-                        .createWith(recorder.chatModel(config, fixedRuntimeConfig, configName));
+                        .createWith(recorder.chatModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
 
@@ -163,7 +160,7 @@ public class OllamaProcessor {
                         .scope(ApplicationScoped.class)
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
-                        .createWith(recorder.streamingChatModel(config, fixedRuntimeConfig, configName));
+                        .createWith(recorder.streamingChatModel(configName));
                 addQualifierIfNecessary(streamingBuilder, configName);
                 beanProducer.produce(streamingBuilder.done());
             }
@@ -178,7 +175,7 @@ public class OllamaProcessor {
                         .defaultBean()
                         .unremovable()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.embeddingModel(config, fixedRuntimeConfig, configName));
+                        .supplier(recorder.embeddingModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/OllamaRecorder.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/OllamaRecorder.java
@@ -34,6 +34,7 @@ import io.quarkiverse.langchain4j.ollama.runtime.config.LangChain4jOllamaConfig;
 import io.quarkiverse.langchain4j.ollama.runtime.config.LangChain4jOllamaFixedRuntimeConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.tls.TlsConfiguration;
 import io.quarkus.tls.TlsConfigurationRegistry;
@@ -43,13 +44,20 @@ public class OllamaRecorder {
 
     private static final String DEFAULT_BASE_URL = "http://localhost:11434";
 
+    private final LangChain4jOllamaFixedRuntimeConfig fixedRuntimeConfig;
+    private final RuntimeValue<LangChain4jOllamaConfig> runtimeConfig;
+
+    public OllamaRecorder(LangChain4jOllamaFixedRuntimeConfig fixedRuntimeConfig,
+            RuntimeValue<LangChain4jOllamaConfig> runtimeConfig) {
+        this.fixedRuntimeConfig = fixedRuntimeConfig;
+        this.runtimeConfig = runtimeConfig;
+    }
+
     private static final TypeLiteral<Instance<ChatModelListener>> CHAT_MODEL_LISTENER_TYPE_LITERAL = new TypeLiteral<>() {
     };
 
-    public Function<SyntheticCreationalContext<ChatModel>, ChatModel> chatModel(
-            LangChain4jOllamaConfig runtimeConfig,
-            LangChain4jOllamaFixedRuntimeConfig fixedRuntimeConfig, String configName) {
-        LangChain4jOllamaConfig.OllamaConfig ollamaConfig = correspondingOllamaConfig(runtimeConfig, configName);
+    public Function<SyntheticCreationalContext<ChatModel>, ChatModel> chatModel(String configName) {
+        LangChain4jOllamaConfig.OllamaConfig ollamaConfig = correspondingOllamaConfig(runtimeConfig.getValue(), configName);
         LangChain4jOllamaFixedRuntimeConfig.OllamaConfig ollamaFixedConfig = correspondingOllamaFixedConfig(fixedRuntimeConfig,
                 configName);
 
@@ -120,9 +128,8 @@ public class OllamaRecorder {
         }
     }
 
-    public Supplier<EmbeddingModel> embeddingModel(LangChain4jOllamaConfig runtimeConfig,
-            LangChain4jOllamaFixedRuntimeConfig fixedRuntimeConfig, String configName) {
-        LangChain4jOllamaConfig.OllamaConfig ollamaConfig = correspondingOllamaConfig(runtimeConfig, configName);
+    public Supplier<EmbeddingModel> embeddingModel(String configName) {
+        LangChain4jOllamaConfig.OllamaConfig ollamaConfig = correspondingOllamaConfig(runtimeConfig.getValue(), configName);
         LangChain4jOllamaFixedRuntimeConfig.OllamaConfig ollamaFixedConfig = correspondingOllamaFixedConfig(fixedRuntimeConfig,
                 configName);
 
@@ -163,10 +170,8 @@ public class OllamaRecorder {
         }
     }
 
-    public Function<SyntheticCreationalContext<StreamingChatModel>, StreamingChatModel> streamingChatModel(
-            LangChain4jOllamaConfig runtimeConfig,
-            LangChain4jOllamaFixedRuntimeConfig fixedRuntimeConfig, String configName) {
-        LangChain4jOllamaConfig.OllamaConfig ollamaConfig = correspondingOllamaConfig(runtimeConfig, configName);
+    public Function<SyntheticCreationalContext<StreamingChatModel>, StreamingChatModel> streamingChatModel(String configName) {
+        LangChain4jOllamaConfig.OllamaConfig ollamaConfig = correspondingOllamaConfig(runtimeConfig.getValue(), configName);
         LangChain4jOllamaFixedRuntimeConfig.OllamaConfig ollamaFixedConfig = correspondingOllamaFixedConfig(fixedRuntimeConfig,
                 configName);
 

--- a/model-providers/ollama/runtime/src/test/java/io/quarkiverse/langchain4j/ollama/runtime/DisabledModelsOllamaRecorderTest.java
+++ b/model-providers/ollama/runtime/src/test/java/io/quarkiverse/langchain4j/ollama/runtime/DisabledModelsOllamaRecorderTest.java
@@ -12,12 +12,13 @@ import io.quarkiverse.langchain4j.ollama.runtime.config.LangChain4jOllamaConfig;
 import io.quarkiverse.langchain4j.ollama.runtime.config.LangChain4jOllamaConfig.OllamaConfig;
 import io.quarkiverse.langchain4j.ollama.runtime.config.LangChain4jOllamaFixedRuntimeConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
+import io.quarkus.runtime.RuntimeValue;
 
 class DisabledModelsOllamaRecorderTest {
     LangChain4jOllamaConfig config = mock(LangChain4jOllamaConfig.class);
     LangChain4jOllamaFixedRuntimeConfig fixedConfig = mock(LangChain4jOllamaFixedRuntimeConfig.class);
     OllamaConfig defaultConfig = mock(OllamaConfig.class);
-    OllamaRecorder recorder = new OllamaRecorder();
+    OllamaRecorder recorder = new OllamaRecorder(fixedConfig, new RuntimeValue<>(config));
 
     @BeforeEach
     void setupMocks() {
@@ -30,14 +31,14 @@ class DisabledModelsOllamaRecorderTest {
 
     @Test
     void disabledChatModel() {
-        assertThat(recorder.chatModel(config, fixedConfig, NamedConfigUtil.DEFAULT_NAME).apply(null))
+        assertThat(recorder.chatModel(NamedConfigUtil.DEFAULT_NAME).apply(null))
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledChatModel.class);
     }
 
     @Test
     void disabledEmbeddingModel() {
-        assertThat(recorder.embeddingModel(config, fixedConfig, NamedConfigUtil.DEFAULT_NAME).get())
+        assertThat(recorder.embeddingModel(NamedConfigUtil.DEFAULT_NAME).get())
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledEmbeddingModel.class);
     }

--- a/model-providers/openai/azure-openai/deployment/src/main/java/io/quarkiverse/langchain4j/azure/openai/deployment/AzureOpenAiProcessor.java
+++ b/model-providers/openai/azure-openai/deployment/src/main/java/io/quarkiverse/langchain4j/azure/openai/deployment/AzureOpenAiProcessor.java
@@ -16,7 +16,6 @@ import org.jboss.jandex.Type;
 
 import io.quarkiverse.langchain4j.ModelName;
 import io.quarkiverse.langchain4j.azure.openai.runtime.AzureOpenAiRecorder;
-import io.quarkiverse.langchain4j.azure.openai.runtime.config.LangChain4jAzureOpenAiConfig;
 import io.quarkiverse.langchain4j.deployment.DotNames;
 import io.quarkiverse.langchain4j.deployment.items.ChatModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.EmbeddingModelProviderCandidateBuildItem;
@@ -68,13 +67,12 @@ public class AzureOpenAiProcessor {
             List<SelectedChatModelProviderBuildItem> selectedChatItem,
             List<SelectedEmbeddingModelCandidateBuildItem> selectedEmbedding,
             List<SelectedImageModelProviderBuildItem> selectedImage,
-            LangChain4jAzureOpenAiConfig config,
             BuildProducer<SyntheticBeanBuildItem> beanProducer) {
         for (var selected : selectedChatItem) {
             if (PROVIDER.equals(selected.getProvider())) {
                 String configName = selected.getConfigName();
 
-                var chatModel = recorder.chatModel(config, configName);
+                var chatModel = recorder.chatModel(configName);
                 var chatBuilder = SyntheticBeanBuildItem
                         .configure(CHAT_MODEL)
                         .setRuntimeInit()
@@ -88,7 +86,7 @@ public class AzureOpenAiProcessor {
                 addQualifierIfNecessary(chatBuilder, configName);
                 beanProducer.produce(chatBuilder.done());
 
-                var streamingChatModel = recorder.streamingChatModel(config, configName);
+                var streamingChatModel = recorder.streamingChatModel(configName);
                 var streamingBuilder = SyntheticBeanBuildItem
                         .configure(STREAMING_CHAT_MODEL)
                         .setRuntimeInit()
@@ -108,7 +106,7 @@ public class AzureOpenAiProcessor {
             if (PROVIDER.equals(selected.getProvider())) {
                 String configName = selected.getConfigName();
 
-                var embeddingModel = recorder.embeddingModel(config, configName);
+                var embeddingModel = recorder.embeddingModel(configName);
                 var builder = SyntheticBeanBuildItem
                         .configure(EMBEDDING_MODEL)
                         .setRuntimeInit()
@@ -127,7 +125,7 @@ public class AzureOpenAiProcessor {
             if (PROVIDER.equals(selected.getProvider())) {
                 String configName = selected.getConfigName();
 
-                var imageModel = recorder.imageModel(config, configName);
+                var imageModel = recorder.imageModel(configName);
                 var builder = SyntheticBeanBuildItem
                         .configure(IMAGE_MODEL)
                         .setRuntimeInit()

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
@@ -36,6 +36,7 @@ import io.quarkiverse.langchain4j.openai.common.QuarkusOpenAiClient;
 import io.quarkiverse.langchain4j.openai.common.runtime.AdditionalPropertiesHack;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
 import io.smallrye.config.ConfigValidationException;
@@ -52,9 +53,15 @@ public class AzureOpenAiRecorder {
     private static final TypeLiteral<Instance<ModelAuthProvider>> MODEL_AUTH_PROVIDER_TYPE_LITERAL = new TypeLiteral<>() {
     };
 
-    public Function<SyntheticCreationalContext<ChatModel>, ChatModel> chatModel(
-            LangChain4jAzureOpenAiConfig runtimeConfig, String configName) {
-        LangChain4jAzureOpenAiConfig.AzureAiConfig azureAiConfig = correspondingAzureOpenAiConfig(runtimeConfig, configName);
+    private final RuntimeValue<LangChain4jAzureOpenAiConfig> runtimeConfig;
+
+    public AzureOpenAiRecorder(RuntimeValue<LangChain4jAzureOpenAiConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public Function<SyntheticCreationalContext<ChatModel>, ChatModel> chatModel(String configName) {
+        LangChain4jAzureOpenAiConfig.AzureAiConfig azureAiConfig = correspondingAzureOpenAiConfig(runtimeConfig.getValue(),
+                configName);
 
         if (azureAiConfig.enableIntegration()) {
             var chatModelConfig = azureAiConfig.chatModel();
@@ -102,10 +109,9 @@ public class AzureOpenAiRecorder {
         }
     }
 
-    public Function<SyntheticCreationalContext<StreamingChatModel>, StreamingChatModel> streamingChatModel(
-            LangChain4jAzureOpenAiConfig runtimeConfig,
-            String configName) {
-        LangChain4jAzureOpenAiConfig.AzureAiConfig azureAiConfig = correspondingAzureOpenAiConfig(runtimeConfig, configName);
+    public Function<SyntheticCreationalContext<StreamingChatModel>, StreamingChatModel> streamingChatModel(String configName) {
+        LangChain4jAzureOpenAiConfig.AzureAiConfig azureAiConfig = correspondingAzureOpenAiConfig(runtimeConfig.getValue(),
+                configName);
 
         if (azureAiConfig.enableIntegration()) {
             ChatModelConfig chatModelConfig = azureAiConfig.chatModel();
@@ -151,9 +157,9 @@ public class AzureOpenAiRecorder {
         }
     }
 
-    public Function<SyntheticCreationalContext<EmbeddingModel>, EmbeddingModel> embeddingModel(
-            LangChain4jAzureOpenAiConfig runtimeConfig, String configName) {
-        LangChain4jAzureOpenAiConfig.AzureAiConfig azureAiConfig = correspondingAzureOpenAiConfig(runtimeConfig, configName);
+    public Function<SyntheticCreationalContext<EmbeddingModel>, EmbeddingModel> embeddingModel(String configName) {
+        LangChain4jAzureOpenAiConfig.AzureAiConfig azureAiConfig = correspondingAzureOpenAiConfig(runtimeConfig.getValue(),
+                configName);
 
         if (azureAiConfig.enableIntegration()) {
             var embeddingModelConfig = azureAiConfig.embeddingModel();
@@ -188,9 +194,9 @@ public class AzureOpenAiRecorder {
         }
     }
 
-    public Function<SyntheticCreationalContext<ImageModel>, ImageModel> imageModel(LangChain4jAzureOpenAiConfig runtimeConfig,
-            String configName) {
-        LangChain4jAzureOpenAiConfig.AzureAiConfig azureAiConfig = correspondingAzureOpenAiConfig(runtimeConfig, configName);
+    public Function<SyntheticCreationalContext<ImageModel>, ImageModel> imageModel(String configName) {
+        LangChain4jAzureOpenAiConfig.AzureAiConfig azureAiConfig = correspondingAzureOpenAiConfig(runtimeConfig.getValue(),
+                configName);
 
         if (azureAiConfig.enableIntegration()) {
             var imageModelConfig = azureAiConfig.imageModel();

--- a/model-providers/openai/azure-openai/runtime/src/test/java/io/quarkiverse/langchain4j/azure/openai/runtime/DisabledModelsAzureOpenAiRecorderTest.java
+++ b/model-providers/openai/azure-openai/runtime/src/test/java/io/quarkiverse/langchain4j/azure/openai/runtime/DisabledModelsAzureOpenAiRecorderTest.java
@@ -14,11 +14,12 @@ import dev.langchain4j.model.image.DisabledImageModel;
 import io.quarkiverse.langchain4j.azure.openai.runtime.config.LangChain4jAzureOpenAiConfig;
 import io.quarkiverse.langchain4j.azure.openai.runtime.config.LangChain4jAzureOpenAiConfig.AzureAiConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
+import io.quarkus.runtime.RuntimeValue;
 
 class DisabledModelsAzureOpenAiRecorderTest {
     LangChain4jAzureOpenAiConfig config = mock(LangChain4jAzureOpenAiConfig.class);
     AzureAiConfig defaultConfig = mock(AzureAiConfig.class);
-    AzureOpenAiRecorder recorder = new AzureOpenAiRecorder();
+    AzureOpenAiRecorder recorder = new AzureOpenAiRecorder(new RuntimeValue<>(config));
 
     @BeforeEach
     void setupMocks() {
@@ -31,28 +32,28 @@ class DisabledModelsAzureOpenAiRecorderTest {
 
     @Test
     void disabledChatModel() {
-        assertThat(recorder.chatModel(config, NamedConfigUtil.DEFAULT_NAME).apply(null))
+        assertThat(recorder.chatModel(NamedConfigUtil.DEFAULT_NAME).apply(null))
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledChatModel.class);
     }
 
     @Test
     void disabledStreamingChatModel() {
-        assertThat(recorder.streamingChatModel(config, NamedConfigUtil.DEFAULT_NAME).apply(null))
+        assertThat(recorder.streamingChatModel(NamedConfigUtil.DEFAULT_NAME).apply(null))
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledStreamingChatModel.class);
     }
 
     @Test
     void disabledEmbeddingModel() {
-        assertThat(recorder.embeddingModel(config, NamedConfigUtil.DEFAULT_NAME).apply(null))
+        assertThat(recorder.embeddingModel(NamedConfigUtil.DEFAULT_NAME).apply(null))
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledEmbeddingModel.class);
     }
 
     @Test
     void disabledImageModel() {
-        assertThat(recorder.imageModel(config, NamedConfigUtil.DEFAULT_NAME).apply(null))
+        assertThat(recorder.imageModel(NamedConfigUtil.DEFAULT_NAME).apply(null))
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledImageModel.class);
     }

--- a/model-providers/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/OpenAiProcessor.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/OpenAiProcessor.java
@@ -36,7 +36,6 @@ import io.quarkiverse.langchain4j.openai.QuarkusOpenAiEmbeddingModelBuilderFacto
 import io.quarkiverse.langchain4j.openai.QuarkusOpenAiModerationModelBuilderFactory;
 import io.quarkiverse.langchain4j.openai.QuarkusOpenAiStreamingChatModelBuilderFactory;
 import io.quarkiverse.langchain4j.openai.runtime.OpenAiRecorder;
-import io.quarkiverse.langchain4j.openai.runtime.config.LangChain4jOpenAiConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -86,7 +85,6 @@ public class OpenAiProcessor {
             List<SelectedEmbeddingModelCandidateBuildItem> selectedEmbedding,
             List<SelectedModerationModelProviderBuildItem> selectedModeration,
             List<SelectedImageModelProviderBuildItem> selectedImage,
-            LangChain4jOpenAiConfig config,
             BuildProducer<SyntheticBeanBuildItem> beanProducer) {
 
         for (var selected : selectedChatItem) {
@@ -99,7 +97,7 @@ public class OpenAiProcessor {
                         .scope(ApplicationScoped.class)
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
-                        .createWith(recorder.chatModel(config, configName));
+                        .createWith(recorder.chatModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
 
@@ -110,7 +108,7 @@ public class OpenAiProcessor {
                         .scope(ApplicationScoped.class)
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
-                        .createWith(recorder.streamingChatModel(config, configName));
+                        .createWith(recorder.streamingChatModel(configName));
                 addQualifierIfNecessary(streamingBuilder, configName);
                 beanProducer.produce(streamingBuilder.done());
             }
@@ -125,7 +123,7 @@ public class OpenAiProcessor {
                         .defaultBean()
                         .unremovable()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.embeddingModel(config, configName));
+                        .supplier(recorder.embeddingModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }
@@ -139,7 +137,7 @@ public class OpenAiProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.moderationModel(config, configName));
+                        .supplier(recorder.moderationModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }
@@ -153,7 +151,7 @@ public class OpenAiProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.imageModel(config, configName));
+                        .supplier(recorder.imageModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
@@ -45,6 +45,7 @@ import io.quarkiverse.langchain4j.openai.runtime.config.LangChain4jOpenAiConfig;
 import io.quarkiverse.langchain4j.openai.runtime.config.ModerationModelConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
 import io.smallrye.config.ConfigValidationException;
@@ -58,9 +59,14 @@ public class OpenAiRecorder {
     private static final String DUMMY_KEY = "dummy";
     private static final String OPENAI_BASE_URL = "https://api.openai.com/v1/";
 
-    public Function<SyntheticCreationalContext<ChatModel>, ChatModel> chatModel(
-            LangChain4jOpenAiConfig runtimeConfig, String configName) {
-        LangChain4jOpenAiConfig.OpenAiConfig openAiConfig = correspondingOpenAiConfig(runtimeConfig, configName);
+    private final RuntimeValue<LangChain4jOpenAiConfig> runtimeConfig;
+
+    public OpenAiRecorder(RuntimeValue<LangChain4jOpenAiConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public Function<SyntheticCreationalContext<ChatModel>, ChatModel> chatModel(String configName) {
+        LangChain4jOpenAiConfig.OpenAiConfig openAiConfig = correspondingOpenAiConfig(runtimeConfig.getValue(), configName);
 
         if (openAiConfig.enableIntegration()) {
             String apiKey = openAiConfig.apiKey();
@@ -118,10 +124,8 @@ public class OpenAiRecorder {
         }
     }
 
-    public Function<SyntheticCreationalContext<StreamingChatModel>, StreamingChatModel> streamingChatModel(
-            LangChain4jOpenAiConfig runtimeConfig,
-            String configName) {
-        LangChain4jOpenAiConfig.OpenAiConfig openAiConfig = correspondingOpenAiConfig(runtimeConfig, configName);
+    public Function<SyntheticCreationalContext<StreamingChatModel>, StreamingChatModel> streamingChatModel(String configName) {
+        LangChain4jOpenAiConfig.OpenAiConfig openAiConfig = correspondingOpenAiConfig(runtimeConfig.getValue(), configName);
 
         if (openAiConfig.enableIntegration()) {
             String apiKey = openAiConfig.apiKey();
@@ -176,8 +180,8 @@ public class OpenAiRecorder {
         }
     }
 
-    public Supplier<EmbeddingModel> embeddingModel(LangChain4jOpenAiConfig runtimeConfig, String configName) {
-        LangChain4jOpenAiConfig.OpenAiConfig openAiConfig = correspondingOpenAiConfig(runtimeConfig, configName);
+    public Supplier<EmbeddingModel> embeddingModel(String configName) {
+        LangChain4jOpenAiConfig.OpenAiConfig openAiConfig = correspondingOpenAiConfig(runtimeConfig.getValue(), configName);
 
         if (openAiConfig.enableIntegration()) {
             String apiKey = openAiConfig.apiKey();
@@ -225,8 +229,8 @@ public class OpenAiRecorder {
         }
     }
 
-    public Supplier<ModerationModel> moderationModel(LangChain4jOpenAiConfig runtimeConfig, String configName) {
-        LangChain4jOpenAiConfig.OpenAiConfig openAiConfig = correspondingOpenAiConfig(runtimeConfig, configName);
+    public Supplier<ModerationModel> moderationModel(String configName) {
+        LangChain4jOpenAiConfig.OpenAiConfig openAiConfig = correspondingOpenAiConfig(runtimeConfig.getValue(), configName);
 
         if (openAiConfig.enableIntegration()) {
             String apiKey = openAiConfig.apiKey();
@@ -270,8 +274,8 @@ public class OpenAiRecorder {
         }
     }
 
-    public Supplier<ImageModel> imageModel(LangChain4jOpenAiConfig runtimeConfig, String configName) {
-        LangChain4jOpenAiConfig.OpenAiConfig openAiConfig = correspondingOpenAiConfig(runtimeConfig, configName);
+    public Supplier<ImageModel> imageModel(String configName) {
+        LangChain4jOpenAiConfig.OpenAiConfig openAiConfig = correspondingOpenAiConfig(runtimeConfig.getValue(), configName);
 
         if (openAiConfig.enableIntegration()) {
             String apiKey = openAiConfig.apiKey();

--- a/model-providers/openai/openai-vanilla/runtime/src/test/java/io/quarkiverse/langchain4j/openai/runtime/DisabledModelsOpenAiRecorderTest.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/test/java/io/quarkiverse/langchain4j/openai/runtime/DisabledModelsOpenAiRecorderTest.java
@@ -14,11 +14,12 @@ import dev.langchain4j.model.moderation.DisabledModerationModel;
 import io.quarkiverse.langchain4j.openai.runtime.config.LangChain4jOpenAiConfig;
 import io.quarkiverse.langchain4j.openai.runtime.config.LangChain4jOpenAiConfig.OpenAiConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
+import io.quarkus.runtime.RuntimeValue;
 
 class DisabledModelsOpenAiRecorderTest {
     LangChain4jOpenAiConfig config = mock(LangChain4jOpenAiConfig.class);
     OpenAiConfig defaultConfig = mock(OpenAiConfig.class);
-    OpenAiRecorder recorder = new OpenAiRecorder();
+    OpenAiRecorder recorder = new OpenAiRecorder(new RuntimeValue<>(config));
 
     @BeforeEach
     void setupMocks() {
@@ -31,35 +32,35 @@ class DisabledModelsOpenAiRecorderTest {
 
     @Test
     void disabledChatModel() {
-        assertThat(recorder.chatModel(config, NamedConfigUtil.DEFAULT_NAME).apply(null))
+        assertThat(recorder.chatModel(NamedConfigUtil.DEFAULT_NAME).apply(null))
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledChatModel.class);
     }
 
     @Test
     void disabledStreamingChatModel() {
-        assertThat(recorder.streamingChatModel(config, NamedConfigUtil.DEFAULT_NAME).apply(null))
+        assertThat(recorder.streamingChatModel(NamedConfigUtil.DEFAULT_NAME).apply(null))
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledStreamingChatModel.class);
     }
 
     @Test
     void disabledEmbeddingModel() {
-        assertThat(recorder.embeddingModel(config, NamedConfigUtil.DEFAULT_NAME).get())
+        assertThat(recorder.embeddingModel(NamedConfigUtil.DEFAULT_NAME).get())
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledEmbeddingModel.class);
     }
 
     @Test
     void disabledImageModel() {
-        assertThat(recorder.imageModel(config, NamedConfigUtil.DEFAULT_NAME).get())
+        assertThat(recorder.imageModel(NamedConfigUtil.DEFAULT_NAME).get())
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledImageModel.class);
     }
 
     @Test
     void disabledModerationModel() {
-        assertThat(recorder.moderationModel(config, NamedConfigUtil.DEFAULT_NAME).get())
+        assertThat(recorder.moderationModel(NamedConfigUtil.DEFAULT_NAME).get())
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledModerationModel.class);
     }

--- a/model-providers/openshift-ai/deployment/src/main/java/io/quarkiverse/langchain4j/openshift/ai/deployment/OpenshiftAiProcessor.java
+++ b/model-providers/openshift-ai/deployment/src/main/java/io/quarkiverse/langchain4j/openshift/ai/deployment/OpenshiftAiProcessor.java
@@ -12,7 +12,6 @@ import io.quarkiverse.langchain4j.ModelName;
 import io.quarkiverse.langchain4j.deployment.items.ChatModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedChatModelProviderBuildItem;
 import io.quarkiverse.langchain4j.openshiftai.runtime.OpenshiftAiRecorder;
-import io.quarkiverse.langchain4j.openshiftai.runtime.config.LangChain4jOpenshiftAiConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
@@ -50,7 +49,6 @@ public class OpenshiftAiProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     void generateBeans(OpenshiftAiRecorder recorder,
             List<SelectedChatModelProviderBuildItem> selectedChatItem,
-            LangChain4jOpenshiftAiConfig config,
             BuildProducer<SyntheticBeanBuildItem> beanProducer) {
 
         for (var selected : selectedChatItem) {
@@ -61,7 +59,7 @@ public class OpenshiftAiProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.chatModel(config, configName));
+                        .supplier(recorder.chatModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }

--- a/model-providers/openshift-ai/runtime/src/main/java/io/quarkiverse/langchain4j/openshiftai/runtime/OpenshiftAiRecorder.java
+++ b/model-providers/openshift-ai/runtime/src/main/java/io/quarkiverse/langchain4j/openshiftai/runtime/OpenshiftAiRecorder.java
@@ -14,6 +14,7 @@ import io.quarkiverse.langchain4j.openshiftai.OpenshiftAiChatModel;
 import io.quarkiverse.langchain4j.openshiftai.runtime.config.ChatModelConfig;
 import io.quarkiverse.langchain4j.openshiftai.runtime.config.LangChain4jOpenshiftAiConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.smallrye.config.ConfigValidationException;
 
@@ -24,9 +25,15 @@ public class OpenshiftAiRecorder {
     private static final String DUMMY_MODEL_ID = "dummy";
     public static final ConfigValidationException.Problem[] EMPTY_PROBLEMS = new ConfigValidationException.Problem[0];
 
-    public Supplier<ChatModel> chatModel(LangChain4jOpenshiftAiConfig runtimeConfig, String configName) {
-        LangChain4jOpenshiftAiConfig.OpenshiftAiConfig openshiftAiConfig = correspondingOpenshiftAiConfig(runtimeConfig,
-                configName);
+    private final RuntimeValue<LangChain4jOpenshiftAiConfig> runtimeConfig;
+
+    public OpenshiftAiRecorder(RuntimeValue<LangChain4jOpenshiftAiConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public Supplier<ChatModel> chatModel(String configName) {
+        LangChain4jOpenshiftAiConfig.OpenshiftAiConfig openshiftAiConfig = correspondingOpenshiftAiConfig(
+                runtimeConfig.getValue(), configName);
 
         if (openshiftAiConfig.enableIntegration()) {
             ChatModelConfig chatModelConfig = openshiftAiConfig.chatModel();

--- a/model-providers/openshift-ai/runtime/src/test/java/io/quarkiverse/langchain4j/openshiftai/runtime/DisabledModelsOpenshiftAiRecorderTest.java
+++ b/model-providers/openshift-ai/runtime/src/test/java/io/quarkiverse/langchain4j/openshiftai/runtime/DisabledModelsOpenshiftAiRecorderTest.java
@@ -10,11 +10,12 @@ import dev.langchain4j.model.chat.DisabledChatModel;
 import io.quarkiverse.langchain4j.openshiftai.runtime.config.LangChain4jOpenshiftAiConfig;
 import io.quarkiverse.langchain4j.openshiftai.runtime.config.LangChain4jOpenshiftAiConfig.OpenshiftAiConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
+import io.quarkus.runtime.RuntimeValue;
 
 class DisabledModelsOpenshiftAiRecorderTest {
     LangChain4jOpenshiftAiConfig config = mock(LangChain4jOpenshiftAiConfig.class);
     OpenshiftAiConfig defaultConfig = mock(OpenshiftAiConfig.class);
-    OpenshiftAiRecorder recorder = new OpenshiftAiRecorder();
+    OpenshiftAiRecorder recorder = new OpenshiftAiRecorder(new RuntimeValue<>(config));
 
     @BeforeEach
     void setupMocks() {
@@ -27,7 +28,7 @@ class DisabledModelsOpenshiftAiRecorderTest {
 
     @Test
     void disabledChatModel() {
-        assertThat(recorder.chatModel(config, NamedConfigUtil.DEFAULT_NAME).get())
+        assertThat(recorder.chatModel(NamedConfigUtil.DEFAULT_NAME).get())
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledChatModel.class);
     }

--- a/model-providers/watsonx/deployment/src/main/java/io/quarkiverse/langchain4j/watsonx/deployment/WatsonxProcessor.java
+++ b/model-providers/watsonx/deployment/src/main/java/io/quarkiverse/langchain4j/watsonx/deployment/WatsonxProcessor.java
@@ -36,7 +36,6 @@ import io.quarkiverse.langchain4j.watsonx.deployment.items.BuiltinServiceBuildIt
 import io.quarkiverse.langchain4j.watsonx.deployment.items.TextExtractionClassBuildItem;
 import io.quarkiverse.langchain4j.watsonx.runtime.BuiltinServiceRecorder;
 import io.quarkiverse.langchain4j.watsonx.runtime.WatsonxRecorder;
-import io.quarkiverse.langchain4j.watsonx.runtime.config.LangChain4jWatsonxConfig;
 import io.quarkiverse.langchain4j.watsonx.runtime.config.LangChain4jWatsonxFixedRuntimeConfig;
 import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.arc.deployment.BeanDiscoveryFinishedBuildItem;
@@ -130,7 +129,6 @@ public class WatsonxProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     void generateBuiltinToolBeans(
             BuiltinServiceRecorder recorder,
-            LangChain4jWatsonxConfig runtimeConfig,
             List<BuiltinServiceBuildItem> builtinToolClasses,
             BuildProducer<SyntheticBeanBuildItem> beanProducer) {
 
@@ -143,11 +141,11 @@ public class WatsonxProcessor {
                     .scope(ApplicationScoped.class);
 
             if (builtinToolClass.getDotName().equals(WatsonxDotNames.GOOGLE_SEARCH_SERVICE))
-                builder.supplier(recorder.googleSearch(runtimeConfig));
+                builder.supplier(recorder.googleSearch());
             else if (builtinToolClass.getDotName().equals(WatsonxDotNames.WEB_CRAWLER_SERVICE))
-                builder.supplier(recorder.webCrawler(runtimeConfig));
+                builder.supplier(recorder.webCrawler());
             else if (builtinToolClass.getDotName().equals(WatsonxDotNames.WEATHER_SERVICE))
-                builder.supplier(recorder.weather(runtimeConfig));
+                builder.supplier(recorder.weather());
             else
                 throw new RuntimeException("BuiltinServiceClass not recognised");
 
@@ -157,7 +155,7 @@ public class WatsonxProcessor {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    void generateBeans(WatsonxRecorder recorder, LangChain4jWatsonxConfig runtimeConfig,
+    void generateBeans(WatsonxRecorder recorder,
             LangChain4jWatsonxFixedRuntimeConfig fixedRuntimeConfig,
             List<SelectedChatModelProviderBuildItem> selectedChatItem,
             List<SelectedEmbeddingModelCandidateBuildItem> selectedEmbedding,
@@ -179,7 +177,7 @@ public class WatsonxProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.textExtraction(runtimeConfig, configName));
+                        .supplier(recorder.textExtraction(configName));
                 addQualifierIfNecessary(textExtractionBuilder, configName);
                 beanProducer.produce(textExtractionBuilder.done());
             }
@@ -199,11 +197,11 @@ public class WatsonxProcessor {
             Function<SyntheticCreationalContext<StreamingChatModel>, StreamingChatModel> streamingChatModel;
 
             if (mode.equalsIgnoreCase("chat")) {
-                chatModel = recorder.chatModel(runtimeConfig, configName);
-                streamingChatModel = recorder.streamingChatModel(runtimeConfig, configName);
+                chatModel = recorder.chatModel(configName);
+                streamingChatModel = recorder.streamingChatModel(configName);
             } else if (mode.equalsIgnoreCase("generation")) {
-                chatModel = recorder.generationModel(runtimeConfig, configName);
-                streamingChatModel = recorder.generationStreamingModel(runtimeConfig, configName);
+                chatModel = recorder.generationModel(configName);
+                streamingChatModel = recorder.generationStreamingModel(configName);
             } else {
                 throw new RuntimeException(
                         "The \"mode\" value for the model \"%s\" is not valid. Choose one between [\"chat\", \"generation\"]"
@@ -244,7 +242,7 @@ public class WatsonxProcessor {
                         .defaultBean()
                         .unremovable()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.embeddingModel(runtimeConfig, configName));
+                        .supplier(recorder.embeddingModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }
@@ -259,7 +257,7 @@ public class WatsonxProcessor {
                         .defaultBean()
                         .unremovable()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.scoringModel(runtimeConfig, configName));
+                        .supplier(recorder.scoringModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/BuiltinServiceRecorder.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/BuiltinServiceRecorder.java
@@ -24,6 +24,7 @@ import io.quarkiverse.langchain4j.watsonx.services.GoogleSearchService;
 import io.quarkiverse.langchain4j.watsonx.services.WeatherService;
 import io.quarkiverse.langchain4j.watsonx.services.WebCrawlerService;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.smallrye.config.ConfigValidationException;
 
@@ -34,20 +35,26 @@ public class BuiltinServiceRecorder {
     private static final String MISSING_BUILTIN_SERVICE_PROPERTY_ERROR = "To use the built-in service classes, you must set the property 'quarkus.langchain4j.watsonx.built-in.%s'";
     private static final String INVALID_BASE_URL_ERROR = "The property 'quarkus.langchain4j.watsonx.base-url' does not have a correct url. Use one of the urls given in the documentation or use the property 'quarkus.langchain4j.watsonx.built-in-service.base-url' to set a custom url.";
 
-    public Supplier<WebCrawlerService> webCrawler(LangChain4jWatsonxConfig runtimeConfig) {
+    private final RuntimeValue<LangChain4jWatsonxConfig> runtimeConfig;
 
-        IAMConfig iamConfig = runtimeConfig.defaultConfig().iam();
-        BuiltinServiceConfig builtinToolConfig = runtimeConfig.builtInService();
+    public BuiltinServiceRecorder(RuntimeValue<LangChain4jWatsonxConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public Supplier<WebCrawlerService> webCrawler() {
+
+        IAMConfig iamConfig = runtimeConfig.getValue().defaultConfig().iam();
+        BuiltinServiceConfig builtinToolConfig = runtimeConfig.getValue().builtInService();
 
         String baseUrl = firstOrDefault(
-                getWxBaseUrl(runtimeConfig.defaultConfig().baseUrl()),
+                getWxBaseUrl(runtimeConfig.getValue().defaultConfig().baseUrl()),
                 builtinToolConfig.baseUrl());
 
-        if (isNull(baseUrl) && runtimeConfig.defaultConfig().baseUrl().isPresent())
+        if (isNull(baseUrl) && runtimeConfig.getValue().defaultConfig().baseUrl().isPresent())
             throw new RuntimeException(INVALID_BASE_URL_ERROR);
 
         String apiKey = firstOrDefault(
-                runtimeConfig.defaultConfig().apiKey().orElse(null),
+                runtimeConfig.getValue().defaultConfig().apiKey().orElse(null),
                 builtinToolConfig.apiKey());
 
         var configProblems = checkConfigurations(baseUrl, apiKey);
@@ -57,14 +64,14 @@ public class BuiltinServiceRecorder {
 
         Duration timeout = firstOrDefault(Duration.ofSeconds(10),
                 builtinToolConfig.timeout(),
-                runtimeConfig.defaultConfig().timeout());
+                runtimeConfig.getValue().defaultConfig().timeout());
 
         boolean logRequests = firstOrDefault(
-                runtimeConfig.defaultConfig().logRequests().orElse(false),
+                runtimeConfig.getValue().defaultConfig().logRequests().orElse(false),
                 builtinToolConfig.logRequests());
 
         boolean logResponses = firstOrDefault(
-                runtimeConfig.defaultConfig().logResponses().orElse(false),
+                runtimeConfig.getValue().defaultConfig().logResponses().orElse(false),
                 builtinToolConfig.logResponses());
 
         return new Supplier<WebCrawlerService>() {
@@ -76,20 +83,20 @@ public class BuiltinServiceRecorder {
         };
     }
 
-    public Supplier<GoogleSearchService> googleSearch(LangChain4jWatsonxConfig runtimeConfig) {
+    public Supplier<GoogleSearchService> googleSearch() {
 
-        IAMConfig iamConfig = runtimeConfig.defaultConfig().iam();
-        BuiltinServiceConfig builtinToolConfig = runtimeConfig.builtInService();
+        IAMConfig iamConfig = runtimeConfig.getValue().defaultConfig().iam();
+        BuiltinServiceConfig builtinToolConfig = runtimeConfig.getValue().builtInService();
 
         String baseUrl = firstOrDefault(
-                getWxBaseUrl(runtimeConfig.defaultConfig().baseUrl()),
+                getWxBaseUrl(runtimeConfig.getValue().defaultConfig().baseUrl()),
                 builtinToolConfig.baseUrl());
 
-        if (isNull(baseUrl) && runtimeConfig.defaultConfig().baseUrl().isPresent())
+        if (isNull(baseUrl) && runtimeConfig.getValue().defaultConfig().baseUrl().isPresent())
             throw new RuntimeException(INVALID_BASE_URL_ERROR);
 
         String apiKey = firstOrDefault(
-                runtimeConfig.defaultConfig().apiKey().orElse(null),
+                runtimeConfig.getValue().defaultConfig().apiKey().orElse(null),
                 builtinToolConfig.apiKey());
 
         var configProblems = checkConfigurations(baseUrl, apiKey);
@@ -99,14 +106,14 @@ public class BuiltinServiceRecorder {
 
         Duration timeout = firstOrDefault(Duration.ofSeconds(10),
                 builtinToolConfig.timeout(),
-                runtimeConfig.defaultConfig().timeout());
+                runtimeConfig.getValue().defaultConfig().timeout());
 
         boolean logRequests = firstOrDefault(
-                runtimeConfig.defaultConfig().logRequests().orElse(false),
+                runtimeConfig.getValue().defaultConfig().logRequests().orElse(false),
                 builtinToolConfig.logRequests());
 
         boolean logResponses = firstOrDefault(
-                runtimeConfig.defaultConfig().logResponses().orElse(false),
+                runtimeConfig.getValue().defaultConfig().logResponses().orElse(false),
                 builtinToolConfig.logResponses());
 
         return new Supplier<GoogleSearchService>() {
@@ -119,20 +126,20 @@ public class BuiltinServiceRecorder {
         };
     }
 
-    public Supplier<WeatherService> weather(LangChain4jWatsonxConfig runtimeConfig) {
+    public Supplier<WeatherService> weather() {
 
-        IAMConfig iamConfig = runtimeConfig.defaultConfig().iam();
-        BuiltinServiceConfig builtinToolConfig = runtimeConfig.builtInService();
+        IAMConfig iamConfig = runtimeConfig.getValue().defaultConfig().iam();
+        BuiltinServiceConfig builtinToolConfig = runtimeConfig.getValue().builtInService();
 
         String baseUrl = firstOrDefault(
-                getWxBaseUrl(runtimeConfig.defaultConfig().baseUrl()),
+                getWxBaseUrl(runtimeConfig.getValue().defaultConfig().baseUrl()),
                 builtinToolConfig.baseUrl());
 
-        if (isNull(baseUrl) && runtimeConfig.defaultConfig().baseUrl().isPresent())
+        if (isNull(baseUrl) && runtimeConfig.getValue().defaultConfig().baseUrl().isPresent())
             throw new RuntimeException(INVALID_BASE_URL_ERROR);
 
         String apiKey = firstOrDefault(
-                runtimeConfig.defaultConfig().apiKey().orElse(null),
+                runtimeConfig.getValue().defaultConfig().apiKey().orElse(null),
                 builtinToolConfig.apiKey());
 
         var configProblems = checkConfigurations(baseUrl, apiKey);
@@ -142,14 +149,14 @@ public class BuiltinServiceRecorder {
 
         Duration timeout = firstOrDefault(Duration.ofSeconds(10),
                 builtinToolConfig.timeout(),
-                runtimeConfig.defaultConfig().timeout());
+                runtimeConfig.getValue().defaultConfig().timeout());
 
         boolean logRequests = firstOrDefault(
-                runtimeConfig.defaultConfig().logRequests().orElse(false),
+                runtimeConfig.getValue().defaultConfig().logRequests().orElse(false),
                 builtinToolConfig.logRequests());
 
         boolean logResponses = firstOrDefault(
-                runtimeConfig.defaultConfig().logResponses().orElse(false),
+                runtimeConfig.getValue().defaultConfig().logResponses().orElse(false),
                 builtinToolConfig.logResponses());
 
         return new Supplier<WeatherService>() {

--- a/model-providers/watsonx/runtime/src/test/java/io/quarkiverse/langchain4j/watsonx/runtime/DisabledModelsWatsonRecorderTest.java
+++ b/model-providers/watsonx/runtime/src/test/java/io/quarkiverse/langchain4j/watsonx/runtime/DisabledModelsWatsonRecorderTest.java
@@ -13,12 +13,13 @@ import dev.langchain4j.model.embedding.DisabledEmbeddingModel;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkiverse.langchain4j.watsonx.runtime.config.LangChain4jWatsonxConfig;
 import io.quarkiverse.langchain4j.watsonx.runtime.config.LangChain4jWatsonxConfig.WatsonConfig;
+import io.quarkus.runtime.RuntimeValue;
 
 class DisabledModelsWatsonRecorderTest {
     LangChain4jWatsonxConfig runtimeConfig = mock(LangChain4jWatsonxConfig.class);
 
     WatsonConfig defaultConfig = mock(WatsonConfig.class);
-    WatsonxRecorder recorder = new WatsonxRecorder();
+    WatsonxRecorder recorder = new WatsonxRecorder(new RuntimeValue<>(runtimeConfig));
 
     @BeforeEach
     void setupMocks() {
@@ -32,16 +33,16 @@ class DisabledModelsWatsonRecorderTest {
     @Test
     void disabledChatModel() {
         assertThat(recorder
-                .generationModel(runtimeConfig, NamedConfigUtil.DEFAULT_NAME).apply(null))
+                .generationModel(NamedConfigUtil.DEFAULT_NAME).apply(null))
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledChatModel.class);
 
         assertThat(
-                recorder.generationStreamingModel(runtimeConfig, NamedConfigUtil.DEFAULT_NAME).apply(null))
+                recorder.generationStreamingModel(NamedConfigUtil.DEFAULT_NAME).apply(null))
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledStreamingChatModel.class);
 
-        assertThat(recorder.embeddingModel(runtimeConfig, NamedConfigUtil.DEFAULT_NAME).get())
+        assertThat(recorder.embeddingModel(NamedConfigUtil.DEFAULT_NAME).get())
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledEmbeddingModel.class);
     }

--- a/rag/easy-rag/runtime/src/main/java/io/quarkiverse/langchain4j/easyrag/EasyRagManualIngestion.java
+++ b/rag/easy-rag/runtime/src/main/java/io/quarkiverse/langchain4j/easyrag/EasyRagManualIngestion.java
@@ -2,20 +2,21 @@ package io.quarkiverse.langchain4j.easyrag;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.spi.CDI;
+import jakarta.inject.Inject;
 
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import io.quarkiverse.langchain4j.easyrag.runtime.EasyRagConfig;
 import io.quarkiverse.langchain4j.easyrag.runtime.EasyRagIngestor;
-import io.quarkiverse.langchain4j.easyrag.runtime.EasyRagRecorder;
 import io.quarkiverse.langchain4j.easyrag.runtime.IngestionStrategy;
 
 @ApplicationScoped
 public class EasyRagManualIngestion {
+    @Inject
+    EasyRagConfig config;
 
     public void ingest() {
-        EasyRagConfig config = EasyRagRecorder.easyRagConfig;
         if (config.ingestionStrategy() != IngestionStrategy.MANUAL) {
             throw new IllegalStateException("Manual ingestion trigger called when " +
                     "`quarkus.langchain4j.easy-rag.ingestion-strategy` is not MANUAL");

--- a/tools/tavily/deployment/src/main/java/io/quarkiverse/langchain4j/tavily/deployment/TavilyProcessor.java
+++ b/tools/tavily/deployment/src/main/java/io/quarkiverse/langchain4j/tavily/deployment/TavilyProcessor.java
@@ -7,7 +7,6 @@ import org.jboss.jandex.DotName;
 
 import dev.langchain4j.web.search.WebSearchEngine;
 import io.quarkiverse.langchain4j.tavily.QuarkusTavilyWebSearchEngine;
-import io.quarkiverse.langchain4j.tavily.runtime.TavilyConfig;
 import io.quarkiverse.langchain4j.tavily.runtime.TavilyRecorder;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
@@ -36,8 +35,7 @@ public class TavilyProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     public void createBean(
             BuildProducer<SyntheticBeanBuildItem> beanProducer,
-            TavilyRecorder recorder,
-            TavilyConfig config) {
+            TavilyRecorder recorder) {
         beanProducer.produce(SyntheticBeanBuildItem
                 .configure(TAVILY_WEB_SEARCH_ENGINE)
                 .types(ClassType.create(WebSearchEngine.class),
@@ -46,7 +44,7 @@ public class TavilyProcessor {
                 .setRuntimeInit()
                 .unremovable()
                 .scope(ApplicationScoped.class)
-                .supplier(recorder.tavilyEngineSupplier(config))
+                .supplier(recorder.tavilyEngineSupplier())
                 .done());
     }
 

--- a/tools/tavily/runtime/src/main/java/io/quarkiverse/langchain4j/tavily/runtime/TavilyRecorder.java
+++ b/tools/tavily/runtime/src/main/java/io/quarkiverse/langchain4j/tavily/runtime/TavilyRecorder.java
@@ -3,26 +3,32 @@ package io.quarkiverse.langchain4j.tavily.runtime;
 import java.util.function.Supplier;
 
 import io.quarkiverse.langchain4j.tavily.QuarkusTavilyWebSearchEngine;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class TavilyRecorder {
+    private final RuntimeValue<TavilyConfig> runtimeConfig;
 
-    public Supplier<QuarkusTavilyWebSearchEngine> tavilyEngineSupplier(TavilyConfig config) {
+    public TavilyRecorder(RuntimeValue<TavilyConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    public Supplier<QuarkusTavilyWebSearchEngine> tavilyEngineSupplier() {
         return new Supplier<>() {
             @Override
             public QuarkusTavilyWebSearchEngine get() {
-                return new QuarkusTavilyWebSearchEngine(config.baseUrl(),
-                        config.apiKey(),
-                        config.maxResults(),
-                        config.timeout(),
-                        config.logRequests().orElse(false),
-                        config.logResponses().orElse(false),
-                        config.searchDepth(),
-                        config.includeAnswer(),
-                        config.includeRawContent(),
-                        config.includeDomains(),
-                        config.excludeDomains());
+                return new QuarkusTavilyWebSearchEngine(runtimeConfig.getValue().baseUrl(),
+                        runtimeConfig.getValue().apiKey(),
+                        runtimeConfig.getValue().maxResults(),
+                        runtimeConfig.getValue().timeout(),
+                        runtimeConfig.getValue().logRequests().orElse(false),
+                        runtimeConfig.getValue().logResponses().orElse(false),
+                        runtimeConfig.getValue().searchDepth(),
+                        runtimeConfig.getValue().includeAnswer(),
+                        runtimeConfig.getValue().includeRawContent(),
+                        runtimeConfig.getValue().includeDomains(),
+                        runtimeConfig.getValue().excludeDomains());
             }
         };
     }


### PR DESCRIPTION
With https://github.com/quarkusio/quarkus/pull/48500, we will disallow the injection of Runtime configuration objects during deployment. The recommended way is to inject it directly into the Recorder, wrapped in a `RuntimeValue`.