### PR TITLE
Update the default chat model id for Gemini to gemini-2.5-flash

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-ai-gemini.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-ai-gemini.adoc
@@ -215,7 +215,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_AI_GEMINI_CHAT_MODEL_MODEL_ID+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`gemini-1.5-flash`
+|`gemini-2.5-flash`
 
 a| [[quarkus-langchain4j-ai-gemini_quarkus-langchain4j-ai-gemini-chat-model-temperature]] [.property-path]##link:#quarkus-langchain4j-ai-gemini_quarkus-langchain4j-ai-gemini-chat-model-temperature[`quarkus.langchain4j.ai.gemini.chat-model.temperature`]##
 ifdef::add-copy-button-to-config-props[]
@@ -275,7 +275,7 @@ Specify a lower value for less random responses and a higher value for more rand
 
 Range: 0.0 - 1.0
 
-gemini-1.0-pro and gemini-1.5-pro don't support topK
+gemini-2.5-flash doesn't support topK
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -304,9 +304,8 @@ Specify a lower value for less random responses and a higher value for more rand
 
 Range: 1-40
 
-Default for gemini-1.5-pro: 0.94
+Default for gemini-2.5-flash: 0.95
 
-Default for gemini-1.0-pro: 1
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -722,7 +721,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_AI_GEMINI__MODEL_NAME__CHAT_MODEL_
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`gemini-1.5-flash`
+|`gemini-2.5-flash`
 
 a| [[quarkus-langchain4j-ai-gemini_quarkus-langchain4j-ai-gemini-model-name-chat-model-temperature]] [.property-path]##link:#quarkus-langchain4j-ai-gemini_quarkus-langchain4j-ai-gemini-model-name-chat-model-temperature[`quarkus.langchain4j.ai.gemini."model-name".chat-model.temperature`]##
 ifdef::add-copy-button-to-config-props[]
@@ -782,7 +781,7 @@ Specify a lower value for less random responses and a higher value for more rand
 
 Range: 0.0 - 1.0
 
-gemini-1.0-pro and gemini-1.5-pro don't support topK
+gemini-2.5-flash doesn't support topK
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -811,9 +810,8 @@ Specify a lower value for less random responses and a higher value for more rand
 
 Range: 1-40
 
-Default for gemini-1.5-pro: 0.94
+Default for gemini-2.5-flash: 0.95
 
-Default for gemini-1.0-pro: 1
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-ai-gemini_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-ai-gemini_quarkus.langchain4j.adoc
@@ -215,7 +215,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_AI_GEMINI_CHAT_MODEL_MODEL_ID+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`gemini-1.5-flash`
+|`gemini-2.5-flash`
 
 a| [[quarkus-langchain4j-ai-gemini_quarkus-langchain4j-ai-gemini-chat-model-temperature]] [.property-path]##link:#quarkus-langchain4j-ai-gemini_quarkus-langchain4j-ai-gemini-chat-model-temperature[`quarkus.langchain4j.ai.gemini.chat-model.temperature`]##
 ifdef::add-copy-button-to-config-props[]
@@ -275,7 +275,7 @@ Specify a lower value for less random responses and a higher value for more rand
 
 Range: 0.0 - 1.0
 
-gemini-1.0-pro and gemini-1.5-pro don't support topK
+gemini-2.5-flash doesn't support topK
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -304,9 +304,8 @@ Specify a lower value for less random responses and a higher value for more rand
 
 Range: 1-40
 
-Default for gemini-1.5-pro: 0.94
+Default for gemini-2.5-flash: 0.95
 
-Default for gemini-1.0-pro: 1
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -722,7 +721,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_AI_GEMINI__MODEL_NAME__CHAT_MODEL_
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`gemini-1.5-flash`
+|`gemini-2.5-flash`
 
 a| [[quarkus-langchain4j-ai-gemini_quarkus-langchain4j-ai-gemini-model-name-chat-model-temperature]] [.property-path]##link:#quarkus-langchain4j-ai-gemini_quarkus-langchain4j-ai-gemini-model-name-chat-model-temperature[`quarkus.langchain4j.ai.gemini."model-name".chat-model.temperature`]##
 ifdef::add-copy-button-to-config-props[]
