### PR TITLE
MCP streamablehttp accept header seprated by comma

### DIFF
--- a/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/http/QuarkusStreamableHttpMcpTransport.java
+++ b/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/http/QuarkusStreamableHttpMcpTransport.java
@@ -113,7 +113,7 @@ public class QuarkusStreamableHttpMcpTransport implements McpTransport {
         }
         RequestOptions options = new RequestOptions()
                 .setAbsoluteURI(url)
-                .addHeader("Accept", "application/json; text/event-stream")
+                .addHeader("Accept", "application/json,text/event-stream")
                 .setMethod(HttpMethod.POST);
         if (mcpSessionId.get() != null) {
             options.addHeader("Mcp-Session-Id", mcpSessionId.get());


### PR DESCRIPTION
the Accept header separates multiple media types with commas (e.g., application/json, text/event-stream). Semicolons are reserved for parameters within a type (e.g., application/json;q=0.9 for quality factors). Sending a semicolon-separated list is malformed, and strict servers may reject it as a bad request during header parsing—before even attempting to read the body. [Accept Header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Accept).

- Fixes: #1628