### PR TITLE
Prevent NPE when delta is null in Azure OpenAI streaming

### DIFF
--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/AzureOpenAiStreamingChatModel.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/AzureOpenAiStreamingChatModel.java
@@ -234,6 +234,9 @@ public class AzureOpenAiStreamingChatModel implements StreamingChatModel {
             return;
         }
         Delta delta = choices.get(0).delta();
+        if (delta == null) {
+            return;
+        }
         String content = delta.content();
         if (content != null) {
             handler.onPartialResponse(content);


### PR DESCRIPTION
## Description
Fixes a NullPointerException that occurs in `AzureOpenAiStreamingChatModel` when Azure OpenAI sends streaming chunks without delta content.

## Problem
Azure OpenAI streaming responses sometimes include chunks without a delta field. The current code assumes delta is always present, causing NPE at line 237: Cannot invoke "dev.langchain4j.model.openai.internal.chat.Delta.content()" because "delta" is null

## Solution
Added null check for `delta` object before accessing its content

## Testing
Tested with streaming requests that previously crashed