@@ -782,7 +781,7 @@ Specify a lower value for less random responses and a higher value for more rand
 
 Range: 0.0 - 1.0
 
-gemini-1.0-pro and gemini-1.5-pro don't support topK
+gemini-2.5-flash doesn't support topK
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -811,9 +810,8 @@ Specify a lower value for less random responses and a higher value for more rand
 
 Range: 1-40
 
-Default for gemini-1.5-pro: 0.94
+Default for gemini-2.5-flash: 0.95
 
-Default for gemini-1.0-pro: 1
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-vertex-ai-gemini.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-vertex-ai-gemini.adoc
@@ -299,7 +299,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_VERTEXAI_GEMINI_CHAT_MODEL_MODEL_I
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`gemini-1.5-pro`
+|`gemini-2.5-flash`
 
 a| [[quarkus-langchain4j-vertex-ai-gemini_quarkus-langchain4j-vertexai-gemini-chat-model-temperature]] [.property-path]##link:#quarkus-langchain4j-vertex-ai-gemini_quarkus-langchain4j-vertexai-gemini-chat-model-temperature[`quarkus.langchain4j.vertexai.gemini.chat-model.temperature`]##
 ifdef::add-copy-button-to-config-props[]
@@ -313,13 +313,10 @@ The temperature is used for sampling during response generation, which occurs wh
 
 If the model returns a response that's too generic, too short, or the model gives a fallback response, try increasing the temperature.
 
-Range for gemini-1.0-pro-001
+Range for gemini-2.5-flash: 0.0 - 2.0
 
-Range for gemini-1.0-pro-002, gemini-1.5-pro: 0.0 - 2.0
+Default for gemini-2.5-flash: 1.0
 
-Default for gemini-1.5-pro and gemini-1.0-pro-002: 1.0
-
-Default for gemini-1.0-pro-001: 0.9
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -367,7 +364,7 @@ Specify a lower value for less random responses and a higher value for more rand
 
 Range: 0.0 - 1.0
 
-gemini-1.0-pro and gemini-1.5-pro don't support topK
+gemini-2.5-flash doesn't support topK
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -396,9 +393,8 @@ Specify a lower value for less random responses and a higher value for more rand
 
 Range: 1-40
 
-Default for gemini-1.5-pro: 0.94
+Default for gemini-2.5-flash: 0.95
 
-Default for gemini-1.0-pro: 1
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -854,7 +850,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_VERTEXAI_GEMINI__MODEL_NAME__CHAT_
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`gemini-1.5-pro`
+|`gemini-2.5-flash`
 
 a| [[quarkus-langchain4j-vertex-ai-gemini_quarkus-langchain4j-vertexai-gemini-model-name-chat-model-temperature]] [.property-path]##link:#quarkus-langchain4j-vertex-ai-gemini_quarkus-langchain4j-vertexai-gemini-model-name-chat-model-temperature[`quarkus.langchain4j.vertexai.gemini."model-name".chat-model.temperature`]##
 ifdef::add-copy-button-to-config-props[]
@@ -868,13 +864,11 @@ The temperature is used for sampling during response generation, which occurs wh
 
 If the model returns a response that's too generic, too short, or the model gives a fallback response, try increasing the temperature.
 
-Range for gemini-1.0-pro-001
 
-Range for gemini-1.0-pro-002, gemini-1.5-pro: 0.0 - 2.0
+Range for gemini-2.5-flash: 0.0 - 2.0
 
-Default for gemini-1.5-pro and gemini-1.0-pro-002: 1.0
+Default for gemini-2.5-flash: 1.0
 
