### PR TITLE
fix: disable topK for anthropic streaming model

### DIFF
--- a/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/AnthropicRecorder.java
+++ b/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/AnthropicRecorder.java
@@ -141,6 +141,10 @@ public class AnthropicRecorder {
 
             ChatModelConfig.ThinkingConfig thinkingConfig = chatModelConfig.thinking();
             if (thinkingConfig.type().isPresent()) {
+                if (chatModelConfig.topK().isPresent()) {
+                    LOG.warn("TopK was not configured because thinking was enabled");
+                }
+                builder.topK(null);
                 builder.thinkingType(thinkingConfig.type().get());
             }
 


### PR DESCRIPTION
We disabled topK when thinking is enabled for anthropic model

https://github.com/quarkiverse/quarkus-langchain4j/pull/1813

We need to apply the same logic for streaming model as well.