### PR TITLE
Several fixes in samples/chatbot pom

### DIFF
--- a/samples/chatbot/pom.xml
+++ b/samples/chatbot/pom.xml
@@ -198,7 +198,7 @@
             </build>
             <properties>
                 <skipITs>false</skipITs>
-                <quarkus.package.type>native</quarkus.package.type>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
             </properties>
         </profile>
 


### PR DESCRIPTION
- Use maven plugin from the platform group in samples/chatbot
This change is required for platform testing. Quarkus quickstarts, which play the similar role for the core as samples for this repo, use it already.
- Use `quarkus.native.enabled=true` instead of `quarkus.package.type=native`
The second property causes warning during the build