### PR TITLE
Change BedrockRecorder to check if the model id contains anthropic in…

### DIFF
--- a/model-providers/bedrock/runtime/src/main/java/io/quarkiverse/langchain4j/bedrock/runtime/BedrockRecorder.java
+++ b/model-providers/bedrock/runtime/src/main/java/io/quarkiverse/langchain4j/bedrock/runtime/BedrockRecorder.java
@@ -130,7 +130,7 @@ public class BedrockRecorder {
             var modelId = modelConfig.modelId().orElse("anthropic.claude-v2");
 
             Supplier<StreamingChatModel> supplier;
-            if (modelId.startsWith("anthropic")) {
+            if (modelId.contains("anthropic")) {
 
                 var paramsBuilder = ChatRequestParameters.builder()
                         .maxOutputTokens(modelConfig.maxTokens());


### PR DESCRIPTION
Change BedrockRecorder to check if the model id contains anthropic instead of a prefix check to allow cross-region reference model ids.
Fixes issue #1639