### PR TITLE
Introduce type safety to outputKey handling

### DIFF
--- a/agentic/deployment/src/main/java/io/quarkiverse/langchain4j/agentic/deployment/AgenticLangChain4jDotNames.java
+++ b/agentic/deployment/src/main/java/io/quarkiverse/langchain4j/agentic/deployment/AgenticLangChain4jDotNames.java
@@ -46,6 +46,8 @@ public final class AgenticLangChain4jDotNames {
 
     public static final List<DotName> ALL_AGENT_ANNOTATIONS = List.of(AGENT, SUB_AGENT, SUPERVISOR_AGENT, SEQUENCE_AGENT,
             PARALLEL_AGENT, LOOP_AGENT, CONDITIONAL_AGENT);
+    public static final List<DotName> AGENT_ANNOTATIONS_WITH_SUB_AGENTS = List.of(SUPERVISOR_AGENT, SEQUENCE_AGENT,
+            PARALLEL_AGENT, LOOP_AGENT, CONDITIONAL_AGENT);
 
     public static final DotName CHAT_MODEL_SUPPLIER = DotName.createSimple(ChatModelSupplier.class.getName());
     public static final DotName AGENTIC_SCOPE = DotName.createSimple(AgenticScope.class);

--- a/agentic/deployment/src/main/java/io/quarkiverse/langchain4j/agentic/deployment/DetectedAiAgentAsMapBuildItem.java
+++ b/agentic/deployment/src/main/java/io/quarkiverse/langchain4j/agentic/deployment/DetectedAiAgentAsMapBuildItem.java
@@ -1,0 +1,32 @@
+package io.quarkiverse.langchain4j.agentic.deployment;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.MethodInfo;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class DetectedAiAgentAsMapBuildItem extends SimpleBuildItem {
+
+    private final Map<DotName, List<MethodInfo>> ifaceToAgentMethodsMap;
+
+    public DetectedAiAgentAsMapBuildItem(Map<DotName, List<MethodInfo>> ifaceToAgentMethodsMap) {
+        this.ifaceToAgentMethodsMap = ifaceToAgentMethodsMap;
+    }
+
+    public static DetectedAiAgentAsMapBuildItem from(Map<ClassInfo, List<MethodInfo>> map) {
+        Map<DotName, List<MethodInfo>> buildItemMap = new HashMap<>();
+        for (Map.Entry<ClassInfo, List<MethodInfo>> entry : map.entrySet()) {
+            buildItemMap.put(entry.getKey().name(), entry.getValue());
+        }
+        return new DetectedAiAgentAsMapBuildItem(buildItemMap);
+    }
+
+    public Map<DotName, List<MethodInfo>> getIfaceToAgentMethodsMap() {
+        return ifaceToAgentMethodsMap;
+    }
+}

--- a/agentic/deployment/src/main/java/io/quarkiverse/langchain4j/agentic/deployment/DetectedAiAgentBuildItem.java
+++ b/agentic/deployment/src/main/java/io/quarkiverse/langchain4j/agentic/deployment/DetectedAiAgentBuildItem.java
@@ -1,6 +1,9 @@
 package io.quarkiverse.langchain4j.agentic.deployment;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.MethodInfo;
@@ -39,5 +42,9 @@ public final class DetectedAiAgentBuildItem extends MultiBuildItem {
 
     public List<MethodInfo> getMcpToolBoxMethods() {
         return mcpToolBoxMethods;
+    }
+
+    public static Set<ClassInfo> allIfaces(Collection<DetectedAiAgentBuildItem> items) {
+        return items.stream().map(DetectedAiAgentBuildItem::getIface).collect(Collectors.toSet());
     }
 }

--- a/agentic/deployment/src/main/java/io/quarkiverse/langchain4j/agentic/deployment/OutputKeyBuildItem.java
+++ b/agentic/deployment/src/main/java/io/quarkiverse/langchain4j/agentic/deployment/OutputKeyBuildItem.java
@@ -1,0 +1,66 @@
+package io.quarkiverse.langchain4j.agentic.deployment;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.jboss.jandex.DotName;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class OutputKeyBuildItem extends SimpleBuildItem {
+
+    private final Map<String, DotName> keyToTypeMap;
+    private final Set<String> userProvidedKeys;
+
+    private OutputKeyBuildItem(Map<String, DotName> keyToTypeMap, Set<String> userProvidedKeys) {
+        this.keyToTypeMap = keyToTypeMap;
+        this.userProvidedKeys = userProvidedKeys;
+    }
+
+    public Map<String, DotName> getKeyToTypeMap() {
+        return keyToTypeMap;
+    }
+
+    public Set<String> getUserProvidedKeys() {
+        return userProvidedKeys;
+    }
+
+    public static Builder of() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private final Map<String, DotName> keyToTypeMap = new HashMap<>();
+        private final Set<String> userProvidedKeys = new HashSet<>();
+
+        private Builder() {
+        }
+
+        public Builder addKeyType(String key, DotName type) {
+            Objects.requireNonNull(key, "key must not be null");
+            Objects.requireNonNull(type, "type must not be null");
+
+            DotName previous = keyToTypeMap.put(key, type);
+            if (previous != null) {
+                if (!previous.equals(type)) {
+                    throw new IllegalStateException(
+                            "Output key '%s' is used both with type '%s' and type '%s' ".formatted(key, previous, type));
+                }
+            }
+            return this;
+        }
+
+        public Builder addUserProvidedKey(String name) {
+            Objects.requireNonNull(name, "name must not be null");
+            userProvidedKeys.add(name);
+            return this;
+        }
+
+        public OutputKeyBuildItem build() {
+            return new OutputKeyBuildItem(Map.copyOf(keyToTypeMap), Set.copyOf(userProvidedKeys));
+        }
+    }
+}

