### PR TITLE
Drop explicit versions of byte-buddy and mockito-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,23 +54,6 @@
   </properties>
   <dependencyManagement>
     <dependencies>
-      <!-- Used to make Mockito work with JDK 24. Needs to precede the Quarkus BOM -->
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <version>5.18.0</version>
-      </dependency>
-      <dependency>
-        <groupId>net.bytebuddy</groupId>
-        <artifactId>byte-buddy</artifactId>
-        <version>1.15.11</version>
-      </dependency>
-      <dependency>
-        <groupId>net.bytebuddy</groupId>
-        <artifactId>byte-buddy-agent</artifactId>
-        <version>1.15.11</version>
-      </dependency>
-
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bom</artifactId>

--- a/samples/fraud-detection/pom.xml
+++ b/samples/fraud-detection/pom.xml
@@ -23,18 +23,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Used to make Hibernate work with JDK 24. Needs to precede the Quarkus BOM -->
-            <dependency>
-                <groupId>net.bytebuddy</groupId>
-                <artifactId>byte-buddy</artifactId>
-                <version>1.15.11</version>
-            </dependency>
-            <dependency>
-                <groupId>net.bytebuddy</groupId>
-                <artifactId>byte-buddy-agent</artifactId>
-                <version>1.15.11</version>
-            </dependency>
-
             <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>

--- a/samples/movie-similarity-search/pom.xml
+++ b/samples/movie-similarity-search/pom.xml
@@ -23,18 +23,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- Used to make Hibernate work with JDK 24. Needs to precede the Quarkus BOM -->
-      <dependency>
-        <groupId>net.bytebuddy</groupId>
-        <artifactId>byte-buddy</artifactId>
-        <version>1.15.11</version>
-      </dependency>
-      <dependency>
-        <groupId>net.bytebuddy</groupId>
-        <artifactId>byte-buddy-agent</artifactId>
-        <version>1.15.11</version>
-      </dependency>
-
       <dependency>
         <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>${quarkus.platform.artifact-id}</artifactId>

--- a/samples/secure-fraud-detection/pom.xml
+++ b/samples/secure-fraud-detection/pom.xml
@@ -34,18 +34,6 @@
     </dependencyManagement>
 
     <dependencies>
-        <!-- Used to make Hibernate work with JDK 24. Needs to precede the Quarkus BOM -->
-        <dependency>
-            <groupId>net.bytebuddy</groupId>
-            <artifactId>byte-buddy</artifactId>
-            <version>1.15.11</version>
-        </dependency>
-        <dependency>
-            <groupId>net.bytebuddy</groupId>
-            <artifactId>byte-buddy-agent</artifactId>
-            <version>1.15.11</version>
-        </dependency>
-
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-jackson</artifactId>

--- a/samples/secure-sql-chatbot/pom.xml
+++ b/samples/secure-sql-chatbot/pom.xml
@@ -23,18 +23,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Used to make Hibernate work with JDK 24. Needs to precede the Quarkus BOM -->
-            <dependency>
-                <groupId>net.bytebuddy</groupId>
-                <artifactId>byte-buddy</artifactId>
-                <version>1.15.11</version>
-            </dependency>
-            <dependency>
-                <groupId>net.bytebuddy</groupId>
-                <artifactId>byte-buddy-agent</artifactId>
-                <version>1.15.11</version>
-            </dependency>
-
             <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>

--- a/samples/sql-chatbot/pom.xml
+++ b/samples/sql-chatbot/pom.xml
@@ -23,18 +23,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Used to make Hibernate work with JDK 24. Needs to precede the Quarkus BOM -->
-            <dependency>
-                <groupId>net.bytebuddy</groupId>
-                <artifactId>byte-buddy</artifactId>
-                <version>1.15.11</version>
-            </dependency>
-            <dependency>
-                <groupId>net.bytebuddy</groupId>
-                <artifactId>byte-buddy-agent</artifactId>
-                <version>1.15.11</version>
-            </dependency>
-            
             <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>


### PR DESCRIPTION
Drop explicit versions of byte-buddy and mockito-core

The same versions from 3c8a68f87407ffd26f0b769cdd3530ee285b6659 are in Quarkus BOM for 3.20.2 now

 * https://github.com/quarkusio/quarkus/blob/3.20.2/pom.xml#L76
 * https://github.com/quarkusio/quarkus/blob/3.20.2/bom/application/pom.xml#L177