### PR TITLE
Patch thought configuration for `quarkus-langchain4j-ai-gemini`

### DIFF
--- a/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/GeminiChatLanguageModel.java
+++ b/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/GeminiChatLanguageModel.java
@@ -67,7 +67,7 @@ public abstract class GeminiChatLanguageModel extends BaseGeminiChatModel implem
                 .temperature(getOrDefault(requestParameters.temperature(), this.temperature))
                 .topK(getOrDefault(requestParameters.topK(), this.topK))
                 .topP(getOrDefault(requestParameters.topP(), this.topP));
-        if (includeThoughts) {
+        if (thinkingBudget != null || includeThoughts) {
             generationConfigBuilder.thinkingConfig(new ThinkingConfig(thinkingBudget, includeThoughts));
         }
         GenerationConfig generationConfig = generationConfigBuilder.build();

--- a/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/GeminiChatLanguageModel.java
+++ b/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/GeminiChatLanguageModel.java
@@ -97,10 +97,8 @@ public abstract class GeminiChatLanguageModel extends BaseGeminiChatModel implem
                     .getToolExecutionRequests(response);
             AiMessage.Builder aiMessageBuilder = AiMessage.builder()
                     .text(text)
-                    .thinking(thoughts);
-            if (!toolExecutionRequests.isEmpty()) {
-                aiMessageBuilder.toolExecutionRequests(toolExecutionRequests);
-            }
+                    .thinking(thoughts)
+                    .toolExecutionRequests(toolExecutionRequests);
             AiMessage aiMessage = aiMessageBuilder.build();
 
             final TokenUsage tokenUsage = GenerateContentResponseHandler.getTokenUsage(response.usageMetadata());

--- a/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/GeminiChatLanguageModel.java
+++ b/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/GeminiChatLanguageModel.java
@@ -91,11 +91,17 @@ public abstract class GeminiChatLanguageModel extends BaseGeminiChatModel implem
             GenerateContentResponse response = generateContext(request);
 
             String text = GenerateContentResponseHandler.getText(response);
+            String thoughts = includeThoughts ? GenerateContentResponseHandler
+                    .getThoughts(response) : null;
             List<ToolExecutionRequest> toolExecutionRequests = GenerateContentResponseHandler
                     .getToolExecutionRequests(response);
-            AiMessage aiMessage = toolExecutionRequests.isEmpty()
-                    ? aiMessage(text)
-                    : aiMessage(text, toolExecutionRequests);
+            AiMessage.Builder aiMessageBuilder = AiMessage.builder()
+                    .text(text)
+                    .thinking(thoughts);
+            if (!toolExecutionRequests.isEmpty()) {
+                aiMessageBuilder.toolExecutionRequests(toolExecutionRequests);
+            }
+            AiMessage aiMessage = aiMessageBuilder.build();
 
             final TokenUsage tokenUsage = GenerateContentResponseHandler.getTokenUsage(response.usageMetadata());
             final FinishReason finishReason = FinishReasonMapper.map(GenerateContentResponseHandler.getFinishReason(response));

--- a/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/GenerateContentResponseHandler.java
+++ b/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/GenerateContentResponseHandler.java
@@ -25,7 +25,33 @@ public final class GenerateContentResponseHandler {
                 List<GenerateContentResponse.Candidate.Part> parts = response.candidates().get(0).content().parts();
                 if (parts != null && !parts.isEmpty()) {
                     for (GenerateContentResponse.Candidate.Part part : parts) {
-                        text.append(part.text());
+                        if (part.thought() == null || !part.thought()) {
+                            text.append(part.text());
+                        }
+                    }
+                }
+            }
+        }
+        return text.toString();
+    }
+
+    public static String getThoughts(GenerateContentResponse response) {
+        GenerateContentResponse.FinishReason finishReason = getFinishReason(response);
+        if (finishReason == GenerateContentResponse.FinishReason.SAFETY) {
+            throw new IllegalArgumentException("The response is blocked due to safety reason.");
+        } else if (finishReason == GenerateContentResponse.FinishReason.RECITATION) {
+            throw new IllegalArgumentException("The response is blocked due to unauthorized citations.");
+        }
+
+        StringBuilder text = new StringBuilder();
+        if (response.candidates() != null && !response.candidates().isEmpty()) {
+            if (response.candidates().get(0).content() != null) {
+                List<GenerateContentResponse.Candidate.Part> parts = response.candidates().get(0).content().parts();
+                if (parts != null && !parts.isEmpty()) {
+                    for (GenerateContentResponse.Candidate.Part part : parts) {
+                        if (part.thought() != null && part.thought()) {
+                            text.append(part.text());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This patches #1711 which were merged in 1.2.0.CR1. It aims to solve the 2 issues which were noted about it in #1694 by myself.  

Note: due to a persistent build error from another extension of quarkus-langchain (see #1694) I have not been able to test this yet. If someone would like to test (or instruct me how I can fix the build error / test), I'd be grateful. 

## Tests that needs to be done before a merge
- Will a Gemini 2.5 model activate thinking (look for the thinkingConfig object in request logging) when the thinking-budget property is set to a non-null property integer?
- Will the property include-thoughts=true make the returned AIMessage hold the model's thoughts (retrievable via .thinking())? Will the actual LLM response (via .text()) NOT include the thoughts?  
