### PR TITLE
pom.xml cleanup

### DIFF
--- a/agentic/runtime/pom.xml
+++ b/agentic/runtime/pom.xml
@@ -17,7 +17,6 @@
     <dependency>
       <groupId>dev.langchain4j</groupId>
       <artifactId>langchain4j-agentic</artifactId>
-      <version>${langchain4j-agentic.version}</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -108,7 +108,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
-            <version>${langchain4j-embeddings.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -82,49 +82,41 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
-            <version>${langchain4j-embeddings.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-all-minilm-l6-v2</artifactId>
-            <version>${langchain4j-embeddings.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-bge-small-en-q</artifactId>
-            <version>${langchain4j-embeddings.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-bge-small-en</artifactId>
-            <version>${langchain4j-embeddings.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-bge-small-zh-q</artifactId>
-            <version>${langchain4j-embeddings.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-bge-small-zh</artifactId>
-            <version>${langchain4j-embeddings.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-e5-small-v2-q</artifactId>
-            <version>${langchain4j-embeddings.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-e5-small-v2</artifactId>
-            <version>${langchain4j-embeddings.version}</version>
             <optional>true</optional>
         </dependency>
 

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
 :project-version: 1.4.2
 :langchain4j-version: 1.8.0
-:langchain4j-embeddings-version: 1.8.0-beta15
+:langchain4j-embeddings-version: ${langchain4j-embeddings.version}
 :examples-dir: ./../examples/

--- a/embedding-stores/chroma/deployment/pom.xml
+++ b/embedding-stores/chroma/deployment/pom.xml
@@ -65,7 +65,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
-            <version>${langchain4j-embeddings.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/embedding-stores/infinispan/deployment/pom.xml
+++ b/embedding-stores/infinispan/deployment/pom.xml
@@ -49,7 +49,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
-            <version>${langchain4j-embeddings.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/embedding-stores/milvus/deployment/pom.xml
+++ b/embedding-stores/milvus/deployment/pom.xml
@@ -57,7 +57,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
-            <version>${langchain4j-embeddings.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/embedding-stores/neo4j/deployment/pom.xml
+++ b/embedding-stores/neo4j/deployment/pom.xml
@@ -55,7 +55,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
-            <version>${langchain4j-embeddings.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/embedding-stores/pgvector/deployment/pom.xml
+++ b/embedding-stores/pgvector/deployment/pom.xml
@@ -66,7 +66,6 @@
     <dependency>
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
-        <version>${langchain4j-embeddings.version}</version>
         <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/embedding-stores/pinecone/deployment/pom.xml
+++ b/embedding-stores/pinecone/deployment/pom.xml
@@ -49,7 +49,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
-            <version>${langchain4j-embeddings.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/embedding-stores/qdrant/deployment/pom.xml
+++ b/embedding-stores/qdrant/deployment/pom.xml
@@ -57,7 +57,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
-            <version>${langchain4j-embeddings.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/embedding-stores/redis/deployment/pom.xml
+++ b/embedding-stores/redis/deployment/pom.xml
@@ -53,7 +53,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
-            <version>${langchain4j-embeddings.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/embedding-stores/weaviate/deployment/pom.xml
+++ b/embedding-stores/weaviate/deployment/pom.xml
@@ -53,7 +53,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
-            <version>${langchain4j-embeddings.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -38,10 +38,7 @@
     <quarkus.version>3.20.2.2</quarkus.version>
     <quarkus.extension-processor.version>${quarkus.version}</quarkus.extension-processor.version>
     <langchain4j.version>1.8.0</langchain4j.version>
-    <langchain4j-beta.version>1.8.0-beta15</langchain4j-beta.version>
-    <langchain4j-agentic.version>1.8.0-beta15</langchain4j-agentic.version>
     <langchain4j-community.version>1.6.0-beta12</langchain4j-community.version>
-    <langchain4j-embeddings.version>1.8.0-beta15</langchain4j-embeddings.version>
     <quarkus-antora.version>2.2.0</quarkus-antora.version>
     <quarkus-poi.version>2.0.4</quarkus-poi.version> <!-- we need to use this version because langchain4j uses POI 5.2.3 instead of 5.2.5 and the substitution needed is different in the two versions -->
     <assertj.version>3.27.3</assertj.version>
@@ -69,11 +66,6 @@
         <version>${langchain4j.version}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>dev.langchain4j</groupId>
-        <artifactId>langchain4j-agentic</artifactId>
-        <version>${langchain4j-agentic.version}</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -148,7 +140,7 @@
                     <dependency>
                       <groupId>dev.langchain4j</groupId>
                       <artifactId>langchain4j-milvus</artifactId>
-                      <version>${langchain4j-beta.version}</version>
+                      <version>${langchain4j.version}</version>
                       <exclusions>
                         <exclusion>
                           <groupId>com.google.android</groupId>
@@ -386,4 +378,24 @@
         </modules>
     </profile>
   </profiles>
+
+  <!-- 
+	  This is to allow building against langchain4j snapshots because they depend on snapshots
+	  of langchain4j-embeddings and those are deployed in the Central Portal.
+	  TODO: this can be removed after langchain4j-embeddings are moved into the main langchain4j repo 
+  -->
+  <repositories>
+    <repository>
+        <releases>
+            <enabled>false</enabled>
+        </releases>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
+        <id>central-portal-snapshots</id>
+        <name>Central Portal Snapshots</name>
+        <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+    </repository>
+  </repositories>
+
 </project>

--- a/rag/easy-rag/deployment/pom.xml
+++ b/rag/easy-rag/deployment/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-bge-small-en-v15-q</artifactId>
-            <version>${langchain4j-embeddings.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/rag/parsers-base/deployment/pom.xml
+++ b/rag/parsers-base/deployment/pom.xml
@@ -41,7 +41,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
-            <version>${langchain4j-embeddings.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/testing/scorer/scorer-strategies/semantic-similarity/pom.xml
+++ b/testing/scorer/scorer-strategies/semantic-similarity/pom.xml
@@ -17,7 +17,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-bge-small-en-v15</artifactId>
-            <version>${langchain4j-embeddings.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>


### PR DESCRIPTION
- remove duplicated version declarations that come from `langchain4j-bom`
- add central portal snapshots repo to allow building against langchain4j snapshots without having to build `langchain4j-embeddings` separately