### PR TITLE
Update OidcMcpAuthProvider to ignore requests without active request context

### DIFF
--- a/mcp-auth-providers/oidc-mcp-auth-provider/runtime/src/main/java/io/quarkiverse/langchain4j/oidc/mcp/runtime/OidcMcpAuthProvider.java
+++ b/mcp-auth-providers/oidc-mcp-auth-provider/runtime/src/main/java/io/quarkiverse/langchain4j/oidc/mcp/runtime/OidcMcpAuthProvider.java
@@ -1,17 +1,22 @@
 package io.quarkiverse.langchain4j.oidc.mcp.runtime;
 
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Inject;
-
 import io.quarkiverse.langchain4j.mcp.auth.McpClientAuthProvider;
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableInstance;
+import io.quarkus.arc.ManagedContext;
 import io.quarkus.security.credential.TokenCredential;
 
 public class OidcMcpAuthProvider implements McpClientAuthProvider {
-    @Inject
-    Instance<TokenCredential> tokenCredential;
 
     @Override
     public String getAuthorization(Input input) {
-        return tokenCredential.isResolvable() ? "Bearer " + tokenCredential.get().getToken() : null;
+        ManagedContext managedContext = Arc.container().requestContext();
+        if (managedContext.isActive()) {
+            InjectableInstance<TokenCredential> tokenCredential = Arc.container().select(TokenCredential.class);
+            if (tokenCredential.isResolvable()) {
+                return "Bearer " + tokenCredential.get().getToken();
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Fixes #1641

This PR makes sure that the OIDC McpClientAuthFilter only does the work if the request context is active, making sure it does not interfere with various MCP protocol specific actions that have no active request context, when activating it on the fly would not work in any case as the new context would have no token.

@KaiSuchomel Can you please verify this PR ?

Note, this PR fixes the  OIDC McpClientAuthFilter reporting ContextNotActiveException. I'm still seeing MCP server auto-ping not working but I think this is no longer the OIDC McpClientAuthFilter's fault.

If it is the case, let's resolve #1641 and please open another issue, once this PR is approved/merged