### PR TITLE
prevent NPE in case of null parts

### DIFF
--- a/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/GenerateContentResponseHandler.java
+++ b/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/GenerateContentResponseHandler.java
@@ -21,10 +21,11 @@ public final class GenerateContentResponseHandler {
 
         StringBuilder text = new StringBuilder();
         List<GenerateContentResponse.Candidate.Part> parts = response.candidates().get(0).content().parts();
-        for (GenerateContentResponse.Candidate.Part part : parts) {
-            text.append(part.text());
+        if (parts != null && !parts.isEmpty()) {
+            for (GenerateContentResponse.Candidate.Part part : parts) {
+                text.append(part.text());
+            }
         }
-
         return text.toString();
     }
 


### PR DESCRIPTION
We found the following Exception in our log:

```
2025-08-20 07:03:11,138 ERROR [io.qua.ver.htt.run.QuarkusErrorHandler] (executor-thread-11) HTTP Request to /ai/chat/-1943124379 failed, error id: 2c9f131e-7b50-499f-8027-d5812ab7548b-1: java.lang.NullPointerException: Cannot invoke "java.util.List.iterator()" because "parts" is null
	at io.quarkiverse.langchain4j.gemini.common.GenerateContentResponseHandler.getText(GenerateContentResponseHandler.java:24)
	at io.quarkiverse.langchain4j.gemini.common.GeminiChatLanguageModel.chat(GeminiChatLanguageModel.java:89)
	at dev.langchain4j.model.chat.ChatModel_CAOdzSz_JXOmbdPru8SBVdBro64_Synthetic_ClientProxy.chat(Unknown Source)
	at io.quarkiverse.langchain4j.runtime.aiservice.AiServiceMethodImplementationSupport.doImplement(AiServiceMethodImplementationSupport.java:454)
	at io.quarkiverse.langchain4j.runtime.aiservice.AiServiceMethodImplementationSupport.implement(AiServiceMethodImplementationSupport.java:154)
	at io.gec.ai.control.GecAiService$$QuarkusImpl.chat(Unknown Source)
```

Added Null Check to prevent the NPE