### PR TITLE
Fix seed parameter overwriting max tokens for AzureOpenAi

### DIFF
--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
@@ -97,7 +97,7 @@ public class AzureOpenAiRecorder {
             }
 
             if (chatModelConfig.seed().isPresent()) {
-                builder.maxTokens(chatModelConfig.seed().get());
+                builder.seed(chatModelConfig.seed().get());
             }
 
             return new Function<>() {


### PR DESCRIPTION
I introduced a bug with the introduction of the seed parameter that seemed to slip through the review.