-Default for gemini-1.0-pro-001: 0.9
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -922,7 +916,7 @@ Specify a lower value for less random responses and a higher value for more rand
 
 Range: 0.0 - 1.0
 
-gemini-1.0-pro and gemini-1.5-pro don't support topK
+gemini-2.5-flash doesn't support topK
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -951,9 +945,8 @@ Specify a lower value for less random responses and a higher value for more rand
 
 Range: 1-40
 
-Default for gemini-1.5-pro: 0.94
+Default for gemini-2.5-flash: 0.95
 
-Default for gemini-1.0-pro: 1
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-vertex-ai-gemini_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-vertex-ai-gemini_quarkus.langchain4j.adoc
@@ -299,7 +299,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_VERTEXAI_GEMINI_CHAT_MODEL_MODEL_I
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`gemini-1.5-pro`
+|`gemini-2.5-flash`
 
 a| [[quarkus-langchain4j-vertex-ai-gemini_quarkus-langchain4j-vertexai-gemini-chat-model-temperature]] [.property-path]##link:#quarkus-langchain4j-vertex-ai-gemini_quarkus-langchain4j-vertexai-gemini-chat-model-temperature[`quarkus.langchain4j.vertexai.gemini.chat-model.temperature`]##
 ifdef::add-copy-button-to-config-props[]
@@ -313,13 +313,11 @@ The temperature is used for sampling during response generation, which occurs wh
 
 If the model returns a response that's too generic, too short, or the model gives a fallback response, try increasing the temperature.
 
-Range for gemini-1.0-pro-001
 
-Range for gemini-1.0-pro-002, gemini-1.5-pro: 0.0 - 2.0
+Range for gemini-2.5-flash: 0.0 - 2.0
 
-Default for gemini-1.5-pro and gemini-1.0-pro-002: 1.0
+Default for gemini-2.5-flash: 1.0
 
-Default for gemini-1.0-pro-001: 0.9
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -367,7 +365,7 @@ Specify a lower value for less random responses and a higher value for more rand
 
 Range: 0.0 - 1.0
 
-gemini-1.0-pro and gemini-1.5-pro don't support topK
+gemini-2.5-flash doesn't support topK
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -396,9 +394,8 @@ Specify a lower value for less random responses and a higher value for more rand
 
 Range: 1-40
 
-Default for gemini-1.5-pro: 0.94
+Default for gemini-2.5-flash: 0.95
 
-Default for gemini-1.0-pro: 1
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -854,7 +851,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_VERTEXAI_GEMINI__MODEL_NAME__CHAT_
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`gemini-1.5-pro`
+|`gemini-2.5-flash`
 
 a| [[quarkus-langchain4j-vertex-ai-gemini_quarkus-langchain4j-vertexai-gemini-model-name-chat-model-temperature]] [.property-path]##link:#quarkus-langchain4j-vertex-ai-gemini_quarkus-langchain4j-vertexai-gemini-model-name-chat-model-temperature[`quarkus.langchain4j.vertexai.gemini."model-name".chat-model.temperature`]##
 ifdef::add-copy-button-to-config-props[]
@@ -868,13 +865,11 @@ The temperature is used for sampling during response generation, which occurs wh
 
 If the model returns a response that's too generic, too short, or the model gives a fallback response, try increasing the temperature.
 
-Range for gemini-1.0-pro-001
 
-Range for gemini-1.0-pro-002, gemini-1.5-pro: 0.0 - 2.0
+Range for gemini-2.5-flash: 0.0 - 2.0
 
-Default for gemini-1.5-pro and gemini-1.0-pro-002: 1.0
+Default for gemini-2.5-flash: 1.0
 
-Default for gemini-1.0-pro-001: 0.9
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -922,7 +917,7 @@ Specify a lower value for less random responses and a higher value for more rand
 
 Range: 0.0 - 1.0
 