--- a/agentic/deployment/src/main/java/io/quarkiverse/langchain4j/agentic/deployment/ValidationUtil.java
+++ b/agentic/deployment/src/main/java/io/quarkiverse/langchain4j/agentic/deployment/ValidationUtil.java
@@ -23,12 +23,13 @@ class ValidationUtil {
     static void validateAllowedReturnTypes(MethodInfo method, Set<DotName> allowedReturnTypes, DotName annotationName) {
         if (!allowedReturnTypes.contains(method.returnType().name())) {
             throw new IllegalConfigurationException(
-                    String.format(
-                            "Methods annotated with '%s' can only use the following return types: '%s'. Offending method is '%s' of class '%s'",
-                            annotationName,
-                            allowedReturnTypes.stream().map(DotName::withoutPackagePrefix).collect(Collectors.joining(",")),
-                            method.name(),
-                            method.declaringClass().name().toString()));
+                    "Methods annotated with '%s' can only use the following return types: '%s'. Offending method is '%s' of class '%s'"
+                            .formatted(
+                                    annotationName,
+                                    allowedReturnTypes.stream().map(DotName::withoutPackagePrefix)
+                                            .collect(Collectors.joining(",")),
+                                    method.name(),
+                                    method.declaringClass().name().toString()));
         }
     }
 
@@ -36,26 +37,26 @@ class ValidationUtil {
             DotName annotationName) {
         if (method.parameters().size() != requiredParameterTypes.size()) {
             throw new IllegalConfigurationException(
-                    String.format(
-                            "Methods annotated with '%s' must use the following parameter types: '%s'. Offending method is '%s' of class '%s'",
-                            annotationName,
-                            requiredParameterTypes.stream().map(DotName::withoutPackagePrefix)
-                                    .collect(Collectors.joining(",")),
-                            method.name(),
-                            method.declaringClass().name().toString()));
+                    "Methods annotated with '%s' must use the following parameter types: '%s'. Offending method is '%s' of class '%s'"
+                            .formatted(
+                                    annotationName,
+                                    requiredParameterTypes.stream().map(DotName::withoutPackagePrefix)
+                                            .collect(Collectors.joining(",")),
+                                    method.name(),
+                                    method.declaringClass().name().toString()));
         }
 
         for (int i = 0; i < requiredParameterTypes.size(); i++) {
             DotName parameterTypeName = method.parameters().get(i).type().name();
             if (!parameterTypeName.equals(requiredParameterTypes.get(i))) {
                 throw new IllegalConfigurationException(
-                        String.format(
-                                "Methods annotated with '%s' must use the following parameter types: '%s'. Offending method is '%s' of class '%s'",
-                                annotationName,
-                                requiredParameterTypes.stream().map(DotName::withoutPackagePrefix)
-                                        .collect(Collectors.joining(",")),
-                                method.name(),
-                                method.declaringClass().name().toString()));
+                        "Methods annotated with '%s' must use the following parameter types: '%s'. Offending method is '%s' of class '%s'"
+                                .formatted(
+                                        annotationName,
+                                        requiredParameterTypes.stream().map(DotName::withoutPackagePrefix)
+                                                .collect(Collectors.joining(",")),
+                                        method.name(),
+                                        method.declaringClass().name().toString()));
             }
         }
     }
