### PR TITLE
Make McpRootsStdioTransportTest work in the Platform CI

### DIFF
--- a/integration-tests/mcp/src/test/java/io/quarkiverse/langchain4j/mcp/test/McpRootsStdioTransportTest.java
+++ b/integration-tests/mcp/src/test/java/io/quarkiverse/langchain4j/mcp/test/McpRootsStdioTransportTest.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.langchain4j.mcp.test;
 
+import static io.quarkiverse.langchain4j.mcp.test.McpServerHelper.copyMcpServerScriptToSrcTestResourcesIfItsNotThereAlready;
 import static io.quarkiverse.langchain4j.mcp.test.McpServerHelper.skipTestsIfJbangNotAvailable;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -25,6 +26,7 @@ class McpRootsStdioTransportTest extends McpRootsTestBase {
 
     @BeforeAll
     static void setup() {
+        copyMcpServerScriptToSrcTestResourcesIfItsNotThereAlready("roots_mcp_server.java");
         skipTestsIfJbangNotAvailable();
     }
 


### PR DESCRIPTION
After merging, I'll backport this to 1.2...
The Quarkus platform 3.27 tests are currently failing due to this (see https://github.com/quarkusio/quarkus-platform/actions/runs/18482753100/job/52660352137)