### PR TITLE
Prevent NPE in case of null temperature/topP

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/listeners/SpanChatModelListener.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/listeners/SpanChatModelListener.java
@@ -50,8 +50,9 @@ public class SpanChatModelListener implements ChatModelListener {
         ChatRequest request = requestContext.chatRequest();
         Span span = tracer.spanBuilder("completion " + request.parameters().modelName())
                 .setAttribute("gen_ai.request.model", request.parameters().modelName())
-                .setAttribute("gen_ai.request.temperature", request.parameters().temperature())
-                .setAttribute("gen_ai.request.top_p", request.parameters().topP())
+                .setAttribute("gen_ai.request.temperature",
+                        request.parameters().temperature() != null ? request.parameters().temperature() : 0D)
+                .setAttribute("gen_ai.request.top_p", request.parameters().topP() != null ? request.parameters().topP() : 0D)
                 .startSpan();
         Scope scope = span.makeCurrent();
 


### PR DESCRIPTION
We found the following NPE in our Log:
```
2025-08-22 11:21:50,801 WARN  [io.qua.lan.gem.com.GeminiChatLanguageModel] (efbdd8b9a7a18d1f1b062854ad2071a4::) Exception while calling model listener: java.lang.NullPointerException: Cannot invoke "java.lang.Double.doubleValue()" because the return value of "dev.langchain4j.model.chat.request.ChatRequestParameters.temperature()" is null
	at io.quarkiverse.langchain4j.runtime.listeners.SpanChatModelListener.onRequest(SpanChatModelListener.java:53)
	at io.quarkiverse.langchain4j.gemini.common.GeminiChatLanguageModel.lambda$chat$0(GeminiChatLanguageModel.java:80)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at io.quarkiverse.langchain4j.gemini.common.GeminiChatLanguageModel.chat(GeminiChatLanguageModel.java:78)
	at dev.langchain4j.model.chat.ChatModel_CAOdzSz_JXOmbdPru8SBVdBro64_Synthetic_ClientProxy.chat(Unknown Source)
```
Added Null Check