### PR TITLE
Adding chat events to be in line with upstream AiServiceTokenStream

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/ChatEvent.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/ChatEvent.java
@@ -23,6 +23,7 @@ import dev.langchain4j.service.tool.ToolExecution;
  * @see PartialResponseEvent
  * @see ContentFetchedEvent
  * @see AccumulatedResponseEvent
+ * @see PartialThinkingEvent
  */
 public class ChatEvent {
 
@@ -49,7 +50,11 @@ public class ChatEvent {
         /**
          * Indicates that responses have been accumulated when using Output Guardrails
          */
-        AccumulatedResponse
+        AccumulatedResponse,
+        /**
+         * Indicates that a partial thinking/reasoning chunk has been received (experimental).
+         */
+        PartialThinking
 
     }
 
@@ -225,6 +230,40 @@ public class ChatEvent {
          */
         public ChatResponseMetadata getMetadata() {
             return metadata;
+        }
+    }
+
+    /**
+     * Event emitted when a partial thinking/reasoning chunk is received during streaming.
+     * This event is typically used when the AI service streams its internal reasoning
+     * process separately from the main response content. This is an experimental feature
+     * and may not be supported by all models.
+     *
+     * <p>
+     * Thinking events allow observing the model's reasoning process, which can be useful
+     * for debugging, auditing, or understanding how the model arrived at its response.
+     * </p>
+     */
+    public static class PartialThinkingEvent extends ChatEvent {
+        private final String text;
+
+        /**
+         * Constructs a new PartialThinkingEvent with the given thinking text.
+         *
+         * @param text a partial piece of the AI's thinking/reasoning text
+         */
+        public PartialThinkingEvent(String text) {
+            super(ChatEventType.PartialThinking);
+            this.text = text;
+        }
+
+        /**
+         * Returns the partial thinking text.
+         *
+         * @return the thinking/reasoning text chunk
+         */
+        public String getText() {
+            return text;
         }
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/ChatEvent.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/ChatEvent.java
@@ -2,6 +2,7 @@ package io.quarkiverse.langchain4j.runtime.aiservice;
 
 import java.util.List;
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.rag.content.Content;
@@ -20,6 +21,7 @@ import dev.langchain4j.service.tool.ToolExecution;
  *
  * @see ChatCompletedEvent
  * @see ToolExecutedEvent
+ * @see BeforeToolExecutionEvent
  * @see PartialResponseEvent
  * @see ContentFetchedEvent
  * @see AccumulatedResponseEvent
@@ -39,6 +41,10 @@ public class ChatEvent {
          * Indicates that a tool has been executed during the chat conversation.
          */
         ToolExecuted,
+        /**
+         * Indicates that a tool is about to be executed during the chat conversation.
+         */
+        BeforeToolExecution,
         /**
          * Indicates that a partial response chunk has been received (used in streaming scenarios).
          */
@@ -132,6 +138,34 @@ public class ChatEvent {
          */
         public ToolExecution getExecution() {
             return execution;
+        }
+    }
+
+    /**
+     * Event emitted when a tool is about to be executed during a chat conversation.
+     * This event is triggered before the tool execution begins, allowing for monitoring,
+     * logging, or preparation steps before the actual tool invocation.
+     */
+    public static class BeforeToolExecutionEvent extends ChatEvent {
+        private final ToolExecutionRequest request;
+
+        /**
+         * Constructs a new BeforeToolExecutionEvent with the given tool execution request.
+         *
+         * @param request the tool execution request that is about to be executed
+         */
+        public BeforeToolExecutionEvent(ToolExecutionRequest request) {
+            super(ChatEventType.BeforeToolExecution);
+            this.request = request;
+        }
+
+        /**
+         * Returns the tool execution request that is about to be executed.
+         *
+         * @return the tool execution request
+         */
+        public ToolExecutionRequest getRequest() {
+            return request;
         }
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/TokenStreamMulti.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/TokenStreamMulti.java
@@ -61,6 +61,7 @@ class TokenStreamMulti extends AbstractMulti<ChatEvent> implements Multi<ChatEve
                 isCallerRunningOnWorkerThread);
         TokenStream tokenStream = stream
                 .onPartialResponse(chunk -> processor.onNext(new ChatEvent.PartialResponseEvent(chunk)))
+                .onPartialThinking(thinking -> processor.onNext(new ChatEvent.PartialThinkingEvent(thinking.text())))
                 .onCompleteResponse(message -> {
                     processor.onNext(new ChatEvent.ChatCompletedEvent(message));
                     processor.onComplete();

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/TokenStreamMulti.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/TokenStreamMulti.java
@@ -67,6 +67,8 @@ class TokenStreamMulti extends AbstractMulti<ChatEvent> implements Multi<ChatEve
                     processor.onComplete();
                 })
                 .onRetrieved(content -> processor.onNext(new ChatEvent.ContentFetchedEvent(content)))
+                .beforeToolExecution(
+                        beforeExecution -> processor.onNext(new ChatEvent.BeforeToolExecutionEvent(beforeExecution.request())))
                 .onToolExecuted(execution -> processor.onNext(new ChatEvent.ToolExecutedEvent(execution)))
                 .onError(processor::onError);
         // This is equivalent to "run subscription on worker thread"

--- a/docs/modules/ROOT/pages/guide-streamed-responses.adoc
+++ b/docs/modules/ROOT/pages/guide-streamed-responses.adoc
@@ -63,9 +63,12 @@ When using a `Multi<ChatEvent>` each emitted item is a subclass of `ChatEvent` w
 
 * `PartialResponseEvent` - A partial text token from the main response
 * `PartialThinkingEvent` - A partial thinking/reasoning text chunk (experimental)
+* `BeforeToolExecutionEvent` - Emitted before a tool is executed
 * `ToolExecutedEvent` - Tool execution metadata
 * `ContentFetchedEvent` - Content retrieved from RAG sources
 * `ChatCompletedEvent` - The final LLM response
+
+NOTE: When tools are used, the event flow is: `BeforeToolExecutionEvent` → (tool execution) → `ToolExecutedEvent`. This allows monitoring both before and after tool execution phases.
 
 [source,java]
 ----

--- a/docs/modules/ROOT/pages/guide-streamed-responses.adoc
+++ b/docs/modules/ROOT/pages/guide-streamed-responses.adoc
@@ -59,7 +59,13 @@ quarkus.langchain4j.ollama.chat-model.model-name=qwen3:1.7b
 
 To enable streaming, your AI service method must return a `Multi<String>` or a `Multi<ChatEvent>`.
 When using a `Multi<String>` each emitted item represents a token or part of the final response.
-When using a `Multi<ChatEvent>` each emitted item is a subclass of `ChatEvent` - ToolExecutedEvent (Tool execution metadata), PartialResponseEvent (A partial token), ContentFetchedEvent (When using Rag) and ChatCompletedEvent (The final LLM response).
+When using a `Multi<ChatEvent>` each emitted item is a subclass of `ChatEvent` with different event types:
+
+* `PartialResponseEvent` - A partial text token from the main response
+* `PartialThinkingEvent` - A partial thinking/reasoning text chunk (experimental)
+* `ToolExecutedEvent` - Tool execution metadata
+* `ContentFetchedEvent` - Content retrieved from RAG sources
+* `ChatCompletedEvent` - The final LLM response
 
 [source,java]
 ----


### PR DESCRIPTION
Added partial thinking chat event and before tool execution chat event.
Based the implementation off what was available in the AiTokenStream.java file in version 1.4.0 of the base LangChain4j library.

Main reason for wanting to add this was to allow for the creation of more transparent ai features, allowing proper display of when tools are executing (and the context) as well as what thinking/reasoning is happening.

I'm unsure if we want to add an accumulated thinking event for guardrail support, keen to hear feedback on this (and anything else)!