### PR TITLE
[1.2] Enable previously disabled tests, since the issues were fixed

### DIFF
--- a/integration-tests/openai/src/test/java/org/acme/example/openai/chat/ChatLanguageModelResourceTest.java
+++ b/integration-tests/openai/src/test/java/org/acme/example/openai/chat/ChatLanguageModelResourceTest.java
@@ -17,7 +17,6 @@ import jakarta.ws.rs.sse.SseEventSource;
 
 import org.acme.example.openai.TestUtils;
 import org.hamcrest.MatcherAssert;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
@@ -43,8 +42,7 @@ public class ChatLanguageModelResourceTest {
     }
 
     @Test
-    @EnabledIfSystemProperty(named = "quarkus.test.profile", matches = "cloud-llm", disabledReason = "mockgpt does not implement moderations")
-    @Disabled("https://github.com/quarkiverse/quarkus-langchain4j/issues/1693")
+    @EnabledIfSystemProperty(named = "quarkus.test.profile", matches = "cloud-llm", disabledReason = "The Mock API does not handle streaming properly")
     public void sse() throws Exception {
         Client client = ClientBuilder.newBuilder().build();
         WebTarget target = client.target(url.toString() + "/streaming");
@@ -86,7 +84,7 @@ public class ChatLanguageModelResourceTest {
     }
 
     @Test
-    @Disabled("https://github.com/quarkiverse/quarkus-langchain4j/issues/1695")
+    @EnabledIfSystemProperty(named = "quarkus.test.profile", matches = "cloud-llm", disabledReason = "The Mock API does not handle streaming properly")
     public void memory() {
         given()
                 .baseUri(url.toString())

--- a/integration-tests/openai/src/test/java/org/acme/example/openai/embedding/EmbeddingModelResourceTest.java
+++ b/integration-tests/openai/src/test/java/org/acme/example/openai/embedding/EmbeddingModelResourceTest.java
@@ -13,7 +13,7 @@ import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@EnabledIfSystemProperty(named = "quarkus.test.profile", matches = "cloud-llm", disabledReason = "mockgpt does not implement moderations")
+@EnabledIfSystemProperty(named = "quarkus.test.profile", matches = "cloud-llm", disabledReason = "mockgpt does not implement embeddings")
 public class EmbeddingModelResourceTest {
 
     @TestHTTPEndpoint(EmbeddingModelResource.class)


### PR DESCRIPTION
Additionally, return the old disabled reasons, which were accidentally changed in https://github.com/quarkiverse/quarkus-langchain4j/commit/06f0af98be5ba2d0b313daafdba458ad23c1c9ef

Backport of https://github.com/quarkiverse/quarkus-langchain4j/pull/1868