### PR TITLE
feat: Added support to auto reinitialize session if not found

### DIFF
--- a/integration-tests/mcp/src/test/java/io/quarkiverse/langchain4j/mcp/test/McpToolsStreamableHttpTransportTest.java
+++ b/integration-tests/mcp/src/test/java/io/quarkiverse/langchain4j/mcp/test/McpToolsStreamableHttpTransportTest.java
@@ -2,15 +2,20 @@ package io.quarkiverse.langchain4j.mcp.test;
 
 import static io.quarkiverse.langchain4j.mcp.test.McpServerHelper.skipTestsIfJbangNotAvailable;
 import static io.quarkiverse.langchain4j.mcp.test.McpServerHelper.startServerHttp;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import dev.langchain4j.agent.tool.ToolSpecification;
 import io.quarkus.test.QuarkusUnitTest;
 
 class McpToolsStreamableHttpTransportTest extends McpToolsTestBase {
@@ -41,6 +46,28 @@ class McpToolsStreamableHttpTransportTest extends McpToolsTestBase {
         if (process != null && process.isAlive()) {
             process.destroyForcibly();
         }
+    }
+
+    @Test
+    void reinitializesSessionWhenMissingFromServer() throws Exception {
+        // Initial call to establish session and verify MCP server is up
+        List<ToolSpecification> toolSpecifications = mcpClient.listTools();
+        assertNotNull(toolSpecifications, "Tool specifications should not be null");
+        assertDoesNotThrow(() -> mcpClient.checkHealth(), "Health check should pass initially");
+
+        // Simulate server crash
+        process.destroyForcibly();
+
+        // Expect failure as server is down
+        assertThrows(
+                Exception.class, () -> mcpClient.checkHealth(), "Expected exception when server is down");
+
+        // Restart the server
+        process = startServerHttp("tools_mcp_server.java");
+
+        // Subsequent call should reinitialize session and succeed
+        assertDoesNotThrow(
+                () -> mcpClient.checkHealth(), "Session should be reinitialized and health check should pass");
     }
 
     //    /**


### PR DESCRIPTION
**Issue**
Closes https://github.com/quarkiverse/quarkus-langchain4j/issues/1951

**Change**
This PR adds support to automatically reinitialize the session with the MCP server if it is not found (e.g., after a server restart). This ensures that clients can recover gracefully without manual intervention or a full restart.

Same reinitialize implementation as it was done for class StreamableHttpMcpTransport with PR https://github.com/langchain4j/langchain4j/pull/3833