### PR TITLE
Anthropic handle tool calls

### DIFF
--- a/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/QuarkusAnthropicClient.java
+++ b/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/QuarkusAnthropicClient.java
@@ -262,23 +262,30 @@ public class QuarkusAnthropicClient extends AnthropicClient {
         }
 
         private void handleMessageStop() {
+            ChatResponse response = build();
+            handler.onCompleteResponse(response);
+        }
+
+        private ChatResponse build() {
             List<ToolExecutionRequest> toolExecutionRequests = List.of();
             if (toolCallBuilder.hasRequests()) {
                 toolExecutionRequests = toolCallBuilder.allRequests();
             }
 
+            String text = contents.stream()
+                    .filter(content -> !content.isEmpty())
+                    .collect(joining("\n"));
+
             AiMessage aiMessage = AiMessage.builder()
-                    .text(String.join("\n", contents))
+                    .text(isNullOrEmpty(text) ? null : text)
                     .toolExecutionRequests(toolExecutionRequests)
                     .build();
 
-            ChatResponse response = ChatResponse.builder()
+            return ChatResponse.builder()
                     .aiMessage(aiMessage)
                     .tokenUsage(new TokenUsage(inputTokenCount.get(), outputTokenCount.get()))
                     .finishReason(toFinishReason(stopReason))
                     .build();
-
-            handler.onCompleteResponse(response);
         }
 
         private void handleError(AnthropicStreamingData data) {


### PR DESCRIPTION
Adding tool_use check to the various message handlers, following the existing implementation in the core LangChain4j library.

Decided to add in passing through the returnThinking boolean config option and also to handle returning the thinking streams as well after comparing the core library.

- Closes: https://github.com/quarkiverse/quarkus-langchain4j/issues/1778
