### PR TITLE
Use deep link for easy rag docs

### DIFF
--- a/rag/easy-rag/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/rag/easy-rag/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -5,7 +5,7 @@ metadata:
   keywords:
     - ai
     - langchain4j
-  guide: "https://docs.quarkiverse.io/quarkus-langchain4j/dev/index.html"
+  guide: "https://docs.quarkiverse.io/quarkus-langchain4j/dev/rag-easy-rag.html"
   categories:
     - "ai"
   status: "preview"


### PR DESCRIPTION
I was a bit disappointed when I followed the guide link for easy rag and it just took me to the top level langchain4j docs. When we have the option and there's an obvious page, should we deep link instead?