-gemini-1.0-pro and gemini-1.5-pro don't support topK
+gemini-2.5-flash doesn't support topK
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -951,9 +946,7 @@ Specify a lower value for less random responses and a higher value for more rand
 
 Range: 1-40
 
-Default for gemini-1.5-pro: 0.94
-
-Default for gemini-1.0-pro: 1
+Default for gemini-2.5-flash: 0.95
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/integration-tests/ai-gemini/src/main/java/org/acme/example/gemini/aiservices/GeminiResource.java
+++ b/integration-tests/ai-gemini/src/main/java/org/acme/example/gemini/aiservices/GeminiResource.java
@@ -16,7 +16,7 @@ import io.vertx.core.json.JsonObject;
 public class GeminiResource {
 
     @POST
-    @Path("v1beta/models/gemini-1.5-flash:generateContent")
+    @Path("v1beta/models/gemini-2.5-flash:generateContent")
     @Produces("application/json")
     @Consumes("application/json")
     public String generateResponse(String generateRequest, @RestQuery String key) {

--- a/integration-tests/vertex-ai-gemini/src/main/java/org/acme/example/gemini/aiservices/GeminiResource.java
+++ b/integration-tests/vertex-ai-gemini/src/main/java/org/acme/example/gemini/aiservices/GeminiResource.java
@@ -14,7 +14,7 @@ import io.vertx.core.json.JsonObject;
 public class GeminiResource {
 
     @POST
-    @Path("v1/projects/my_google_project_id/locations/west-europe/publishers/google/models/gemini-1.5-pro:generateContent")
+    @Path("v1/projects/my_google_project_id/locations/west-europe/publishers/google/models/gemini-2.5-flash:generateContent")
     @Produces("application/json")
     @Consumes("application/json")
     public String generateResponse(String generateRequest) {

--- a/model-providers/google/gemini/ai-gemini/deployment/src/test/java/io/quarkiverse/langchain4j/ai/gemini/deployment/AiGeminiChatLanguageModelAuthProviderSmokeTest.java
+++ b/model-providers/google/gemini/ai-gemini/deployment/src/test/java/io/quarkiverse/langchain4j/ai/gemini/deployment/AiGeminiChatLanguageModelAuthProviderSmokeTest.java
@@ -26,7 +26,7 @@ import io.quarkus.test.QuarkusUnitTest;
 public class AiGeminiChatLanguageModelAuthProviderSmokeTest extends WiremockAware {
 
     private static final String API_KEY = "dummy";
-    private static final String CHAT_MODEL_ID = "gemini-1.5-flash";
+    private static final String CHAT_MODEL_ID = "gemini-2.5-flash";
 
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()

--- a/model-providers/google/gemini/ai-gemini/deployment/src/test/java/io/quarkiverse/langchain4j/ai/gemini/deployment/AiGeminiChatLanguageModelSmokeTest.java
+++ b/model-providers/google/gemini/ai-gemini/deployment/src/test/java/io/quarkiverse/langchain4j/ai/gemini/deployment/AiGeminiChatLanguageModelSmokeTest.java
@@ -23,7 +23,7 @@ import io.quarkus.test.QuarkusUnitTest;
 public class AiGeminiChatLanguageModelSmokeTest extends WiremockAware {
 
     private static final String API_KEY = "dummy";
-    private static final String CHAT_MODEL_ID = "gemini-1.5-flash";
+    private static final String CHAT_MODEL_ID = "gemini-2.5-flash";
 
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()

--- a/model-providers/google/gemini/ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/ai/runtime/gemini/config/ChatModelConfig.java
+++ b/model-providers/google/gemini/ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/ai/runtime/gemini/config/ChatModelConfig.java
@@ -20,7 +20,7 @@ public interface ChatModelConfig {
      * @see <a href=
      *      "https://ai.google.dev/gemini-api/docs/models/gemini">https://ai.google.dev/gemini-api/docs/models/gemini</a>
      */
-    @WithDefault("gemini-1.5-flash")
+    @WithDefault("gemini-2.5-flash")
     String modelId();
 
     /**
@@ -54,7 +54,7 @@ public interface ChatModelConfig {
      * <p>
      * Range: 0.0 - 1.0
      * <p>
-     * gemini-1.0-pro and gemini-1.5-pro don't support topK
+     * Default for gemini-2.5-flash: 0.95
      */
     OptionalDouble topP();
 
@@ -70,9 +70,7 @@ public interface ChatModelConfig {
      * <p>
      * Range: 1-40
      * <p>
-     * Default for gemini-1.5-pro: 0.94
-     * <p>
-     * Default for gemini-1.0-pro: 1
+     * gemini-2.5-flash doesn't support topK
      */
     OptionalInt topK();
 

--- a/model-providers/google/vertex-ai-gemini/deployment/src/test/java/io/quarkiverse/langchain4j/vertexai/gemini/deployment/VertexAiGeminiChatLanguageModelSmokeTest.java
+++ b/model-providers/google/vertex-ai-gemini/deployment/src/test/java/io/quarkiverse/langchain4j/vertexai/gemini/deployment/VertexAiGeminiChatLanguageModelSmokeTest.java
@@ -26,7 +26,7 @@ import io.quarkus.test.QuarkusUnitTest;
 public class VertexAiGeminiChatLanguageModelSmokeTest extends WiremockAware {
 
     private static final String API_KEY = "somekey";
-    private static final String CHAT_MODEL_ID = "gemini-1.5-pro";
+    private static final String CHAT_MODEL_ID = "gemini-2.5-flash";
 
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()

--- a/model-providers/google/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/config/ChatModelConfig.java
+++ b/model-providers/google/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/config/ChatModelConfig.java
@@ -18,7 +18,7 @@ public interface ChatModelConfig {
      * @see <a href=
      *      "https://ai.google.dev/gemini-api/docs/models/gemini">https://ai.google.dev/gemini-api/docs/models/gemini</a>
      */
-    @WithDefault("gemini-1.5-pro")
+    @WithDefault("gemini-2.5-flash")
     String modelId();
 
     /**
@@ -31,13 +31,9 @@ public interface ChatModelConfig {
      * If the model returns a response that's too generic, too short, or the model gives a fallback response, try increasing the
      * temperature.
      * <p>
-     * Range for gemini-1.0-pro-001
+     * Range for gemini-2.5-flash: 0.0 - 2.0
      * <p>
-     * Range for gemini-1.0-pro-002, gemini-1.5-pro: 0.0 - 2.0
-     * <p>
-     * Default for gemini-1.5-pro and gemini-1.0-pro-002: 1.0
-     * <p>
-     * Default for gemini-1.0-pro-001: 0.9
+     * Default for gemini-2.5-flash: 1.0
      */
     @WithDefault("${quarkus.langchain4j.temperature}")
     OptionalDouble temperature();
@@ -60,7 +56,7 @@ public interface ChatModelConfig {
      * <p>
      * Range: 0.0 - 1.0
      * <p>
-     * gemini-1.0-pro and gemini-1.5-pro don't support topK
+     * Default for gemini-2.5-flash: 0.95
      */
     OptionalDouble topP();
 
@@ -76,9 +72,7 @@ public interface ChatModelConfig {
      * <p>
      * Range: 1-40
      * <p>
-     * Default for gemini-1.5-pro: 0.94
-     * <p>
-     * Default for gemini-1.0-pro: 1
+     * gemini-2.5-flash doesn't support topK
      */
     OptionalInt topK();
 


### PR DESCRIPTION
This PR updates the default chat model id for the Gemini chat model to `gemini-2.5-flash` since `gemini-1.5-flash` has been discontinued from Sept. 24th.

Fixes https://github.com/quarkiverse/quarkus-langchain4j/issues/1819