@@ -63,11 +64,11 @@ class ValidationUtil {
     static void validateNoMethodParameters(MethodInfo method, DotName annotationName) {
         if (!method.parameters().isEmpty()) {
             throw new IllegalConfigurationException(
-                    String.format(
-                            "Methods annotated with '%s' cannot have any method parameters. Offending method is '%s' of class '%s'",
-                            annotationName,
-                            method.name(),
-                            method.declaringClass().name().toString()));
+                    "Methods annotated with '%s' cannot have any method parameters. Offending method is '%s' of class '%s'"
+                            .formatted(
+                                    annotationName,
+                                    method.name(),
+                                    method.declaringClass().name().toString()));
         }
     }
 }

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgentBeanSmokeTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgentBeanSmokeTest.java
@@ -12,6 +12,7 @@ import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
 import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
 import io.quarkus.test.QuarkusUnitTest;
 
+@SuppressWarnings("CdiInjectionPointsInspection")
 public class AgentBeanSmokeTest extends OpenAiBaseTest {
 
     @RegisterExtension
@@ -31,6 +32,15 @@ public class AgentBeanSmokeTest extends OpenAiBaseTest {
 
     @Inject
     Agents.SupervisorStoryCreator supervisorStoryCreator;
+
+    @Inject
+    Agents.EveningPlannerAgent eveningPlannerAgent;
+
+    @Inject
+    Agents.MedicalExpertWithMemory medicalExpertWithMemory;
+
+    @Inject
+    Agents.StoryCreator storyCreator;
 
     @Test
     public void test() {

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/validation/InvalidOutputKeyTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/validation/InvalidOutputKeyTest.java
@@ -1,0 +1,80 @@
+package io.quarkiverse.langchain4j.agentic.deployment.validation;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.SequenceAgent;
+import dev.langchain4j.agentic.declarative.SubAgent;
+import dev.langchain4j.service.IllegalConfigurationException;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class InvalidOutputKeyTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class))
+            .assertException(
+                    throwable -> Assertions.assertThat(throwable).isInstanceOf(IllegalConfigurationException.class)
+                            .hasMessageContaining("No agent provides an output key named"));
+
+    @Test
+    public void test() {
+        fail("should never be called");
+    }
+
+    public interface StoryCreator {
+
+        @SequenceAgent(outputKey = "story-final", subAgents = {
+                @SubAgent(type = CreativeWriter.class, outputKey = "story-initial"),
+                @SubAgent(type = AudienceEditor.class, outputKey = "story-edited"),
+                @SubAgent(type = StyleEditor.class, outputKey = "story-final")
+        })
+        String write(@V("topic") String topic, @V("style") String style, @V("audience") String audience);
+    }
+
+    public interface CreativeWriter {
+
+        @UserMessage("""
+                You are a creative writer.
+                Generate a draft of a story long no more than 3 sentence around the given topic.
+                Return only the story and nothing else.
+                The topic is {{topic}}.
+                """)
+        @Agent("Generate a story based on the given topic")
+        String generateStory(@V("topic") String topic);
+    }
+
+    public interface AudienceEditor {
+
+        @UserMessage("""
+                You are a professional editor.
+                Analyze and rewrite the following story to better align with the target audience of {{audience}}.
+                Return only the story and nothing else.
+                The story is "{{story}}".
+                """)
+        @Agent("Edit a story to better fit a given audience")
+        String editStory(@V("story") String story, @V("audience") String audience);
+    }
+
+    public interface StyleEditor {
+
+        @UserMessage("""
+                You are a professional editor.
+                Analyze and rewrite the following story to better fit and be more coherent with the {{style}} style.
+                Return only the story and nothing else.
+                The story is "{{story}}".
+                """)
+        @Agent("Edit a story to better fit a given style")
+        String editStory(@V("story") String story, @V("style") String style);
+    }
+
+}

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/LangChain4jDotNames.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/LangChain4jDotNames.java
@@ -69,7 +69,7 @@ public class LangChain4jDotNames {
     static final DotName DESCRIPTION = DotName.createSimple(Description.class);
     static final DotName STRUCTURED_PROMPT = DotName.createSimple(StructuredPrompt.class);
     static final DotName STRUCTURED_PROMPT_PROCESSOR = DotName.createSimple(StructuredPromptProcessor.class);
-    static final DotName V = DotName.createSimple(dev.langchain4j.service.V.class);
+    public static final DotName V = DotName.createSimple(dev.langchain4j.service.V.class);
 
     public static final DotName MODEL_NAME = DotName.createSimple(ModelName.class);
     public static final DotName REGISTER_AI_SERVICES = DotName.createSimple(RegisterAiService.class);


### PR DESCRIPTION
This is done in order to provide build time errors when the parameter types of agentic method do not match what the agent declares as an output type