### PR TITLE
Update Gemini and OpenAi ModelAuthProvider to use ManagedExecutor

### DIFF
--- a/integration-tests/vertex-ai-gemini/src/main/java/org/acme/example/gemini/aiservices/DummyAuthProvider.java
+++ b/integration-tests/vertex-ai-gemini/src/main/java/org/acme/example/gemini/aiservices/DummyAuthProvider.java
@@ -9,6 +9,10 @@ public class DummyAuthProvider implements ModelAuthProvider {
 
     @Override
     public String getAuthorization(Input input) {
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException ex) {
+        }
         return "Bearer token";
     }
 


### PR DESCRIPTION
Fixes #1612

This PR follows up the update to [McpClientAuthFilter](https://github.com/quarkiverse/quarkus-langchain4j/pull/1614/files#diff-b0673f85d8d7d9c02d1040fd7e2df500d3cc3b07b61085acaf82d55c12be6485) in #1614.

I can confirm that on `main`, after adding a 5sec sleep to the dummy auth filter in the `integration-tests/vertx-ai-gemini`, the following is reported:

```
2025-07-29 09:46:04,571 INFO  [io.quarkus] (main) Installed features: [cdi, langchain4j, langchain4j-vertexai-gemini, micrometer, qute, rest, rest-client, rest-client-jackson, rest-jackson, smallrye-context-propagation, smallrye-fault-tolerance, vertx]
2025-07-29 09:46:08,420 WARN  [io.ver.cor.imp.BlockedThreadChecker] (vertx-blocked-thread-checker) Thread Thread[vert.x-eventloop-thread-1,5,main] has been blocked for 3294 ms, time limit is 2000 ms: io.vertx.core.VertxException: Thread blocked
	at java.base/java.lang.Thread.sleep0(Native Method)
	at java.base/java.lang.Thread.sleep(Thread.java:509)
	at org.acme.example.gemini.aiservices.DummyAuthProvider.getAuthorization(DummyAuthProvider.java:13)
	at io.quarkiverse.langchain4j.gemini.common.ModelAuthProviderFilter.setAuthorization(ModelAuthProviderFilter.java:69)
	at io.quarkiverse.langchain4j.gemini.common.ModelAuthProviderFilter$1.run(ModelAuthProviderFilter.java:45)
	at io.quarkiverse.langchain4j.gemini.common.ModelAuthProviderFilter$2.lambda$execute$0(ModelAuthProviderFilter.java:63)
	at io.vertx.core.impl.ContextInternal.dispatch(ContextInternal.java:270)
	at io.vertx.core.impl.ContextInternal.dispatch(ContextInternal.java:252)
	at io.vertx.core.impl.ContextInternal.lambda$runOnContext$0(ContextInternal.java:50)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:998)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:1583)

2025-07-29 09:46:10,263 INFO  [io.qua.lan.ver.run.gem.VertxAiGeminiRestApi$VertxAiClientLogger] (vert.x-eventloop-thread-1) Request:
- method: POST
- url: http://localhost:8081/gemini/v1/projects/my_google_project_id/locations/west-europe/publishers/google/models/gemini-1.5-pro:generateContent
- headers: [Authorization: Bearer to...en], [Content-Type: application/json], [User-Agent: Quarkus REST Client], [content-length: 357]
- body: {"contents":[{"role":"user","parts":[{"text":"This is a test"}]}],"tools":[{"functionDeclarations":[{"name":"duplicateContent","description":"Duplicate content","parameters":{"type":"object","properties":{"content":{"type":"string"}},"required":["content"]}}]}],"generationConfig":{"maxOutputTokens":8192,"responseMimeType":"text/plain","stopSequences":[]}}
2025-07-29 09:46:10,273 INFO  [io.qua.lan.ver.run.gem.VertxAiGeminiRestApi$VertxAiClientLogger] (vert.x-eventloop-thread-1) Response:
- status code: 200
```

But this warning is gone with the PR model auth porvider executor updates.

I meant to work on improving the tests - because the test is supposed to fail if the thread gets blocked, but I guess it requires changes at the core or at the test support level as well, so perhaps we can do it later