### PR TITLE
Introduce seed parameter for azure openai chat models

### DIFF
--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/AzureOpenAiChatModel.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/AzureOpenAiChatModel.java
@@ -65,6 +65,7 @@ public class AzureOpenAiChatModel implements ChatModel {
 
     private final OpenAiClient client;
     private final Double temperature;
+    private final Integer seed;
     private final Double topP;
     private final Integer maxTokens;
     private final Double presencePenalty;
@@ -80,6 +81,7 @@ public class AzureOpenAiChatModel implements ChatModel {
             String adToken,
             TokenCountEstimator tokenizer,
             Double temperature,
+            Integer seed,
             Double topP,
             Integer maxTokens,
             Double presencePenalty,
@@ -112,6 +114,7 @@ public class AzureOpenAiChatModel implements ChatModel {
                 .build();
 
         this.temperature = getOrDefault(temperature, 0.7);
+        this.seed = seed;
         this.topP = topP;
         this.maxTokens = maxTokens;
         this.presencePenalty = presencePenalty;
@@ -135,6 +138,7 @@ public class AzureOpenAiChatModel implements ChatModel {
         ChatCompletionRequest.Builder requestBuilder = ChatCompletionRequest.builder()
                 .messages(toOpenAiMessages(messages))
                 .temperature(temperature)
+                .seed(seed)
                 .topP(topP)
                 .maxTokens(maxTokens)
                 .presencePenalty(presencePenalty)
@@ -247,6 +251,7 @@ public class AzureOpenAiChatModel implements ChatModel {
         private String adToken;
         private TokenCountEstimator tokenizer;
         private Double temperature;
+        private Integer seed;
         private Double topP;
         private Integer maxTokens;
         private Double presencePenalty;
@@ -314,6 +319,11 @@ public class AzureOpenAiChatModel implements ChatModel {
             return this;
         }
 
+        public Builder seed(Integer seed) {
+            this.seed = seed;
+            return this;
+        }
+
         public Builder topP(Double topP) {
             this.topP = topP;
             return this;
@@ -376,6 +386,7 @@ public class AzureOpenAiChatModel implements ChatModel {
                     adToken,
                     tokenizer,
                     temperature,
+                    seed,
                     topP,
                     maxTokens,
                     presencePenalty,

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
@@ -96,6 +96,10 @@ public class AzureOpenAiRecorder {
                 builder.maxTokens(chatModelConfig.maxTokens().get());
             }
 
+            if (chatModelConfig.seed().isPresent()) {
+                builder.maxTokens(chatModelConfig.seed().get());
+            }
+
             return new Function<>() {
                 @Override
                 public ChatModel apply(SyntheticCreationalContext<ChatModel> context) {

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/ChatModelConfig.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/ChatModelConfig.java
@@ -73,6 +73,13 @@ public interface ChatModelConfig {
     Double topP();
 
     /**
+     * If specified, our system will make the best effort to sample deterministically, such that repeated requests with the same
+     * seed and parameters should return the same result. Determinism isn't guaranteed.
+     * Support for reproducible output was first added in API version 2023-12-01-preview
+     */
+    Optional<Integer> seed();
+
+    /**
      * The maximum number of tokens to generate in the completion. The token count of your prompt plus max_tokens can't exceed
      * the model's context length.
      * Most models have a context length of 2048 tokens (except for the newest models, which support 4096).

--- a/model-providers/openai/azure-openai/runtime/src/test/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorderEndpointTests.java
+++ b/model-providers/openai/azure-openai/runtime/src/test/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorderEndpointTests.java
@@ -260,6 +260,11 @@ class AzureOpenAiRecorderEndpointTests {
                 }
 
                 @Override
+                public Optional<Integer> seed() {
+                    return Optional.empty();
+                }
+
+                @Override
                 public Optional<Integer> maxTokens() {
                     return Optional.empty();
                 }


### PR DESCRIPTION
In langchain4j and azure's openai service there is the possibility to specify a seed for more deterministic inference.

https://github.com/langchain4j/langchain4j/blob/main/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiChatModel.java

https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/reproducible-output


- Closes: #1909