### PR TITLE
Add google search capability to quarkus vertex ai

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-azure-openai.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-azure-openai.adoc
@@ -603,6 +603,27 @@ endif::add-copy-button-to-env-var[]
 |double
 |`1.0`
 
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-seed]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-seed[`quarkus.langchain4j.azure-openai.chat-model.seed`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.chat-model.seed+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+If specified, our system will make the best effort to sample deterministically, such that repeated requests with the same seed and parameters should return the same result. Determinism isn't guaranteed. Support for reproducible output was first added in API version 2023-12-01-preview
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_CHAT_MODEL_SEED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_CHAT_MODEL_SEED+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-max-tokens]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-max-tokens[`quarkus.langchain4j.azure-openai.chat-model.max-tokens`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.azure-openai.chat-model.max-tokens+++[]
@@ -1829,6 +1850,27 @@ endif::add-copy-button-to-env-var[]
 --
 |double
 |`1.0`
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-seed]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-seed[`quarkus.langchain4j.azure-openai."model-name".chat-model.seed`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".chat-model.seed+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+If specified, our system will make the best effort to sample deterministically, such that repeated requests with the same seed and parameters should return the same result. Determinism isn't guaranteed. Support for reproducible output was first added in API version 2023-12-01-preview
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__CHAT_MODEL_SEED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__CHAT_MODEL_SEED+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
 
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-max-tokens]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-max-tokens[`quarkus.langchain4j.azure-openai."model-name".chat-model.max-tokens`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-azure-openai_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-azure-openai_quarkus.langchain4j.adoc
@@ -603,6 +603,27 @@ endif::add-copy-button-to-env-var[]
 |double
 |`1.0`
 
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-seed]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-seed[`quarkus.langchain4j.azure-openai.chat-model.seed`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.chat-model.seed+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+If specified, our system will make the best effort to sample deterministically, such that repeated requests with the same seed and parameters should return the same result. Determinism isn't guaranteed. Support for reproducible output was first added in API version 2023-12-01-preview
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_CHAT_MODEL_SEED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_CHAT_MODEL_SEED+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-max-tokens]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-max-tokens[`quarkus.langchain4j.azure-openai.chat-model.max-tokens`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.azure-openai.chat-model.max-tokens+++[]
@@ -1829,6 +1850,27 @@ endif::add-copy-button-to-env-var[]
 --
 |double
 |`1.0`
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-seed]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-seed[`quarkus.langchain4j.azure-openai."model-name".chat-model.seed`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".chat-model.seed+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+If specified, our system will make the best effort to sample deterministically, such that repeated requests with the same seed and parameters should return the same result. Determinism isn't guaranteed. Support for reproducible output was first added in API version 2023-12-01-preview
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__CHAT_MODEL_SEED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__CHAT_MODEL_SEED+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
 
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-max-tokens]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-max-tokens[`quarkus.langchain4j.azure-openai."model-name".chat-model.max-tokens`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-gpu-llama3.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-gpu-llama3.adoc
@@ -1,0 +1,457 @@
+[.configuration-legend]
+icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
+[.configuration-reference.searchable, cols="80,.^10,.^10"]
+|===
+
+h|[.header-title]##Configuration property##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-include-models-in-artifact]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-include-models-in-artifact[`quarkus.langchain4j.gpu-llama3.include-models-in-artifact`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.include-models-in-artifact+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Determines whether the necessary GPULlama3 models are downloaded and included in the jar at build time. Currently, this option is only valid for `fast-jar` deployments.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_INCLUDE_MODELS_IN_ARTIFACT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_INCLUDE_MODELS_IN_ARTIFACT+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-enabled]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-enabled[`quarkus.langchain4j.gpu-llama3.chat-model.enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.chat-model.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the model should be enabled
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-model-name]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-model-name[`quarkus.langchain4j.gpu-llama3.chat-model.model-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.chat-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Model name to use
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`beehive-lab/Llama-3.2-1B-Instruct-GGUF`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-quantization]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-quantization[`quarkus.langchain4j.gpu-llama3.chat-model.quantization`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.chat-model.quantization+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Quantization of the model to use
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_QUANTIZATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_QUANTIZATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`FP16`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-models-path]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-models-path[`quarkus.langchain4j.gpu-llama3.models-path`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.models-path+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Location on the file-system which serves as a cache for the models
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_MODELS_PATH+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_MODELS_PATH+++`
+endif::add-copy-button-to-env-var[]
+--
+|path
+|`${user.home}/.langchain4j/models`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-temperature]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-temperature[`quarkus.langchain4j.gpu-llama3.chat-model.temperature`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.chat-model.temperature+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+What sampling temperature to use, between 0.0 and 1.0.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_TEMPERATURE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_TEMPERATURE+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|`0.3`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-top-p]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-top-p[`quarkus.langchain4j.gpu-llama3.chat-model.top-p`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.chat-model.top-p+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+What sampling topP to use, between 0.0 and 1.0.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_TOP_P+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_TOP_P+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|`0.85`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-seed]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-seed[`quarkus.langchain4j.gpu-llama3.chat-model.seed`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.chat-model.seed+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+What seed value to use.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_SEED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_SEED+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`1234`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-max-tokens]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-max-tokens[`quarkus.langchain4j.gpu-llama3.chat-model.max-tokens`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.chat-model.max-tokens+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The maximum number of tokens to generate in the completion.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_MAX_TOKENS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_MAX_TOKENS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`512`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-enable-integration]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-enable-integration[`quarkus.langchain4j.gpu-llama3.enable-integration`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.enable-integration+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to enable the integration. Set to `false` to disable all requests.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_ENABLE_INTEGRATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_ENABLE_INTEGRATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-log-requests]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-log-requests[`quarkus.langchain4j.gpu-llama3.log-requests`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether GPULlama3 should log requests
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-log-responses]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-log-responses[`quarkus.langchain4j.gpu-llama3.log-responses`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether GPULlama3 client should log responses
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+h|[[quarkus-langchain4j-gpu-llama3_section_quarkus-langchain4j-gpu-llama3]] [.section-name.section-level0]##link:#quarkus-langchain4j-gpu-llama3_section_quarkus-langchain4j-gpu-llama3[Named model config]##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-model-name]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-model-name[`quarkus.langchain4j.gpu-llama3."model-name".chat-model.model-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Model name to use
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`beehive-lab/Llama-3.2-1B-Instruct-GGUF`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-quantization]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-quantization[`quarkus.langchain4j.gpu-llama3."model-name".chat-model.quantization`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.quantization+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Quantization of the model to use
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_QUANTIZATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_QUANTIZATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`FP16`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-temperature]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-temperature[`quarkus.langchain4j.gpu-llama3."model-name".chat-model.temperature`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.temperature+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+What sampling temperature to use, between 0.0 and 1.0.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_TEMPERATURE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_TEMPERATURE+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|`0.3`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-top-p]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-top-p[`quarkus.langchain4j.gpu-llama3."model-name".chat-model.top-p`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.top-p+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+What sampling topP to use, between 0.0 and 1.0.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_TOP_P+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_TOP_P+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|`0.85`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-seed]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-seed[`quarkus.langchain4j.gpu-llama3."model-name".chat-model.seed`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.seed+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+What seed value to use.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_SEED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_SEED+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`1234`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-max-tokens]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-max-tokens[`quarkus.langchain4j.gpu-llama3."model-name".chat-model.max-tokens`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.max-tokens+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The maximum number of tokens to generate in the completion.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_MAX_TOKENS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_MAX_TOKENS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`512`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-enable-integration]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-enable-integration[`quarkus.langchain4j.gpu-llama3."model-name".enable-integration`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".enable-integration+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to enable the integration. Set to `false` to disable all requests.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__ENABLE_INTEGRATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__ENABLE_INTEGRATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-log-requests]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-log-requests[`quarkus.langchain4j.gpu-llama3."model-name".log-requests`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether GPULlama3 should log requests
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-log-responses]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-log-responses[`quarkus.langchain4j.gpu-llama3."model-name".log-responses`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether GPULlama3 client should log responses
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+
+|===
+

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-gpu-llama3_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-gpu-llama3_quarkus.langchain4j.adoc
@@ -1,0 +1,457 @@
+[.configuration-legend]
+icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
+[.configuration-reference.searchable, cols="80,.^10,.^10"]
+|===
+
+h|[.header-title]##Configuration property##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-include-models-in-artifact]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-include-models-in-artifact[`quarkus.langchain4j.gpu-llama3.include-models-in-artifact`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.include-models-in-artifact+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Determines whether the necessary GPULlama3 models are downloaded and included in the jar at build time. Currently, this option is only valid for `fast-jar` deployments.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_INCLUDE_MODELS_IN_ARTIFACT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_INCLUDE_MODELS_IN_ARTIFACT+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-enabled]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-enabled[`quarkus.langchain4j.gpu-llama3.chat-model.enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.chat-model.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the model should be enabled
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-model-name]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-model-name[`quarkus.langchain4j.gpu-llama3.chat-model.model-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.chat-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Model name to use
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`beehive-lab/Llama-3.2-1B-Instruct-GGUF`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-quantization]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-quantization[`quarkus.langchain4j.gpu-llama3.chat-model.quantization`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.chat-model.quantization+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Quantization of the model to use
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_QUANTIZATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_QUANTIZATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`FP16`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-models-path]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-models-path[`quarkus.langchain4j.gpu-llama3.models-path`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.models-path+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Location on the file-system which serves as a cache for the models
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_MODELS_PATH+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_MODELS_PATH+++`
+endif::add-copy-button-to-env-var[]
+--
+|path
+|`${user.home}/.langchain4j/models`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-temperature]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-temperature[`quarkus.langchain4j.gpu-llama3.chat-model.temperature`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.chat-model.temperature+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+What sampling temperature to use, between 0.0 and 1.0.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_TEMPERATURE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_TEMPERATURE+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|`0.3`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-top-p]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-top-p[`quarkus.langchain4j.gpu-llama3.chat-model.top-p`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.chat-model.top-p+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+What sampling topP to use, between 0.0 and 1.0.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_TOP_P+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_TOP_P+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|`0.85`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-seed]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-seed[`quarkus.langchain4j.gpu-llama3.chat-model.seed`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.chat-model.seed+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+What seed value to use.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_SEED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_SEED+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`1234`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-max-tokens]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-max-tokens[`quarkus.langchain4j.gpu-llama3.chat-model.max-tokens`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.chat-model.max-tokens+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The maximum number of tokens to generate in the completion.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_MAX_TOKENS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_MAX_TOKENS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`512`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-enable-integration]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-enable-integration[`quarkus.langchain4j.gpu-llama3.enable-integration`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.enable-integration+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to enable the integration. Set to `false` to disable all requests.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_ENABLE_INTEGRATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_ENABLE_INTEGRATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-log-requests]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-log-requests[`quarkus.langchain4j.gpu-llama3.log-requests`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether GPULlama3 should log requests
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-log-responses]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-log-responses[`quarkus.langchain4j.gpu-llama3.log-responses`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether GPULlama3 client should log responses
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+h|[[quarkus-langchain4j-gpu-llama3_section_quarkus-langchain4j-gpu-llama3]] [.section-name.section-level0]##link:#quarkus-langchain4j-gpu-llama3_section_quarkus-langchain4j-gpu-llama3[Named model config]##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-model-name]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-model-name[`quarkus.langchain4j.gpu-llama3."model-name".chat-model.model-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Model name to use
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`beehive-lab/Llama-3.2-1B-Instruct-GGUF`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-quantization]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-quantization[`quarkus.langchain4j.gpu-llama3."model-name".chat-model.quantization`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.quantization+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Quantization of the model to use
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_QUANTIZATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_QUANTIZATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`FP16`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-temperature]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-temperature[`quarkus.langchain4j.gpu-llama3."model-name".chat-model.temperature`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.temperature+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+What sampling temperature to use, between 0.0 and 1.0.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_TEMPERATURE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_TEMPERATURE+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|`0.3`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-top-p]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-top-p[`quarkus.langchain4j.gpu-llama3."model-name".chat-model.top-p`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.top-p+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+What sampling topP to use, between 0.0 and 1.0.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_TOP_P+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_TOP_P+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|`0.85`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-seed]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-seed[`quarkus.langchain4j.gpu-llama3."model-name".chat-model.seed`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.seed+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+What seed value to use.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_SEED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_SEED+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`1234`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-max-tokens]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-max-tokens[`quarkus.langchain4j.gpu-llama3."model-name".chat-model.max-tokens`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.max-tokens+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The maximum number of tokens to generate in the completion.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_MAX_TOKENS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_MAX_TOKENS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`512`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-enable-integration]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-enable-integration[`quarkus.langchain4j.gpu-llama3."model-name".enable-integration`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".enable-integration+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to enable the integration. Set to `false` to disable all requests.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__ENABLE_INTEGRATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__ENABLE_INTEGRATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-log-requests]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-log-requests[`quarkus.langchain4j.gpu-llama3."model-name".log-requests`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether GPULlama3 should log requests
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-log-responses]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-log-responses[`quarkus.langchain4j.gpu-llama3."model-name".log-responses`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether GPULlama3 client should log responses
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+
+|===
+

--- a/model-providers/google/gemini/ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/ai/runtime/gemini/AiGeminiChatLanguageModel.java
+++ b/model-providers/google/gemini/ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/ai/runtime/gemini/AiGeminiChatLanguageModel.java
@@ -25,7 +25,7 @@ public class AiGeminiChatLanguageModel extends GeminiChatLanguageModel {
 
     private AiGeminiChatLanguageModel(Builder builder) {
         super(builder.modelId, builder.temperature, builder.maxOutputTokens, builder.topK, builder.topP, builder.responseFormat,
-                builder.listeners, builder.thinkingBudget, builder.includeThoughts);
+                builder.listeners, builder.thinkingBudget, builder.includeThoughts, builder.useGoogleSearch);
 
         this.apiMetadata = AiGeminiRestApi.ApiMetadata
                 .builder()
@@ -83,6 +83,7 @@ public class AiGeminiChatLanguageModel extends GeminiChatLanguageModel {
         private List<ChatModelListener> listeners = Collections.emptyList();
         private Long thinkingBudget;
         private boolean includeThoughts = false;
+        private boolean useGoogleSearch = false;
 
         public Builder configName(String configName) {
             this.configName = configName;
@@ -156,6 +157,11 @@ public class AiGeminiChatLanguageModel extends GeminiChatLanguageModel {
 
         public Builder includeThoughts(Boolean includeThoughts) {
             this.includeThoughts = includeThoughts;
+            return this;
+        }
+
+        public Builder useGoogleSearch(boolean useGoogleSearch) {
+            this.useGoogleSearch = useGoogleSearch;
             return this;
         }
 

--- a/model-providers/google/gemini/ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/ai/runtime/gemini/AiGeminiStreamingChatLanguageModel.java
+++ b/model-providers/google/gemini/ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/ai/runtime/gemini/AiGeminiStreamingChatLanguageModel.java
@@ -27,7 +27,7 @@ public class AiGeminiStreamingChatLanguageModel extends GeminiStreamingChatLangu
 
     private AiGeminiStreamingChatLanguageModel(Builder builder) {
         super(builder.modelId, builder.temperature, builder.maxOutputTokens, builder.topK, builder.topP, builder.responseFormat,
-                builder.listeners);
+                builder.listeners, builder.useGoogleSearch);
 
         this.apiMetadata = AiGeminiRestApi.ApiMetadata
                 .builder()
@@ -83,6 +83,7 @@ public class AiGeminiStreamingChatLanguageModel extends GeminiStreamingChatLangu
         private Boolean logRequests = false;
         private Boolean logResponses = false;
         private List<ChatModelListener> listeners = Collections.emptyList();
+        private boolean useGoogleSearch = false;
 
         public Builder configName(String configName) {
             this.configName = configName;
@@ -146,6 +147,11 @@ public class AiGeminiStreamingChatLanguageModel extends GeminiStreamingChatLangu
 
         public Builder listeners(List<ChatModelListener> listeners) {
             this.listeners = listeners;
+            return this;
+        }
+
+        public Builder useGoogleSearch(boolean useGoogleSearch) {
+            this.useGoogleSearch = useGoogleSearch;
             return this;
         }
 

--- a/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/BaseGeminiChatModel.java
+++ b/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/BaseGeminiChatModel.java
@@ -19,10 +19,11 @@ public class BaseGeminiChatModel {
     protected final List<ChatModelListener> listeners;
     protected final Long thinkingBudget;
     protected final boolean includeThoughts;
+    protected final boolean useGoogleSearch;
 
     public BaseGeminiChatModel(String modelId, Double temperature, Integer maxOutputTokens, Integer topK, Double topP,
             ResponseFormat responseFormat, List<ChatModelListener> listeners, Long thinkingBudget,
-            boolean includeThoughts) {
+            boolean includeThoughts, boolean useGoogleSearch) {
         this.modelId = modelId;
         this.temperature = temperature;
         this.maxOutputTokens = maxOutputTokens;
@@ -32,5 +33,6 @@ public class BaseGeminiChatModel {
         this.listeners = listeners;
         this.thinkingBudget = thinkingBudget;
         this.includeThoughts = includeThoughts;
+        this.useGoogleSearch = useGoogleSearch;
     }
 }

--- a/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/GeminiChatLanguageModel.java
+++ b/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/GeminiChatLanguageModel.java
@@ -37,8 +37,9 @@ public abstract class GeminiChatLanguageModel extends BaseGeminiChatModel implem
 
     public GeminiChatLanguageModel(String modelId, Double temperature, Integer maxOutputTokens, Integer topK,
             Double topP, ResponseFormat responseFormat, List<ChatModelListener> listeners, Long thinkingBudget,
-            boolean includeThoughts) {
-        super(modelId, temperature, maxOutputTokens, topK, topP, responseFormat, listeners, thinkingBudget, includeThoughts);
+            boolean includeThoughts, boolean useGoogleSearch) {
+        super(modelId, temperature, maxOutputTokens, topK, topP, responseFormat, listeners, thinkingBudget, includeThoughts,
+                useGoogleSearch);
     }
 
     @Override
@@ -72,7 +73,7 @@ public abstract class GeminiChatLanguageModel extends BaseGeminiChatModel implem
         }
         GenerationConfig generationConfig = generationConfigBuilder.build();
         GenerateContentRequest request = ContentMapper.map(chatRequest.messages(), chatRequest.toolSpecifications(),
-                generationConfig);
+                generationConfig, this.modelId, this.useGoogleSearch);
 
         ChatRequest modelListenerRequest = createModelListenerRequest(request, chatRequest.messages(),
                 chatRequest.toolSpecifications());

--- a/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/GeminiStreamingChatLanguageModel.java
+++ b/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/GeminiStreamingChatLanguageModel.java
@@ -35,8 +35,8 @@ import io.smallrye.mutiny.Multi;
 public abstract class GeminiStreamingChatLanguageModel extends BaseGeminiChatModel implements StreamingChatModel {
 
     public GeminiStreamingChatLanguageModel(String modelId, Double temperature, Integer maxOutputTokens, Integer topK,
-            Double topP, ResponseFormat responseFormat, List<ChatModelListener> listeners) {
-        super(modelId, temperature, maxOutputTokens, topK, topP, responseFormat, listeners, null, false);
+            Double topP, ResponseFormat responseFormat, List<ChatModelListener> listeners, boolean useGoogleSearch) {
+        super(modelId, temperature, maxOutputTokens, topK, topP, responseFormat, listeners, null, false, useGoogleSearch);
     }
 
     @Override
@@ -67,7 +67,7 @@ public abstract class GeminiStreamingChatLanguageModel extends BaseGeminiChatMod
                 .topP(getOrDefault(requestParameters.topP(), this.topP))
                 .build();
         GenerateContentRequest request = ContentMapper.map(chatRequest.messages(), chatRequest.toolSpecifications(),
-                generationConfig);
+                generationConfig, this.modelId, this.useGoogleSearch);
 
         ChatRequest modelListenerRequest = createModelListenerRequest(request, chatRequest.messages(),
                 chatRequest.toolSpecifications());

--- a/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/GenerateContentRequest.java
+++ b/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/GenerateContentRequest.java
@@ -2,6 +2,8 @@ package io.quarkiverse.langchain4j.gemini.common;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record GenerateContentRequest(List<Content> contents, SystemInstruction systemInstruction, List<Tool> tools,
         GenerationConfig generationConfig) {
 
@@ -16,8 +18,28 @@ public record GenerateContentRequest(List<Content> contents, SystemInstruction s
         }
     }
 
-    public record Tool(List<FunctionDeclaration> functionDeclarations) {
+    public record Tool(
+            List<FunctionDeclaration> functionDeclarations,
+            @JsonProperty("google_search") GoogleSearch googleSearch,
+            @JsonProperty("google_search_retrieval") GoogleSearchRetrieval googleSearchRetrieval) {
 
+        public static Tool ofFunctionDeclarations(List<FunctionDeclaration> functionDeclarations) {
+            return new Tool(functionDeclarations, null, null);
+        }
+
+        public static Tool ofGoogleSearch() {
+            return new Tool(null, new GoogleSearch(), null);
+        }
+
+        public static Tool ofGoogleSearchRetrieval() {
+            return new Tool(null, null, new GoogleSearchRetrieval());
+        }
+
+        public record GoogleSearch() {
+        }
+
+        public record GoogleSearchRetrieval() {
+        }
     }
 
 }

--- a/model-providers/google/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/VertexAiGeminiChatLanguageModel.java
+++ b/model-providers/google/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/VertexAiGeminiChatLanguageModel.java
@@ -27,7 +27,7 @@ public class VertexAiGeminiChatLanguageModel extends GeminiChatLanguageModel {
 
     private VertexAiGeminiChatLanguageModel(Builder builder) {
         super(builder.modelId, builder.temperature, builder.maxOutputTokens, builder.topK, builder.topP, builder.responseFormat,
-                builder.listeners, null, false);
+                builder.listeners, null, false, builder.useGoogleSearch);
 
         this.apiMetadata = VertxAiGeminiRestApi.ApiMetadata
                 .builder()
@@ -94,6 +94,7 @@ public class VertexAiGeminiChatLanguageModel extends GeminiChatLanguageModel {
         private Boolean logResponses = false;
         private List<ChatModelListener> listeners = Collections.emptyList();
         private Proxy proxy;
+        private boolean useGoogleSearch = false;
 
         public Builder baseUrl(Optional<String> baseUrl) {
             this.baseUrl = baseUrl;
@@ -167,6 +168,11 @@ public class VertexAiGeminiChatLanguageModel extends GeminiChatLanguageModel {
 
         public Builder proxy(Proxy proxy) {
             this.proxy = proxy;
+            return this;
+        }
+
+        public Builder useGoogleSearch(boolean useGoogleSearch) {
+            this.useGoogleSearch = useGoogleSearch;
             return this;
         }
 

--- a/model-providers/google/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/VertexAiGeminiStreamingChatLanguageModel.java
+++ b/model-providers/google/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/VertexAiGeminiStreamingChatLanguageModel.java
@@ -29,7 +29,7 @@ public class VertexAiGeminiStreamingChatLanguageModel extends GeminiStreamingCha
 
     private VertexAiGeminiStreamingChatLanguageModel(Builder builder) {
         super(builder.modelId, builder.temperature, builder.maxOutputTokens, builder.topK, builder.topP, builder.responseFormat,
-                builder.listeners);
+                builder.listeners, builder.useGoogleSearch);
 
         this.apiMetadata = VertxAiGeminiRestApi.ApiMetadata
                 .builder()
@@ -95,6 +95,7 @@ public class VertexAiGeminiStreamingChatLanguageModel extends GeminiStreamingCha
         private Boolean logResponses = false;
         private List<ChatModelListener> listeners = Collections.emptyList();
         private Proxy proxy;
+        private boolean useGoogleSearch = false;
 
         public Builder baseUrl(Optional<String> baseUrl) {
             this.baseUrl = baseUrl;
@@ -168,6 +169,11 @@ public class VertexAiGeminiStreamingChatLanguageModel extends GeminiStreamingCha
 
         public Builder proxy(Proxy proxy) {
             this.proxy = proxy;
+            return this;
+        }
+
+        public Builder useGoogleSearch(boolean useGoogleSearch) {
+            this.useGoogleSearch = useGoogleSearch;
             return this;
         }
 


### PR DESCRIPTION
Vanilla Langchain4j provides a functionality called `useGoogleSearch` for Vertex AI, which can be configured as: `VertexAiGeminiChatModelBuilder.builder().useGoogleSearch(true).build()`
This integrates Google Search into Vertex AI’s tool-calling functionality though it is handled a bit differently.
Langchain4j reference: https://github.com/langchain4j/langchain4j/blob/47504a03c064a15751a4e9bb2d96bd9f0d58d53e/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModel.java#L394

At present, this capability is not available in `VertexAiGeminiChatLanguageModel`, We need to add the support.