### PR TITLE
Use more precise guide link for Ollama

### DIFF
--- a/model-providers/ollama/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/model-providers/ollama/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,7 +6,7 @@ metadata:
     - ai
     - langchain4j
     - openai
-  guide: "https://docs.quarkiverse.io/quarkus-langchain4j/dev/index.html"
+  guide: "https://docs.quarkiverse.io/quarkus-langchain4j/dev/guide-ollama.html"
   categories:
     - "ai"
   status: "preview"


### PR DESCRIPTION
The current link just links to the top level and makes users search.