### PR TITLE
Check the if id is null or not before starting the SSE channel

### DIFF
--- a/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/http/QuarkusStreamableHttpMcpTransport.java
+++ b/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/http/QuarkusStreamableHttpMcpTransport.java
@@ -142,8 +142,9 @@ public class QuarkusStreamableHttpMcpTransport implements McpTransport {
                                         log.debug("Assigned MCP session ID: " + mcpSessionId);
                                         this.mcpSessionId.set(mcpSessionId);
                                     }
+
                                     String contentType = response.result().getHeader("Content-Type");
-                                    if (contentType != null && contentType.contains("text/event-stream")) {
+                                    if (id != null && contentType != null && contentType.contains("text/event-stream")) {
                                         // the server has started a SSE channel
                                         response.result().handler(bodyBuffer -> {
                                             String responseString = bodyBuffer.toString();


### PR DESCRIPTION
In the [QuarkusStreamableHttpMcpTransport.java#L146](https://github.com/quarkiverse/quarkus-langchain4j/blob/e8e5dc89a8934e6c3f0d2bd81520cda7a8bc5b1d/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/http/QuarkusStreamableHttpMcpTransport.java#L146)  start the SSE channel only for non null ID responses. otherwise it will end up in the 'java.util.concurrent.TimeoutException'