### PR TITLE
Add tool guardrails for function calling validation and transformation

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/LangChain4jDotNames.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/LangChain4jDotNames.java
@@ -40,6 +40,10 @@ import io.quarkiverse.langchain4j.PdfUrl;
 import io.quarkiverse.langchain4j.RegisterAiService;
 import io.quarkiverse.langchain4j.SeedMemory;
 import io.quarkiverse.langchain4j.VideoUrl;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrails;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrails;
 import io.quarkiverse.langchain4j.runtime.aiservice.ChatEvent;
 import io.quarkiverse.langchain4j.runtime.aiservice.QuarkusAiServiceContextQualifier;
 
@@ -54,6 +58,10 @@ public class LangChain4jDotNames {
     public static final DotName TOKEN_STREAM = DotName.createSimple(TokenStream.class);
     public static final DotName OUTPUT_GUARDRAILS = DotName.createSimple(OutputGuardrails.class);
     public static final DotName INPUT_GUARDRAILS = DotName.createSimple(InputGuardrails.class);
+    public static final DotName TOOL_OUTPUT_GUARDRAILS = DotName.createSimple(ToolOutputGuardrails.class);
+    public static final DotName TOOL_INPUT_GUARDRAILS = DotName.createSimple(ToolInputGuardrails.class);
+    public static final DotName TOOL_OUTPUT_GUARDRAIL = DotName.createSimple(ToolOutputGuardrail.class);
+    public static final DotName TOOL_INPUT_GUARDRAIL = DotName.createSimple(ToolInputGuardrail.class);
     static final DotName AI_SERVICES = DotName.createSimple(AiServices.class);
     static final DotName CREATED_AWARE = DotName.createSimple(CreatedAware.class);
     public static final DotName SYSTEM_MESSAGE = DotName.createSimple(SystemMessage.class);

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/UsedToolGuardrailClassesBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/UsedToolGuardrailClassesBuildItem.java
@@ -1,0 +1,24 @@
+package io.quarkiverse.langchain4j.deployment;
+
+import java.util.List;
+
+import org.jboss.jandex.DotName;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Internal build items collecting the tool guardrail classes.
+ */
+public final class UsedToolGuardrailClassesBuildItem extends SimpleBuildItem {
+
+    private final List<DotName> classes;
+
+    public UsedToolGuardrailClassesBuildItem(List<DotName> classes) {
+        this.classes = classes;
+    }
+
+    public List<DotName> getClasses() {
+        return classes;
+    }
+
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ToolExecutorTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ToolExecutorTest.java
@@ -292,7 +292,7 @@ class ToolExecutorTest {
                 toolExecutor = new QuarkusToolExecutor(
                         new QuarkusToolExecutor.Context(testTool, invokerClassName, methodCreateInfo.methodName(),
                                 methodCreateInfo.argumentMapperClassName(), methodCreateInfo.executionModel(),
-                                methodCreateInfo.returnBehavior(), false));
+                                methodCreateInfo.returnBehavior(), false, methodCreateInfo));
                 break;
             }
         }

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/ErrorHandlingTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/ErrorHandlingTest.java
@@ -1,0 +1,353 @@
+package io.quarkiverse.langchain4j.test.guardrails;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.ToolBox;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailResult;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrails;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrailRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrailResult;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrails;
+import io.quarkiverse.langchain4j.runtime.aiservice.NoopChatMemory;
+import io.quarkiverse.langchain4j.test.Lists;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests for error handling in tool guardrails.
+ * Covers:
+ * - Guardrails throwing unexpected exceptions
+ * - Null handling in request/result builders
+ * - Runtime error scenarios
+ */
+public class ErrorHandlingTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(
+                            MyAiService.class,
+                            RuntimeExceptionGuardrail.class,
+                            NullPointerExceptionGuardrail.class,
+                            OutputRuntimeExceptionGuardrail.class,
+                            Lists.class));
+
+    @Inject
+    MyAiService aiService;
+
+    @Inject
+    MyTools tools;
+
+    @BeforeEach
+    void setUp() {
+        RuntimeExceptionGuardrail.reset();
+        NullPointerExceptionGuardrail.reset();
+        OutputRuntimeExceptionGuardrail.reset();
+        tools.reset();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testInputGuardrail_throwsRuntimeException() {
+        // When a guardrail throws an unexpected runtime exception,
+        // it propagates directly (not wrapped)
+        assertThatThrownBy(() -> aiService.chat("test", "runtimeExceptionTool - anything"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Unexpected error in guardrail");
+
+        // Guardrail should have been executed
+        assertThat(RuntimeExceptionGuardrail.executionCount).isEqualTo(1);
+
+        // Tool should NOT have been executed
+        assertThat(tools.runtimeExceptionToolExecuted).isFalse();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testInputGuardrail_throwsNullPointerException() {
+        // NPE propagates directly
+        assertThatThrownBy(() -> aiService.chat("test", "nullPointerTool - anything"))
+                .isInstanceOf(NullPointerException.class);
+
+        assertThat(NullPointerExceptionGuardrail.executionCount).isEqualTo(1);
+        assertThat(tools.nullPointerToolExecuted).isFalse();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testInputGuardrail_recoversFromException() {
+        // After an exception, subsequent calls should still work
+        assertThatThrownBy(() -> aiService.chat("test", "runtimeExceptionTool - anything"))
+                .isInstanceOf(RuntimeException.class);
+
+        tools.reset();
+
+        // This should work (different tool, no exception)
+        var ignored = aiService.chat("test", "normalTool - data");
+        assertThat(tools.normalToolExecuted).isTrue();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testOutputGuardrail_throwsRuntimeException() {
+        // When an output guardrail throws an unexpected runtime exception,
+        // it propagates directly
+        assertThatThrownBy(() -> aiService.chat("test", "outputExceptionTool - anything"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Unexpected error in output guardrail");
+
+        // Tool SHOULD have been executed (output guardrails run after tool)
+        assertThat(tools.outputExceptionToolExecuted).isTrue();
+
+        // Guardrail should have been executed
+        assertThat(OutputRuntimeExceptionGuardrail.executionCount).isEqualTo(1);
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testOutputGuardrail_recoversFromException() {
+        // After an exception, subsequent calls should still work
+        assertThatThrownBy(() -> aiService.chat("test", "outputExceptionTool - anything"))
+                .isInstanceOf(RuntimeException.class);
+
+        tools.reset();
+
+        // This should work
+        String result = aiService.chat("test", "normalTool - data");
+        assertThat(tools.normalToolExecuted).isTrue();
+    }
+
+    @Test
+    void testToolInputGuardrailRequest_allowsNullToolMetadata() {
+        // Tool metadata can be null (optional context)
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                .id("test-id")
+                .name("test-tool")
+                .arguments("{}")
+                .build();
+
+        // Records allow nulls, so this should work
+        ToolInputGuardrailRequest guardrailRequest = new ToolInputGuardrailRequest(
+                request,
+                null, // toolMetadata
+                null); // invocationContext
+
+        assertThat(guardrailRequest.executionRequest()).isEqualTo(request);
+        assertThat(guardrailRequest.toolMetadata()).isNull();
+        assertThat(guardrailRequest.invocationContext()).isNull();
+        assertThat(guardrailRequest.memoryId()).isNull();
+    }
+
+    @Test
+    void testToolOutputGuardrailRequest_allowsNullExecutionRequest() {
+        // executionRequest is optional for output guardrails
+        dev.langchain4j.service.tool.ToolExecutionResult result = dev.langchain4j.service.tool.ToolExecutionResult.builder()
+                .resultText("test result")
+                .build();
+
+        ToolOutputGuardrailRequest guardrailRequest = new ToolOutputGuardrailRequest(
+                result,
+                null, // executionRequest
+                null, // toolMetadata
+                null); // invocationContext
+
+        assertThat(guardrailRequest.executionResult()).isEqualTo(result);
+        assertThat(guardrailRequest.executionRequest()).isNull();
+        assertThat(guardrailRequest.toolName()).isNull();
+    }
+
+    @Test
+    void testToolInputGuardrailResult_nullMessage() {
+        // Null error message should be allowed for success
+        ToolInputGuardrailResult result = ToolInputGuardrailResult.success();
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.errorMessage()).isNull();
+        assertThat(result.cause()).isNull();
+    }
+
+    @Test
+    void testToolOutputGuardrailResult_nullMessage() {
+        // Null error message should be allowed for success
+        ToolOutputGuardrailResult result = ToolOutputGuardrailResult.success();
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.errorMessage()).isNull();
+        assertThat(result.cause()).isNull();
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = MyMemoryProviderSupplier.class)
+    public interface MyAiService {
+        @ToolBox(MyTools.class)
+        String chat(@MemoryId String memoryId, @UserMessage String userMessage);
+    }
+
+    @Singleton
+    public static class MyTools {
+        boolean runtimeExceptionToolExecuted = false;
+        boolean nullPointerToolExecuted = false;
+        boolean outputExceptionToolExecuted = false;
+        boolean normalToolExecuted = false;
+
+        @Tool
+        @ToolInputGuardrails({ RuntimeExceptionGuardrail.class })
+        public String runtimeExceptionTool(String input) {
+            runtimeExceptionToolExecuted = true;
+            return "Result: " + input;
+        }
+
+        @Tool
+        @ToolInputGuardrails({ NullPointerExceptionGuardrail.class })
+        public String nullPointerTool(String input) {
+            nullPointerToolExecuted = true;
+            return "Result: " + input;
+        }
+
+        @Tool
+        @ToolOutputGuardrails({ OutputRuntimeExceptionGuardrail.class })
+        public String outputExceptionTool(String input) {
+            outputExceptionToolExecuted = true;
+            return "Result: " + input;
+        }
+
+        @Tool
+        public String normalTool(String input) {
+            normalToolExecuted = true;
+            return "Normal result: " + input;
+        }
+
+        void reset() {
+            runtimeExceptionToolExecuted = false;
+            nullPointerToolExecuted = false;
+            outputExceptionToolExecuted = false;
+            normalToolExecuted = false;
+        }
+    }
+
+    @ApplicationScoped
+    public static class RuntimeExceptionGuardrail implements ToolInputGuardrail {
+        static int executionCount = 0;
+
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            executionCount++;
+            throw new RuntimeException("Unexpected error in guardrail");
+        }
+
+        static void reset() {
+            executionCount = 0;
+        }
+    }
+
+    @ApplicationScoped
+    public static class NullPointerExceptionGuardrail implements ToolInputGuardrail {
+        static int executionCount = 0;
+
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            executionCount++;
+            // Simulate accidental NPE
+            String nullString = null;
+            nullString.length(); // This will throw NPE
+            return ToolInputGuardrailResult.success();
+        }
+
+        static void reset() {
+            executionCount = 0;
+        }
+    }
+
+    @ApplicationScoped
+    public static class OutputRuntimeExceptionGuardrail implements ToolOutputGuardrail {
+        static int executionCount = 0;
+
+        @Override
+        public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+            executionCount++;
+            throw new RuntimeException("Unexpected error in output guardrail");
+        }
+
+        static void reset() {
+            executionCount = 0;
+        }
+    }
+
+    public static class MyChatModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new MyChatModel();
+        }
+    }
+
+    public static class MyChatModel implements ChatModel {
+        @Override
+        public ChatResponse chat(List<ChatMessage> messages) {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            List<ChatMessage> messages = chatRequest.messages();
+            if (messages.size() == 1) {
+                String text = ((dev.langchain4j.data.message.UserMessage) messages.get(0)).singleText();
+                String[] segments = text.split(" - ");
+                String toolName = segments[0];
+                String input = segments.length > 1 ? segments[1] : "";
+
+                return ChatResponse.builder()
+                        .aiMessage(new AiMessage("executing tool", List.of(ToolExecutionRequest.builder()
+                                .id("tool-id-1")
+                                .name(toolName)
+                                .arguments("{\"input\":\"" + input + "\"}")
+                                .build())))
+                        .tokenUsage(new TokenUsage(0, 0))
+                        .finishReason(FinishReason.TOOL_EXECUTION)
+                        .build();
+            } else if (messages.size() == 3) {
+                ToolExecutionResultMessage last = (ToolExecutionResultMessage) Lists.last(messages);
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.from("response: " + last.text()))
+                        .build();
+            }
+            return ChatResponse.builder()
+                    .aiMessage(new AiMessage("Unexpected"))
+                    .build();
+        }
+    }
+
+    public static class MyMemoryProviderSupplier implements Supplier<ChatMemoryProvider> {
+        @Override
+        public ChatMemoryProvider get() {
+            return memoryId -> new NoopChatMemory();
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/GuardrailChainOrderingTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/GuardrailChainOrderingTest.java
@@ -1,0 +1,708 @@
+package io.quarkiverse.langchain4j.test.guardrails;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.tool.ToolExecutionResult;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.ToolBox;
+import io.quarkiverse.langchain4j.guardrails.ToolGuardrailException;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailResult;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrails;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrailRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrailResult;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrails;
+import io.quarkiverse.langchain4j.runtime.aiservice.NoopChatMemory;
+import io.quarkiverse.langchain4j.test.Lists;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests for guardrail chain execution and ordering.
+ * Tests the sequential execution, fail-fast semantics, and request/result propagation.
+ */
+public class GuardrailChainOrderingTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(
+                            MyAiService.class,
+                            InputGuardrail1.class,
+                            InputGuardrail2.class,
+                            InputGuardrail3.class,
+                            InputGuardrail4.class,
+                            InputGuardrail5.class,
+                            OutputGuardrail1.class,
+                            OutputGuardrail2.class,
+                            OutputGuardrail3.class,
+                            OutputGuardrail4.class,
+                            OutputGuardrail5.class,
+                            Lists.class));
+
+    @Inject
+    MyAiService aiService;
+
+    @Inject
+    MyTools tools;
+
+    @BeforeEach
+    void setUp() {
+        ExecutionTracker.reset();
+        tools.reset();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testInputChain_executesInOrder() {
+        aiService.chat("test", "inputChain5 - hello");
+
+        // Verify all 5 guardrails executed in the correct order
+        List<String> executions = ExecutionTracker.getInputExecutions();
+        assertThat(executions).containsExactly(
+                "InputGuardrail1",
+                "InputGuardrail2",
+                "InputGuardrail3",
+                "InputGuardrail4",
+                "InputGuardrail5");
+
+        // Verify they executed sequentially with increasing timestamps
+        List<Long> timestamps = ExecutionTracker.getInputTimestamps();
+        assertThat(timestamps).hasSize(5);
+        for (int i = 1; i < timestamps.size(); i++) {
+            assertThat(timestamps.get(i)).isGreaterThan(timestamps.get(i - 1));
+        }
+
+        // Tool should have been executed after all guardrails
+        assertThat(tools.inputChain5Executed).isTrue();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testInputChain_propagatesModifications() {
+        aiService.chat("test", "inputChain5 - transform");
+
+        // InputGuardrail1 adds "[G1]"
+        // InputGuardrail2 adds "[G2]"
+        // InputGuardrail3 adds "[G3]"
+        // InputGuardrail4 adds "[G4]"
+        // InputGuardrail5 adds "[G5]"
+        // Final result should have all transformations
+        assertThat(tools.lastInput).isEqualTo("transform[G1][G2][G3][G4][G5]");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testInputChain_stopsOnFirstFailure() {
+        // InputGuardrail2 will fail when input contains "fail-at-2"
+        String result = aiService.chat("test", "inputChain5 - fail-at-2");
+
+        // Only first 2 guardrails should have executed
+        List<String> executions = ExecutionTracker.getInputExecutions();
+        assertThat(executions).containsExactly(
+                "InputGuardrail1",
+                "InputGuardrail2");
+
+        // Guardrails 3, 4, 5 should NOT have executed
+        assertThat(executions).doesNotContain(
+                "InputGuardrail3",
+                "InputGuardrail4",
+                "InputGuardrail5");
+
+        // Tool should NOT have been executed
+        assertThat(tools.inputChain5Executed).isFalse();
+
+        // Result should contain the error message
+        assertThat(result).contains("Failed at guardrail 2");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testInputChain_stopsOnMiddleFailure() {
+        // InputGuardrail4 will fail when input contains "fail-at-4"
+        String result = aiService.chat("test", "inputChain5 - fail-at-4");
+
+        // First 4 guardrails should have executed
+        List<String> executions = ExecutionTracker.getInputExecutions();
+        assertThat(executions).containsExactly(
+                "InputGuardrail1",
+                "InputGuardrail2",
+                "InputGuardrail3",
+                "InputGuardrail4");
+
+        // Guardrail 5 should NOT have executed
+        assertThat(executions).doesNotContain("InputGuardrail5");
+
+        // Tool should NOT have been executed
+        assertThat(tools.inputChain5Executed).isFalse();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testInputChain_fatalFailureStopsImmediately() {
+        // InputGuardrail3 will fail fatally when input contains "fatal-at-3"
+        assertThatThrownBy(() -> aiService.chat("test", "inputChain5 - fatal-at-3"))
+                .isInstanceOf(ToolGuardrailException.class)
+                .hasMessageContaining("Fatal failure at guardrail 3")
+                .hasCauseInstanceOf(SecurityException.class);
+
+        // Only first 3 guardrails should have executed
+        List<String> executions = ExecutionTracker.getInputExecutions();
+        assertThat(executions).containsExactly(
+                "InputGuardrail1",
+                "InputGuardrail2",
+                "InputGuardrail3");
+
+        // Tool should NOT have been executed
+        assertThat(tools.inputChain5Executed).isFalse();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testOutputChain_executesInOrder() {
+        aiService.chat("test", "outputChain5 - hello");
+
+        // Verify all 5 guardrails executed in the correct order
+        List<String> executions = ExecutionTracker.getOutputExecutions();
+        assertThat(executions).containsExactly(
+                "OutputGuardrail1",
+                "OutputGuardrail2",
+                "OutputGuardrail3",
+                "OutputGuardrail4",
+                "OutputGuardrail5");
+
+        // Verify they executed sequentially with increasing timestamps
+        List<Long> timestamps = ExecutionTracker.getOutputTimestamps();
+        assertThat(timestamps).hasSize(5);
+        for (int i = 1; i < timestamps.size(); i++) {
+            assertThat(timestamps.get(i)).isGreaterThan(timestamps.get(i - 1));
+        }
+
+        // Tool should have been executed before all guardrails
+        assertThat(tools.outputChain5Executed).isTrue();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testOutputChain_propagatesModifications() {
+        String result = aiService.chat("test", "outputChain5 - transform");
+
+        // OutputGuardrail1 adds "[G1]"
+        // OutputGuardrail2 adds "[G2]"
+        // OutputGuardrail3 adds "[G3]"
+        // OutputGuardrail4 adds "[G4]"
+        // OutputGuardrail5 adds "[G5]"
+        // Final result should have all transformations
+        // (Mock LLM wraps with "response: " prefix and quotes)
+        assertThat(result).contains("[G1][G2][G3][G4][G5]");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testOutputChain_stopsOnFirstFailure() {
+        // OutputGuardrail2 will fail when result contains "fail-at-2"
+        String result = aiService.chat("test", "outputChain5 - fail-at-2");
+
+        // Only first 2 guardrails should have executed
+        List<String> executions = ExecutionTracker.getOutputExecutions();
+        assertThat(executions).containsExactly(
+                "OutputGuardrail1",
+                "OutputGuardrail2");
+
+        // Guardrails 3, 4, 5 should NOT have executed
+        assertThat(executions).doesNotContain(
+                "OutputGuardrail3",
+                "OutputGuardrail4",
+                "OutputGuardrail5");
+
+        // Tool SHOULD have been executed (output guardrails run after tool)
+        assertThat(tools.outputChain5Executed).isTrue();
+
+        // Result should contain the error message
+        assertThat(result).contains("Failed at guardrail 2");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testOutputChain_stopsOnMiddleFailure() {
+        // OutputGuardrail4 will fail when result contains "fail-at-4"
+        String result = aiService.chat("test", "outputChain5 - fail-at-4");
+
+        // First 4 guardrails should have executed
+        List<String> executions = ExecutionTracker.getOutputExecutions();
+        assertThat(executions).containsExactly(
+                "OutputGuardrail1",
+                "OutputGuardrail2",
+                "OutputGuardrail3",
+                "OutputGuardrail4");
+
+        // Guardrail 5 should NOT have executed
+        assertThat(executions).doesNotContain("OutputGuardrail5");
+
+        // Tool SHOULD have been executed
+        assertThat(tools.outputChain5Executed).isTrue();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testOutputChain_fatalFailureStopsImmediately() {
+        // OutputGuardrail3 will fail fatally when result contains "fatal-at-3"
+        assertThatThrownBy(() -> aiService.chat("test", "outputChain5 - fatal-at-3"))
+                .isInstanceOf(ToolGuardrailException.class)
+                .hasMessageContaining("Fatal failure at guardrail 3")
+                .hasCauseInstanceOf(SecurityException.class);
+
+        // Only first 3 guardrails should have executed
+        List<String> executions = ExecutionTracker.getOutputExecutions();
+        assertThat(executions).containsExactly(
+                "OutputGuardrail1",
+                "OutputGuardrail2",
+                "OutputGuardrail3");
+
+        // Tool SHOULD have been executed (output guardrails run after tool)
+        assertThat(tools.outputChain5Executed).isTrue();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testMixedChain_inputThenOutput() {
+        aiService.chat("test", "mixedChain - hello");
+
+        // All input guardrails should execute first
+        List<String> inputExecutions = ExecutionTracker.getInputExecutions();
+        assertThat(inputExecutions).containsExactly(
+                "InputGuardrail1",
+                "InputGuardrail2");
+
+        // Then the tool executes
+        assertThat(tools.mixedChainExecuted).isTrue();
+
+        // Then all output guardrails should execute
+        List<String> outputExecutions = ExecutionTracker.getOutputExecutions();
+        assertThat(outputExecutions).containsExactly(
+                "OutputGuardrail1",
+                "OutputGuardrail2");
+
+        // Input guardrails should complete before output guardrails start
+        long lastInputTimestamp = ExecutionTracker.getInputTimestamps().get(
+                ExecutionTracker.getInputTimestamps().size() - 1);
+        long firstOutputTimestamp = ExecutionTracker.getOutputTimestamps().get(0);
+        assertThat(firstOutputTimestamp).isGreaterThan(lastInputTimestamp);
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testMixedChain_inputFailureSkipsOutput() {
+        // InputGuardrail2 will fail
+        String result = aiService.chat("test", "mixedChain - fail-input");
+
+        // Input guardrails should have executed
+        List<String> inputExecutions = ExecutionTracker.getInputExecutions();
+        assertThat(inputExecutions).hasSize(2);
+
+        // Tool should NOT have executed
+        assertThat(tools.mixedChainExecuted).isFalse();
+
+        // Output guardrails should NOT have executed
+        List<String> outputExecutions = ExecutionTracker.getOutputExecutions();
+        assertThat(outputExecutions).isEmpty();
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = MyMemoryProviderSupplier.class)
+    public interface MyAiService {
+        @ToolBox(MyTools.class)
+        String chat(@MemoryId String memoryId, @UserMessage String userMessage);
+    }
+
+    @Singleton
+    public static class MyTools {
+        boolean inputChain5Executed = false;
+        boolean outputChain5Executed = false;
+        boolean mixedChainExecuted = false;
+        String lastInput = null;
+
+        @Tool
+        @ToolInputGuardrails({
+                InputGuardrail1.class,
+                InputGuardrail2.class,
+                InputGuardrail3.class,
+                InputGuardrail4.class,
+                InputGuardrail5.class
+        })
+        public String inputChain5(String input) {
+            inputChain5Executed = true;
+            lastInput = input;
+            return "Result: " + input;
+        }
+
+        @Tool
+        @ToolOutputGuardrails({
+                OutputGuardrail1.class,
+                OutputGuardrail2.class,
+                OutputGuardrail3.class,
+                OutputGuardrail4.class,
+                OutputGuardrail5.class
+        })
+        public String outputChain5(String input) {
+            outputChain5Executed = true;
+            lastInput = input;
+            return "Result: " + input;
+        }
+
+        @Tool
+        @ToolInputGuardrails({ InputGuardrail1.class, InputGuardrail2.class })
+        @ToolOutputGuardrails({ OutputGuardrail1.class, OutputGuardrail2.class })
+        public String mixedChain(String input) {
+            mixedChainExecuted = true;
+            lastInput = input;
+            return "Result: " + input;
+        }
+
+        void reset() {
+            inputChain5Executed = false;
+            outputChain5Executed = false;
+            mixedChainExecuted = false;
+            lastInput = null;
+        }
+    }
+
+    public static class ExecutionTracker {
+        private static final List<String> inputExecutions = new ArrayList<>();
+        private static final List<Long> inputTimestamps = new ArrayList<>();
+        private static final List<String> outputExecutions = new ArrayList<>();
+        private static final List<Long> outputTimestamps = new ArrayList<>();
+
+        public static void recordInput(String guardrailName) {
+            inputExecutions.add(guardrailName);
+            inputTimestamps.add(System.nanoTime());
+        }
+
+        public static void recordOutput(String guardrailName) {
+            outputExecutions.add(guardrailName);
+            outputTimestamps.add(System.nanoTime());
+        }
+
+        public static List<String> getInputExecutions() {
+            return new ArrayList<>(inputExecutions);
+        }
+
+        public static List<Long> getInputTimestamps() {
+            return new ArrayList<>(inputTimestamps);
+        }
+
+        public static List<String> getOutputExecutions() {
+            return new ArrayList<>(outputExecutions);
+        }
+
+        public static List<Long> getOutputTimestamps() {
+            return new ArrayList<>(outputTimestamps);
+        }
+
+        public static void reset() {
+            inputExecutions.clear();
+            inputTimestamps.clear();
+            outputExecutions.clear();
+            outputTimestamps.clear();
+        }
+    }
+
+    @ApplicationScoped
+    public static class InputGuardrail1 implements ToolInputGuardrail {
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            ExecutionTracker.recordInput("InputGuardrail1");
+
+            if (request.arguments().contains("transform")) {
+                ToolExecutionRequest modified = ToolExecutionRequest.builder()
+                        .id(request.executionRequest().id())
+                        .name(request.executionRequest().name())
+                        .arguments(request.arguments().replace("\"transform\"", "\"transform[G1]\""))
+                        .build();
+                return ToolInputGuardrailResult.successWith(modified);
+            }
+
+            return ToolInputGuardrailResult.success();
+        }
+    }
+
+    @ApplicationScoped
+    public static class InputGuardrail2 implements ToolInputGuardrail {
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            ExecutionTracker.recordInput("InputGuardrail2");
+
+            if (request.arguments().contains("fail-at-2")) {
+                return ToolInputGuardrailResult.failure("Failed at guardrail 2");
+            }
+
+            if (request.arguments().contains("fail-input")) {
+                return ToolInputGuardrailResult.failure("Input validation failed");
+            }
+
+            if (request.arguments().contains("transform")) {
+                String args = request.arguments();
+                String modified = args.replace("[G1]\"", "[G1][G2]\"");
+                ToolExecutionRequest modifiedRequest = ToolExecutionRequest.builder()
+                        .id(request.executionRequest().id())
+                        .name(request.executionRequest().name())
+                        .arguments(modified)
+                        .build();
+                return ToolInputGuardrailResult.successWith(modifiedRequest);
+            }
+
+            return ToolInputGuardrailResult.success();
+        }
+    }
+
+    @ApplicationScoped
+    public static class InputGuardrail3 implements ToolInputGuardrail {
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            ExecutionTracker.recordInput("InputGuardrail3");
+
+            if (request.arguments().contains("fatal-at-3")) {
+                return ToolInputGuardrailResult.failure(
+                        "Fatal failure at guardrail 3",
+                        new SecurityException("Unauthorized"));
+            }
+
+            if (request.arguments().contains("transform")) {
+                String args = request.arguments();
+                String modified = args.replace("[G2]\"", "[G2][G3]\"");
+                ToolExecutionRequest modifiedRequest = ToolExecutionRequest.builder()
+                        .id(request.executionRequest().id())
+                        .name(request.executionRequest().name())
+                        .arguments(modified)
+                        .build();
+                return ToolInputGuardrailResult.successWith(modifiedRequest);
+            }
+
+            return ToolInputGuardrailResult.success();
+        }
+    }
+
+    @ApplicationScoped
+    public static class InputGuardrail4 implements ToolInputGuardrail {
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            ExecutionTracker.recordInput("InputGuardrail4");
+
+            if (request.arguments().contains("fail-at-4")) {
+                return ToolInputGuardrailResult.failure("Failed at guardrail 4");
+            }
+
+            if (request.arguments().contains("transform")) {
+                String args = request.arguments();
+                String modified = args.replace("[G3]\"", "[G3][G4]\"");
+                ToolExecutionRequest modifiedRequest = ToolExecutionRequest.builder()
+                        .id(request.executionRequest().id())
+                        .name(request.executionRequest().name())
+                        .arguments(modified)
+                        .build();
+                return ToolInputGuardrailResult.successWith(modifiedRequest);
+            }
+
+            return ToolInputGuardrailResult.success();
+        }
+    }
+
+    @ApplicationScoped
+    public static class InputGuardrail5 implements ToolInputGuardrail {
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            ExecutionTracker.recordInput("InputGuardrail5");
+
+            if (request.arguments().contains("transform")) {
+                String args = request.arguments();
+                String modified = args.replace("[G4]\"", "[G4][G5]\"");
+                ToolExecutionRequest modifiedRequest = ToolExecutionRequest.builder()
+                        .id(request.executionRequest().id())
+                        .name(request.executionRequest().name())
+                        .arguments(modified)
+                        .build();
+                return ToolInputGuardrailResult.successWith(modifiedRequest);
+            }
+
+            return ToolInputGuardrailResult.success();
+        }
+    }
+
+    @ApplicationScoped
+    public static class OutputGuardrail1 implements ToolOutputGuardrail {
+        @Override
+        public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+            ExecutionTracker.recordOutput("OutputGuardrail1");
+
+            if (request.resultText().contains("transform")) {
+                ToolExecutionResult modified = ToolExecutionResult.builder()
+                        .resultText(request.resultText() + "[G1]")
+                        .build();
+                return ToolOutputGuardrailResult.successWith(modified);
+            }
+
+            return ToolOutputGuardrailResult.success();
+        }
+    }
+
+    @ApplicationScoped
+    public static class OutputGuardrail2 implements ToolOutputGuardrail {
+        @Override
+        public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+            ExecutionTracker.recordOutput("OutputGuardrail2");
+
+            if (request.resultText().contains("fail-at-2")) {
+                return ToolOutputGuardrailResult.failure("Failed at guardrail 2");
+            }
+
+            if (request.resultText().contains("transform")) {
+                ToolExecutionResult modified = ToolExecutionResult.builder()
+                        .resultText(request.resultText() + "[G2]")
+                        .build();
+                return ToolOutputGuardrailResult.successWith(modified);
+            }
+
+            return ToolOutputGuardrailResult.success();
+        }
+    }
+
+    @ApplicationScoped
+    public static class OutputGuardrail3 implements ToolOutputGuardrail {
+        @Override
+        public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+            ExecutionTracker.recordOutput("OutputGuardrail3");
+
+            if (request.resultText().contains("fatal-at-3")) {
+                return ToolOutputGuardrailResult.failure(
+                        "Fatal failure at guardrail 3",
+                        new SecurityException("Data leak detected"));
+            }
+
+            if (request.resultText().contains("transform")) {
+                ToolExecutionResult modified = ToolExecutionResult.builder()
+                        .resultText(request.resultText() + "[G3]")
+                        .build();
+                return ToolOutputGuardrailResult.successWith(modified);
+            }
+
+            return ToolOutputGuardrailResult.success();
+        }
+    }
+
+    @ApplicationScoped
+    public static class OutputGuardrail4 implements ToolOutputGuardrail {
+        @Override
+        public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+            ExecutionTracker.recordOutput("OutputGuardrail4");
+
+            if (request.resultText().contains("fail-at-4")) {
+                return ToolOutputGuardrailResult.failure("Failed at guardrail 4");
+            }
+
+            if (request.resultText().contains("transform")) {
+                ToolExecutionResult modified = ToolExecutionResult.builder()
+                        .resultText(request.resultText() + "[G4]")
+                        .build();
+                return ToolOutputGuardrailResult.successWith(modified);
+            }
+
+            return ToolOutputGuardrailResult.success();
+        }
+    }
+
+    @ApplicationScoped
+    public static class OutputGuardrail5 implements ToolOutputGuardrail {
+        @Override
+        public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+            ExecutionTracker.recordOutput("OutputGuardrail5");
+
+            if (request.resultText().contains("transform")) {
+                ToolExecutionResult modified = ToolExecutionResult.builder()
+                        .resultText(request.resultText() + "[G5]")
+                        .build();
+                return ToolOutputGuardrailResult.successWith(modified);
+            }
+
+            return ToolOutputGuardrailResult.success();
+        }
+    }
+
+    public static class MyChatModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new MyChatModel();
+        }
+    }
+
+    public static class MyChatModel implements ChatModel {
+        @Override
+        public ChatResponse chat(List<ChatMessage> messages) {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            List<ChatMessage> messages = chatRequest.messages();
+            if (messages.size() == 1) {
+                String text = ((dev.langchain4j.data.message.UserMessage) messages.get(0)).singleText();
+                String[] segments = text.split(" - ");
+                String toolName = segments[0];
+                String input = segments[1];
+
+                return ChatResponse.builder()
+                        .aiMessage(new AiMessage("executing tool", List.of(ToolExecutionRequest.builder()
+                                .id("tool-id-1")
+                                .name(toolName)
+                                .arguments("{\"input\":\"" + input + "\"}")
+                                .build())))
+                        .tokenUsage(new TokenUsage(0, 0))
+                        .finishReason(FinishReason.TOOL_EXECUTION)
+                        .build();
+            } else if (messages.size() == 3) {
+                ToolExecutionResultMessage last = (ToolExecutionResultMessage) Lists.last(messages);
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.from("response: " + last.text()))
+                        .build();
+            }
+            return ChatResponse.builder()
+                    .aiMessage(new AiMessage("Unexpected"))
+                    .build();
+        }
+    }
+
+    public static class MyMemoryProviderSupplier implements Supplier<ChatMemoryProvider> {
+        @Override
+        public ChatMemoryProvider get() {
+            return memoryId -> new NoopChatMemory();
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/GuardrailEventLoopBlockingTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/GuardrailEventLoopBlockingTest.java
@@ -1,0 +1,377 @@
+package io.quarkiverse.langchain4j.test.guardrails;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.exception.ToolExecutionException;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.ToolBox;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailResult;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrails;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrailRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrailResult;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrails;
+import io.quarkiverse.langchain4j.runtime.aiservice.NoopChatMemory;
+import io.quarkiverse.langchain4j.test.Lists;
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Tests that guardrails CANNOT be executed on the Vert.x event loop.
+ * <p>
+ * This test verifies that:
+ * <ul>
+ * <li>Attempting to use tools with guardrails on the event loop throws ToolExecutionException</li>
+ * <li>Guardrails work correctly when invoked from worker threads</li>
+ * </ul>
+ * <p>
+ * The architectural decision is that tools with guardrails must be marked as BLOCKING,
+ * because guardrails have synchronous APIs and cannot execute on the event loop.
+ * </p>
+ */
+public class GuardrailEventLoopBlockingTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(
+                            MyAiService.class,
+                            MyTools.class,
+                            SimpleInputGuardrail.class,
+                            SimpleOutputGuardrail.class,
+                            Lists.class));
+
+    @Inject
+    Vertx vertx;
+
+    @Inject
+    MyAiService aiService;
+
+    @Inject
+    MyTools tools;
+
+    @BeforeEach
+    void setUp() {
+        MyTools.reset();
+        SimpleInputGuardrail.reset();
+        SimpleOutputGuardrail.reset();
+    }
+
+    /**
+     * CRITICAL TEST: Verifies that attempting to use guardrails on the event loop
+     * throws ToolExecutionException.
+     * <p>
+     * This test actually runs the AI service call ON the event loop using vertx.runOnContext().
+     * </p>
+     */
+    @Test
+    void toolWithInputGuardrail_throwsException_whenCalledFromEventLoop() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Throwable> exceptionRef = new AtomicReference<>();
+
+        // Run on event loop thread
+        vertx.runOnContext(v -> {
+            try {
+                // Verify we're on event loop
+                assertThat(io.vertx.core.Context.isOnEventLoopThread())
+                        .as("Test setup: should be on event loop")
+                        .isTrue();
+
+                // This should throw ToolExecutionException because guardrails cannot run on event loop
+                Arc.container().requestContext().activate();
+                try {
+                    aiService.chat("test", "toolWithInputGuardrail - hello");
+                } finally {
+                    Arc.container().requestContext().terminate();
+                }
+            } catch (Throwable e) {
+                exceptionRef.set(e);
+            } finally {
+                latch.countDown();
+            }
+        });
+
+        // Wait for event loop execution
+        assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+
+        // Verify the expected exception was thrown
+        Throwable exception = exceptionRef.get();
+        assertThat(exception)
+                .isNotNull()
+                .isInstanceOf(ToolExecutionException.class);
+
+        // Our ToolGuardrailsWrapper should catch the event loop and throw a clear error
+        assertThat(exception.getMessage())
+                .contains("Cannot execute guardrails")
+                .contains("event loop thread")
+                .contains("blocking");
+    }
+
+    /**
+     * Tests that tools with output guardrails also throw exception on event loop.
+     */
+    @Test
+    void toolWithOutputGuardrail_throwsException_whenCalledFromEventLoop() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Throwable> exceptionRef = new AtomicReference<>();
+
+        vertx.runOnContext(v -> {
+            try {
+                assertThat(io.vertx.core.Context.isOnEventLoopThread()).isTrue();
+
+                Arc.container().requestContext().activate();
+                try {
+                    aiService.chat("test", "toolWithOutputGuardrail - hello");
+                } finally {
+                    Arc.container().requestContext().terminate();
+                }
+            } catch (Throwable e) {
+                exceptionRef.set(e);
+            } finally {
+                latch.countDown();
+            }
+        });
+
+        assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+
+        Throwable exception = exceptionRef.get();
+        assertThat(exception)
+                .isNotNull()
+                .isInstanceOf(ToolExecutionException.class);
+
+        assertThat(exception.getMessage())
+                .contains("Cannot execute guardrails")
+                .contains("event loop thread")
+                .contains("blocking");
+    }
+
+    /**
+     * Verifies that guardrails work correctly when NOT on event loop.
+     * <p>
+     * This test runs on the regular test thread (not event loop).
+     * </p>
+     */
+    @Test
+    void toolWithGuardrails_worksCorrectly_whenNotOnEventLoop() {
+        // Verify we're NOT on event loop
+        assertThat(io.vertx.core.Context.isOnEventLoopThread())
+                .as("Test setup: should NOT be on event loop")
+                .isFalse();
+
+        // Activate request context manually since we're not using @ActivateRequestContext
+        Arc.container().requestContext().activate();
+        try {
+            String result = aiService.chat("test", "toolWithInputGuardrail - hello");
+
+            // Verify guardrail was executed
+            assertThat(SimpleInputGuardrail.executed).isTrue();
+            assertThat(SimpleInputGuardrail.ranOnEventLoop).isFalse();
+
+            // Verify tool executed successfully
+            assertThat(MyTools.toolWithInputGuardrailExecuted).isTrue();
+            assertThat(result).contains("Input: hello");
+        } finally {
+            Arc.container().requestContext().terminate();
+        }
+    }
+
+    /**
+     * Verifies that output guardrails work correctly when NOT on event loop.
+     */
+    @Test
+    void toolWithOutputGuardrail_worksCorrectly_whenNotOnEventLoop() {
+        assertThat(io.vertx.core.Context.isOnEventLoopThread()).isFalse();
+
+        Arc.container().requestContext().activate();
+        try {
+            String result = aiService.chat("test", "toolWithOutputGuardrail - secret");
+
+            // Verify guardrail was executed
+            assertThat(SimpleOutputGuardrail.executed).isTrue();
+            assertThat(SimpleOutputGuardrail.ranOnEventLoop).isFalse();
+
+            // Verify tool executed successfully
+            assertThat(MyTools.toolWithOutputGuardrailExecuted).isTrue();
+
+            // Verify output was filtered by guardrail
+            assertThat(result).contains("[FILTERED]");
+            assertThat(result).doesNotContain("secret");
+        } finally {
+            Arc.container().requestContext().terminate();
+        }
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = MyMemoryProviderSupplier.class)
+    public interface MyAiService {
+        @ToolBox(MyTools.class)
+        String chat(@MemoryId String memoryId, @UserMessage String userMessage);
+    }
+
+    @ApplicationScoped
+    public static class MyTools {
+        static boolean toolWithInputGuardrailExecuted = false;
+        static boolean toolWithOutputGuardrailExecuted = false;
+
+        @Tool("Tool with input guardrail")
+        @ToolInputGuardrails({ SimpleInputGuardrail.class })
+        public String toolWithInputGuardrail(String input) {
+            toolWithInputGuardrailExecuted = true;
+            return "Input: " + input;
+        }
+
+        @Tool("Tool with output guardrail")
+        @ToolOutputGuardrails({ SimpleOutputGuardrail.class })
+        public String toolWithOutputGuardrail(String input) {
+            toolWithOutputGuardrailExecuted = true;
+            return "Output: " + input;
+        }
+
+        static void reset() {
+            toolWithInputGuardrailExecuted = false;
+            toolWithOutputGuardrailExecuted = false;
+        }
+    }
+
+    /**
+     * Simple input guardrail that tracks execution context.
+     */
+    @ApplicationScoped
+    public static class SimpleInputGuardrail implements ToolInputGuardrail {
+        static boolean executed = false;
+        static boolean ranOnEventLoop = false;
+
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            executed = true;
+            ranOnEventLoop = io.vertx.core.Context.isOnEventLoopThread();
+
+            JsonObject args = request.argumentsAsJson();
+            String input = args.getString("input");
+
+            if (input == null || input.isEmpty()) {
+                return ToolInputGuardrailResult.failure("Input is required");
+            }
+
+            return ToolInputGuardrailResult.success();
+        }
+
+        static void reset() {
+            executed = false;
+            ranOnEventLoop = false;
+        }
+    }
+
+    /**
+     * Simple output guardrail that filters sensitive data.
+     */
+    @ApplicationScoped
+    public static class SimpleOutputGuardrail implements ToolOutputGuardrail {
+        static boolean executed = false;
+        static boolean ranOnEventLoop = false;
+
+        @Override
+        public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+            executed = true;
+            ranOnEventLoop = io.vertx.core.Context.isOnEventLoopThread();
+
+            String result = request.resultText();
+            String filtered = result.replace("secret", "[FILTERED]");
+
+            if (!filtered.equals(result)) {
+                return ToolOutputGuardrailResult.successWith(
+                        dev.langchain4j.service.tool.ToolExecutionResult.builder()
+                                .resultText(filtered)
+                                .build());
+            }
+
+            return ToolOutputGuardrailResult.success();
+        }
+
+        static void reset() {
+            executed = false;
+            ranOnEventLoop = false;
+        }
+    }
+
+    public static class MyChatModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new MyChatModel();
+        }
+    }
+
+    public static class MyChatModel implements ChatModel {
+        @Override
+        public ChatResponse chat(List<ChatMessage> messages) {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            List<ChatMessage> messages = chatRequest.messages();
+            if (messages.size() == 1) {
+                String text = ((dev.langchain4j.data.message.UserMessage) messages.get(0)).singleText();
+                String[] segments = text.split(" - ");
+                String toolName = segments[0];
+                String input = segments.length > 1 ? segments[1] : "";
+
+                return ChatResponse.builder()
+                        .aiMessage(new AiMessage("executing tool", List.of(ToolExecutionRequest.builder()
+                                .id("tool-id-1")
+                                .name(toolName)
+                                .arguments("{\"input\":\"" + input + "\"}")
+                                .build())))
+                        .tokenUsage(new TokenUsage(0, 0))
+                        .finishReason(FinishReason.TOOL_EXECUTION)
+                        .build();
+            } else if (messages.size() == 3) {
+                ToolExecutionResultMessage last = (ToolExecutionResultMessage) Lists.last(messages);
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.from("response: " + last.text()))
+                        .build();
+            }
+            return ChatResponse.builder()
+                    .aiMessage(new AiMessage("Unexpected"))
+                    .build();
+        }
+    }
+
+    public static class MyMemoryProviderSupplier implements Supplier<ChatMemoryProvider> {
+        @Override
+        public ChatMemoryProvider get() {
+            return memoryId -> new NoopChatMemory();
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/MoreRealWorldToolGuardrailsTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/MoreRealWorldToolGuardrailsTest.java
@@ -1,0 +1,752 @@
+package io.quarkiverse.langchain4j.test.guardrails;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.tool.ToolExecutionResult;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.ToolBox;
+import io.quarkiverse.langchain4j.guardrails.ToolGuardrailException;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailResult;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrails;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrailRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrailResult;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrails;
+import io.quarkiverse.langchain4j.runtime.aiservice.NoopChatMemory;
+import io.quarkiverse.langchain4j.test.Lists;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Real-world scenario tests for tool guardrails (PII filtering, rate limiting, authentication,
+ * input sanitization, output size limits, and combined guardrails)
+ */
+public class MoreRealWorldToolGuardrailsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(
+                            MyAiService.class,
+                            PiiFilterGuardrail.class,
+                            RateLimitGuardrail.class,
+                            AuthenticationGuardrail.class,
+                            InputSanitizationGuardrail.class,
+                            OutputSizeLimitGuardrail.class,
+                            SqlInjectionGuardrail.class,
+                            Lists.class));
+
+    @Inject
+    MyAiService aiService;
+
+    @Inject
+    MyTools tools;
+
+    @BeforeEach
+    void setUp() {
+        PiiFilterGuardrail.reset();
+        RateLimitGuardrail.reset();
+        AuthenticationGuardrail.reset();
+        InputSanitizationGuardrail.reset();
+        OutputSizeLimitGuardrail.reset();
+        SqlInjectionGuardrail.reset();
+        tools.reset();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testPiiFilter_redactsSsn() {
+        String result = aiService.chat("test", "searchUser - John SSN:123-45-6789");
+
+        // Tool should have executed with original input
+        assertThat(tools.searchUserExecuted).isTrue();
+        assertThat(tools.lastInput).contains("123-45-6789");
+
+        // Output should have SSN redacted
+        assertThat(result).contains("SSN:***-**-****");
+        assertThat(result).doesNotContain("123-45-6789");
+
+        // PII filter should have been executed
+        assertThat(PiiFilterGuardrail.executionCount).isEqualTo(1);
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testPiiFilter_redactsCreditCard() {
+        String result = aiService.chat("test", "searchUser - Card:4532-1111-2222-3333");
+
+        // Output should have credit card redacted
+        assertThat(result).contains("Card:****-****-****-****");
+        assertThat(result).doesNotContain("4532-1111-2222-3333");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testPiiFilter_redactsEmail() {
+        String result = aiService.chat("test", "searchUser - Contact:john.doe@example.com");
+
+        // Output should have email redacted
+        assertThat(result).contains("Contact:***@***");
+        assertThat(result).doesNotContain("john.doe@example.com");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testPiiFilter_redactsMultiplePiiTypes() {
+        String result = aiService.chat("test",
+                "searchUser - John SSN:123-45-6789 Email:john@example.com Card:4532-1111-2222-3333");
+
+        // All PII should be redacted
+        assertThat(result).contains("SSN:***-**-****");
+        assertThat(result).contains("Email:***@***");
+        assertThat(result).contains("Card:****-****-****-****");
+
+        // Original values should not be present
+        assertThat(result).doesNotContain("123-45-6789");
+        assertThat(result).doesNotContain("john@example.com");
+        assertThat(result).doesNotContain("4532-1111-2222-3333");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testRateLimit_allowsWithinLimit() {
+        // First call should succeed
+        String result = aiService.chat("user1", "rateLimitedSearch - query1");
+        assertThat(tools.rateLimitedSearchExecuted).isTrue();
+        assertThat(result).contains("Search: query1");
+
+        tools.reset();
+
+        // Second call should also succeed (within limit)
+        result = aiService.chat("user1", "rateLimitedSearch - query2");
+        assertThat(tools.rateLimitedSearchExecuted).isTrue();
+        assertThat(result).contains("Search: query2");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testRateLimit_blocksWhenExceeded() {
+        // Exhaust the rate limit (3 calls per user)
+        aiService.chat("user2", "rateLimitedSearch - query1");
+        tools.reset();
+        aiService.chat("user2", "rateLimitedSearch - query2");
+        tools.reset();
+        aiService.chat("user2", "rateLimitedSearch - query3");
+        tools.reset();
+
+        // Fourth call should be rate limited
+        String result = aiService.chat("user2", "rateLimitedSearch - query4");
+
+        // Tool should NOT have been executed
+        assertThat(tools.rateLimitedSearchExecuted).isFalse();
+
+        // Result should contain rate limit message
+        assertThat(result).contains("Rate limit exceeded");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testRateLimit_separatePerUser() {
+        // User1 makes calls
+        aiService.chat("user3", "rateLimitedSearch - query1");
+        aiService.chat("user3", "rateLimitedSearch - query2");
+        aiService.chat("user3", "rateLimitedSearch - query3");
+
+        // User2 should still be able to make calls (separate quota)
+        tools.reset();
+        String result = aiService.chat("user4", "rateLimitedSearch - query1");
+
+        assertThat(tools.rateLimitedSearchExecuted).isTrue();
+        assertThat(result).contains("Search: query1");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testAuthentication_allowsAuthenticatedUser() {
+        // Set authenticated user
+        AuthenticationGuardrail.setCurrentUser("admin");
+
+        String result = aiService.chat("test", "secureOperation - data");
+
+        // Tool should have executed
+        assertThat(tools.secureOperationExecuted).isTrue();
+        assertThat(result).contains("Operation: data");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testAuthentication_blocksUnauthenticatedUser() {
+        // No user authenticated
+        AuthenticationGuardrail.setCurrentUser(null);
+
+        assertThatThrownBy(() -> aiService.chat("test", "secureOperation - data"))
+                .isInstanceOf(ToolGuardrailException.class)
+                .hasMessageContaining("Authentication required");
+
+        // Tool should NOT have been executed
+        assertThat(tools.secureOperationExecuted).isFalse();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testAuthentication_blocksUnauthorizedUser() {
+        // Set user without required role
+        AuthenticationGuardrail.setCurrentUser("guest");
+
+        assertThatThrownBy(() -> aiService.chat("test", "secureOperation - data"))
+                .isInstanceOf(ToolGuardrailException.class)
+                .hasMessageContaining("Insufficient permissions");
+
+        // Tool should NOT have been executed
+        assertThat(tools.secureOperationExecuted).isFalse();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testInputSanitization_allowsCleanInput() {
+        String result = aiService.chat("test", "processInput - Hello World");
+
+        // Tool should have executed
+        assertThat(tools.processInputExecuted).isTrue();
+        assertThat(result).contains("Processed: Hello World");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testInputSanitization_blocksXssAttempt() {
+        String result = aiService.chat("test", "processInput - <script>alert('xss')</script>");
+
+        // Tool should NOT have been executed
+        assertThat(tools.processInputExecuted).isFalse();
+
+        // Result should contain sanitization error
+        assertThat(result).contains("Input validation failed");
+        assertThat(result).contains("potentially malicious content");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testInputSanitization_blocksSqlInjection() {
+        String result = aiService.chat("test", "databaseQuery - SELECT * FROM users WHERE id=1 OR 1=1");
+
+        // Tool should NOT have been executed
+        assertThat(tools.databaseQueryExecuted).isFalse();
+
+        // Result should contain SQL injection warning
+        assertThat(result).contains("SQL injection attempt detected");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testInputSanitization_allowsParameterizedQuery() {
+        String result = aiService.chat("test", "databaseQuery - user_id:12345");
+
+        // Tool should have executed (safe parameterized format)
+        assertThat(tools.databaseQueryExecuted).isTrue();
+        assertThat(result).contains("Query result for: user_id:12345");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testOutputSizeLimit_allowsNormalOutput() {
+        String result = aiService.chat("test", "generateReport - short");
+
+        // Tool should have executed
+        assertThat(tools.generateReportExecuted).isTrue();
+        assertThat(result).contains("Report: short data");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testOutputSizeLimit_truncatesLargeOutput() {
+        String result = aiService.chat("test", "generateReport - large");
+
+        // Tool should have executed
+        assertThat(tools.generateReportExecuted).isTrue();
+
+        // Output should be truncated
+        assertThat(result).contains("[Output truncated");
+        assertThat(result).contains("exceeded maximum size");
+
+        // Original large output should not be fully present
+        assertThat(result.length()).isLessThan(10000); // Original was 15000 chars
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testCombinedGuardrails_allPass() {
+        // Set up authentication
+        AuthenticationGuardrail.setCurrentUser("admin");
+
+        String result = aiService.chat("user5", "secureSearch - John Doe");
+
+        // All guardrails should pass, tool should execute
+        assertThat(tools.secureSearchExecuted).isTrue();
+
+        // Output should have PII filtered
+        assertThat(AuthenticationGuardrail.executionCount).isEqualTo(1);
+        assertThat(RateLimitGuardrail.executionCount).isEqualTo(1);
+        assertThat(PiiFilterGuardrail.executionCount).isEqualTo(1);
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testCombinedGuardrails_authenticationFailsFirst() {
+        // No authentication
+        AuthenticationGuardrail.setCurrentUser(null);
+
+        assertThatThrownBy(() -> aiService.chat("user6", "secureSearch - query"))
+                .isInstanceOf(ToolGuardrailException.class)
+                .hasMessageContaining("Authentication required");
+
+        // Tool should NOT have been executed
+        assertThat(tools.secureSearchExecuted).isFalse();
+
+        // Authentication failed, so rate limit should not be checked
+        assertThat(AuthenticationGuardrail.executionCount).isEqualTo(1);
+        assertThat(RateLimitGuardrail.executionCount).isEqualTo(0);
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testCombinedGuardrails_rateLimitFailsSecond() {
+        // Set up authentication
+        AuthenticationGuardrail.setCurrentUser("admin");
+
+        // Exhaust rate limit
+        aiService.chat("user7", "secureSearch - query1");
+        aiService.chat("user7", "secureSearch - query2");
+        aiService.chat("user7", "secureSearch - query3");
+
+        tools.reset();
+
+        // Next call should be rate limited
+        String result = aiService.chat("user7", "secureSearch - query4");
+
+        // Tool should NOT have been executed
+        assertThat(tools.secureSearchExecuted).isFalse();
+
+        // Result should contain rate limit message
+        assertThat(result).contains("Rate limit exceeded");
+
+        // Auth passed, rate limit checked, PII filter not reached
+        assertThat(AuthenticationGuardrail.executionCount).isEqualTo(4);
+        assertThat(RateLimitGuardrail.executionCount).isEqualTo(4);
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = MyMemoryProviderSupplier.class)
+    public interface MyAiService {
+        @ToolBox(MyTools.class)
+        String chat(@MemoryId String memoryId, @UserMessage String userMessage);
+    }
+
+    @Singleton
+    public static class MyTools {
+        boolean searchUserExecuted = false;
+        boolean rateLimitedSearchExecuted = false;
+        boolean secureOperationExecuted = false;
+        boolean processInputExecuted = false;
+        boolean databaseQueryExecuted = false;
+        boolean generateReportExecuted = false;
+        boolean secureSearchExecuted = false;
+        String lastInput = null;
+
+        @Tool
+        @ToolOutputGuardrails({ PiiFilterGuardrail.class })
+        public String searchUser(String query) {
+            searchUserExecuted = true;
+            lastInput = query;
+            // Return result that might contain PII
+            return "User found: " + query;
+        }
+
+        @Tool
+        @ToolInputGuardrails({ RateLimitGuardrail.class })
+        public String rateLimitedSearch(String query) {
+            rateLimitedSearchExecuted = true;
+            lastInput = query;
+            return "Search: " + query;
+        }
+
+        @Tool
+        @ToolInputGuardrails({ AuthenticationGuardrail.class })
+        public String secureOperation(String data) {
+            secureOperationExecuted = true;
+            lastInput = data;
+            return "Operation: " + data;
+        }
+
+        @Tool
+        @ToolInputGuardrails({ InputSanitizationGuardrail.class })
+        public String processInput(String input) {
+            processInputExecuted = true;
+            lastInput = input;
+            return "Processed: " + input;
+        }
+
+        @Tool
+        @ToolInputGuardrails({ SqlInjectionGuardrail.class })
+        public String databaseQuery(String query) {
+            databaseQueryExecuted = true;
+            lastInput = query;
+            return "Query result for: " + query;
+        }
+
+        @Tool
+        @ToolOutputGuardrails({ OutputSizeLimitGuardrail.class })
+        public String generateReport(String type) {
+            generateReportExecuted = true;
+            lastInput = type;
+
+            if ("short".equals(type)) {
+                return "Report: short data";
+            } else if ("large".equals(type)) {
+                // Generate a large output (15000 characters total - triggers truncation)
+                return "Report: " + "x".repeat(14992);
+            }
+
+            return "Report: " + type;
+        }
+
+        @Tool
+        @ToolInputGuardrails({ AuthenticationGuardrail.class, RateLimitGuardrail.class })
+        @ToolOutputGuardrails({ PiiFilterGuardrail.class })
+        public String secureSearch(String query) {
+            secureSearchExecuted = true;
+            lastInput = query;
+            return "Secure result: " + query;
+        }
+
+        void reset() {
+            searchUserExecuted = false;
+            rateLimitedSearchExecuted = false;
+            secureOperationExecuted = false;
+            processInputExecuted = false;
+            databaseQueryExecuted = false;
+            generateReportExecuted = false;
+            secureSearchExecuted = false;
+            lastInput = null;
+        }
+    }
+
+    @ApplicationScoped
+    public static class PiiFilterGuardrail implements ToolOutputGuardrail {
+        static int executionCount = 0;
+
+        // PII patterns
+        private static final Pattern SSN_PATTERN = Pattern.compile("\\d{3}-\\d{2}-\\d{4}");
+        private static final Pattern CREDIT_CARD_PATTERN = Pattern.compile("\\d{4}-\\d{4}-\\d{4}-\\d{4}");
+        private static final Pattern EMAIL_PATTERN = Pattern.compile("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}");
+
+        @Override
+        public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+            executionCount++;
+
+            String resultText = request.resultText();
+            String filtered = resultText;
+
+            // Redact SSN
+            filtered = SSN_PATTERN.matcher(filtered).replaceAll("***-**-****");
+
+            // Redact credit cards
+            filtered = CREDIT_CARD_PATTERN.matcher(filtered).replaceAll("****-****-****-****");
+
+            // Redact emails
+            filtered = EMAIL_PATTERN.matcher(filtered).replaceAll("***@***");
+
+            // If anything was redacted, return modified result
+            if (!filtered.equals(resultText)) {
+                ToolExecutionResult modifiedResult = ToolExecutionResult.builder()
+                        .resultText(filtered)
+                        .build();
+                return ToolOutputGuardrailResult.successWith(modifiedResult);
+            }
+
+            return ToolOutputGuardrailResult.success();
+        }
+
+        static void reset() {
+            executionCount = 0;
+        }
+    }
+
+    @ApplicationScoped
+    public static class RateLimitGuardrail implements ToolInputGuardrail {
+        static int executionCount = 0;
+
+        // Track calls per user: userId -> list of call timestamps
+        private static final Map<String, List<Instant>> callHistory = new ConcurrentHashMap<>();
+        private static final int MAX_CALLS_PER_WINDOW = 3;
+        private static final Duration TIME_WINDOW = Duration.ofMinutes(1);
+
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            executionCount++;
+
+            // Extract user ID from memory ID (in real app, would come from security context)
+            String userId = request.memoryId().toString();
+
+            // Get or create call history for this user
+            List<Instant> userCalls = callHistory.computeIfAbsent(userId, k -> new java.util.ArrayList<>());
+
+            // Remove old calls outside the time window
+            Instant now = Instant.now();
+            Instant windowStart = now.minus(TIME_WINDOW);
+            userCalls.removeIf(callTime -> callTime.isBefore(windowStart));
+
+            // Check if rate limit exceeded
+            if (userCalls.size() >= MAX_CALLS_PER_WINDOW) {
+                return ToolInputGuardrailResult.failure(
+                        "Rate limit exceeded. Maximum " + MAX_CALLS_PER_WINDOW + " calls per " +
+                                TIME_WINDOW.toMinutes() + " minute(s). Please try again later.");
+            }
+
+            // Record this call
+            userCalls.add(now);
+
+            return ToolInputGuardrailResult.success();
+        }
+
+        static void reset() {
+            executionCount = 0;
+            callHistory.clear();
+        }
+    }
+
+    @ApplicationScoped
+    public static class AuthenticationGuardrail implements ToolInputGuardrail {
+        static int executionCount = 0;
+
+        // Simulated security context (in real app, would use Quarkus Security)
+        private static final ThreadLocal<String> currentUser = new ThreadLocal<>();
+        private static final List<String> ADMIN_USERS = List.of("admin", "superuser");
+
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            executionCount++;
+
+            String user = currentUser.get();
+
+            // Check if user is authenticated
+            if (user == null) {
+                return ToolInputGuardrailResult.failure(
+                        "Authentication required. Please log in to use this tool.",
+                        new SecurityException("Unauthenticated access attempt"));
+            }
+
+            // Check if user has required role
+            if (!ADMIN_USERS.contains(user)) {
+                return ToolInputGuardrailResult.failure(
+                        "Insufficient permissions. Administrator role required.",
+                        new SecurityException("Unauthorized access attempt by user: " + user));
+            }
+
+            return ToolInputGuardrailResult.success();
+        }
+
+        static void setCurrentUser(String user) {
+            if (user == null) {
+                currentUser.remove();
+            } else {
+                currentUser.set(user);
+            }
+        }
+
+        static void reset() {
+            executionCount = 0;
+            currentUser.remove();
+        }
+    }
+
+    @ApplicationScoped
+    public static class InputSanitizationGuardrail implements ToolInputGuardrail {
+        static int executionCount = 0;
+
+        // Patterns for malicious input
+        private static final Pattern SCRIPT_TAG_PATTERN = Pattern.compile("<script[^>]*>.*?</script>",
+                Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+        private static final Pattern HTML_TAG_PATTERN = Pattern.compile("<[^>]+>");
+
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            executionCount++;
+
+            String args = request.arguments();
+
+            // Check for script tags (XSS)
+            if (SCRIPT_TAG_PATTERN.matcher(args).find()) {
+                return ToolInputGuardrailResult.failure(
+                        "Input validation failed: potentially malicious content detected (XSS attempt)");
+            }
+
+            // Check for HTML tags
+            if (HTML_TAG_PATTERN.matcher(args).find()) {
+                return ToolInputGuardrailResult.failure(
+                        "Input validation failed: HTML tags not allowed");
+            }
+
+            return ToolInputGuardrailResult.success();
+        }
+
+        static void reset() {
+            executionCount = 0;
+        }
+    }
+
+    @ApplicationScoped
+    public static class SqlInjectionGuardrail implements ToolInputGuardrail {
+        static int executionCount = 0;
+
+        // Common SQL injection patterns
+        private static final Pattern SQL_INJECTION_PATTERN = Pattern.compile(
+                ".*(\\bOR\\b|\\bAND\\b)\\s+\\d+\\s*=\\s*\\d+.*|.*\\bUNION\\b.*\\bSELECT\\b.*|.*\\bDROP\\b.*\\bTABLE\\b.*",
+                Pattern.CASE_INSENSITIVE);
+
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            executionCount++;
+
+            String args = request.arguments();
+
+            // Check for SQL injection patterns
+            if (SQL_INJECTION_PATTERN.matcher(args).find()) {
+                return ToolInputGuardrailResult.failure(
+                        "Input validation failed: SQL injection attempt detected");
+            }
+
+            return ToolInputGuardrailResult.success();
+        }
+
+        static void reset() {
+            executionCount = 0;
+        }
+    }
+
+    @ApplicationScoped
+    public static class OutputSizeLimitGuardrail implements ToolOutputGuardrail {
+        static int executionCount = 0;
+
+        private static final int MAX_OUTPUT_SIZE = 10000; // 10KB
+        private static final int TRUNCATION_SIZE = 5000; // Keep first 5KB
+
+        @Override
+        public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+            executionCount++;
+
+            String resultText = request.resultText();
+
+            // Check if output exceeds limit
+            if (resultText.length() > MAX_OUTPUT_SIZE) {
+                String truncated = resultText.substring(0, TRUNCATION_SIZE) +
+                        "\n\n[Output truncated - exceeded maximum size of " + MAX_OUTPUT_SIZE + " characters]";
+
+                ToolExecutionResult modifiedResult = ToolExecutionResult.builder()
+                        .resultText(truncated)
+                        .build();
+
+                return ToolOutputGuardrailResult.successWith(modifiedResult);
+            }
+
+            return ToolOutputGuardrailResult.success();
+        }
+
+        static void reset() {
+            executionCount = 0;
+        }
+    }
+
+    public static class MyChatModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new MyChatModel();
+        }
+    }
+
+    public static class MyChatModel implements ChatModel {
+        @Override
+        public ChatResponse chat(List<ChatMessage> messages) {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            List<ChatMessage> messages = chatRequest.messages();
+            if (messages.size() == 1) {
+                String text = ((dev.langchain4j.data.message.UserMessage) messages.get(0)).singleText();
+                String[] segments = text.split(" - ");
+                String toolName = segments[0];
+                String input = segments.length > 1 ? segments[1] : "";
+
+                return ChatResponse.builder()
+                        .aiMessage(new AiMessage("executing tool", List.of(ToolExecutionRequest.builder()
+                                .id("tool-id-1")
+                                .name(toolName)
+                                .arguments("{\"" + getParamName(toolName) + "\":\"" + input + "\"}")
+                                .build())))
+                        .tokenUsage(new TokenUsage(0, 0))
+                        .finishReason(FinishReason.TOOL_EXECUTION)
+                        .build();
+            } else if (messages.size() == 3) {
+                ToolExecutionResultMessage last = (ToolExecutionResultMessage) Lists.last(messages);
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.from("response: " + last.text()))
+                        .build();
+            }
+            return ChatResponse.builder()
+                    .aiMessage(new AiMessage("Unexpected"))
+                    .build();
+        }
+
+        private String getParamName(String toolName) {
+            return switch (toolName) {
+                case "searchUser", "rateLimitedSearch", "secureSearch" -> "query";
+                case "secureOperation" -> "data";
+                case "processInput" -> "input";
+                case "databaseQuery" -> "query";
+                case "generateReport" -> "type";
+                default -> "input";
+            };
+        }
+    }
+
+    public static class MyMemoryProviderSupplier implements Supplier<ChatMemoryProvider> {
+        @Override
+        public ChatMemoryProvider get() {
+            return memoryId -> new NoopChatMemory();
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/NonCDIBeanGuardrailTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/NonCDIBeanGuardrailTest.java
@@ -1,0 +1,53 @@
+package io.quarkiverse.langchain4j.test.guardrails;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.Tool;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailResult;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrails;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Test that should FAIL at build time because the guardrail is NOT a CDI bean.
+ */
+public class NonCDIBeanGuardrailTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyTools.class, NotACDIBeanGuardrail.class))
+            .assertException(t -> {
+                // Expect build-time validation error for non-CDI bean guardrail
+                if (t.getMessage() != null && t.getMessage().contains("is not a CDI bean")) {
+                    System.out.println("✓ Correctly caught non-CDI bean guardrail: " + t.getMessage());
+                } else {
+                    throw new AssertionError("Expected 'is not a CDI bean' error but got: " + t.getMessage());
+                }
+            });
+
+    @Test
+    void testShouldFailAtBuildTime() {
+        // This test should never run - build should fail
+    }
+
+    public static class MyTools {
+        @Tool("Test tool")
+        @ToolInputGuardrails({ NotACDIBeanGuardrail.class })
+        public String testTool(String input) {
+            return "result";
+        }
+    }
+
+    // NOTE: This class is intentionally NOT annotated with @ApplicationScoped or any CDI annotation
+    public static class NotACDIBeanGuardrail implements ToolInputGuardrail {
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            return ToolInputGuardrailResult.success();
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/ToolGuardrailWithObjectTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/ToolGuardrailWithObjectTest.java
@@ -1,0 +1,593 @@
+package io.quarkiverse.langchain4j.test.guardrails;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.tool.ToolExecutionResult;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.ToolBox;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailResult;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrails;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrailRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrailResult;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrails;
+import io.quarkiverse.langchain4j.runtime.aiservice.NoopChatMemory;
+import io.quarkiverse.langchain4j.test.Lists;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests for tools that return structured objects instead of strings.
+ * Covers:
+ * - Tools returning POJOs/records
+ * - Tools returning lists of objects
+ * - Tools returning nested objects
+ * - Input/output guardrails working with structured data
+ */
+public class ToolGuardrailWithObjectTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(
+                            MyAiService.class,
+                            MyTools.class,
+                            Customer.class,
+                            Address.class,
+                            CustomerListResponse.class,
+                            IdValidationGuardrail.class,
+                            SensitiveFieldFilter.class,
+                            CustomerListSizeGuardrail.class,
+                            Lists.class));
+
+    @Inject
+    MyAiService aiService;
+
+    @Inject
+    MyTools tools;
+
+    @BeforeEach
+    void setUp() {
+        tools.reset();
+        IdValidationGuardrail.reset();
+        SensitiveFieldFilter.reset();
+        CustomerListSizeGuardrail.reset();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testToolReturningSimpleObject() {
+        String result = aiService.chat("test", "getCustomer - 123");
+
+        assertThat(tools.getCustomerExecuted).isTrue();
+        assertThat(result).contains("123"); // ID
+        assertThat(result).contains("John Doe");
+        assertThat(result).contains("john@example.com");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testToolReturningRecord() {
+        String result = aiService.chat("test", "getAddress - 456");
+
+        assertThat(tools.getAddressExecuted).isTrue();
+        assertThat(result).contains("street"); // JSON field
+        assertThat(result).contains("123 Main St");
+        assertThat(result).contains("New York");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testToolReturningListOfObjects() {
+        String result = aiService.chat("test", "listCustomers - premium");
+
+        assertThat(tools.listCustomersExecuted).isTrue();
+        assertThat(result).contains("customers");
+        assertThat(result).contains("Alice");
+        assertThat(result).contains("Bob");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testToolReturningNestedObject() {
+        String result = aiService.chat("test", "getCustomerWithAddress - 789");
+
+        assertThat(tools.getCustomerWithAddressExecuted).isTrue();
+        assertThat(result).contains("Charlie"); // Customer name
+        assertThat(result).contains("address"); // Nested object field
+        assertThat(result).contains("456 Oak Ave");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testInputGuardrail_withStructuredObjectTool_success() {
+        String result = aiService.chat("test", "getValidatedCustomer - 100");
+
+        assertThat(IdValidationGuardrail.executionCount).isEqualTo(1);
+        assertThat(IdValidationGuardrail.lastValidatedId).isEqualTo("100");
+        assertThat(tools.getValidatedCustomerExecuted).isTrue();
+        assertThat(result).contains("Valid Customer"); // Customer name
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testInputGuardrail_withStructuredObjectTool_failure() {
+        String result = aiService.chat("test", "getValidatedCustomer - -5");
+
+        assertThat(IdValidationGuardrail.executionCount).isEqualTo(1);
+        assertThat(IdValidationGuardrail.lastValidatedId).isEqualTo("-5");
+        assertThat(tools.getValidatedCustomerExecuted).isFalse();
+        assertThat(result).contains("Invalid customer ID");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testOutputGuardrail_filterSensitiveFieldsFromObject() {
+        String result = aiService.chat("test", "getFilteredCustomer - 200");
+
+        assertThat(tools.getFilteredCustomerExecuted).isTrue();
+        assertThat(SensitiveFieldFilter.executionCount).isEqualTo(1);
+
+        // SSN should be filtered
+        assertThat(result).doesNotContain("123-45-6789");
+        assertThat(result).contains("[REDACTED]");
+
+        // Other fields should remain
+        assertThat(result).contains("Jane Smith");
+        assertThat(result).contains("jane@example.com");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testOutputGuardrail_transformStructuredObject() {
+        String result = aiService.chat("test", "getLimitedCustomers - all");
+
+        assertThat(tools.getLimitedCustomersExecuted).isTrue();
+        assertThat(CustomerListSizeGuardrail.executionCount).isEqualTo(1);
+
+        // Original list has 5 customers, guardrail limits to 3
+        assertThat(CustomerListSizeGuardrail.originalSize).isEqualTo(5);
+        assertThat(CustomerListSizeGuardrail.limitedSize).isEqualTo(3);
+
+        // Should contain truncation notice
+        assertThat(result).contains("truncated");
+        assertThat(result).contains("showing 3 of 5");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testOutputGuardrail_withNestedObject_filtersSensitiveData() {
+        String result = aiService.chat("test", "getFilteredCustomerWithAddress - 300");
+
+        assertThat(tools.getFilteredCustomerWithAddressExecuted).isTrue();
+        assertThat(SensitiveFieldFilter.executionCount).isEqualTo(1);
+
+        // SSN should be filtered even in nested structure
+        assertThat(result).doesNotContain("987-65-4321");
+        assertThat(result).contains("[REDACTED]");
+
+        // Other nested data should remain
+        assertThat(result).contains("789 Elm St");
+        assertThat(result).contains("Los Angeles");
+    }
+
+    /**
+     * Simple POJO customer class
+     */
+    public static class Customer {
+        private String id;
+        private String name;
+        private String email;
+        private String ssn;
+        private Address address;
+
+        public Customer() {
+        }
+
+        public Customer(String id, String name, String email, String ssn) {
+            this.id = id;
+            this.name = name;
+            this.email = email;
+            this.ssn = ssn;
+        }
+
+        public Customer(String id, String name, String email, String ssn, Address address) {
+            this.id = id;
+            this.name = name;
+            this.email = email;
+            this.ssn = ssn;
+            this.address = address;
+        }
+
+        // Getters and setters
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getEmail() {
+            return email;
+        }
+
+        public void setEmail(String email) {
+            this.email = email;
+        }
+
+        public String getSsn() {
+            return ssn;
+        }
+
+        public void setSsn(String ssn) {
+            this.ssn = ssn;
+        }
+
+        public Address getAddress() {
+            return address;
+        }
+
+        public void setAddress(Address address) {
+            this.address = address;
+        }
+    }
+
+    /**
+     * Record for address (Java 17+)
+     */
+    public record Address(String street, String city, String zipCode) {
+    }
+
+    /**
+     * Response wrapper for list of customers
+     */
+    public static class CustomerListResponse {
+        private List<Customer> customers;
+        private int total;
+        private boolean truncated;
+        private String message;
+
+        public CustomerListResponse() {
+        }
+
+        public CustomerListResponse(List<Customer> customers, int total, boolean truncated, String message) {
+            this.customers = customers;
+            this.total = total;
+            this.truncated = truncated;
+            this.message = message;
+        }
+
+        // Getters and setters
+        public List<Customer> getCustomers() {
+            return customers;
+        }
+
+        public void setCustomers(List<Customer> customers) {
+            this.customers = customers;
+        }
+
+        public int getTotal() {
+            return total;
+        }
+
+        public void setTotal(int total) {
+            this.total = total;
+        }
+
+        public boolean isTruncated() {
+            return truncated;
+        }
+
+        public void setTruncated(boolean truncated) {
+            this.truncated = truncated;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public void setMessage(String message) {
+            this.message = message;
+        }
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = MyMemoryProviderSupplier.class)
+    public interface MyAiService {
+        @ToolBox(MyTools.class)
+        String chat(@MemoryId String memoryId, @UserMessage String userMessage);
+    }
+
+    @Singleton
+    public static class MyTools {
+        boolean getCustomerExecuted = false;
+        boolean getAddressExecuted = false;
+        boolean listCustomersExecuted = false;
+        boolean getCustomerWithAddressExecuted = false;
+        boolean getValidatedCustomerExecuted = false;
+        boolean getFilteredCustomerExecuted = false;
+        boolean getLimitedCustomersExecuted = false;
+        boolean getFilteredCustomerWithAddressExecuted = false;
+
+        @Tool
+        public Customer getCustomer(String customerId) {
+            getCustomerExecuted = true;
+            return new Customer(customerId, "John Doe", "john@example.com", "111-22-3333");
+        }
+
+        @Tool
+        public Address getAddress(String addressId) {
+            getAddressExecuted = true;
+            return new Address("123 Main St", "New York", "10001");
+        }
+
+        @Tool
+        public CustomerListResponse listCustomers(String filter) {
+            listCustomersExecuted = true;
+            List<Customer> customers = List.of(
+                    new Customer("1", "Alice", "alice@example.com", "111-11-1111"),
+                    new Customer("2", "Bob", "bob@example.com", "222-22-2222"));
+            return new CustomerListResponse(customers, customers.size(), false, null);
+        }
+
+        @Tool
+        public Customer getCustomerWithAddress(String customerId) {
+            getCustomerWithAddressExecuted = true;
+            Address address = new Address("456 Oak Ave", "Boston", "02101");
+            return new Customer(customerId, "Charlie", "charlie@example.com", "333-33-3333", address);
+        }
+
+        @Tool
+        @ToolInputGuardrails({ IdValidationGuardrail.class })
+        public Customer getValidatedCustomer(String customerId) {
+            getValidatedCustomerExecuted = true;
+            return new Customer(customerId, "Valid Customer", "valid@example.com", "444-44-4444");
+        }
+
+        @Tool
+        @ToolOutputGuardrails({ SensitiveFieldFilter.class })
+        public Customer getFilteredCustomer(String customerId) {
+            getFilteredCustomerExecuted = true;
+            return new Customer(customerId, "Jane Smith", "jane@example.com", "123-45-6789");
+        }
+
+        @Tool
+        @ToolOutputGuardrails({ CustomerListSizeGuardrail.class })
+        public CustomerListResponse getLimitedCustomers(String filter) {
+            getLimitedCustomersExecuted = true;
+            List<Customer> customers = List.of(
+                    new Customer("1", "Customer 1", "c1@example.com", "111-11-1111"),
+                    new Customer("2", "Customer 2", "c2@example.com", "222-22-2222"),
+                    new Customer("3", "Customer 3", "c3@example.com", "333-33-3333"),
+                    new Customer("4", "Customer 4", "c4@example.com", "444-44-4444"),
+                    new Customer("5", "Customer 5", "c5@example.com", "555-55-5555"));
+            return new CustomerListResponse(customers, customers.size(), false, null);
+        }
+
+        @Tool
+        @ToolOutputGuardrails({ SensitiveFieldFilter.class })
+        public Customer getFilteredCustomerWithAddress(String customerId) {
+            getFilteredCustomerWithAddressExecuted = true;
+            Address address = new Address("789 Elm St", "Los Angeles", "90001");
+            return new Customer(customerId, "Nested Customer", "nested@example.com", "987-65-4321", address);
+        }
+
+        void reset() {
+            getCustomerExecuted = false;
+            getAddressExecuted = false;
+            listCustomersExecuted = false;
+            getCustomerWithAddressExecuted = false;
+            getValidatedCustomerExecuted = false;
+            getFilteredCustomerExecuted = false;
+            getLimitedCustomersExecuted = false;
+            getFilteredCustomerWithAddressExecuted = false;
+        }
+    }
+
+    @ApplicationScoped
+    public static class IdValidationGuardrail implements ToolInputGuardrail {
+        static int executionCount = 0;
+        static String lastValidatedId = null;
+
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            executionCount++;
+            try {
+                ObjectMapper mapper = new ObjectMapper();
+                var args = mapper.readTree(request.arguments());
+                String customerId = args.get("customerId").asText();
+                lastValidatedId = customerId;
+
+                // Validate ID is positive number
+                int id = Integer.parseInt(customerId);
+                if (id <= 0) {
+                    return ToolInputGuardrailResult.failure(
+                            "Invalid customer ID: " + customerId + ". ID must be a positive number.");
+                }
+
+                return ToolInputGuardrailResult.success();
+            } catch (Exception e) {
+                return ToolInputGuardrailResult.failure("Failed to validate customer ID: " + e.getMessage(), e);
+            }
+        }
+
+        static void reset() {
+            executionCount = 0;
+            lastValidatedId = null;
+        }
+    }
+
+    @ApplicationScoped
+    public static class SensitiveFieldFilter implements ToolOutputGuardrail {
+        static int executionCount = 0;
+
+        @Override
+        public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+            executionCount++;
+            try {
+                String resultText = request.resultText();
+
+                // Parse the JSON result
+                ObjectMapper mapper = new ObjectMapper();
+                var jsonNode = mapper.readTree(resultText);
+
+                // Filter SSN fields (handles both direct and nested)
+                String filtered = resultText.replaceAll("\"ssn\"\\s*:\\s*\"[^\"]+\"", "\"ssn\":\"[REDACTED]\"");
+
+                if (!filtered.equals(resultText)) {
+                    return ToolOutputGuardrailResult.successWith(
+                            ToolExecutionResult.builder()
+                                    .resultText(filtered)
+                                    .build());
+                }
+
+                return ToolOutputGuardrailResult.success();
+            } catch (Exception e) {
+                return ToolOutputGuardrailResult.failure("Failed to filter sensitive fields: " + e.getMessage(), e);
+            }
+        }
+
+        static void reset() {
+            executionCount = 0;
+        }
+    }
+
+    @ApplicationScoped
+    public static class CustomerListSizeGuardrail implements ToolOutputGuardrail {
+        static int executionCount = 0;
+        static int originalSize = 0;
+        static int limitedSize = 0;
+        private static final int MAX_CUSTOMERS = 3;
+
+        @Override
+        public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+            executionCount++;
+            try {
+                String resultText = request.resultText();
+                ObjectMapper mapper = new ObjectMapper();
+                CustomerListResponse response = mapper.readValue(resultText, CustomerListResponse.class);
+
+                originalSize = response.getCustomers().size();
+
+                if (originalSize > MAX_CUSTOMERS) {
+                    // Limit the list
+                    List<Customer> limited = response.getCustomers().subList(0, MAX_CUSTOMERS);
+                    limitedSize = limited.size();
+
+                    CustomerListResponse modifiedResponse = new CustomerListResponse(
+                            limited,
+                            originalSize,
+                            true,
+                            "Results truncated - showing " + limitedSize + " of " + originalSize + " customers");
+
+                    String modifiedJson = mapper.writeValueAsString(modifiedResponse);
+
+                    return ToolOutputGuardrailResult.successWith(
+                            ToolExecutionResult.builder()
+                                    .resultText(modifiedJson)
+                                    .build());
+                }
+
+                limitedSize = originalSize;
+                return ToolOutputGuardrailResult.success();
+            } catch (Exception e) {
+                return ToolOutputGuardrailResult.failure("Failed to limit customer list: " + e.getMessage(), e);
+            }
+        }
+
+        static void reset() {
+            executionCount = 0;
+            originalSize = 0;
+            limitedSize = 0;
+        }
+    }
+
+    public static class MyChatModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new MyChatModel();
+        }
+    }
+
+    public static class MyChatModel implements ChatModel {
+        @Override
+        public ChatResponse chat(List<ChatMessage> messages) {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            List<ChatMessage> messages = chatRequest.messages();
+            if (messages.size() == 1) {
+                String text = ((dev.langchain4j.data.message.UserMessage) messages.get(0)).singleText();
+                String[] segments = text.split(" - ");
+                String toolName = segments[0];
+                String input = segments.length > 1 ? segments[1] : "";
+
+                return ChatResponse.builder()
+                        .aiMessage(new AiMessage("executing tool", List.of(ToolExecutionRequest.builder()
+                                .id("tool-id-1")
+                                .name(toolName)
+                                .arguments("{\"customerId\":\"" + input + "\",\"addressId\":\"" + input
+                                        + "\",\"filter\":\"" + input + "\"}")
+                                .build())))
+                        .tokenUsage(new TokenUsage(0, 0))
+                        .finishReason(FinishReason.TOOL_EXECUTION)
+                        .build();
+            } else if (messages.size() == 3) {
+                ToolExecutionResultMessage last = (ToolExecutionResultMessage) Lists.last(messages);
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.from("response: " + last.text()))
+                        .build();
+            }
+            return ChatResponse.builder()
+                    .aiMessage(new AiMessage("Unexpected"))
+                    .build();
+        }
+    }
+
+    public static class MyMemoryProviderSupplier implements Supplier<ChatMemoryProvider> {
+        @Override
+        public ChatMemoryProvider get() {
+            return memoryId -> new NoopChatMemory();
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/ToolGuardrailWithUniTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/ToolGuardrailWithUniTest.java
@@ -1,0 +1,603 @@
+package io.quarkiverse.langchain4j.test.guardrails;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.tool.ToolExecutionResult;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.ToolBox;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailResult;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrails;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrailRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrailResult;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrails;
+import io.quarkiverse.langchain4j.runtime.aiservice.NoopChatMemory;
+import io.quarkiverse.langchain4j.test.Lists;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Tests for tools returning reactive types (Uni) with guardrails.
+ * Covers:
+ * - Tools returning Uni<String>
+ * - Tools returning Uni<Object>
+ * - Input/output guardrails with reactive tools
+ * - Async execution with guardrails
+ */
+public class ToolGuardrailWithUniTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(
+                            MyAiService.class,
+                            MyTools.class,
+                            Product.class,
+                            InventoryStatus.class,
+                            MessageValidationGuardrail.class,
+                            ProductIdValidationGuardrail.class,
+                            PriceFilterGuardrail.class,
+                            InventoryStatusTransformGuardrail.class,
+                            Lists.class));
+
+    @Inject
+    MyAiService aiService;
+
+    @Inject
+    MyTools tools;
+
+    @BeforeEach
+    void setUp() {
+        tools.reset();
+        MessageValidationGuardrail.reset();
+        ProductIdValidationGuardrail.reset();
+        PriceFilterGuardrail.reset();
+        InventoryStatusTransformGuardrail.reset();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testToolReturningUniString() {
+        String result = aiService.chat("test", "getMessage - hello");
+
+        assertThat(tools.getMessageExecuted).isTrue();
+        assertThat(result).contains("Message: hello");
+        assertThat(result).contains("async");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testToolReturningUniObject() {
+        String result = aiService.chat("test", "getProduct - 123");
+
+        assertThat(tools.getProductExecuted).isTrue();
+        assertThat(result).contains("123"); // Product ID
+        assertThat(result).contains("name"); // JSON field
+        assertThat(result).contains("Laptop");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testToolReturningUniObjectWithDelay() {
+        String result = aiService.chat("test", "getProductDelayed - 456");
+
+        assertThat(tools.getProductDelayedExecuted).isTrue();
+        assertThat(result).contains("Tablet");
+        assertThat(result).contains("price");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testToolReturningUniNestedObject() {
+        String result = aiService.chat("test", "getInventoryStatus - 789");
+
+        assertThat(tools.getInventoryStatusExecuted).isTrue();
+        assertThat(result).contains("product");
+        assertThat(result).contains("inStock");
+        assertThat(result).contains("quantity");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testInputGuardrail_withReactiveTool_success() {
+        String result = aiService.chat("test", "getValidatedMessage - validmessage");
+
+        assertThat(MessageValidationGuardrail.executionCount).isEqualTo(1);
+        assertThat(MessageValidationGuardrail.lastMessage).isEqualTo("validmessage");
+        assertThat(tools.getValidatedMessageExecuted).isTrue();
+        assertThat(result).contains("Validated: validmessage");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testInputGuardrail_withReactiveTool_failure() {
+        String result = aiService.chat("test", "getValidatedMessage - bad!");
+
+        assertThat(MessageValidationGuardrail.executionCount).isEqualTo(1);
+        assertThat(MessageValidationGuardrail.lastMessage).isEqualTo("bad!");
+        assertThat(tools.getValidatedMessageExecuted).isFalse();
+        assertThat(result).contains("Invalid message");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testInputGuardrail_withReactiveObjectTool_success() {
+        String result = aiService.chat("test", "getValidatedProduct - 100");
+
+        assertThat(ProductIdValidationGuardrail.executionCount).isEqualTo(1);
+        assertThat(tools.getValidatedProductExecuted).isTrue();
+        assertThat(result).contains("Validated Product");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testInputGuardrail_withReactiveObjectTool_failure() {
+        String result = aiService.chat("test", "getValidatedProduct - 999");
+
+        assertThat(ProductIdValidationGuardrail.executionCount).isEqualTo(1);
+        assertThat(tools.getValidatedProductExecuted).isFalse();
+        assertThat(result).contains("Product ID must be less than 500");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testOutputGuardrail_withReactiveStringTool() {
+        String result = aiService.chat("test", "getFilteredMessage - price is $99.99");
+
+        assertThat(tools.getFilteredMessageExecuted).isTrue();
+        assertThat(PriceFilterGuardrail.executionCount).isEqualTo(1);
+
+        // Price should be filtered
+        assertThat(result).doesNotContain("$99.99");
+        assertThat(result).contains("[PRICE REDACTED]");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testOutputGuardrail_withReactiveObjectTool() {
+        String result = aiService.chat("test", "getFilteredProduct - 200");
+
+        assertThat(tools.getFilteredProductExecuted).isTrue();
+        assertThat(PriceFilterGuardrail.executionCount).isEqualTo(1);
+
+        // Price field should be redacted in JSON
+        assertThat(result).contains("price");
+        assertThat(result).contains("REDACTED");
+        assertThat(result).doesNotContain("999.99");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testOutputGuardrail_transformReactiveObject() {
+        String result = aiService.chat("test", "getTransformedInventory - 300");
+
+        assertThat(tools.getTransformedInventoryExecuted).isTrue();
+        assertThat(InventoryStatusTransformGuardrail.executionCount).isEqualTo(1);
+
+        // Quantity should be transformed to category
+        assertThat(result).contains("availabilityCategory");
+        assertThat(result).contains("HIGH_STOCK");
+    }
+
+    /**
+     * Product POJO
+     */
+    public static class Product {
+        private String id;
+        private String name;
+        private double price;
+
+        public Product() {
+        }
+
+        public Product(String id, String name, double price) {
+            this.id = id;
+            this.name = name;
+            this.price = price;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public double getPrice() {
+            return price;
+        }
+
+        public void setPrice(double price) {
+            this.price = price;
+        }
+    }
+
+    /**
+     * Inventory status with nested product
+     */
+    public static class InventoryStatus {
+        private Product product;
+        private boolean inStock;
+        private int quantity;
+        private String availabilityCategory;
+
+        public InventoryStatus() {
+        }
+
+        public InventoryStatus(Product product, boolean inStock, int quantity) {
+            this.product = product;
+            this.inStock = inStock;
+            this.quantity = quantity;
+        }
+
+        public Product getProduct() {
+            return product;
+        }
+
+        public void setProduct(Product product) {
+            this.product = product;
+        }
+
+        public boolean isInStock() {
+            return inStock;
+        }
+
+        public void setInStock(boolean inStock) {
+            this.inStock = inStock;
+        }
+
+        public int getQuantity() {
+            return quantity;
+        }
+
+        public void setQuantity(int quantity) {
+            this.quantity = quantity;
+        }
+
+        public String getAvailabilityCategory() {
+            return availabilityCategory;
+        }
+
+        public void setAvailabilityCategory(String category) {
+            this.availabilityCategory = category;
+        }
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = MyMemoryProviderSupplier.class)
+    public interface MyAiService {
+        @ToolBox(MyTools.class)
+        String chat(@MemoryId String memoryId, @UserMessage String userMessage);
+    }
+
+    @Singleton
+    public static class MyTools {
+        boolean getMessageExecuted = false;
+        boolean getProductExecuted = false;
+        boolean getProductDelayedExecuted = false;
+        boolean getInventoryStatusExecuted = false;
+        boolean getValidatedMessageExecuted = false;
+        boolean getValidatedProductExecuted = false;
+        boolean getFilteredMessageExecuted = false;
+        boolean getFilteredProductExecuted = false;
+        boolean getTransformedInventoryExecuted = false;
+
+        @Tool
+        public Uni<String> getMessage(String message) {
+            return Uni.createFrom().item(() -> {
+                getMessageExecuted = true;
+                return "Message: " + message + " (processed on thread: " + Thread.currentThread().getName() + " - async)";
+            });
+        }
+
+        @Tool
+        public Uni<Product> getProduct(String productId) {
+            return Uni.createFrom().item(() -> {
+                getProductExecuted = true;
+                return new Product(productId, "Laptop", 1299.99);
+            });
+        }
+
+        @Tool
+        public Uni<Product> getProductDelayed(String productId) {
+            return Uni.createFrom().item(() -> {
+                getProductDelayedExecuted = true;
+                return new Product(productId, "Tablet", 599.99);
+            }).onItem().delayIt().by(Duration.ofMillis(100));
+        }
+
+        @Tool
+        public Uni<InventoryStatus> getInventoryStatus(String productId) {
+            return Uni.createFrom().item(() -> {
+                getInventoryStatusExecuted = true;
+                Product product = new Product(productId, "Smartphone", 899.99);
+                return new InventoryStatus(product, true, 150);
+            });
+        }
+
+        @Tool
+        @ToolInputGuardrails({ MessageValidationGuardrail.class })
+        public Uni<String> getValidatedMessage(String message) {
+            return Uni.createFrom().item(() -> {
+                getValidatedMessageExecuted = true;
+                return "Validated: " + message;
+            });
+        }
+
+        @Tool
+        @ToolInputGuardrails({ ProductIdValidationGuardrail.class })
+        public Uni<Product> getValidatedProduct(String productId) {
+            return Uni.createFrom().item(() -> {
+                getValidatedProductExecuted = true;
+                return new Product(productId, "Validated Product", 299.99);
+            });
+        }
+
+        @Tool
+        @ToolOutputGuardrails({ PriceFilterGuardrail.class })
+        public Uni<String> getFilteredMessage(String message) {
+            return Uni.createFrom().item(() -> {
+                getFilteredMessageExecuted = true;
+                return message;
+            });
+        }
+
+        @Tool
+        @ToolOutputGuardrails({ PriceFilterGuardrail.class })
+        public Uni<Product> getFilteredProduct(String productId) {
+            return Uni.createFrom().item(() -> {
+                getFilteredProductExecuted = true;
+                return new Product(productId, "Expensive Item", 999.99);
+            });
+        }
+
+        @Tool
+        @ToolOutputGuardrails({ InventoryStatusTransformGuardrail.class })
+        public Uni<InventoryStatus> getTransformedInventory(String productId) {
+            return Uni.createFrom().item(() -> {
+                getTransformedInventoryExecuted = true;
+                Product product = new Product(productId, "High Stock Item", 199.99);
+                return new InventoryStatus(product, true, 500);
+            });
+        }
+
+        void reset() {
+            getMessageExecuted = false;
+            getProductExecuted = false;
+            getProductDelayedExecuted = false;
+            getInventoryStatusExecuted = false;
+            getValidatedMessageExecuted = false;
+            getValidatedProductExecuted = false;
+            getFilteredMessageExecuted = false;
+            getFilteredProductExecuted = false;
+            getTransformedInventoryExecuted = false;
+        }
+    }
+
+    @ApplicationScoped
+    public static class MessageValidationGuardrail implements ToolInputGuardrail {
+        static int executionCount = 0;
+        static String lastMessage = null;
+
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            executionCount++;
+            try {
+                ObjectMapper mapper = new ObjectMapper();
+                var args = mapper.readTree(request.arguments());
+                String message = args.get("message").asText();
+                lastMessage = message;
+
+                // Reject messages with special characters
+                if (message.matches(".*[!@#$%^&*].*")) {
+                    return ToolInputGuardrailResult.failure(
+                            "Invalid message: contains special characters");
+                }
+
+                return ToolInputGuardrailResult.success();
+            } catch (Exception e) {
+                return ToolInputGuardrailResult.failure("Failed to validate message: " + e.getMessage(), e);
+            }
+        }
+
+        static void reset() {
+            executionCount = 0;
+            lastMessage = null;
+        }
+    }
+
+    @ApplicationScoped
+    public static class ProductIdValidationGuardrail implements ToolInputGuardrail {
+        static int executionCount = 0;
+
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            executionCount++;
+            try {
+                ObjectMapper mapper = new ObjectMapper();
+                var args = mapper.readTree(request.arguments());
+                String productId = args.get("productId").asText();
+
+                // Validate product ID range
+                int id = Integer.parseInt(productId);
+                if (id >= 500) {
+                    return ToolInputGuardrailResult.failure(
+                            "Product ID must be less than 500");
+                }
+
+                return ToolInputGuardrailResult.success();
+            } catch (Exception e) {
+                return ToolInputGuardrailResult.failure("Failed to validate product ID: " + e.getMessage(), e);
+            }
+        }
+
+        static void reset() {
+            executionCount = 0;
+        }
+    }
+
+    @ApplicationScoped
+    public static class PriceFilterGuardrail implements ToolOutputGuardrail {
+        static int executionCount = 0;
+
+        @Override
+        public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+            executionCount++;
+            try {
+                String resultText = request.resultText();
+
+                // Filter dollar amounts from text
+                String filtered = resultText.replaceAll("\\$[0-9]+\\.[0-9]{2}", "[PRICE REDACTED]");
+
+                // Filter price field from JSON
+                filtered = filtered.replaceAll("\"price\"\\s*:\\s*[0-9]+\\.[0-9]+", "\"price\":\"REDACTED\"");
+
+                if (!filtered.equals(resultText)) {
+                    return ToolOutputGuardrailResult.successWith(
+                            ToolExecutionResult.builder()
+                                    .resultText(filtered)
+                                    .build());
+                }
+
+                return ToolOutputGuardrailResult.success();
+            } catch (Exception e) {
+                return ToolOutputGuardrailResult.failure("Failed to filter prices: " + e.getMessage(), e);
+            }
+        }
+
+        static void reset() {
+            executionCount = 0;
+        }
+    }
+
+    @ApplicationScoped
+    public static class InventoryStatusTransformGuardrail implements ToolOutputGuardrail {
+        static int executionCount = 0;
+
+        @Override
+        public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+            executionCount++;
+            try {
+                String resultText = request.resultText();
+                ObjectMapper mapper = new ObjectMapper();
+                InventoryStatus status = mapper.readValue(resultText, InventoryStatus.class);
+
+                // Transform quantity to availability category
+                String category;
+                if (status.getQuantity() > 100) {
+                    category = "HIGH_STOCK";
+                } else if (status.getQuantity() > 10) {
+                    category = "MEDIUM_STOCK";
+                } else {
+                    category = "LOW_STOCK";
+                }
+
+                status.setAvailabilityCategory(category);
+
+                String modifiedJson = mapper.writeValueAsString(status);
+
+                return ToolOutputGuardrailResult.successWith(
+                        ToolExecutionResult.builder()
+                                .resultText(modifiedJson)
+                                .build());
+            } catch (Exception e) {
+                return ToolOutputGuardrailResult.failure(
+                        "Failed to transform inventory status: " + e.getMessage(), e);
+            }
+        }
+
+        static void reset() {
+            executionCount = 0;
+        }
+    }
+
+    public static class MyChatModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new MyChatModel();
+        }
+    }
+
+    public static class MyChatModel implements ChatModel {
+        @Override
+        public ChatResponse chat(List<ChatMessage> messages) {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            List<ChatMessage> messages = chatRequest.messages();
+            if (messages.size() == 1) {
+                String text = ((dev.langchain4j.data.message.UserMessage) messages.get(0)).singleText();
+                String[] segments = text.split(" - ");
+                String toolName = segments[0];
+                String input = segments.length > 1 ? segments[1] : "";
+
+                return ChatResponse.builder()
+                        .aiMessage(new AiMessage("executing tool", List.of(ToolExecutionRequest.builder()
+                                .id("tool-id-1")
+                                .name(toolName)
+                                .arguments("{\"message\":\"" + input + "\",\"productId\":\"" + input + "\"}")
+                                .build())))
+                        .tokenUsage(new TokenUsage(0, 0))
+                        .finishReason(FinishReason.TOOL_EXECUTION)
+                        .build();
+            } else if (messages.size() == 3) {
+                ToolExecutionResultMessage last = (ToolExecutionResultMessage) Lists.last(messages);
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.from("response: " + last.text()))
+                        .build();
+            }
+            return ChatResponse.builder()
+                    .aiMessage(new AiMessage("Unexpected"))
+                    .build();
+        }
+    }
+
+    public static class MyMemoryProviderSupplier implements Supplier<ChatMemoryProvider> {
+        @Override
+        public ChatMemoryProvider get() {
+            return memoryId -> new NoopChatMemory();
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/ToolGuardrailsTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/ToolGuardrailsTest.java
@@ -1,0 +1,131 @@
+package io.quarkiverse.langchain4j.test.guardrails;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.Tool;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailResult;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrails;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrailRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrailResult;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrails;
+import io.quarkiverse.langchain4j.runtime.ToolsRecorder;
+import io.quarkiverse.langchain4j.runtime.tool.ToolMethodCreateInfo;
+import io.quarkus.test.QuarkusUnitTest;
+
+class ToolGuardrailsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(
+                            TestTools.class,
+                            ValidationInputGuardrail.class,
+                            TransformInputGuardrail.class,
+                            FilterOutputGuardrail.class));
+
+    @Test
+    void testInputGuardrails_metadata() {
+        // Verify that input guardrails are properly registered in metadata
+        List<ToolMethodCreateInfo> methodCreateInfos = ToolsRecorder.getMetadata().get(TestTools.class.getName());
+        assertThat(methodCreateInfos).isNotNull();
+
+        // Find validatedTool and verify it has input guardrails
+        ToolMethodCreateInfo validatedToolInfo = methodCreateInfos.stream()
+                .filter(info -> "validatedTool".equals(info.toolSpecification().name()))
+                .findFirst()
+                .orElse(null);
+        assertThat(validatedToolInfo).isNotNull();
+        assertThat(validatedToolInfo.getInputGuardrails()).isNotNull();
+        assertThat(validatedToolInfo.getInputGuardrails().hasGuardrails()).isTrue();
+        assertThat(validatedToolInfo.getInputGuardrails().getClassNames())
+                .contains("io.quarkiverse.langchain4j.test.guardrails.ToolGuardrailsTest$ValidationInputGuardrail");
+    }
+
+    @Test
+    void testOutputGuardrails_metadata() {
+        // Verify that output guardrails are properly registered in metadata
+        List<ToolMethodCreateInfo> methodCreateInfos = ToolsRecorder.getMetadata().get(TestTools.class.getName());
+        assertThat(methodCreateInfos).isNotNull();
+
+        // Find filteredTool and verify it has output guardrails
+        ToolMethodCreateInfo filteredToolInfo = methodCreateInfos.stream()
+                .filter(info -> "filteredTool".equals(info.toolSpecification().name()))
+                .findFirst()
+                .orElse(null);
+        assertThat(filteredToolInfo).isNotNull();
+        assertThat(filteredToolInfo.getOutputGuardrails()).isNotNull();
+        assertThat(filteredToolInfo.getOutputGuardrails().hasGuardrails()).isTrue();
+        assertThat(filteredToolInfo.getOutputGuardrails().getClassNames())
+                .contains("io.quarkiverse.langchain4j.test.guardrails.ToolGuardrailsTest$FilterOutputGuardrail");
+    }
+
+    @Test
+    void testMultipleGuardrails_metadata() {
+        // Verify that multiple guardrails can be registered
+        List<ToolMethodCreateInfo> methodCreateInfos = ToolsRecorder.getMetadata().get(TestTools.class.getName());
+        assertThat(methodCreateInfos).isNotNull();
+
+        // Verify we have all expected tools
+        assertThat(methodCreateInfos).hasSize(3);
+        assertThat(methodCreateInfos).extracting(info -> info.toolSpecification().name())
+                .containsExactlyInAnyOrder("validatedTool", "transformedTool", "filteredTool");
+    }
+
+    // Test Tools
+    private static class TestTools {
+
+        @Tool
+        @ToolInputGuardrails({ ValidationInputGuardrail.class })
+        String validatedTool(String input) {
+            return "Processed: " + input;
+        }
+
+        @Tool
+        @ToolInputGuardrails({ TransformInputGuardrail.class })
+        String transformedTool(String input) {
+            return "Processed: " + input;
+        }
+
+        @Tool
+        @ToolOutputGuardrails({ FilterOutputGuardrail.class })
+        String filteredTool(String input) {
+            return "Processed: " + input;
+        }
+    }
+
+    @ApplicationScoped
+    public static class ValidationInputGuardrail implements ToolInputGuardrail {
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            return ToolInputGuardrailResult.success();
+        }
+    }
+
+    @ApplicationScoped
+    public static class TransformInputGuardrail implements ToolInputGuardrail {
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            return ToolInputGuardrailResult.success();
+        }
+    }
+
+    @ApplicationScoped
+    public static class FilterOutputGuardrail implements ToolOutputGuardrail {
+        @Override
+        public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+            return ToolOutputGuardrailResult.success();
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/ToolInputGuardrailsExecutionTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/ToolInputGuardrailsExecutionTest.java
@@ -1,0 +1,436 @@
+package io.quarkiverse.langchain4j.test.guardrails;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.ToolBox;
+import io.quarkiverse.langchain4j.guardrails.ToolGuardrailException;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailResult;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrails;
+import io.quarkiverse.langchain4j.runtime.aiservice.NoopChatMemory;
+import io.quarkiverse.langchain4j.test.Lists;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Test for tool input guardrails with AI Service execution.
+ */
+public class ToolInputGuardrailsExecutionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(
+                            MyAiService.class,
+                            ValidationGuardrail.class,
+                            TransformGuardrail.class,
+                            FailureGuardrail.class,
+                            FatalFailureGuardrail.class,
+                            FirstGuardrail.class,
+                            SecondGuardrail.class,
+                            Lists.class));
+
+    @Inject
+    MyAiService aiService;
+
+    @Inject
+    MyTools tools;
+
+    @BeforeEach
+    void setUp() {
+        // Reset all state
+        ValidationGuardrail.reset();
+        TransformGuardrail.reset();
+        FailureGuardrail.reset();
+        FatalFailureGuardrail.reset();
+        FirstGuardrail.reset();
+        SecondGuardrail.reset();
+        tools.reset();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testInputGuardrail_success() {
+        String result = aiService.chat("test", "validatedTool - hello");
+
+        // Guardrail should have been executed
+        assertThat(ValidationGuardrail.executionCount).isEqualTo(1);
+        assertThat(ValidationGuardrail.lastRequest).isNotNull();
+        assertThat(ValidationGuardrail.lastRequest.toolName()).isEqualTo("validatedTool");
+
+        // Tool should have been executed
+        assertThat(tools.validatedToolExecuted).isTrue();
+        assertThat(tools.lastInput).isEqualTo("hello");
+
+        // Result should contain tool output
+        assertThat(result).contains("Validated: hello");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testInputGuardrail_modifiesRequest() {
+        String result = aiService.chat("test", "transformedTool - hello");
+
+        // Guardrail should have been executed
+        assertThat(TransformGuardrail.executionCount).isEqualTo(1);
+
+        // Tool should have been executed with transformed input (uppercase)
+        assertThat(tools.transformedToolExecuted).isTrue();
+        assertThat(tools.lastInput).isEqualTo("HELLO"); // Transformed by guardrail
+
+        // Result should contain transformed tool output
+        assertThat(result).contains("Transformed: HELLO");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testInputGuardrail_failure() {
+        // Guardrail will fail because input contains "invalid"
+        // Non-fatal failure returns error result to LLM, not exception
+        String result = aiService.chat("test", "failingTool - invalid");
+
+        // Guardrail should have been executed
+        assertThat(FailureGuardrail.executionCount).isEqualTo(1);
+
+        // Tool should NOT have been executed
+        assertThat(tools.failingToolExecuted).isFalse();
+
+        // Result should contain the error message
+        assertThat(result).contains("Input validation failed");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testInputGuardrail_fatalFailure() {
+        // Guardrail will fail fatally
+        assertThatThrownBy(() -> aiService.chat("test", "fatalTool - anything"))
+                .isInstanceOf(ToolGuardrailException.class)
+                .hasMessageContaining("Fatal validation error")
+                .hasCauseInstanceOf(SecurityException.class);
+
+        // Guardrail should have been executed
+        assertThat(FatalFailureGuardrail.executionCount).isEqualTo(1);
+
+        // Tool should NOT have been executed
+        assertThat(tools.fatalToolExecuted).isFalse();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testInputGuardrails_chainExecution() {
+        String result = aiService.chat("test", "chainedTool - hello");
+
+        // Both guardrails should have been executed in order
+        assertThat(FirstGuardrail.executionCount).isEqualTo(1);
+        assertThat(SecondGuardrail.executionCount).isEqualTo(1);
+
+        // Second guardrail should execute after first
+        assertThat(SecondGuardrail.executionOrder).isGreaterThan(FirstGuardrail.executionOrder);
+
+        // Tool should have been executed
+        assertThat(tools.chainedToolExecuted).isTrue();
+
+        // Result should contain tool output
+        assertThat(result).contains("Chained: hello");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testInputGuardrails_chainStopsOnFailure() {
+        // First guardrail will fail (non-fatal)
+        // Non-fatal failure returns error result to LLM, not exception
+        String result = aiService.chat("test", "chainedTool - fail-first");
+
+        // First guardrail should have been executed
+        assertThat(FirstGuardrail.executionCount).isEqualTo(1);
+
+        // Second guardrail should NOT have been executed (fail-fast)
+        assertThat(SecondGuardrail.executionCount).isEqualTo(0);
+
+        // Tool should NOT have been executed
+        assertThat(tools.chainedToolExecuted).isFalse();
+
+        // Result should contain the error message
+        assertThat(result).contains("First guardrail failed");
+    }
+
+    // AI Service
+    @RegisterAiService(chatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = MyMemoryProviderSupplier.class)
+    public interface MyAiService {
+        @ToolBox(MyTools.class)
+        String chat(@MemoryId String memoryId, @UserMessage String userMessage);
+    }
+
+    // Tools
+    @Singleton
+    public static class MyTools {
+        boolean validatedToolExecuted = false;
+        boolean transformedToolExecuted = false;
+        boolean failingToolExecuted = false;
+        boolean fatalToolExecuted = false;
+        boolean chainedToolExecuted = false;
+        String lastInput = null;
+
+        @Tool
+        @ToolInputGuardrails({ ValidationGuardrail.class })
+        public String validatedTool(String input) {
+            validatedToolExecuted = true;
+            lastInput = input;
+            return "Validated: " + input;
+        }
+
+        @Tool
+        @ToolInputGuardrails({ TransformGuardrail.class })
+        public String transformedTool(String input) {
+            transformedToolExecuted = true;
+            lastInput = input;
+            return "Transformed: " + input;
+        }
+
+        @Tool
+        @ToolInputGuardrails({ FailureGuardrail.class })
+        public String failingTool(String input) {
+            failingToolExecuted = true;
+            lastInput = input;
+            return "Should not execute";
+        }
+
+        @Tool
+        @ToolInputGuardrails({ FatalFailureGuardrail.class })
+        public String fatalTool(String input) {
+            fatalToolExecuted = true;
+            lastInput = input;
+            return "Should not execute";
+        }
+
+        @Tool
+        @ToolInputGuardrails({ FirstGuardrail.class, SecondGuardrail.class })
+        public String chainedTool(String input) {
+            chainedToolExecuted = true;
+            lastInput = input;
+            return "Chained: " + input;
+        }
+
+        void reset() {
+            validatedToolExecuted = false;
+            transformedToolExecuted = false;
+            failingToolExecuted = false;
+            fatalToolExecuted = false;
+            chainedToolExecuted = false;
+            lastInput = null;
+        }
+    }
+
+    // Guardrails
+
+    @ApplicationScoped
+    public static class ValidationGuardrail implements ToolInputGuardrail {
+        static int executionCount = 0;
+        static ToolInputGuardrailRequest lastRequest = null;
+
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            executionCount++;
+            lastRequest = request;
+            return ToolInputGuardrailResult.success();
+        }
+
+        static void reset() {
+            executionCount = 0;
+            lastRequest = null;
+        }
+    }
+
+    @ApplicationScoped
+    public static class TransformGuardrail implements ToolInputGuardrail {
+        static int executionCount = 0;
+
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            executionCount++;
+
+            // Transform input to uppercase in JSON
+            String args = request.arguments();
+            String transformedArgs = args.replace("hello", "HELLO");
+
+            ToolExecutionRequest modifiedRequest = ToolExecutionRequest.builder()
+                    .id(request.executionRequest().id())
+                    .name(request.executionRequest().name())
+                    .arguments(transformedArgs)
+                    .build();
+
+            return ToolInputGuardrailResult.successWith(modifiedRequest);
+        }
+
+        static void reset() {
+            executionCount = 0;
+        }
+    }
+
+    @ApplicationScoped
+    public static class FailureGuardrail implements ToolInputGuardrail {
+        static int executionCount = 0;
+
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            executionCount++;
+
+            if (request.arguments().contains("invalid")) {
+                return ToolInputGuardrailResult.failure("Input validation failed: contains 'invalid'");
+            }
+
+            return ToolInputGuardrailResult.success();
+        }
+
+        static void reset() {
+            executionCount = 0;
+        }
+    }
+
+    @ApplicationScoped
+    public static class FatalFailureGuardrail implements ToolInputGuardrail {
+        static int executionCount = 0;
+
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            executionCount++;
+            return ToolInputGuardrailResult.failure(
+                    "Fatal validation error",
+                    new SecurityException("Unauthorized access"));
+        }
+
+        static void reset() {
+            executionCount = 0;
+        }
+    }
+
+    @ApplicationScoped
+    public static class FirstGuardrail implements ToolInputGuardrail {
+        static int executionCount = 0;
+        static long executionOrder = 0;
+
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            executionCount++;
+            executionOrder = System.nanoTime();
+
+            if (request.arguments().contains("fail-first")) {
+                return ToolInputGuardrailResult.failure("First guardrail failed");
+            }
+
+            return ToolInputGuardrailResult.success();
+        }
+
+        static void reset() {
+            executionCount = 0;
+            executionOrder = 0;
+        }
+    }
+
+    @ApplicationScoped
+    public static class SecondGuardrail implements ToolInputGuardrail {
+        static int executionCount = 0;
+        static long executionOrder = 0;
+
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            executionCount++;
+            executionOrder = System.nanoTime();
+            return ToolInputGuardrailResult.success();
+        }
+
+        static void reset() {
+            executionCount = 0;
+            executionOrder = 0;
+        }
+    }
+
+    // Mock Chat Model
+    public static class MyChatModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new MyChatModel();
+        }
+    }
+
+    public static class MyChatModel implements ChatModel {
+        @Override
+        public ChatResponse chat(List<ChatMessage> messages) {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            List<ChatMessage> messages = chatRequest.messages();
+            if (messages.size() == 1) {
+                // Only the user message, extract tool name and arguments
+                String text = ((dev.langchain4j.data.message.UserMessage) messages.get(0)).singleText();
+                String[] segments = text.split(" - ");
+                String toolName = segments[0];
+                String input = segments[1];
+
+                // Return tool execution request
+                return ChatResponse.builder()
+                        .aiMessage(new AiMessage("executing tool", List.of(ToolExecutionRequest.builder()
+                                .id("tool-id-1")
+                                .name(toolName)
+                                .arguments("{\"input\":\"" + input + "\"}")
+                                .build())))
+                        .tokenUsage(new TokenUsage(0, 0))
+                        .finishReason(FinishReason.TOOL_EXECUTION)
+                        .build();
+            } else if (messages.size() == 3) {
+                // user -> tool request -> tool response
+                ToolExecutionResultMessage last = (ToolExecutionResultMessage) Lists.last(messages);
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.from("response: " + last.text()))
+                        .build();
+            }
+            return ChatResponse.builder()
+                    .aiMessage(new AiMessage("Unexpected"))
+                    .build();
+        }
+    }
+
+    public static class MyMemoryProviderSupplier implements Supplier<ChatMemoryProvider> {
+        @Override
+        public ChatMemoryProvider get() {
+            return new ChatMemoryProvider() {
+                @Override
+                public ChatMemory get(Object memoryId) {
+                    return new NoopChatMemory();
+                }
+            };
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/ToolInputGuardrailsTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/ToolInputGuardrailsTest.java
@@ -1,0 +1,372 @@
+package io.quarkiverse.langchain4j.test.guardrails;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailResult;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrails;
+import io.quarkiverse.langchain4j.runtime.ToolsRecorder;
+import io.quarkiverse.langchain4j.runtime.tool.ToolMethodCreateInfo;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Integration tests for tool input guardrails.
+ * Tests that guardrails are properly registered as CDI beans and can be invoked.
+ * Full end-to-end execution with AI Services is tested in separate integration tests.
+ */
+class ToolInputGuardrailsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(
+                            MyTools.class,
+                            ValidationGuardrail.class,
+                            TransformGuardrail.class,
+                            FailureGuardrail.class,
+                            FatalFailureGuardrail.class,
+                            FirstGuardrail.class,
+                            SecondGuardrail.class));
+
+    @Inject
+    ValidationGuardrail validationGuardrail;
+
+    @Inject
+    TransformGuardrail transformGuardrail;
+
+    @Inject
+    FailureGuardrail failureGuardrail;
+
+    @Inject
+    FatalFailureGuardrail fatalFailureGuardrail;
+
+    @Inject
+    FirstGuardrail firstGuardrail;
+
+    @Inject
+    SecondGuardrail secondGuardrail;
+
+    @BeforeEach
+    void setUp() {
+        // Reset all guardrail execution counters
+        ValidationGuardrail.reset();
+        TransformGuardrail.reset();
+        FailureGuardrail.reset();
+        FatalFailureGuardrail.reset();
+        FirstGuardrail.reset();
+        SecondGuardrail.reset();
+    }
+
+    @Test
+    void testGuardrails_registeredInMetadata() {
+        // Verify that guardrails are properly registered in tool metadata
+        List<ToolMethodCreateInfo> methodCreateInfos = ToolsRecorder.getMetadata().get(MyTools.class.getName());
+        assertThat(methodCreateInfos).isNotNull().hasSize(5);
+
+        // Find validatedTool and verify it has input guardrails
+        ToolMethodCreateInfo validatedToolInfo = methodCreateInfos.stream()
+                .filter(info -> "validatedTool".equals(info.toolSpecification().name()))
+                .findFirst()
+                .orElse(null);
+        assertThat(validatedToolInfo).isNotNull();
+        assertThat(validatedToolInfo.getInputGuardrails()).isNotNull();
+        assertThat(validatedToolInfo.getInputGuardrails().hasGuardrails()).isTrue();
+        assertThat(validatedToolInfo.getInputGuardrails().getClassNames())
+                .contains("io.quarkiverse.langchain4j.test.guardrails.ToolInputGuardrailsTest$ValidationGuardrail");
+
+        // Find chainedTool and verify it has multiple guardrails
+        ToolMethodCreateInfo chainedToolInfo = methodCreateInfos.stream()
+                .filter(info -> "chainedTool".equals(info.toolSpecification().name()))
+                .findFirst()
+                .orElse(null);
+        assertThat(chainedToolInfo).isNotNull();
+        assertThat(chainedToolInfo.getInputGuardrails()).isNotNull();
+        assertThat(chainedToolInfo.getInputGuardrails().getClassNames()).hasSize(2);
+    }
+
+    @Test
+    void testInputGuardrail_success() {
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                .id("test-id")
+                .name("validatedTool")
+                .arguments("{\"input\": \"hello\"}")
+                .build();
+
+        ToolInputGuardrailRequest guardrailRequest = new ToolInputGuardrailRequest(request, null, null);
+        ToolInputGuardrailResult result = validationGuardrail.validate(guardrailRequest);
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.modifiedRequest()).isNull();
+        assertThat(result.errorMessage()).isNull();
+        assertThat(ValidationGuardrail.executionCount).isEqualTo(1);
+        assertThat(ValidationGuardrail.lastRequest).isNotNull();
+        assertThat(ValidationGuardrail.lastRequest.toolName()).isEqualTo("validatedTool");
+    }
+
+    @Test
+    void testInputGuardrail_modifiesRequest() {
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                .id("test-id")
+                .name("transformedTool")
+                .arguments("{\"input\": \"hello\"}")
+                .build();
+
+        ToolInputGuardrailRequest guardrailRequest = new ToolInputGuardrailRequest(request, null, null);
+        ToolInputGuardrailResult result = transformGuardrail.validate(guardrailRequest);
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.modifiedRequest()).isNotNull();
+        assertThat(result.modifiedRequest().arguments()).contains("HELLO");
+        assertThat(TransformGuardrail.executionCount).isEqualTo(1);
+    }
+
+    @Test
+    void testInputGuardrail_failure() {
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                .id("test-id")
+                .name("failingTool")
+                .arguments("{\"input\": \"invalid\"}")
+                .build();
+
+        ToolInputGuardrailRequest guardrailRequest = new ToolInputGuardrailRequest(request, null, null);
+        ToolInputGuardrailResult result = failureGuardrail.validate(guardrailRequest);
+
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.errorMessage()).contains("Input validation failed");
+        assertThat(FailureGuardrail.executionCount).isEqualTo(1);
+    }
+
+    @Test
+    void testInputGuardrail_fatalFailure() {
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                .id("test-id")
+                .name("fatalTool")
+                .arguments("{\"input\": \"anything\"}")
+                .build();
+
+        ToolInputGuardrailRequest guardrailRequest = new ToolInputGuardrailRequest(request, null, null);
+        ToolInputGuardrailResult result = fatalFailureGuardrail.validate(guardrailRequest);
+
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.errorMessage()).contains("Fatal validation error");
+        assertThat(result.cause()).isInstanceOf(SecurityException.class);
+        assertThat(FatalFailureGuardrail.executionCount).isEqualTo(1);
+    }
+
+    @Test
+    void testInputGuardrails_canBeChained() {
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                .id("test-id")
+                .name("chainedTool")
+                .arguments("{\"input\": \"test\"}")
+                .build();
+
+        // Simulate chaining - execute first guardrail
+        ToolInputGuardrailRequest firstRequest = new ToolInputGuardrailRequest(request, null, null);
+        ToolInputGuardrailResult firstResult = firstGuardrail.validate(firstRequest);
+
+        assertThat(firstResult.isSuccess()).isTrue();
+        assertThat(FirstGuardrail.executionCount).isEqualTo(1);
+
+        // Execute second guardrail
+        ToolInputGuardrailRequest secondRequest = new ToolInputGuardrailRequest(request, null, null);
+        ToolInputGuardrailResult secondResult = secondGuardrail.validate(secondRequest);
+
+        assertThat(secondResult.isSuccess()).isTrue();
+        assertThat(SecondGuardrail.executionCount).isEqualTo(1);
+
+        // Verify execution order
+        assertThat(SecondGuardrail.executionOrder).isGreaterThan(FirstGuardrail.executionOrder);
+    }
+
+    @Test
+    void testInputGuardrail_chainStopsOnFailure() {
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                .id("test-id")
+                .name("chainedTool")
+                .arguments("{\"input\": \"fail-first\"}")
+                .build();
+
+        // Simulate chaining - execute first guardrail (should fail)
+        ToolInputGuardrailRequest firstRequest = new ToolInputGuardrailRequest(request, null, null);
+        ToolInputGuardrailResult firstResult = firstGuardrail.validate(firstRequest);
+
+        assertThat(firstResult.isSuccess()).isFalse();
+        assertThat(firstResult.errorMessage()).contains("First guardrail failed");
+        assertThat(FirstGuardrail.executionCount).isEqualTo(1);
+
+        // Second guardrail should NOT be executed in real scenario
+        assertThat(SecondGuardrail.executionCount).isEqualTo(0);
+    }
+
+    // Tools
+    private static class MyTools {
+        @Tool
+        @ToolInputGuardrails({ ValidationGuardrail.class })
+        String validatedTool(String input) {
+            return "Validated: " + input;
+        }
+
+        @Tool
+        @ToolInputGuardrails({ TransformGuardrail.class })
+        String transformedTool(String input) {
+            return "Transformed: " + input;
+        }
+
+        @Tool
+        @ToolInputGuardrails({ FailureGuardrail.class })
+        String failingTool(String input) {
+            return "Should not execute";
+        }
+
+        @Tool
+        @ToolInputGuardrails({ FatalFailureGuardrail.class })
+        String fatalTool(String input) {
+            return "Should not execute";
+        }
+
+        @Tool
+        @ToolInputGuardrails({ FirstGuardrail.class, SecondGuardrail.class })
+        String chainedTool(String input) {
+            return "Chained: " + input;
+        }
+    }
+
+    // Guardrails
+
+    @ApplicationScoped
+    public static class ValidationGuardrail implements ToolInputGuardrail {
+        static int executionCount = 0;
+        static ToolInputGuardrailRequest lastRequest = null;
+
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            executionCount++;
+            lastRequest = request;
+            return ToolInputGuardrailResult.success();
+        }
+
+        static void reset() {
+            executionCount = 0;
+            lastRequest = null;
+        }
+    }
+
+    @ApplicationScoped
+    public static class TransformGuardrail implements ToolInputGuardrail {
+        static int executionCount = 0;
+
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            executionCount++;
+
+            // Transform input to uppercase in JSON
+            String args = request.arguments();
+            String transformedArgs = args.replace("hello", "HELLO");
+
+            ToolExecutionRequest modifiedRequest = ToolExecutionRequest.builder()
+                    .id(request.executionRequest().id())
+                    .name(request.executionRequest().name())
+                    .arguments(transformedArgs)
+                    .build();
+
+            return ToolInputGuardrailResult.successWith(modifiedRequest);
+        }
+
+        static void reset() {
+            executionCount = 0;
+        }
+    }
+
+    @ApplicationScoped
+    public static class FailureGuardrail implements ToolInputGuardrail {
+        static int executionCount = 0;
+
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            executionCount++;
+
+            if (request.arguments().contains("invalid")) {
+                return ToolInputGuardrailResult.failure("Input validation failed: contains 'invalid'");
+            }
+
+            return ToolInputGuardrailResult.success();
+        }
+
+        static void reset() {
+            executionCount = 0;
+        }
+    }
+
+    @ApplicationScoped
+    public static class FatalFailureGuardrail implements ToolInputGuardrail {
+        static int executionCount = 0;
+
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            executionCount++;
+            return ToolInputGuardrailResult.failure(
+                    "Fatal validation error",
+                    new SecurityException("Unauthorized access"));
+        }
+
+        static void reset() {
+            executionCount = 0;
+        }
+    }
+
+    @ApplicationScoped
+    public static class FirstGuardrail implements ToolInputGuardrail {
+        static int executionCount = 0;
+        static long executionOrder = 0;
+
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            executionCount++;
+            executionOrder = System.nanoTime();
+
+            if (request.arguments().contains("fail-first")) {
+                return ToolInputGuardrailResult.failure("First guardrail failed");
+            }
+
+            return ToolInputGuardrailResult.success();
+        }
+
+        static void reset() {
+            executionCount = 0;
+            executionOrder = 0;
+        }
+    }
+
+    @ApplicationScoped
+    public static class SecondGuardrail implements ToolInputGuardrail {
+        static int executionCount = 0;
+        static long executionOrder = 0;
+
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            executionCount++;
+            executionOrder = System.nanoTime();
+            return ToolInputGuardrailResult.success();
+        }
+
+        static void reset() {
+            executionCount = 0;
+            executionOrder = 0;
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/ToolOutputGuardrailAccessArgumentsTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/ToolOutputGuardrailAccessArgumentsTest.java
@@ -1,0 +1,352 @@
+package io.quarkiverse.langchain4j.test.guardrails;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.ToolBox;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrailRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrailResult;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrails;
+import io.quarkiverse.langchain4j.runtime.aiservice.NoopChatMemory;
+import io.quarkiverse.langchain4j.test.Lists;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Tests that output guardrails can access the original function parameters
+ * both as raw JSON string and as parsed JsonObject.
+ */
+public class ToolOutputGuardrailAccessArgumentsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(
+                            MyAiService.class,
+                            ArgumentAccessingGuardrail.class,
+                            InputOutputValidatingGuardrail.class,
+                            Lists.class));
+
+    @Inject
+    MyAiService aiService;
+
+    @Inject
+    MyTools tools;
+
+    @BeforeEach
+    void setUp() {
+        ArgumentAccessingGuardrail.reset();
+        InputOutputValidatingGuardrail.reset();
+        tools.reset();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void outputGuardrail_canAccessArgumentsAsRawString() {
+        String ignored = aiService.chat("test", "processData - 100 - 50");
+
+        // Verify guardrail was executed
+        assertThat(ArgumentAccessingGuardrail.executed).isTrue();
+
+        // Verify guardrail could access raw arguments string
+        assertThat(ArgumentAccessingGuardrail.rawArguments)
+                .isNotNull()
+                .contains("\"maxValue\":100")
+                .contains("\"minValue\":50");
+
+        // Verify tool executed
+        assertThat(tools.processDataExecuted).isTrue();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void outputGuardrail_canAccessArgumentsAsJsonObject() {
+        String ignored = aiService.chat("test", "processData - 200 - 25");
+
+        // Verify guardrail was executed
+        assertThat(ArgumentAccessingGuardrail.executed).isTrue();
+
+        // Verify guardrail could parse and access arguments as JsonObject
+        assertThat(ArgumentAccessingGuardrail.parsedArguments).isNotNull();
+        assertThat(ArgumentAccessingGuardrail.maxValueFromArgs).isEqualTo(200);
+        assertThat(ArgumentAccessingGuardrail.minValueFromArgs).isEqualTo(25);
+
+        // Verify tool executed
+        assertThat(tools.processDataExecuted).isTrue();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void outputGuardrail_canValidateOutputAgainstInputParameters() {
+        // This should succeed - output value 75 is between min=50 and max=100
+        String result = aiService.chat("test", "calculateValue - 100 - 50");
+
+        assertThat(InputOutputValidatingGuardrail.executed).isTrue();
+        assertThat(InputOutputValidatingGuardrail.validationPassed).isTrue();
+        assertThat(result).contains("Value: 75");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void outputGuardrail_failsWhenOutputViolatesInputConstraints() {
+        // This should fail - output value 150 exceeds max=100
+        String result = aiService.chat("test", "calculateValue - 100 - 10");
+
+        assertThat(InputOutputValidatingGuardrail.executed).isTrue();
+        assertThat(InputOutputValidatingGuardrail.validationPassed).isFalse();
+
+        // Result should contain error from guardrail
+        assertThat(result).contains("Output validation failed");
+        assertThat(result).contains("exceeds maximum allowed value");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void outputGuardrail_canAccessComplexNestedArguments() {
+        String ignored = aiService.chat("test", "complexTool - config1 - true");
+
+        assertThat(ArgumentAccessingGuardrail.executed).isTrue();
+        assertThat(ArgumentAccessingGuardrail.parsedArguments).isNotNull();
+
+        // Verify guardrail could access complex parameters
+        assertThat(ArgumentAccessingGuardrail.configNameFromArgs).isEqualTo("config1");
+        assertThat(ArgumentAccessingGuardrail.enabledFromArgs).isTrue();
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = MyMemoryProviderSupplier.class)
+    public interface MyAiService {
+        @ToolBox(MyTools.class)
+        String chat(@MemoryId String memoryId, @UserMessage String userMessage);
+    }
+
+    @Singleton
+    public static class MyTools {
+        boolean processDataExecuted = false;
+        boolean calculateValueExecuted = false;
+        boolean complexToolExecuted = false;
+
+        @Tool("Process data with min and max values")
+        @ToolOutputGuardrails({ ArgumentAccessingGuardrail.class })
+        public String processData(int maxValue, int minValue) {
+            processDataExecuted = true;
+            return "Processed: max=" + maxValue + ", min=" + minValue;
+        }
+
+        @Tool("Calculate a value within range")
+        @ToolOutputGuardrails({ InputOutputValidatingGuardrail.class })
+        public String calculateValue(int maxValue, int minValue) {
+            calculateValueExecuted = true;
+            // Simulate calculation that might exceed max
+            // When max=100 and min=50, return 75 (valid)
+            // When max=100 and min=10, return 150 (exceeds max - invalid)
+            int calculatedValue = (maxValue == 100 && minValue == 10) ? 150 : 75;
+            return "Value: " + calculatedValue;
+        }
+
+        @Tool("Complex tool with nested parameters")
+        @ToolOutputGuardrails({ ArgumentAccessingGuardrail.class })
+        public String complexTool(String configName, boolean enabled) {
+            complexToolExecuted = true;
+            return "Config: " + configName + ", enabled=" + enabled;
+        }
+
+        void reset() {
+            processDataExecuted = false;
+            calculateValueExecuted = false;
+            complexToolExecuted = false;
+        }
+    }
+
+    @ApplicationScoped
+    public static class ArgumentAccessingGuardrail implements ToolOutputGuardrail {
+        static boolean executed = false;
+        static String rawArguments = null;
+        static JsonObject parsedArguments = null;
+        static Integer maxValueFromArgs = null;
+        static Integer minValueFromArgs = null;
+        static String configNameFromArgs = null;
+        static Boolean enabledFromArgs = null;
+
+        @Override
+        public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+            executed = true;
+
+            // Test 1: Access raw arguments string
+            if (request.executionRequest() != null) {
+                rawArguments = request.executionRequest().arguments();
+            }
+
+            // Test 2: Access arguments as parsed JsonObject
+            parsedArguments = request.argumentsAsJson();
+
+            if (parsedArguments != null) {
+                // Extract different types of parameters to test parsing
+                if (parsedArguments.containsKey("maxValue")) {
+                    maxValueFromArgs = parsedArguments.getInteger("maxValue");
+                    minValueFromArgs = parsedArguments.getInteger("minValue");
+                }
+                if (parsedArguments.containsKey("configName")) {
+                    configNameFromArgs = parsedArguments.getString("configName");
+                    enabledFromArgs = parsedArguments.getBoolean("enabled");
+                }
+            }
+
+            return ToolOutputGuardrailResult.success();
+        }
+
+        static void reset() {
+            executed = false;
+            rawArguments = null;
+            parsedArguments = null;
+            maxValueFromArgs = null;
+            minValueFromArgs = null;
+            configNameFromArgs = null;
+            enabledFromArgs = null;
+        }
+    }
+
+    @ApplicationScoped
+    public static class InputOutputValidatingGuardrail implements ToolOutputGuardrail {
+        static boolean executed = false;
+        static boolean validationPassed = false;
+
+        @Override
+        public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+            executed = true;
+            validationPassed = false;
+
+            // Get input parameters
+            JsonObject args = request.argumentsAsJson();
+            if (args == null) {
+                return ToolOutputGuardrailResult.failure("Cannot access input arguments");
+            }
+
+            int maxValue = args.getInteger("maxValue");
+            int minValue = args.getInteger("minValue");
+
+            // Parse output value
+            String resultText = request.resultText();
+            // Extract number from "Value: 75" format
+            if (!resultText.contains("Value: ")) {
+                return ToolOutputGuardrailResult.failure("Invalid output format: " + resultText);
+            }
+
+            String valueStr = resultText.substring(resultText.indexOf("Value: ") + 7).trim();
+            // Remove any quotes if present
+            valueStr = valueStr.replaceAll("\"", "");
+            int outputValue = Integer.parseInt(valueStr);
+
+            // Validate output is within input constraints
+            if (outputValue < minValue) {
+                return ToolOutputGuardrailResult.failure(
+                        "Output validation failed: value " + outputValue +
+                                " is below minimum allowed value " + minValue);
+            }
+
+            if (outputValue > maxValue) {
+                return ToolOutputGuardrailResult.failure(
+                        "Output validation failed: value " + outputValue +
+                                " exceeds maximum allowed value " + maxValue);
+            }
+
+            validationPassed = true;
+            return ToolOutputGuardrailResult.success();
+        }
+
+        static void reset() {
+            executed = false;
+            validationPassed = false;
+        }
+    }
+
+    public static class MyChatModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new MyChatModel();
+        }
+    }
+
+    public static class MyChatModel implements ChatModel {
+        @Override
+        public ChatResponse chat(List<ChatMessage> messages) {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            List<ChatMessage> messages = chatRequest.messages();
+            if (messages.size() == 1) {
+                // Parse: "toolName - param1 - param2"
+                String text = ((dev.langchain4j.data.message.UserMessage) messages.get(0)).singleText();
+                String[] segments = text.split(" - ");
+                String toolName = segments[0];
+
+                String arguments;
+                if (toolName.equals("processData") || toolName.equals("calculateValue")) {
+                    int maxValue = Integer.parseInt(segments[1]);
+                    int minValue = Integer.parseInt(segments[2]);
+                    arguments = String.format("{\"maxValue\":%d,\"minValue\":%d}", maxValue, minValue);
+                } else if (toolName.equals("complexTool")) {
+                    String configName = segments[1];
+                    boolean enabled = Boolean.parseBoolean(segments[2]);
+                    arguments = String.format("{\"configName\":\"%s\",\"enabled\":%b}", configName, enabled);
+                } else {
+                    arguments = "{}";
+                }
+
+                return ChatResponse.builder()
+                        .aiMessage(new AiMessage("executing tool", List.of(ToolExecutionRequest.builder()
+                                .id("tool-id-1")
+                                .name(toolName)
+                                .arguments(arguments)
+                                .build())))
+                        .tokenUsage(new TokenUsage(0, 0))
+                        .finishReason(FinishReason.TOOL_EXECUTION)
+                        .build();
+            } else if (messages.size() == 3) {
+                ToolExecutionResultMessage last = (ToolExecutionResultMessage) Lists.last(messages);
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.from("response: " + last.text()))
+                        .build();
+            }
+            return ChatResponse.builder()
+                    .aiMessage(new AiMessage("Unexpected"))
+                    .build();
+        }
+    }
+
+    public static class MyMemoryProviderSupplier implements Supplier<ChatMemoryProvider> {
+        @Override
+        public ChatMemoryProvider get() {
+            return memoryId -> new NoopChatMemory();
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/ToolOutputGuardrailsExecutionTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/guardrails/ToolOutputGuardrailsExecutionTest.java
@@ -1,0 +1,441 @@
+package io.quarkiverse.langchain4j.test.guardrails;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.tool.ToolExecutionResult;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.ToolBox;
+import io.quarkiverse.langchain4j.guardrails.ToolGuardrailException;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrailRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrailResult;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrails;
+import io.quarkiverse.langchain4j.runtime.aiservice.NoopChatMemory;
+import io.quarkiverse.langchain4j.test.Lists;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Integration test for tool output guardrails with AI Service execution.
+ * Tests that guardrails are invoked after tool execution through AI Services.
+ */
+public class ToolOutputGuardrailsExecutionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(
+                            MyAiService.class,
+                            ValidationGuardrail.class,
+                            FilterGuardrail.class,
+                            FailureGuardrail.class,
+                            FatalFailureGuardrail.class,
+                            FirstGuardrail.class,
+                            SecondGuardrail.class,
+                            Lists.class));
+
+    @Inject
+    MyAiService aiService;
+
+    @Inject
+    MyTools tools;
+
+    @BeforeEach
+    void setUp() {
+        // Reset all state
+        ValidationGuardrail.reset();
+        FilterGuardrail.reset();
+        FailureGuardrail.reset();
+        FatalFailureGuardrail.reset();
+        FirstGuardrail.reset();
+        SecondGuardrail.reset();
+        tools.reset();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testOutputGuardrail_success() {
+        String result = aiService.chat("test", "validatedTool - hello");
+
+        // Guardrail should have been executed
+        assertThat(ValidationGuardrail.executionCount).isEqualTo(1);
+        assertThat(ValidationGuardrail.lastRequest).isNotNull();
+        assertThat(ValidationGuardrail.lastRequest.toolName()).isEqualTo("validatedTool");
+
+        // Tool should have been executed
+        assertThat(tools.validatedToolExecuted).isTrue();
+        assertThat(tools.lastInput).isEqualTo("hello");
+
+        // Result should contain tool output
+        assertThat(result).contains("Validated: hello");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testOutputGuardrail_modifiesResult() {
+        String result = aiService.chat("test", "filteredTool - secret123");
+
+        // Guardrail should have been executed
+        assertThat(FilterGuardrail.executionCount).isEqualTo(1);
+
+        // Tool should have been executed
+        assertThat(tools.filteredToolExecuted).isTrue();
+        assertThat(tools.lastInput).isEqualTo("secret123");
+
+        // Result should contain filtered output (secrets redacted)
+        assertThat(result).contains("Filtered: ***");
+        assertThat(result).doesNotContain("secret123");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testOutputGuardrail_failure() {
+        // Guardrail will fail because output contains "forbidden"
+        // Non-fatal failure returns error result to LLM, not exception
+        String result = aiService.chat("test", "failingTool - forbidden");
+
+        // Guardrail should have been executed
+        assertThat(FailureGuardrail.executionCount).isEqualTo(1);
+
+        // Tool should have been executed (output guardrails run AFTER tool execution)
+        assertThat(tools.failingToolExecuted).isTrue();
+
+        // Result should contain the error message from guardrail
+        assertThat(result).contains("Output validation failed");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testOutputGuardrail_fatalFailure() {
+        // Guardrail will fail fatally
+        assertThatThrownBy(() -> aiService.chat("test", "fatalTool - anything"))
+                .isInstanceOf(ToolGuardrailException.class)
+                .hasMessageContaining("Fatal output validation error")
+                .hasCauseInstanceOf(SecurityException.class);
+
+        // Guardrail should have been executed
+        assertThat(FatalFailureGuardrail.executionCount).isEqualTo(1);
+
+        // Tool should have been executed (output guardrails run AFTER tool execution)
+        assertThat(tools.fatalToolExecuted).isTrue();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testOutputGuardrails_chainExecution() {
+        String result = aiService.chat("test", "chainedTool - hello");
+
+        // Both guardrails should have been executed in order
+        assertThat(FirstGuardrail.executionCount).isEqualTo(1);
+        assertThat(SecondGuardrail.executionCount).isEqualTo(1);
+
+        // Second guardrail should execute after first
+        assertThat(SecondGuardrail.executionOrder).isGreaterThan(FirstGuardrail.executionOrder);
+
+        // Tool should have been executed
+        assertThat(tools.chainedToolExecuted).isTrue();
+
+        // Result should contain tool output
+        assertThat(result).contains("Chained: hello");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testOutputGuardrails_chainStopsOnFailure() {
+        // First guardrail will fail (non-fatal)
+        // Non-fatal failure returns error result to LLM, not exception
+        String result = aiService.chat("test", "chainedTool - fail-first");
+
+        // First guardrail should have been executed
+        assertThat(FirstGuardrail.executionCount).isEqualTo(1);
+
+        // Second guardrail should NOT have been executed (fail-fast)
+        assertThat(SecondGuardrail.executionCount).isEqualTo(0);
+
+        // Tool should have been executed (output guardrails run AFTER tool execution)
+        assertThat(tools.chainedToolExecuted).isTrue();
+
+        // Result should contain the error message
+        assertThat(result).contains("First output guardrail failed");
+    }
+
+    // AI Service
+    @RegisterAiService(chatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = MyMemoryProviderSupplier.class)
+    public interface MyAiService {
+        @ToolBox(MyTools.class)
+        String chat(@MemoryId String memoryId, @UserMessage String userMessage);
+    }
+
+    // Tools
+    @Singleton
+    public static class MyTools {
+        boolean validatedToolExecuted = false;
+        boolean filteredToolExecuted = false;
+        boolean failingToolExecuted = false;
+        boolean fatalToolExecuted = false;
+        boolean chainedToolExecuted = false;
+        String lastInput = null;
+
+        @Tool
+        @ToolOutputGuardrails({ ValidationGuardrail.class })
+        public String validatedTool(String input) {
+            validatedToolExecuted = true;
+            lastInput = input;
+            return "Validated: " + input;
+        }
+
+        @Tool
+        @ToolOutputGuardrails({ FilterGuardrail.class })
+        public String filteredTool(String input) {
+            filteredToolExecuted = true;
+            lastInput = input;
+            return "Filtered: " + input;
+        }
+
+        @Tool
+        @ToolOutputGuardrails({ FailureGuardrail.class })
+        public String failingTool(String input) {
+            failingToolExecuted = true;
+            lastInput = input;
+            return "Contains forbidden word";
+        }
+
+        @Tool
+        @ToolOutputGuardrails({ FatalFailureGuardrail.class })
+        public String fatalTool(String input) {
+            fatalToolExecuted = true;
+            lastInput = input;
+            return "Sensitive data leaked";
+        }
+
+        @Tool
+        @ToolOutputGuardrails({ FirstGuardrail.class, SecondGuardrail.class })
+        public String chainedTool(String input) {
+            chainedToolExecuted = true;
+            lastInput = input;
+            return "Chained: " + input;
+        }
+
+        void reset() {
+            validatedToolExecuted = false;
+            filteredToolExecuted = false;
+            failingToolExecuted = false;
+            fatalToolExecuted = false;
+            chainedToolExecuted = false;
+            lastInput = null;
+        }
+    }
+
+    // Guardrails
+
+    @ApplicationScoped
+    public static class ValidationGuardrail implements ToolOutputGuardrail {
+        static int executionCount = 0;
+        static ToolOutputGuardrailRequest lastRequest = null;
+
+        @Override
+        public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+            executionCount++;
+            lastRequest = request;
+            return ToolOutputGuardrailResult.success();
+        }
+
+        static void reset() {
+            executionCount = 0;
+            lastRequest = null;
+        }
+    }
+
+    @ApplicationScoped
+    public static class FilterGuardrail implements ToolOutputGuardrail {
+        static int executionCount = 0;
+
+        @Override
+        public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+            executionCount++;
+
+            // Filter sensitive data from output
+            String resultText = request.resultText();
+            String filteredText = resultText.replaceAll("secret\\d+", "***");
+
+            if (!filteredText.equals(resultText)) {
+                ToolExecutionResult modifiedResult = ToolExecutionResult.builder()
+                        .resultText(filteredText)
+                        .build();
+                return ToolOutputGuardrailResult.successWith(modifiedResult);
+            }
+
+            return ToolOutputGuardrailResult.success();
+        }
+
+        static void reset() {
+            executionCount = 0;
+        }
+    }
+
+    @ApplicationScoped
+    public static class FailureGuardrail implements ToolOutputGuardrail {
+        static int executionCount = 0;
+
+        @Override
+        public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+            executionCount++;
+
+            if (request.resultText().contains("forbidden")) {
+                return ToolOutputGuardrailResult.failure("Output validation failed: contains forbidden content");
+            }
+
+            return ToolOutputGuardrailResult.success();
+        }
+
+        static void reset() {
+            executionCount = 0;
+        }
+    }
+
+    @ApplicationScoped
+    public static class FatalFailureGuardrail implements ToolOutputGuardrail {
+        static int executionCount = 0;
+
+        @Override
+        public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+            executionCount++;
+            return ToolOutputGuardrailResult.failure(
+                    "Fatal output validation error",
+                    new SecurityException("Data leak detected"));
+        }
+
+        static void reset() {
+            executionCount = 0;
+        }
+    }
+
+    @ApplicationScoped
+    public static class FirstGuardrail implements ToolOutputGuardrail {
+        static int executionCount = 0;
+        static long executionOrder = 0;
+
+        @Override
+        public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+            executionCount++;
+            executionOrder = System.nanoTime();
+
+            // Check if result contains "fail-first" to trigger failure
+            if (request.resultText().contains("fail-first")) {
+                return ToolOutputGuardrailResult.failure("First output guardrail failed");
+            }
+
+            return ToolOutputGuardrailResult.success();
+        }
+
+        static void reset() {
+            executionCount = 0;
+            executionOrder = 0;
+        }
+    }
+
+    @ApplicationScoped
+    public static class SecondGuardrail implements ToolOutputGuardrail {
+        static int executionCount = 0;
+        static long executionOrder = 0;
+
+        @Override
+        public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+            executionCount++;
+            executionOrder = System.nanoTime();
+            return ToolOutputGuardrailResult.success();
+        }
+
+        static void reset() {
+            executionCount = 0;
+            executionOrder = 0;
+        }
+    }
+
+    // Mock Chat Model
+    public static class MyChatModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new MyChatModel();
+        }
+    }
+
+    public static class MyChatModel implements ChatModel {
+        @Override
+        public ChatResponse chat(List<ChatMessage> messages) {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            List<ChatMessage> messages = chatRequest.messages();
+            if (messages.size() == 1) {
+                // Only the user message, extract tool name and arguments
+                String text = ((dev.langchain4j.data.message.UserMessage) messages.get(0)).singleText();
+                String[] segments = text.split(" - ");
+                String toolName = segments[0];
+                String input = segments[1];
+
+                // Return tool execution request
+                return ChatResponse.builder()
+                        .aiMessage(new AiMessage("executing tool", List.of(ToolExecutionRequest.builder()
+                                .id("tool-id-1")
+                                .name(toolName)
+                                .arguments("{\"input\":\"" + input + "\"}")
+                                .build())))
+                        .tokenUsage(new TokenUsage(0, 0))
+                        .finishReason(FinishReason.TOOL_EXECUTION)
+                        .build();
+            } else if (messages.size() == 3) {
+                // user -> tool request -> tool response
+                ToolExecutionResultMessage last = (ToolExecutionResultMessage) Lists.last(messages);
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.from("response: " + last.text()))
+                        .build();
+            }
+            return ChatResponse.builder()
+                    .aiMessage(new AiMessage("Unexpected"))
+                    .build();
+        }
+    }
+
+    public static class MyMemoryProviderSupplier implements Supplier<ChatMemoryProvider> {
+        @Override
+        public ChatMemoryProvider get() {
+            return new ChatMemoryProvider() {
+                @Override
+                public ChatMemory get(Object memoryId) {
+                    return new NoopChatMemory();
+                }
+            };
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ClassProvidingAnnotationLiteral.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ClassProvidingAnnotationLiteral.java
@@ -41,15 +41,15 @@ public abstract sealed class ClassProvidingAnnotationLiteral<A extends Annotatio
         return getClasses();
     }
 
-    private boolean neesCacheInitialization() {
+    private boolean needsCacheInitialization() {
         return (this.guardrailClasses == null) || this.guardrailClasses.size() != this.classNames.size();
     }
 
     private void checkClassCache() {
         // Using double-checked locking pattern for cache initialization
-        if (neesCacheInitialization()) {
+        if (needsCacheInitialization()) {
             synchronized (this) {
-                if (neesCacheInitialization()) {
+                if (needsCacheInitialization()) {
                     var classLoader = Thread.currentThread().getContextClassLoader();
                     this.guardrailClasses = this.classNames.stream()
                             .map(className -> {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolGuardrail.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolGuardrail.java
@@ -1,0 +1,83 @@
+package io.quarkiverse.langchain4j.guardrails;
+
+/**
+ * Base interface for all tool guardrails that validate and control tool (function) invocations.
+ * <p>
+ *
+ * <h2>Guardrail Types</h2>
+ * <p>
+ * There are two types of guardrails, each executed at different stages of tool invocation:
+ * </p>
+ * <ul>
+ * <li><strong>{@link ToolInputGuardrail}</strong> - Executes <em>before</em> the tool, validating
+ * parameters and context. Can block execution, modify parameters, or allow execution to proceed.</li>
+ * <li><strong>{@link ToolOutputGuardrail}</strong> - Executes <em>after</em> the tool, validating
+ * or transforming results. Can filter sensitive data, validate output format, or request LLM to retry.</li>
+ * </ul>
+ *
+ * <h2>Result Types</h2>
+ * <p>
+ * Guardrails return one of several result types to control execution flow:
+ * </p>
+ * <ul>
+ * <li><strong>success()</strong> - Validation passed, continue with original request/result</li>
+ * <li><strong>successWith(...)</strong> - Validation passed with modifications to request/result</li>
+ * <li><strong>failure(message)</strong> - Non-fatal validation failure, error returned to LLM</li>
+ * <li><strong>failure(message, cause)</strong> - Fatal failure, throws exception and stops execution</li>
+ * </ul>
+ *
+ * <h2>CDI Integration</h2>
+ * <p>
+ * All guardrail implementations must be CDI beans.
+ *
+ *
+ * <h2>Execution Model</h2>
+ * <p>
+ * Multiple guardrails can be applied to a single tool and execute in <strong>order</strong>:
+ * </p>
+ *
+ * <pre>{@code
+ * @Tool("Send email")
+ * @ToolInputGuardrails({
+ *         EmailFormatValidator.class, // Executes first
+ *         UserAuthorizationGuardrail.class, // Executes second
+ *         RateLimitGuardrail.class // Executes third
+ * })
+ * public String sendEmail(String to, String subject, String body) {
+ *     // Implementation
+ * }
+ * }</pre>
+ * <p>
+ * Input guardrails use <strong>fail-fast</strong> behavior: execution stops at the first failure.
+ * </p>
+ *
+ * <h2>Event Loop Limitation</h2>
+ * <p>
+ * <strong>IMPORTANT:</strong> Guardrails have synchronous/blocking APIs and <strong>cannot execute
+ * on the Vert.x event loop</strong>. Tools with guardrails must be marked or detected as blocking.
+ * Attempting to use guardrails on the event loop will throw {@code ToolExecutionException}.
+ * </p>
+ *
+ * @param <P> the guardrail request type providing context for validation
+ * @param <R> the guardrail result type indicating validation outcome
+ * @see ToolInputGuardrail
+ * @see ToolOutputGuardrail
+ * @see ToolInputGuardrails
+ * @see ToolOutputGuardrails
+ * @see ToolGuardrailRequest
+ * @see ToolGuardrailResult
+ */
+public interface ToolGuardrail<P extends ToolGuardrailRequest, R extends ToolGuardrailResult<R>> {
+
+    /**
+     * Validates the tool invocation and returns a result indicating whether to proceed.
+     * <p>
+     * This method is called synchronously during tool execution and must not block for
+     * extended periods. For I/O-bound operations, ensure the tool is marked as blocking.
+     * </p>
+     *
+     * @param request the guardrail request containing tool context and parameters
+     * @return the validation result indicating success, failure, or modification
+     */
+    R validate(P request);
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolGuardrailException.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolGuardrailException.java
@@ -1,0 +1,46 @@
+package io.quarkiverse.langchain4j.guardrails;
+
+/**
+ * Exception thrown when tool guardrail validation fails critically.
+ * <p>
+ * This exception is thrown in the following scenarios:
+ * </p>
+ * <ul>
+ * <li>An input guardrail returns {@link ToolInputGuardrailResult#failure(String, Throwable)}
+ * indicating a fatal validation failure</li>
+ * <li>An output guardrail returns {@link ToolOutputGuardrailResult#failure(String, Throwable)}
+ * indicating a fatal validation failure</li>
+ * <li>A guardrail bean cannot be looked up via CDI</li>
+ * </ul>
+ * <p>
+ * For non-fatal validation failures, guardrails should return a failure result without
+ * a cause exception, which will result in an error message being returned to the LLM
+ * rather than throwing this exception.
+ * </p>
+ *
+ * @see ToolInputGuardrail
+ * @see ToolOutputGuardrail
+ * @see ToolInputGuardrailResult
+ * @see ToolOutputGuardrailResult
+ */
+public class ToolGuardrailException extends RuntimeException {
+
+    /**
+     * Constructs a new tool guardrail exception with the specified detail message.
+     *
+     * @param message the detail message
+     */
+    public ToolGuardrailException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new tool guardrail exception with the specified detail message and cause.
+     *
+     * @param message the detail message
+     * @param cause the cause of the exception
+     */
+    public ToolGuardrailException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolGuardrailRequest.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolGuardrailRequest.java
@@ -1,0 +1,79 @@
+package io.quarkiverse.langchain4j.guardrails;
+
+/**
+ * Base sealed interface for tool guardrail request objects containing validation context.
+ * <p>
+ * Request objects encapsulate all information needed by guardrails to perform validation,
+ * including tool metadata, invocation context, and either input parameters or output results
+ * depending on the guardrail type.
+ * </p>
+ *
+ * <h2>Request Types</h2>
+ * <p>
+ * This sealed interface permits exactly two implementations, corresponding to the two
+ * stages of tool invocation where guardrails can execute:
+ * </p>
+ * <ul>
+ * <li><strong>{@link ToolInputGuardrailRequest}</strong> - Provides access to tool input
+ * parameters before execution. Contains the tool execution request with arguments, tool
+ * metadata, and invocation context. Used by input guardrails to validate parameters,
+ * check authorization, or modify the request before the tool executes.</li>
+ * <li><strong>{@link ToolOutputGuardrailRequest}</strong> - Provides access to tool output
+ * results after execution. Contains the execution result, original request, tool metadata,
+ * and invocation context. Used by output guardrails to filter sensitive data, validate
+ * output format, or transform results before returning to the LLM.</li>
+ * </ul>
+ *
+ * <h2>Available Context</h2>
+ * <p>
+ * Both request types provide rich contextual information for validation:
+ * </p>
+ * <ul>
+ * <li><strong>Tool Information</strong>: Tool name, description, parameter schemas</li>
+ * <li><strong>Invocation Context</strong>: Memory ID, custom parameters, conversation state</li>
+ * <li><strong>Arguments</strong>: Raw JSON string and parsed {@code JsonObject} via {@code argumentsAsJson()}</li>
+ * <li><strong>Metadata</strong>: Tool specifications, declarative metadata, runtime information</li>
+ * </ul>
+ *
+ * <h2>Parameter Access</h2>
+ * <p>
+ * Request objects provide convenient methods for accessing tool parameters:
+ * </p>
+ *
+ * <pre>{@code
+ * // Raw JSON string access
+ * String rawArgs = request.executionRequest().arguments();
+ *
+ * // Parsed JsonObject for easy access
+ * JsonObject args = request.argumentsAsJson();
+ * String email = args.getString("email");
+ * int maxResults = args.getInteger("maxResults", 10);
+ *
+ * // POJO mapping for complex parameters
+ * MyParams params = args.mapTo(MyParams.class);
+ * }</pre>
+ *
+ * <h2>Immutability</h2>
+ * <p>
+ * Request objects are immutable value objects. Modifications to tool execution must be
+ * returned via result objects ({@link ToolGuardrailResult}) using {@code successWith()}.
+ * </p>
+ *
+ * <h2>Thread Safety</h2>
+ * <p>
+ * Request objects are thread-safe and can be safely accessed from multiple threads.
+ * However, guardrail execution itself is always single-threaded per tool invocation.
+ * </p>
+ *
+ * @param <P> the concrete request type (self-bounded generic for type safety)
+ * @see ToolInputGuardrailRequest
+ * @see ToolOutputGuardrailRequest
+ * @see ToolGuardrail
+ * @see ToolGuardrailResult
+ * @see ToolInvocationContext
+ * @see ToolMetadata
+ */
+public sealed interface ToolGuardrailRequest<P extends ToolGuardrailRequest<P>>
+        permits ToolInputGuardrailRequest, ToolOutputGuardrailRequest {
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolGuardrailResult.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolGuardrailResult.java
@@ -1,0 +1,133 @@
+package io.quarkiverse.langchain4j.guardrails;
+
+/**
+ * Base sealed interface for tool guardrail validation results.
+ * <p>
+ * Result objects communicate the outcome of guardrail validation and control the execution
+ * flow of tool invocations. Guardrails return result objects to indicate whether validation
+ * succeeded, failed, or requires modifications to the request or response.
+ * </p>
+ *
+ * <h2>Result Types</h2>
+ * <p>
+ * This sealed interface permits exactly two implementations, corresponding to the two
+ * guardrail types:
+ * </p>
+ * <ul>
+ * <li><strong>{@link ToolInputGuardrailResult}</strong> - Returned by input guardrails to
+ * control whether tool execution proceeds. Can allow execution with original or modified
+ * parameters, or block execution with an error message.</li>
+ * <li><strong>{@link ToolOutputGuardrailResult}</strong> - Returned by output guardrails to
+ * control what result is returned to the LLM. Can return original or modified output,
+ * return an error, or request the LLM to retry with guidance (reprompt).</li>
+ * </ul>
+ *
+ * <h2>Result Outcomes</h2>
+ * <p>
+ * Guardrails can return several types of results to control execution flow:
+ * </p>
+ * <ul>
+ * <li><strong>Success</strong> - Validation passed, continue with original request/result:
+ *
+ * <pre>{@code
+ * return ToolInputGuardrailResult.success();
+ * return ToolOutputGuardrailResult.success();
+ * }</pre>
+ *
+ * </li>
+ * <li><strong>Success with Modification</strong> - Validation passed, but request/result modified:
+ *
+ * <pre>{@code
+ * // Modify input parameters
+ * ToolExecutionRequest modified = ToolExecutionRequest.builder()
+ *         .id(request.executionRequest().id())
+ *         .name(request.executionRequest().name())
+ *         .arguments(normalizedArgs)
+ *         .build();
+ * return ToolInputGuardrailResult.successWith(modified);
+ *
+ * // Filter output data
+ * ToolExecutionResult filtered = ToolExecutionResult.builder()
+ *         .resultText(filteredOutput)
+ *         .build();
+ * return ToolOutputGuardrailResult.successWith(filtered);
+ * }</pre>
+ *
+ * </li>
+ * <li><strong>Non-Fatal Failure</strong> - Validation failed, error returned to LLM:
+ *
+ * <pre>{@code
+ * // Tool will not execute, error message returned to LLM
+ * return ToolInputGuardrailResult.failure("Invalid email format");
+ *
+ * // Original output discarded, error message returned to LLM
+ * return ToolOutputGuardrailResult.failure("Output too large");
+ * }</pre>
+ *
+ * </li>
+ * <li><strong>Fatal Failure</strong> - Critical error, throws exception:
+ *
+ * <pre>{@code
+ * // Execution stops completely, exception thrown
+ * return ToolInputGuardrailResult.failure(
+ *         "Security violation", new SecurityException("Unauthorized"));
+ * }</pre>
+ *
+ * </li>
+ * </ul>
+ *
+ * <h2>Execution Flow Control</h2>
+ * <p>
+ * Result objects control the execution flow of tool invocations:
+ * </p>
+ * <ul>
+ * <li><strong>Input Guardrails</strong>:
+ * <ul>
+ * <li>Success → Tool executes with (possibly modified) parameters</li>
+ * <li>Failure → Tool does NOT execute, error returned to LLM</li>
+ * <li>Fatal Failure → Exception thrown, execution stops</li>
+ * </ul>
+ * </li>
+ * <li><strong>Output Guardrails</strong>:
+ * <ul>
+ * <li>Success → LLM receives (possibly modified) result</li>
+ * <li>Failure → LLM receives error message instead of result</li>
+ * <li>Fatal Failure → Exception thrown, execution stops</li>
+ * </ul>
+ * </li>
+ * </ul>
+ *
+ * <h2>Chained Guardrails</h2>
+ * <p>
+ * When multiple guardrails are applied to a tool, they execute in <strong>array order</strong>
+ * with <strong>fail-fast</strong> behavior for input guardrails:
+ * </p>
+ *
+ * <pre>{@code
+ * &#64;ToolInputGuardrails({
+ *     FormatValidator.class,    // Executes first
+ *     AuthorizationCheck.class, // Executes second (only if first succeeds)
+ *     RateLimiter.class         // Executes third (only if first two succeed)
+ * })
+ * }</pre>
+ * <p>
+ * If any guardrail returns a failure result, subsequent guardrails in the chain are
+ * <strong>not executed</strong>, and the tool does not run.
+ * </p>
+ *
+ * <h2>Immutability</h2>
+ * <p>
+ * Result objects are immutable value objects created through static factory methods.
+ * Once created, their state cannot be modified.
+ * </p>
+ *
+ * @param <GR> the concrete result type (self-bounded generic for type safety)
+ * @see ToolInputGuardrailResult
+ * @see ToolOutputGuardrailResult
+ * @see ToolGuardrail
+ * @see ToolGuardrailRequest
+ */
+public sealed interface ToolGuardrailResult<GR extends ToolGuardrailResult<GR>>
+        permits ToolInputGuardrailResult, ToolOutputGuardrailResult {
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolInputGuardrail.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolInputGuardrail.java
@@ -1,0 +1,88 @@
+package io.quarkiverse.langchain4j.guardrails;
+
+/**
+ * Interface for validating tool input parameters before execution.
+ * <p>
+ * Implementations of this interface are used to validate and potentially modify
+ * tool execution requests before the actual tool method is invoked. This allows for:
+ * </p>
+ * <ul>
+ * <li>Input parameter validation (format, range, business rules)</li>
+ * <li>Authorization checks (user permissions, rate limiting)</li>
+ * <li>Input sanitization or transformation</li>
+ * <li>Security validations (injection prevention, data access control)</li>
+ * </ul>
+ *
+ * <p>
+ * Example implementation:
+ * </p>
+ *
+ * <pre>
+ * {
+ *     &#64;code
+ *     &#64;ApplicationScoped
+ *     public class EmailFormatValidator implements ToolInputGuardrail {
+ *
+ *         private static final Pattern EMAIL_PATTERN = Pattern.compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$");
+ *
+ *         @Override
+ *         public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+ *             JsonNode args = parseArguments(request.arguments());
+ *             String email = args.get("to").asText();
+ *
+ *             if (!EMAIL_PATTERN.matcher(email).matches()) {
+ *                 return ToolInputGuardrailResult.failure(
+ *                         "Invalid email format: " + email);
+ *             }
+ *
+ *             return ToolInputGuardrailResult.success();
+ *         }
+ *     }
+ * }
+ * </pre>
+ *
+ * <p>
+ * Implementations must be CDI beans to enable dependency injection.
+ * Common scopes include {@code @ApplicationScoped} for stateless guardrails
+ * and {@code @RequestScoped} for guardrails that need per-request state.
+ * </p>
+ *
+ * <p>
+ * <strong>Execution Order:</strong> When multiple guardrails are specified via
+ * {@link ToolInputGuardrails}, they execute in array order with fail-fast semantics.
+ * The first guardrail returning a non-success result stops the chain.
+ * </p>
+ *
+ * @see ToolInputGuardrails
+ * @see ToolInputGuardrailRequest
+ * @see ToolInputGuardrailResult
+ */
+public interface ToolInputGuardrail extends ToolGuardrail<ToolInputGuardrailRequest, ToolInputGuardrailResult> {
+
+    /**
+     * Validates the tool execution request before the tool is invoked.
+     * <p>
+     * This method receives complete context about the tool invocation, including:
+     * </p>
+     * <ul>
+     * <li>Tool name and arguments from the LLM</li>
+     * <li>Tool metadata (specification, parameters)</li>
+     * <li>Invocation context (memory ID, custom parameters)</li>
+     * </ul>
+     *
+     * <p>
+     * The implementation should return:
+     * </p>
+     * <ul>
+     * <li>{@link ToolInputGuardrailResult#success()} if validation passes</li>
+     * <li>{@link ToolInputGuardrailResult#successWith(dev.langchain4j.agent.tool.ToolExecutionRequest)}
+     * to modify the request</li>
+     * <li>{@link ToolInputGuardrailResult#failure(String)} for non-fatal validation failures</li>
+     * <li>{@link ToolInputGuardrailResult#failure(String, Throwable)} for fatal failures with exceptions</li>
+     * </ul>
+     *
+     * @param request the tool input guardrail request containing all validation context
+     * @return the validation result indicating success, failure, or request modification
+     */
+    ToolInputGuardrailResult validate(ToolInputGuardrailRequest request);
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolInputGuardrailRequest.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolInputGuardrailRequest.java
@@ -1,0 +1,125 @@
+package io.quarkiverse.langchain4j.guardrails;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Request object for tool input guardrails containing all context needed for validation.
+ * <p>
+ * This record provides complete information about the tool invocation that is about to occur,
+ * including the LLM's request, tool metadata, and invocation context. Guardrails can use this
+ * information to validate inputs, check permissions, or make other decisions before tool execution.
+ * </p>
+ *
+ * <p>
+ * Example usage in a guardrail:
+ * </p>
+ *
+ * <pre>
+ * {@code
+ * @Override
+ * public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+ *     String toolName = request.toolName();
+ *     String arguments = request.arguments();
+ *     Object memoryId = request.memoryId();
+ *
+ *     // Perform validation logic
+ *     if (isInvalid(arguments)) {
+ *         return ToolInputGuardrailResult.failure("Invalid input");
+ *     }
+ *
+ *     return ToolInputGuardrailResult.success();
+ * }
+ * }
+ * </pre>
+ *
+ * @param executionRequest the tool execution request from the LLM containing tool name and arguments
+ * @param toolMetadata metadata about the tool including specification and instance
+ * @param invocationContext the invocation context containing memory ID and custom parameters
+ *
+ * @see ToolInputGuardrail
+ * @see ToolExecutionRequest
+ * @see ToolMetadata
+ * @see ToolInvocationContext
+ */
+public record ToolInputGuardrailRequest(
+        ToolExecutionRequest executionRequest,
+        ToolMetadata toolMetadata,
+        ToolInvocationContext invocationContext) implements ToolGuardrailRequest<ToolInputGuardrailRequest> {
+
+    /**
+     * Compact constructor for validation.
+     *
+     * @param executionRequest the tool execution request (must not be null)
+     * @param toolMetadata the tool metadata (can be null)
+     * @param invocationContext the invocation context (can be null)
+     * @throws IllegalArgumentException if executionRequest is null
+     */
+    public ToolInputGuardrailRequest {
+        if (executionRequest == null) {
+            throw new IllegalArgumentException("executionRequest cannot be null");
+        }
+    }
+
+    /**
+     * Convenience method to get the tool name from the execution request.
+     *
+     * @return the tool name
+     */
+    public String toolName() {
+        return executionRequest.name();
+    }
+
+    /**
+     * Convenience method to get the arguments JSON from the execution request.
+     *
+     * @return the arguments as JSON string
+     */
+    public String arguments() {
+        return executionRequest.arguments();
+    }
+
+    /**
+     * Convenience method to get the memory ID from the invocation context.
+     *
+     * @return the memory ID, or null if no invocation context
+     */
+    public Object memoryId() {
+        return invocationContext != null ? invocationContext.memoryId() : null;
+    }
+
+    /**
+     * Parses the tool arguments as a Vert.x JsonObject for easier parameter access.
+     * <p>
+     * This provides a convenient way to access individual parameters without manually parsing JSON.
+     * The JsonObject can map to POJOs using {@code mapTo(Class)}.
+     * </p>
+     *
+     * <p>
+     * Example usage:
+     * </p>
+     *
+     * <pre>
+     * {@code
+     * // Simple parameter access
+     * JsonObject args = request.argumentsAsJson();
+     * int x = args.getInteger("x");
+     * String name = args.getString("name");
+     *
+     * // Map to POJO
+     * record Params(int x, String name) {
+     * }
+     *
+     * Params params = args.mapTo(Params.class);
+     * }
+     * </pre>
+     *
+     * @return the arguments as a Vert.x JsonObject
+     * @throws io.vertx.core.json.DecodeException if the arguments string is not valid JSON
+     * @see JsonObject
+     * @see JsonObject#mapTo(Class)
+     */
+    public JsonObject argumentsAsJson() {
+        return new JsonObject(arguments());
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolInputGuardrailResult.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolInputGuardrailResult.java
@@ -1,0 +1,116 @@
+package io.quarkiverse.langchain4j.guardrails;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+
+/**
+ * Result of tool input guardrail validation.
+ * <p>
+ * This record represents the outcome of input validation, indicating whether the tool
+ * execution should proceed, be modified, or be rejected. Guardrails return instances
+ * of this class to communicate their validation decision.
+ * </p>
+ *
+ * <p>
+ * There are four possible outcomes:
+ * </p>
+ * <ul>
+ * <li><strong>Success:</strong> Validation passed, proceed with the original request</li>
+ * <li><strong>Success with modification:</strong> Validation passed with a modified request</li>
+ * <li><strong>Failure:</strong> Validation failed, return error message to the LLM</li>
+ * <li><strong>Fatal failure:</strong> Critical validation failure with exception</li>
+ * </ul>
+ *
+ * <p>
+ * Example usage:
+ * </p>
+ *
+ * <pre>
+ * {@code
+ * // Validation passes
+ * return ToolInputGuardrailResult.success();
+ *
+ * // Validation fails with message to LLM
+ * return ToolInputGuardrailResult.failure("Invalid email format");
+ *
+ * // Fatal failure with exception
+ * return ToolInputGuardrailResult.failure("Unauthorized", new SecurityException());
+ *
+ * // Modify the request (e.g., sanitize input)
+ * ToolExecutionRequest modified = ToolExecutionRequest.builder()
+ *         .name(request.toolName())
+ *         .arguments(sanitizedArgs)
+ *         .build();
+ * return ToolInputGuardrailResult.successWith(modified);
+ * }
+ * </pre>
+ *
+ * @param isSuccess true if validation passed, false otherwise
+ * @param errorMessage error message to return to the LLM (null if success)
+ * @param cause exception that caused the failure (null unless fatal failure)
+ * @param modifiedRequest modified tool execution request (null unless request was modified)
+ *
+ * @see ToolInputGuardrail
+ * @see ToolInputGuardrailRequest
+ */
+public record ToolInputGuardrailResult(
+        boolean isSuccess,
+        String errorMessage,
+        Throwable cause,
+        ToolExecutionRequest modifiedRequest) implements ToolGuardrailResult<ToolInputGuardrailResult> {
+
+    /**
+     * Creates a successful validation result.
+     * <p>
+     * The tool execution will proceed with the original request.
+     * </p>
+     *
+     * @return a success result
+     */
+    public static ToolInputGuardrailResult success() {
+        return new ToolInputGuardrailResult(true, null, null, null);
+    }
+
+    /**
+     * Creates a successful validation result with a modified request.
+     * <p>
+     * The tool execution will proceed with the modified request instead of the original.
+     * This is useful for input sanitization or transformation.
+     * </p>
+     *
+     * @param modifiedRequest the modified tool execution request to use
+     * @return a success result with request modification
+     */
+    public static ToolInputGuardrailResult successWith(ToolExecutionRequest modifiedRequest) {
+        return new ToolInputGuardrailResult(true, null, null, modifiedRequest);
+    }
+
+    /**
+     * Creates a failure result with an error message.
+     * <p>
+     * The tool execution will be skipped, and the error message will be returned to the LLM
+     * as the tool result. This is a non-fatal failure that allows the conversation to continue.
+     * </p>
+     *
+     * @param errorMessage the error message to return to the LLM
+     * @return a failure result
+     */
+    public static ToolInputGuardrailResult failure(String errorMessage) {
+        return new ToolInputGuardrailResult(false, errorMessage, null, null);
+    }
+
+    /**
+     * Creates a fatal failure result with an error message and exception.
+     * <p>
+     * The tool execution will be skipped, and the exception will be thrown, stopping
+     * the conversation. This should be used for critical failures that cannot be recovered from,
+     * such as authorization failures or system errors.
+     * </p>
+     *
+     * @param errorMessage the error message describing the failure
+     * @param cause the exception that caused the failure
+     * @return a fatal failure result
+     */
+    public static ToolInputGuardrailResult failure(String errorMessage, Throwable cause) {
+        return new ToolInputGuardrailResult(false, errorMessage, cause, null);
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolInputGuardrails.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolInputGuardrails.java
@@ -1,0 +1,63 @@
+package io.quarkiverse.langchain4j.guardrails;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies guardrails to be executed before tool execution.
+ * <p>
+ * Guardrails validate tool input parameters and execution context before the tool method is invoked.
+ * Multiple guardrails are executed in the order they appear in the array, with fail-fast semantics
+ * (the first guardrail that fails stops the execution chain).
+ * </p>
+ *
+ * <p>
+ * Example usage:
+ * </p>
+ *
+ * <pre>
+ * {@code
+ * &#64;Tool("Send an email")
+ * @ToolInputGuardrails({
+ *         EmailFormatValidator.class,
+ *         UserAuthorizationGuardrail.class
+ * })
+ * public String sendEmail(String to,
+ *         String subject,
+ *         String body) {
+ *     // Implementation
+ * }
+ * }
+ * </pre>
+ *
+ * <p>
+ * Guardrail implementations must be CDI beans (e.g., {@code @ApplicationScoped} or {@code @RequestScoped})
+ * and implement the {@link ToolInputGuardrail} interface.
+ * </p>
+ *
+ * <p>
+ * <strong>Note:</strong> This feature is implemented in Quarkus LangChain4j and may be contributed
+ * to the upstream LangChain4j library in the future.
+ * </p>
+ *
+ * @see ToolInputGuardrail
+ * @see ToolOutputGuardrails
+ */
+@Target({ ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ToolInputGuardrails {
+
+    /**
+     * Array of guardrail classes to execute before tool invocation.
+     * <p>
+     * Guardrails are executed in the order they appear in the array.
+     * The first guardrail that returns a failure result will stop the execution chain
+     * and prevent the tool from being invoked.
+     * </p>
+     *
+     * @return array of guardrail classes
+     */
+    Class<? extends ToolInputGuardrail>[] value();
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolInvocationContext.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolInvocationContext.java
@@ -1,0 +1,112 @@
+package io.quarkiverse.langchain4j.guardrails;
+
+import java.util.Collections;
+import java.util.Map;
+
+import dev.langchain4j.invocation.InvocationContext;
+
+/**
+ * Context information available during tool invocation.
+ * <p>
+ * This record provides contextual information about the tool invocation that can be used
+ * by guardrails for validation decisions. It includes the memory ID (which can correlate
+ * to a user session or conversation) and custom parameters that can carry additional context
+ * such as user information, security principals, or request metadata.
+ * </p>
+ *
+ * <p>
+ * Example usage in a guardrail:
+ * </p>
+ *
+ * <pre>
+ * {@code
+ * @Override
+ * public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+ *     ToolInvocationContext context = request.invocationContext();
+ *     if (context != null) {
+ *         Object memoryId = context.getMemoryId();
+ *         Object userId = context.getParameter("user");
+ *
+ *         // Use context for authorization or rate limiting
+ *         if (!isAuthorized(userId, request.toolName())) {
+ *             return ToolInputGuardrailResult.failure("Unauthorized");
+ *         }
+ *     }
+ *     return ToolInputGuardrailResult.success();
+ * }
+ * }
+ * </pre>
+ *
+ * <p>
+ * Custom parameters can be populated by integrating with Quarkus security,
+ * CDI request context, or other contextual sources during tool execution setup.
+ * </p>
+ *
+ * @param context the invocation context
+ * @see ToolInputGuardrailRequest
+ * @see ToolOutputGuardrailRequest
+ */
+public record ToolInvocationContext(
+        InvocationContext context) {
+
+    public ToolInvocationContext {
+        if (context == null) {
+            throw new IllegalArgumentException("context cannot be null");
+        }
+    }
+
+    /**
+     * Gets the underlying LangChain4j invocation context.
+     * <p>
+     * Advanced use cases can access the full context to retrieve additional
+     * metadata not exposed by convenience methods, such as custom invocation
+     * parameters or model-specific context.
+     * </p>
+     *
+     * @return the invocation context, never null
+     */
+    @Override
+    public InvocationContext context() {
+        return context;
+    }
+
+    /**
+     * Gets a parameter value by key.
+     * <p>
+     * Common parameter keys might include:
+     * </p>
+     * <ul>
+     * <li>"user" - User ID or principal</li>
+     * <li>"session" - Session ID</li>
+     * <li>"tenant" - Tenant ID for multi-tenant applications</li>
+     * <li>"requestId" - Request correlation ID</li>
+     * </ul>
+     *
+     * @param key the parameter key
+     * @return the parameter value, or null if not present
+     */
+    public Object parameter(String key) {
+        if (context.invocationParameters() == null) {
+            return null;
+        }
+        return context.invocationParameters().get(key);
+    }
+
+    public Object memoryId() {
+        return context.chatMemoryId();
+    }
+
+    public Map<String, Object> parameters() {
+        if (context.invocationParameters() == null) {
+            return Collections.emptyMap();
+        }
+        return Collections.unmodifiableMap(context().invocationParameters().asMap());
+    }
+
+    public boolean hasParameter(String key) {
+        if (context.invocationParameters() == null) {
+            return false;
+        }
+        return context.invocationParameters().containsKey(key);
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolMetadata.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolMetadata.java
@@ -1,0 +1,71 @@
+package io.quarkiverse.langchain4j.guardrails;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+
+/**
+ * Metadata about a tool for use in guardrails.
+ * <p>
+ * This record provides information about the tool being executed, including its specification
+ * and the actual tool instance. Guardrails can use this metadata to make informed validation
+ * decisions based on tool characteristics.
+ * </p>
+ *
+ * <p>
+ * Example usage in a guardrail:
+ * </p>
+ *
+ * <pre>
+ * {@code
+ * @Override
+ * public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+ *     ToolMetadata metadata = request.toolMetadata();
+ *     if (metadata != null) {
+ *         String toolName = metadata.toolName();
+ *         String description = metadata.description();
+ *         ToolSpecification spec = metadata.specification();
+ *
+ *         // Use metadata for validation decisions
+ *         if (requiresAdminAccess(toolName)) {
+ *             // Check authorization
+ *         }
+ *     }
+ *     return ToolInputGuardrailResult.success();
+ * }
+ * }
+ * </pre>
+ *
+ * @param specification the tool specification from LangChain4j containing parameter definitions
+ * @param toolInstance the actual tool instance (may be null if omitted)
+ *
+ * @see ToolSpecification
+ * @see ToolInputGuardrailRequest
+ * @see ToolOutputGuardrailRequest
+ */
+public record ToolMetadata(
+        ToolSpecification specification,
+        Object toolInstance) {
+
+    public ToolMetadata {
+        if (specification == null) {
+            throw new IllegalArgumentException("specification cannot be null");
+        }
+    }
+
+    /**
+     * Convenience method to get the tool name from the specification.
+     *
+     * @return the tool name
+     */
+    public String toolName() {
+        return specification.name();
+    }
+
+    /**
+     * Convenience method to get the tool description from the specification.
+     *
+     * @return the tool description, or null if not specified
+     */
+    public String description() {
+        return specification.description();
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolOutputGuardrail.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolOutputGuardrail.java
@@ -1,0 +1,92 @@
+package io.quarkiverse.langchain4j.guardrails;
+
+/**
+ * Interface for validating and transforming tool output after execution.
+ * <p>
+ * Implementations of this interface are used to validate and potentially modify
+ * tool execution results before they are returned to the LLM. This allows for:
+ * </p>
+ * <ul>
+ * <li>Output validation (format, content, size constraints)</li>
+ * <li>Sensitive data filtering (PII redaction, data masking)</li>
+ * <li>Result transformation (truncation, summarization)</li>
+ * <li>Compliance checks (data privacy, content policies)</li>
+ * </ul>
+ *
+ * <p>
+ * Example implementation:
+ * </p>
+ *
+ * <pre>
+ * {
+ *     &#64;code
+ *     &#64;ApplicationScoped
+ *     public class SensitiveDataFilter implements ToolOutputGuardrail {
+ *
+ *         private static final Pattern SSN_PATTERN = Pattern.compile("\\d{3}-\\d{2}-\\d{4}");
+ *
+ *         @Override
+ *         public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+ *             String result = request.resultText();
+ *             String filtered = SSN_PATTERN.matcher(result)
+ *                     .replaceAll("XXX-XX-XXXX");
+ *
+ *             if (!filtered.equals(result)) {
+ *                 ToolExecutionResult modifiedResult = ToolExecutionResult.builder()
+ *                         .resultText(filtered)
+ *                         .build();
+ *                 return ToolOutputGuardrailResult.successWith(modifiedResult);
+ *             }
+ *
+ *             return ToolOutputGuardrailResult.success();
+ *         }
+ *     }
+ * }
+ * </pre>
+ *
+ * <p>
+ * Implementations must be CDI beans to enable dependency injection.
+ * Common scopes include {@code @ApplicationScoped} for stateless guardrails
+ * and {@code @RequestScoped} for guardrails that need per-request state.
+ * </p>
+ *
+ * <p>
+ * <strong>Execution Order:</strong> When multiple guardrails are specified via
+ * {@link ToolOutputGuardrails}, they execute in array order with fail-fast semantics.
+ * The first guardrail returning a non-success result stops the chain.
+ * </p>
+ *
+ * @see ToolOutputGuardrails
+ * @see ToolOutputGuardrailRequest
+ * @see ToolOutputGuardrailResult
+ */
+public interface ToolOutputGuardrail extends ToolGuardrail<ToolOutputGuardrailRequest, ToolOutputGuardrailResult> {
+
+    /**
+     * Validates the tool execution result after the tool has been invoked.
+     * <p>
+     * This method receives complete context about the tool execution, including:
+     * </p>
+     * <ul>
+     * <li>Tool execution result (text, error status)</li>
+     * <li>Original tool execution request</li>
+     * <li>Tool metadata (specification, parameters)</li>
+     * <li>Invocation context (memory ID, custom parameters)</li>
+     * </ul>
+     *
+     * <p>
+     * The implementation should return:
+     * </p>
+     * <ul>
+     * <li>{@link ToolOutputGuardrailResult#success()} if validation passes</li>
+     * <li>{@link ToolOutputGuardrailResult#successWith(dev.langchain4j.service.tool.ToolExecutionResult)}
+     * to modify the result</li>
+     * <li>{@link ToolOutputGuardrailResult#failure(String)} for validation failures</li>
+     * <li>{@link ToolOutputGuardrailResult#failure(String, Throwable)} for fatal failures with exceptions</li>
+     * </ul>
+     *
+     * @param request the tool output guardrail request containing all validation context
+     * @return the validation result indicating success, failure, or result modification
+     */
+    ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request);
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolOutputGuardrailRequest.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolOutputGuardrailRequest.java
@@ -1,0 +1,143 @@
+package io.quarkiverse.langchain4j.guardrails;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Request object for tool output guardrails containing all context needed for validation.
+ * <p>
+ * This record provides complete information about the tool execution that has occurred,
+ * including the result, the original request, tool metadata, and invocation context.
+ * Guardrails can use this information to validate outputs, filter sensitive data,
+ * or transform results before they are returned to the LLM.
+ * </p>
+ *
+ * <p>
+ * Example usage in a guardrail:
+ * </p>
+ *
+ * <pre>
+ * {@code
+ * @Override
+ * public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+ *     String result = request.resultText();
+ *     boolean hasError = request.isError();
+ *
+ *     // Validate or transform the result
+ *     if (result.length() > MAX_SIZE) {
+ *         String truncated = result.substring(0, MAX_SIZE) + "...";
+ *         ToolExecutionResult modified = ToolExecutionResult.builder()
+ *                 .resultText(truncated)
+ *                 .build();
+ *         return ToolOutputGuardrailResult.successWith(modified);
+ *     }
+ *
+ *     return ToolOutputGuardrailResult.success();
+ * }
+ * }
+ * </pre>
+ *
+ * @param executionResult the tool execution result containing output text and error status
+ * @param executionRequest the original tool execution request from the LLM
+ * @param toolMetadata metadata about the tool including specification and instance
+ * @param invocationContext the invocation context containing memory ID and custom parameters
+ * @see ToolOutputGuardrail
+ * @see dev.langchain4j.service.tool.ToolExecutionResult
+ * @see ToolExecutionRequest
+ * @see ToolMetadata
+ * @see ToolInvocationContext
+ */
+public record ToolOutputGuardrailRequest(
+        dev.langchain4j.service.tool.ToolExecutionResult executionResult,
+        ToolExecutionRequest executionRequest,
+        ToolMetadata toolMetadata,
+        ToolInvocationContext invocationContext) implements ToolGuardrailRequest<ToolOutputGuardrailRequest> {
+
+    /**
+     * Constructor for validation.
+     *
+     * @param executionResult the tool execution result (must not be null)
+     * @param executionRequest the original tool execution request (can be null)
+     * @param toolMetadata the tool metadata (can be null)
+     * @param invocationContext the invocation context (can be null)
+     * @throws IllegalArgumentException if executionResult is null
+     */
+    public ToolOutputGuardrailRequest {
+        if (executionResult == null) {
+            throw new IllegalArgumentException("executionResult cannot be null");
+        }
+    }
+
+    /**
+     * Convenience method to get the tool name from the execution request.
+     *
+     * @return the tool name, or null if no execution request
+     */
+    public String toolName() {
+        return executionRequest != null ? executionRequest.name() : null;
+    }
+
+    /**
+     * Convenience method to get the result text from the execution result.
+     *
+     * @return the result text
+     */
+    public String resultText() {
+        return executionResult.resultText();
+    }
+
+    /**
+     * Convenience method to check if the execution resulted in an error.
+     * <p>
+     * When an error occurs, use {@link #resultText()} to get the error message.
+     * The original exception is not available in ToolExecutionResult.
+     * </p>
+     *
+     * @return true if the execution failed, false otherwise
+     */
+    public boolean isError() {
+        return executionResult.isError();
+    }
+
+    /**
+     * Convenience method to get the memory ID from the invocation context.
+     *
+     * @return the memory ID, or null if no invocation context
+     */
+    public Object memoryId() {
+        return invocationContext != null ? invocationContext.memoryId() : null;
+    }
+
+    /**
+     * Parses the tool arguments as a Vert.x JsonObject for easier parameter access.
+     * <p>
+     * This provides access to the original tool arguments that produced this output,
+     * enabling guardrails to validate the relationship between inputs and outputs.
+     * </p>
+     *
+     * <p>
+     * Example usage:
+     * </p>
+     *
+     * <pre>
+     * {@code
+     * // Check if output matches input expectations
+     * JsonObject args = request.argumentsAsJson();
+     * int expectedValue = args.getInteger("expectedMax");
+     *
+     * int actualValue = parseResult(request.resultText());
+     * if (actualValue > expectedValue) {
+     *     return ToolOutputGuardrailResult.failure("Result exceeds expected maximum");
+     * }
+     * }
+     * </pre>
+     *
+     * @return the arguments as a Vert.x JsonObject, or null if no execution request
+     * @throws io.vertx.core.json.DecodeException if the arguments string is not valid JSON
+     * @see JsonObject
+     */
+    public JsonObject argumentsAsJson() {
+        return executionRequest != null ? new JsonObject(executionRequest.arguments()) : null;
+    }
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolOutputGuardrailResult.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolOutputGuardrailResult.java
@@ -1,0 +1,115 @@
+package io.quarkiverse.langchain4j.guardrails;
+
+/**
+ * Result of tool output guardrail validation.
+ * <p>
+ * This record represents the outcome of output validation, indicating whether the tool result
+ * should be returned as-is, be modified, or be rejected. Guardrails return
+ * instances of this class to communicate their validation decision.
+ * </p>
+ *
+ * <p>
+ * There are four possible outcomes:
+ * </p>
+ * <ul>
+ * <li><strong>Success:</strong> Validation passed, return the original result to the LLM</li>
+ * <li><strong>Success with modification:</strong> Validation passed with a modified result</li>
+ * <li><strong>Failure:</strong> Validation failed, return error message to the LLM</li>
+ * <li><strong>Fatal failure:</strong> Critical validation failure with exception</li>
+ * </ul>
+ *
+ * <p>
+ * Example usage:
+ * </p>
+ *
+ * <pre>
+ * {@code
+ * // Validation passes
+ * return ToolOutputGuardrailResult.success();
+ *
+ * // Transform the result (e.g., filter sensitive data)
+ * ToolExecutionResult filtered = ToolExecutionResult.builder()
+ *         .resultText(filterSensitiveData(result.resultText()))
+ *         .build();
+ * return ToolOutputGuardrailResult.successWith(filtered);
+ *
+ * // Validation fails with message to LLM
+ * return ToolOutputGuardrailResult.failure("Output validation failed");
+ *
+ * // Fatal failure with exception
+ * return ToolOutputGuardrailResult.failure("Critical error", exception);
+ * }
+ * </pre>
+ *
+ *
+ * @param isSuccess true if validation passed, false otherwise
+ * @param errorMessage error message to return to the LLM (null if success)
+ * @param cause exception that caused the failure (null unless fatal failure)
+ * @param modifiedResult modified tool execution result (null unless result was modified)
+ * @see ToolOutputGuardrail
+ * @see ToolOutputGuardrailRequest
+ */
+public record ToolOutputGuardrailResult(
+        boolean isSuccess,
+        String errorMessage,
+        Throwable cause,
+        dev.langchain4j.service.tool.ToolExecutionResult modifiedResult)
+        implements
+            ToolGuardrailResult<ToolOutputGuardrailResult> {
+
+    /**
+     * Creates a successful validation result.
+     * <p>
+     * The tool result will be returned to the LLM as-is.
+     * </p>
+     *
+     * @return a success result
+     */
+    public static ToolOutputGuardrailResult success() {
+        return new ToolOutputGuardrailResult(true, null, null, null);
+    }
+
+    /**
+     * Creates a successful validation result with a modified result.
+     * <p>
+     * The modified result will be returned to the LLM instead of the original.
+     * This is useful for filtering sensitive data, truncating large outputs,
+     * or transforming the result format.
+     * </p>
+     *
+     * @param modifiedResult the modified tool execution result to return
+     * @return a success result with result modification
+     */
+    public static ToolOutputGuardrailResult successWith(dev.langchain4j.service.tool.ToolExecutionResult modifiedResult) {
+        return new ToolOutputGuardrailResult(true, null, null, modifiedResult);
+    }
+
+    /**
+     * Creates a failure result with an error message.
+     * <p>
+     * The error message will be returned to the LLM as the tool result instead of the
+     * actual output. This is a non-fatal failure that allows the conversation to continue.
+     * </p>
+     *
+     * @param errorMessage the error message to return to the LLM
+     * @return a failure result
+     */
+    public static ToolOutputGuardrailResult failure(String errorMessage) {
+        return new ToolOutputGuardrailResult(false, errorMessage, null, null);
+    }
+
+    /**
+     * Creates a fatal failure result with an error message and exception.
+     * <p>
+     * The exception will be thrown, stopping the conversation. This should be used for
+     * critical failures that cannot be recovered from, such as system errors or security violations.
+     * </p>
+     *
+     * @param errorMessage the error message describing the failure
+     * @param cause the exception that caused the failure
+     * @return a fatal failure result
+     */
+    public static ToolOutputGuardrailResult failure(String errorMessage, Throwable cause) {
+        return new ToolOutputGuardrailResult(false, errorMessage, cause, null);
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolOutputGuardrails.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/guardrails/ToolOutputGuardrails.java
@@ -1,0 +1,61 @@
+package io.quarkiverse.langchain4j.guardrails;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies guardrails to be executed after tool execution.
+ * <p>
+ * Guardrails validate tool output and can transform results before they are returned to the LLM.
+ * Multiple guardrails are executed in the order they appear in the array, with fail-fast semantics
+ * (the first guardrail that fails stops the execution chain).
+ * </p>
+ *
+ * <p>
+ * Example usage:
+ * </p>
+ *
+ * <pre>
+ * {@code
+ * &#64;Tool("Fetch user data")
+ * @ToolOutputGuardrails({
+ *         SensitiveDataFilter.class,
+ *         OutputSizeLimiter.class
+ * })
+ * public String getUserData(String userId) {
+ *     // Implementation
+ * }
+ * }
+ * </pre>
+ *
+ * <p>
+ * Guardrail implementations must be CDI beans (e.g., {@code @ApplicationScoped} or {@code @RequestScoped})
+ * and implement the {@link ToolOutputGuardrail} interface.
+ * </p>
+ *
+ *
+ * <p>
+ * <strong>Note:</strong> This feature is implemented in Quarkus LangChain4j and may be contributed
+ * to the upstream LangChain4j library in the future.
+ * </p>
+ *
+ * @see ToolOutputGuardrail
+ * @see ToolInputGuardrails
+ */
+@Target({ ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ToolOutputGuardrails {
+
+    /**
+     * Array of guardrail classes to execute after tool invocation.
+     * <p>
+     * Guardrails are executed in the order they appear in the array.
+     * The first guardrail that returns a failure result will stop the execution chain.
+     * </p>
+     *
+     * @return array of guardrail classes
+     */
+    Class<? extends ToolOutputGuardrail>[] value();
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/ToolsRecorder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/ToolsRecorder.java
@@ -53,7 +53,7 @@ public class ToolsRecorder {
                 QuarkusToolExecutor.Context executorContext = new QuarkusToolExecutor.Context(objectWithTool,
                         invokerClassName, methodCreateInfo.methodName(),
                         methodCreateInfo.argumentMapperClassName(), methodCreateInfo.executionModel(),
-                        methodCreateInfo.returnBehavior(), false);
+                        methodCreateInfo.returnBehavior(), false, methodCreateInfo);
                 toolExecutors.put(toolSpecification.name(), toolExecutorFactory.create(executorContext));
             }
         }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/devui/ChatJsonRPCService.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/devui/ChatJsonRPCService.java
@@ -117,7 +117,7 @@ public class ChatJsonRPCService {
                     QuarkusToolExecutor.Context executorContext = new QuarkusToolExecutor.Context(objectWithTool,
                             methodCreateInfo.invokerClassName(), methodCreateInfo.methodName(),
                             methodCreateInfo.argumentMapperClassName(), methodCreateInfo.executionModel(),
-                            methodCreateInfo.returnBehavior(), false);
+                            methodCreateInfo.returnBehavior(), false, methodCreateInfo);
                     toolExecutors.put(methodCreateInfo.toolSpecification().name(),
                             toolExecutorFactory.create(executorContext));
                     toolSpecifications.add(methodCreateInfo.toolSpecification());

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/QuarkusToolExecutor.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/QuarkusToolExecutor.java
@@ -31,13 +31,22 @@ public class QuarkusToolExecutor implements ToolExecutor {
 
     public record Context(Object tool, String toolInvokerName, String methodName, String argumentMapperClassName,
             ToolMethodCreateInfo.ExecutionModel executionModel, ReturnBehavior returnBehavior,
-            boolean propagateToolExecutionExceptions) {
+            boolean propagateToolExecutionExceptions, ToolMethodCreateInfo methodCreateInfo) {
+    }
+
+    /**
+     * Gets the tool method metadata including guardrail configuration.
+     *
+     * @return the method create info, or null if not available
+     */
+    public ToolMethodCreateInfo getMethodCreateInfo() {
+        return context.methodCreateInfo;
     }
 
     public interface Wrapper {
 
         ToolExecutionResult wrap(ToolExecutionRequest toolExecutionRequest, InvocationContext invocationContext,
-                BiFunction<ToolExecutionRequest, InvocationContext, ToolExecutionResult> fun);
+                BiFunction<ToolExecutionRequest, InvocationContext, ToolExecutionResult> fun, QuarkusToolExecutor executor);
     }
 
     public QuarkusToolExecutor(Context context) {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/QuarkusToolExecutorFactory.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/QuarkusToolExecutorFactory.java
@@ -29,6 +29,7 @@ public class QuarkusToolExecutorFactory {
 
         return new QuarkusToolExecutor(context) {
             final QuarkusToolExecutor originalTool = new QuarkusToolExecutor(context);
+            final QuarkusToolExecutor executor = this;
 
             @Override
             public ToolExecutionResult executeWithContext(ToolExecutionRequest toolExecutionRequest,
@@ -41,7 +42,8 @@ public class QuarkusToolExecutorFactory {
                     var currentFun = funRef.get();
                     BiFunction<ToolExecutionRequest, InvocationContext, ToolExecutionResult> newFunction = (
                             toolExecutionRequest1,
-                            invocationContext1) -> wrapper.wrap(toolExecutionRequest1, invocationContext1, currentFun);
+                            invocationContext1) -> wrapper.wrap(toolExecutionRequest1, invocationContext1, currentFun,
+                                    executor);
                     funRef.set(newFunction);
                 }
 

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/ToolMethodCreateInfo.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/ToolMethodCreateInfo.java
@@ -2,13 +2,18 @@ package io.quarkiverse.langchain4j.runtime.tool;
 
 import dev.langchain4j.agent.tool.ReturnBehavior;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import io.quarkiverse.langchain4j.guardrails.ToolMetadata;
+import io.quarkiverse.langchain4j.runtime.tool.guardrails.ToolInputGuardrailsLiteral;
+import io.quarkiverse.langchain4j.runtime.tool.guardrails.ToolOutputGuardrailsLiteral;
 
 public record ToolMethodCreateInfo(String methodName,
         String invokerClassName,
         ToolSpecification toolSpecification,
         String argumentMapperClassName,
         ExecutionModel executionModel,
-        ReturnBehavior returnBehavior) {
+        ReturnBehavior returnBehavior,
+        ToolInputGuardrailsLiteral inputGuardrails,
+        ToolOutputGuardrailsLiteral outputGuardrails) {
 
     public enum ExecutionModel {
         BLOCKING,
@@ -16,4 +21,31 @@ public record ToolMethodCreateInfo(String methodName,
         VIRTUAL_THREAD
     }
 
+    /**
+     * Creates ToolMetadata from the tool specification.
+     * The tool instance is not available at this level and will be null.
+     *
+     * @return the tool metadata
+     */
+    public ToolMetadata getToolMetadata() {
+        return new ToolMetadata(toolSpecification, null);
+    }
+
+    /**
+     * Gets the input guardrails annotation literal for this tool method.
+     *
+     * @return the input guardrails literal, or null if none configured
+     */
+    public ToolInputGuardrailsLiteral getInputGuardrails() {
+        return inputGuardrails;
+    }
+
+    /**
+     * Gets the output guardrails annotation literal for this tool method.
+     *
+     * @return the output guardrails literal, or null if none configured
+     */
+    public ToolOutputGuardrailsLiteral getOutputGuardrails() {
+        return outputGuardrails;
+    }
 }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/ToolSpanWrapper.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/ToolSpanWrapper.java
@@ -32,7 +32,7 @@ public class ToolSpanWrapper implements QuarkusToolExecutor.Wrapper {
 
     @Override
     public ToolExecutionResult wrap(ToolExecutionRequest toolExecutionRequest, InvocationContext invocationContext,
-            BiFunction<ToolExecutionRequest, InvocationContext, ToolExecutionResult> fun) {
+            BiFunction<ToolExecutionRequest, InvocationContext, ToolExecutionResult> fun, QuarkusToolExecutor executor) {
 
         // from https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-spans.md#execute-tool-span
         Span span = tracer.spanBuilder("langchain4j.tools." + toolExecutionRequest.name())

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/guardrails/ToolGuardrailAnnotationLiteral.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/guardrails/ToolGuardrailAnnotationLiteral.java
@@ -1,0 +1,118 @@
+package io.quarkiverse.langchain4j.runtime.tool.guardrails;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+
+import io.quarkiverse.langchain4j.guardrails.ToolGuardrail;
+
+/**
+ * Base class for tool guardrail annotation literals.
+ * <p>
+ * This class handles lazy class loading of guardrail classes, enabling serialization
+ * at build time and proper class resolution at runtime. It follows the same pattern
+ * as the LLM guardrails' {@code ClassProvidingAnnotationLiteral}.
+ * </p>
+ * <p>
+ * The class stores guardrail class names as strings and lazily loads the actual
+ * {@code Class} objects when needed, using double-checked locking for thread safety.
+ * </p>
+ *
+ * @param <A> the annotation type ( ToolInputGuardrails or ToolOutputGuardrails)
+ * @param <G> the guardrail interface type (ToolInputGuardrail or ToolOutputGuardrail)
+ */
+public abstract sealed class ToolGuardrailAnnotationLiteral<A extends Annotation, G extends ToolGuardrail>
+        extends AnnotationLiteral<A> permits ToolInputGuardrailsLiteral, ToolOutputGuardrailsLiteral {
+
+    private final List<String> classNames = new ArrayList<>();
+    private transient volatile List<Class<G>> guardrailClasses;
+
+    /**
+     * Constructs a new tool guardrail annotation literal with the given guardrail class names.
+     *
+     * @param classNames the list of guardrail class names (fully qualified)
+     */
+    protected ToolGuardrailAnnotationLiteral(List<String> classNames) {
+        if (classNames != null) {
+            this.classNames.addAll(classNames);
+        }
+    }
+
+    /**
+     * Gets the list of guardrail class names.
+     * <p>
+     * This method is needed for serialization/deserialization.
+     * </p>
+     *
+     * @return the list of class names
+     */
+    public List<String> getClassNames() {
+        return classNames;
+    }
+
+    /**
+     * Gets the guardrail classes as an array, implementing the annotation's {@code value()} method.
+     *
+     * @return array of guardrail classes
+     */
+    public Class<? extends G>[] value() {
+        return getClasses();
+    }
+
+    /**
+     * Checks if the class cache needs to be initialized or refreshed.
+     *
+     * @return true if initialization is needed
+     */
+    private boolean needsCacheInitialization() {
+        return (this.guardrailClasses == null) || this.guardrailClasses.size() != this.classNames.size();
+    }
+
+    /**
+     * Initializes the class cache using lazy loading with double-checked locking.
+     */
+    private void checkClassCache() {
+        // Using double-checked locking pattern for cache initialization
+        if (needsCacheInitialization()) {
+            synchronized (this) {
+                if (needsCacheInitialization()) {
+                    var classLoader = Thread.currentThread().getContextClassLoader();
+                    this.guardrailClasses = this.classNames.stream()
+                            .map(className -> {
+                                try {
+                                    return (Class<G>) Class.forName(className, false, classLoader);
+                                } catch (ClassNotFoundException e) {
+                                    throw new RuntimeException(e);
+                                }
+                            })
+                            .toList();
+                }
+            }
+        }
+    }
+
+    /**
+     * Gets the guardrail classes, ensuring the cache is initialized.
+     *
+     * @return array of guardrail classes
+     */
+    protected final Class<? extends G>[] getClasses() {
+        checkClassCache();
+        return this.guardrailClasses.toArray(Class[]::new);
+    }
+
+    /**
+     * Checks if any guardrails are configured.
+     * <p>
+     * This method does not trigger class loading and is safe to call during
+     * metadata inspection.
+     * </p>
+     *
+     * @return true if at least one guardrail is configured, false otherwise
+     */
+    public boolean hasGuardrails() {
+        return !this.classNames.isEmpty();
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/guardrails/ToolGuardrailService.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/guardrails/ToolGuardrailService.java
@@ -1,0 +1,284 @@
+package io.quarkiverse.langchain4j.runtime.tool.guardrails;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.AmbiguousResolutionException;
+import jakarta.enterprise.inject.UnsatisfiedResolutionException;
+import jakarta.enterprise.inject.spi.CDI;
+
+import org.jboss.logging.Logger;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.service.tool.ToolExecutionResult;
+import io.quarkiverse.langchain4j.guardrails.*;
+import io.quarkiverse.langchain4j.runtime.tool.ToolMethodCreateInfo;
+
+/**
+ * Service for managing and executing tool guardrails.
+ * <p>
+ * This service is responsible for:
+ * </p>
+ * <ul>
+ * <li>Checking if a tool has input or output guardrails configured</li>
+ * <li>Executing guardrails in the order they are declared</li>
+ * <li>Handling guardrail failures with appropriate error handling</li>
+ * <li>Managing request/result transformations from guardrails</li>
+ * </ul>
+ * <p>
+ * Guardrails are executed with fail-fast semantics: the first guardrail that
+ * returns a non-success result stops the chain and returns the failure.
+ * </p>
+ * <p>
+ * Guardrail beans are looked up via CDI, enabling dependency injection and
+ * support for different scopes (ApplicationScoped, RequestScoped, etc.).
+ * </p>
+ *
+ * @see ToolInputGuardrail
+ * @see ToolOutputGuardrail
+ * @see ToolMethodCreateInfo
+ */
+@ApplicationScoped
+public class ToolGuardrailService {
+
+    private static final Logger log = Logger.getLogger(ToolGuardrailService.class);
+
+    /**
+     * Checks if the tool method has input guardrails configured.
+     *
+     * @param methodCreateInfo the tool method metadata
+     * @return true if input guardrails are present, false otherwise
+     */
+    public boolean hasInputGuardrails(ToolMethodCreateInfo methodCreateInfo) {
+        return methodCreateInfo.getInputGuardrails() != null
+                && methodCreateInfo.getInputGuardrails().hasGuardrails();
+    }
+
+    /**
+     * Checks if the tool method has output guardrails configured.
+     *
+     * @param methodCreateInfo the tool method metadata
+     * @return true if output guardrails are present, false otherwise
+     */
+    public boolean hasOutputGuardrails(ToolMethodCreateInfo methodCreateInfo) {
+        return methodCreateInfo.getOutputGuardrails() != null
+                && methodCreateInfo.getOutputGuardrails().hasGuardrails();
+    }
+
+    /**
+     * Executes input guardrails for a tool execution request.
+     * <p>
+     * Guardrails are executed in the order they appear in the {@link ToolInputGuardrails}
+     * annotation. The first guardrail that returns a non-success result stops the chain.
+     * </p>
+     * <p>
+     * If a guardrail returns a modified request via {@link ToolInputGuardrailResult#successWith},
+     * that modified request is passed to subsequent guardrails and eventually returned.
+     * </p>
+     *
+     * @param request the tool execution request to validate
+     * @param methodCreateInfo the tool method metadata containing guardrail configuration
+     * @param context the invocation context
+     * @return the original or modified tool execution request
+     * @throws ToolGuardrailException if a guardrail returns a fatal failure
+     */
+    public ToolExecutionRequest executeInputGuardrails(
+            ToolExecutionRequest request,
+            ToolMethodCreateInfo methodCreateInfo,
+            ToolInvocationContext context) {
+
+        Class<? extends ToolInputGuardrail>[] guardrailClasses = methodCreateInfo.getInputGuardrails().value();
+
+        ToolExecutionRequest currentRequest = request;
+        ToolMetadata toolMetadata = methodCreateInfo.getToolMetadata();
+
+        for (Class<? extends ToolInputGuardrail> guardrailClass : guardrailClasses) {
+            if (log.isDebugEnabled()) {
+                log.debugv("Executing input guardrail {0} for tool {1}",
+                        guardrailClass.getSimpleName(), request.name());
+            }
+
+            ToolInputGuardrail guardrail = lookupGuardrail(guardrailClass);
+
+            ToolInputGuardrailRequest guardrailRequest = new ToolInputGuardrailRequest(
+                    currentRequest,
+                    toolMetadata,
+                    context);
+
+            ToolInputGuardrailResult result = guardrail.validate(guardrailRequest);
+
+            if (!result.isSuccess()) {
+                return handleInputGuardrailFailure(result, guardrailClass, request.name());
+            }
+
+            // Apply request modification if present
+            if (result.modifiedRequest() != null) {
+                if (log.isDebugEnabled()) {
+                    log.debugv("Input guardrail {0} modified the request for tool {1}",
+                            guardrailClass.getSimpleName(), request.name());
+                }
+                currentRequest = result.modifiedRequest();
+            }
+        }
+
+        return currentRequest;
+    }
+
+    /**
+     * Executes output guardrails for a tool execution result.
+     * <p>
+     * Guardrails are executed in the order they appear in the {@link ToolOutputGuardrails}
+     * annotation. The first guardrail that returns a non-success result stops the chain.
+     * </p>
+     * <p>
+     * If a guardrail returns a modified result via {@link ToolOutputGuardrailResult#successWith},
+     * that modified result is passed to subsequent guardrails and eventually returned.
+     * </p>
+     *
+     * @param result the tool execution result to validate
+     * @param request the original tool execution request
+     * @param methodCreateInfo the tool method metadata containing guardrail configuration
+     * @param context the invocation context
+     * @return the original or modified tool execution result
+     * @throws ToolGuardrailException if a guardrail returns a fatal failure
+     */
+    public ToolExecutionResult executeOutputGuardrails(
+            ToolExecutionResult result,
+            ToolExecutionRequest request,
+            ToolMethodCreateInfo methodCreateInfo,
+            ToolInvocationContext context) {
+
+        Class<? extends ToolOutputGuardrail>[] guardrailClasses = methodCreateInfo.getOutputGuardrails().value();
+
+        ToolExecutionResult currentResult = result;
+        ToolMetadata toolMetadata = methodCreateInfo.getToolMetadata();
+
+        for (Class<? extends ToolOutputGuardrail> guardrailClass : guardrailClasses) {
+            if (log.isDebugEnabled()) {
+                log.debugv("Executing output guardrail {0} for tool {1}",
+                        guardrailClass.getSimpleName(), request.name());
+            }
+
+            ToolOutputGuardrail guardrail = lookupGuardrail(guardrailClass);
+
+            ToolOutputGuardrailRequest guardrailRequest = new ToolOutputGuardrailRequest(
+                    currentResult,
+                    request,
+                    toolMetadata,
+                    context);
+
+            ToolOutputGuardrailResult guardrailResult = guardrail.validate(guardrailRequest);
+
+            if (!guardrailResult.isSuccess()) {
+                return handleOutputGuardrailFailure(guardrailResult, guardrailClass, request.name());
+            }
+
+            // Apply result modification if present
+            if (guardrailResult.modifiedResult() != null) {
+                if (log.isDebugEnabled()) {
+                    log.debugv("Output guardrail {0} modified the result for tool {1}",
+                            guardrailClass.getSimpleName(), request.name());
+                }
+                currentResult = guardrailResult.modifiedResult();
+            }
+        }
+
+        return currentResult;
+    }
+
+    /**
+     * Looks up a guardrail bean via CDI.
+     *
+     * @param guardrailClass the guardrail class
+     * @param <T> the guardrail type
+     * @return the guardrail instance
+     * @throws IllegalStateException if the guardrail bean cannot be found
+     */
+    private <T> T lookupGuardrail(Class<T> guardrailClass) {
+        try {
+            return CDI.current().select(guardrailClass).get();
+        } catch (UnsatisfiedResolutionException e) {
+            throw new IllegalStateException(
+                    String.format("Failed to lookup guardrail bean '%s'. " +
+                            "Common causes:\n" +
+                            "  1. Missing CDI scope annotation (@ApplicationScoped, @RequestScoped, etc.)\n" +
+                            "  2. Class not included in Jandex index\n" +
+                            "  3. Bean explicitly removed by Arc optimization\n" +
+                            "Verify the guardrail is a valid CDI bean.",
+                            guardrailClass.getName()),
+                    e);
+        } catch (AmbiguousResolutionException e) {
+            throw new IllegalStateException(
+                    String.format("Multiple CDI beans found for guardrail '%s'. " +
+                            "Ensure only one implementation exists or use @Priority for disambiguation.",
+                            guardrailClass.getName()),
+                    e);
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                    "Unexpected error looking up guardrail bean: " + guardrailClass.getName(),
+                    e);
+        }
+    }
+
+    /**
+     * Handles input guardrail validation failure.
+     *
+     * @param result the guardrail result indicating failure
+     * @param guardrailClass the guardrail class that failed
+     * @param toolName the tool name
+     * @return a tool execution request (never actually returns, always throws)
+     * @throws ToolGuardrailException if the failure has a cause (fatal failure)
+     */
+    private ToolExecutionRequest handleInputGuardrailFailure(
+            ToolInputGuardrailResult result,
+            Class<? extends ToolInputGuardrail> guardrailClass,
+            String toolName) {
+
+        String errorMessage = result.errorMessage() != null
+                ? result.errorMessage()
+                : "Input validation failed";
+
+        if (result.cause() != null) {
+            // Fatal failure - throw exception
+            log.errorv("Input guardrail {0} failed fatally for tool {1}: {2}",
+                    guardrailClass.getSimpleName(), toolName, errorMessage);
+            throw new ToolGuardrailException(errorMessage, result.cause());
+        }
+
+        // Non-fatal failure - this will be caught by the wrapper and converted to a ToolExecutionResult
+        log.warnv("Input guardrail {0} failed for tool {1}: {2}",
+                guardrailClass.getSimpleName(), toolName, errorMessage);
+        throw new ToolGuardrailException(errorMessage);
+    }
+
+    /**
+     * Handles output guardrail validation failure.
+     *
+     * @param result the guardrail result indicating failure
+     * @param guardrailClass the guardrail class that failed
+     * @param toolName the tool name
+     * @return a tool execution result containing the error message
+     */
+    private ToolExecutionResult handleOutputGuardrailFailure(
+            ToolOutputGuardrailResult result,
+            Class<? extends ToolOutputGuardrail> guardrailClass,
+            String toolName) {
+
+        String errorMessage = result.errorMessage() != null
+                ? result.errorMessage()
+                : "Output validation failed";
+
+        if (result.cause() != null) {
+            // Fatal failure - throw exception
+            log.errorv("Output guardrail {0} failed fatally for tool {1}: {2}",
+                    guardrailClass.getSimpleName(), toolName, errorMessage);
+            throw new ToolGuardrailException(errorMessage, result.cause());
+        }
+
+        // Non-fatal failure - return error as tool result
+        log.warnv("Output guardrail {0} failed for tool {1}: {2}",
+                guardrailClass.getSimpleName(), toolName, errorMessage);
+        return ToolExecutionResult.builder()
+                .isError(true)
+                .resultText("Output validation failed: " + errorMessage)
+                .build();
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/guardrails/ToolGuardrailsWrapper.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/guardrails/ToolGuardrailsWrapper.java
@@ -1,0 +1,184 @@
+package io.quarkiverse.langchain4j.runtime.tool.guardrails;
+
+import java.util.function.BiFunction;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.logging.Logger;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.exception.ToolExecutionException;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.service.tool.ToolExecutionResult;
+import io.quarkiverse.langchain4j.guardrails.ToolGuardrailException;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolInvocationContext;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrail;
+import io.quarkiverse.langchain4j.runtime.tool.QuarkusToolExecutor;
+import io.quarkiverse.langchain4j.runtime.tool.ToolMethodCreateInfo;
+
+/**
+ * Wrapper that integrates tool guardrails into the tool execution flow.
+ * <p>
+ * The wrapper is registered as a CDI bean and automatically discovered by
+ * {@link io.quarkiverse.langchain4j.runtime.tool.QuarkusToolExecutorFactory}.
+ * </p>
+ * <p>
+ * <strong>Event Loop:</strong> When guardrails are invoked on the Vert.x event loop (e.g., with
+ * reactive/streaming tools), the guardrail execution is automatically dispatched to a worker thread to prevent
+ * blocking the event loop.
+ * </p>
+ *
+ * @see ToolGuardrailService
+ * @see ToolInputGuardrail
+ * @see ToolOutputGuardrail
+ */
+@ApplicationScoped
+public class ToolGuardrailsWrapper implements QuarkusToolExecutor.Wrapper {
+
+    private static final Logger log = Logger.getLogger(ToolGuardrailsWrapper.class);
+
+    private final ToolGuardrailService guardrailService;
+
+    @Inject
+    public ToolGuardrailsWrapper(ToolGuardrailService guardrailService) {
+        this.guardrailService = guardrailService;
+    }
+
+    @Override
+    public ToolExecutionResult wrap(
+            ToolExecutionRequest toolExecutionRequest,
+            InvocationContext invocationContext,
+            BiFunction<ToolExecutionRequest, InvocationContext, ToolExecutionResult> next,
+            QuarkusToolExecutor executor) {
+
+        // Get the tool method metadata from the executor
+        ToolMethodCreateInfo methodCreateInfo = executor.getMethodCreateInfo();
+
+        // If no metadata found or no guardrails configured, just proceed
+        if (methodCreateInfo == null
+                || (!guardrailService.hasInputGuardrails(methodCreateInfo)
+                        && !guardrailService.hasOutputGuardrails(methodCreateInfo))) {
+            return next.apply(toolExecutionRequest, invocationContext);
+        }
+
+        // We cannot have guardrails if we are invoked on the event loop because guardrail may be blocking.
+
+        // Check if we're on the Vert.x event loop
+        // If so, dispatch guardrail execution to worker thread to prevent blocking
+        if (io.vertx.core.Context.isOnEventLoopThread()) {
+            throw new ToolExecutionException(
+                    "Cannot execute guardrails tools on the event loop thread. Make sure your tool function is marked or detected as blocking.");
+        }
+
+        // Execute guardrails directly
+        return executeWithGuardrails(toolExecutionRequest, invocationContext, next, methodCreateInfo);
+    }
+
+    /**
+     * Executes the tool with input and output guardrails.
+     * This method contains the actual guardrail execution logic and is called either:
+     * <ul>
+     * <li>Directly from {@link #wrap(ToolExecutionRequest, InvocationContext, BiFunction, QuarkusToolExecutor)} when already on
+     * a worker thread</li>
+     * <li>Via Uni dispatch when on event loop (to prevent blocking)</li>
+     * </ul>
+     *
+     * @param toolExecutionRequest the original tool execution request
+     * @param invocationContext the invocation context
+     * @param next the next function in the chain (actual tool execution)
+     * @param methodCreateInfo the tool method metadata
+     * @return the tool execution result (possibly modified by guardrails)
+     */
+    private ToolExecutionResult executeWithGuardrails(
+            ToolExecutionRequest toolExecutionRequest,
+            InvocationContext invocationContext,
+            BiFunction<ToolExecutionRequest, InvocationContext, ToolExecutionResult> next,
+            ToolMethodCreateInfo methodCreateInfo) {
+
+        // Create invocation context for guardrails
+        ToolInvocationContext context = new ToolInvocationContext(invocationContext);
+
+        // Execute input guardrails (if any)
+        ToolExecutionRequest processedRequest = toolExecutionRequest;
+        if (guardrailService.hasInputGuardrails(methodCreateInfo)) {
+            try {
+                processedRequest = guardrailService.executeInputGuardrails(
+                        toolExecutionRequest,
+                        methodCreateInfo,
+                        context);
+
+                if (log.isDebugEnabled() && processedRequest != toolExecutionRequest) {
+                    log.debugv("Input guardrails modified the request for tool {0}", toolExecutionRequest.name());
+                }
+            } catch (ToolGuardrailException e) {
+                // Check if this is a fatal failure (has a cause)
+                if (e.getCause() != null) {
+                    // Fatal failure - re-throw to stop execution
+                    log.errorv("Input guardrail failed fatally for tool {0}: {1}",
+                            toolExecutionRequest.name(), e.getMessage());
+                    throw e;
+                }
+
+                // Non-fatal failure - return error result to LLM
+                log.warnv("Input guardrail failed for tool {0}: {1}", toolExecutionRequest.name(), e.getMessage());
+                return ToolExecutionResult.builder()
+                        .isError(true)
+                        .resultText("Input validation failed: " + e.getMessage())
+                        .build();
+            }
+        }
+
+        // Execute the actual tool
+        ToolExecutionResult result;
+        try {
+            result = next.apply(processedRequest, invocationContext);
+        } catch (Exception e) {
+            // Tool execution failed - let it propagate or return error
+            // No need to run output guardrails on errors
+            if (log.isDebugEnabled() && processedRequest != toolExecutionRequest) {
+                log.debugv("Tool {0} failed after input guardrail modifications. " +
+                        "Original arguments: {1}, Modified arguments: {2}",
+                        toolExecutionRequest.name(),
+                        toolExecutionRequest.arguments(),
+                        processedRequest.arguments());
+            }
+            throw e;
+        }
+
+        // Execute output guardrails (if any)
+        if (guardrailService.hasOutputGuardrails(methodCreateInfo)) {
+            try {
+                result = guardrailService.executeOutputGuardrails(
+                        result,
+                        processedRequest,
+                        methodCreateInfo,
+                        context);
+
+                if (log.isDebugEnabled()) {
+                    log.debugv("Output guardrails processed result for tool {0}", toolExecutionRequest.name());
+                }
+            } catch (ToolGuardrailException e) {
+                // Check if this is a fatal failure (has a cause)
+                if (e.getCause() != null) {
+                    // Fatal failure - re-throw to stop execution
+                    log.errorv("Output guardrail failed fatally for tool {0}: {1}",
+                            toolExecutionRequest.name(), e.getMessage());
+                    throw e;
+                }
+
+                // Non-fatal failure - return error result
+                log.warnv("Output guardrail failed for tool {0}: {1}",
+                        toolExecutionRequest.name(), e.getMessage());
+                return ToolExecutionResult.builder()
+                        .isError(true)
+                        .resultText("Output validation failed: " + e.getMessage())
+                        .build();
+            }
+        }
+
+        return result;
+    }
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/guardrails/ToolInputGuardrailsLiteral.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/guardrails/ToolInputGuardrailsLiteral.java
@@ -1,0 +1,36 @@
+package io.quarkiverse.langchain4j.runtime.tool.guardrails;
+
+import java.util.List;
+
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrails;
+
+/**
+ * Annotation literal for {@link ToolInputGuardrails}.
+ *
+ * @see ToolInputGuardrails
+ * @see ToolGuardrailAnnotationLiteral
+ */
+public final class ToolInputGuardrailsLiteral
+        extends ToolGuardrailAnnotationLiteral<ToolInputGuardrails, ToolInputGuardrail>
+        implements ToolInputGuardrails {
+
+    /**
+     * Default constructor required for serialization/deserialization.
+     * <p>
+     * Creates an empty literal with no guardrails configured.
+     * </p>
+     */
+    public ToolInputGuardrailsLiteral() {
+        this(List.of());
+    }
+
+    /**
+     * Constructs a new tool input guardrails literal with the specified guardrail class names.
+     *
+     * @param guardrailClassNames the list of fully qualified guardrail class names
+     */
+    public ToolInputGuardrailsLiteral(List<String> guardrailClassNames) {
+        super(guardrailClassNames);
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/guardrails/ToolOutputGuardrailsLiteral.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/guardrails/ToolOutputGuardrailsLiteral.java
@@ -1,0 +1,36 @@
+package io.quarkiverse.langchain4j.runtime.tool.guardrails;
+
+import java.util.List;
+
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrails;
+
+/**
+ * Annotation literal for {@link ToolOutputGuardrails}.
+ *
+ * @see ToolOutputGuardrails
+ * @see ToolGuardrailAnnotationLiteral
+ */
+public final class ToolOutputGuardrailsLiteral
+        extends ToolGuardrailAnnotationLiteral<ToolOutputGuardrails, ToolOutputGuardrail>
+        implements ToolOutputGuardrails {
+
+    /**
+     * Default constructor required for serialization/deserialization.
+     * <p>
+     * Creates an empty literal with no guardrails configured.
+     * </p>
+     */
+    public ToolOutputGuardrailsLiteral() {
+        this(List.of());
+    }
+
+    /**
+     * Constructs a new tool output guardrails literal with the specified guardrail class names.
+     *
+     * @param guardrailClassNames the list of fully qualified guardrail class names
+     */
+    public ToolOutputGuardrailsLiteral(List<String> guardrailClassNames) {
+        super(guardrailClassNames);
+    }
+}

--- a/core/runtime/src/test/java/io/quarkiverse/langchain4j/runtime/tool/guardrails/ToolGuardrailServiceTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/langchain4j/runtime/tool/guardrails/ToolGuardrailServiceTest.java
@@ -1,0 +1,104 @@
+package io.quarkiverse.langchain4j.runtime.tool.guardrails;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import io.quarkiverse.langchain4j.runtime.tool.ToolMethodCreateInfo;
+
+/**
+ * Unit tests for ToolGuardrailService focusing on metadata inspection.
+ * Full integration tests with actual guardrail execution are in the deployment module.
+ */
+class ToolGuardrailServiceTest {
+
+    private ToolGuardrailService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ToolGuardrailService();
+    }
+
+    @Test
+    void testHasInputGuardrails_withGuardrails() {
+        ToolInputGuardrailsLiteral inputGuardrails = new ToolInputGuardrailsLiteral(
+                List.of("com.example.TestGuardrail"));
+        ToolMethodCreateInfo info = createMethodCreateInfo(inputGuardrails, null);
+
+        assertTrue(service.hasInputGuardrails(info));
+    }
+
+    @Test
+    void testHasInputGuardrails_withoutGuardrails() {
+        ToolMethodCreateInfo info = createMethodCreateInfo(null, null);
+
+        assertFalse(service.hasInputGuardrails(info));
+    }
+
+    @Test
+    void testHasInputGuardrails_withEmptyGuardrails() {
+        ToolInputGuardrailsLiteral inputGuardrails = new ToolInputGuardrailsLiteral(List.of());
+        ToolMethodCreateInfo info = createMethodCreateInfo(inputGuardrails, null);
+
+        assertFalse(service.hasInputGuardrails(info));
+    }
+
+    @Test
+    void testHasOutputGuardrails_withGuardrails() {
+        ToolOutputGuardrailsLiteral outputGuardrails = new ToolOutputGuardrailsLiteral(
+                List.of("com.example.TestGuardrail"));
+        ToolMethodCreateInfo info = createMethodCreateInfo(null, outputGuardrails);
+
+        assertTrue(service.hasOutputGuardrails(info));
+    }
+
+    @Test
+    void testHasOutputGuardrails_withoutGuardrails() {
+        ToolMethodCreateInfo info = createMethodCreateInfo(null, null);
+
+        assertFalse(service.hasOutputGuardrails(info));
+    }
+
+    @Test
+    void testHasOutputGuardrails_withEmptyGuardrails() {
+        ToolOutputGuardrailsLiteral outputGuardrails = new ToolOutputGuardrailsLiteral(List.of());
+        ToolMethodCreateInfo info = createMethodCreateInfo(null, outputGuardrails);
+
+        assertFalse(service.hasOutputGuardrails(info));
+    }
+
+    @Test
+    void testHasBothGuardrails() {
+        ToolInputGuardrailsLiteral inputGuardrails = new ToolInputGuardrailsLiteral(
+                List.of("com.example.InputGuardrail"));
+        ToolOutputGuardrailsLiteral outputGuardrails = new ToolOutputGuardrailsLiteral(
+                List.of("com.example.OutputGuardrail"));
+        ToolMethodCreateInfo info = createMethodCreateInfo(inputGuardrails, outputGuardrails);
+
+        assertTrue(service.hasInputGuardrails(info));
+        assertTrue(service.hasOutputGuardrails(info));
+    }
+
+    private ToolMethodCreateInfo createMethodCreateInfo(
+            ToolInputGuardrailsLiteral inputGuardrails,
+            ToolOutputGuardrailsLiteral outputGuardrails) {
+        ToolSpecification spec = ToolSpecification.builder()
+                .name("testTool")
+                .description("Test tool")
+                .build();
+
+        return new ToolMethodCreateInfo(
+                "testMethod",
+                "TestInvoker",
+                spec,
+                "TestMapper",
+                ToolMethodCreateInfo.ExecutionModel.BLOCKING,
+                null,
+                inputGuardrails,
+                outputGuardrails);
+    }
+}

--- a/core/runtime/src/test/java/io/quarkiverse/langchain4j/runtime/tool/guardrails/ToolInputGuardrailRequestTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/langchain4j/runtime/tool/guardrails/ToolInputGuardrailRequestTest.java
@@ -1,0 +1,101 @@
+package io.quarkiverse.langchain4j.runtime.tool.guardrails;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.invocation.InvocationParameters;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolInvocationContext;
+import io.quarkiverse.langchain4j.guardrails.ToolMetadata;
+
+class ToolInputGuardrailRequestTest {
+
+    @Test
+    void testConstruction() {
+        ToolExecutionRequest executionRequest = createToolExecutionRequest();
+        ToolMetadata toolMetadata = createToolMetadata();
+        ToolInvocationContext invocationContext = new ToolInvocationContext(
+                InvocationContext.builder().chatMemoryId("memory-123")
+                        .invocationParameters(InvocationParameters.from("user", "alice")).build());
+
+        ToolInputGuardrailRequest request = new ToolInputGuardrailRequest(
+                executionRequest, toolMetadata, invocationContext);
+
+        assertSame(executionRequest, request.executionRequest());
+        assertSame(toolMetadata, request.toolMetadata());
+        assertSame(invocationContext, request.invocationContext());
+    }
+
+    @Test
+    void testConstruction_nullExecutionRequest() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new ToolInvocationContext(null));
+    }
+
+    @Test
+    void testConstruction_nullMetadataAndContext() {
+        // Metadata and context can be null
+        ToolExecutionRequest executionRequest = createToolExecutionRequest();
+
+        ToolInputGuardrailRequest request = new ToolInputGuardrailRequest(executionRequest, null, null);
+
+        assertSame(executionRequest, request.executionRequest());
+        assertNull(request.toolMetadata());
+        assertNull(request.invocationContext());
+    }
+
+    @Test
+    void testToolName() {
+        ToolExecutionRequest executionRequest = createToolExecutionRequest();
+        ToolInputGuardrailRequest request = new ToolInputGuardrailRequest(executionRequest, null, null);
+
+        assertEquals("testTool", request.toolName());
+    }
+
+    @Test
+    void testArguments() {
+        ToolExecutionRequest executionRequest = createToolExecutionRequest();
+        ToolInputGuardrailRequest request = new ToolInputGuardrailRequest(executionRequest, null, null);
+
+        assertEquals("{\"param\": \"value\"}", request.arguments());
+    }
+
+    @Test
+    void testMemoryId() {
+        ToolExecutionRequest executionRequest = createToolExecutionRequest();
+        ToolInvocationContext invocationContext = new ToolInvocationContext(
+                InvocationContext.builder().chatMemoryId("memory-123")
+                        .invocationParameters(InvocationParameters.from("user", "alice")).build());
+        ToolInputGuardrailRequest request = new ToolInputGuardrailRequest(executionRequest, null, invocationContext);
+
+        assertEquals("memory-123", request.memoryId());
+    }
+
+    @Test
+    void testMemoryId_nullContext() {
+        ToolExecutionRequest executionRequest = createToolExecutionRequest();
+        ToolInputGuardrailRequest request = new ToolInputGuardrailRequest(executionRequest, null, null);
+
+        assertNull(request.memoryId());
+    }
+
+    private ToolExecutionRequest createToolExecutionRequest() {
+        return ToolExecutionRequest.builder()
+                .id("test-id")
+                .name("testTool")
+                .arguments("{\"param\": \"value\"}")
+                .build();
+    }
+
+    private ToolMetadata createToolMetadata() {
+        ToolSpecification spec = ToolSpecification.builder()
+                .name("testTool")
+                .description("Test tool")
+                .build();
+        return new ToolMetadata(spec, null);
+    }
+}

--- a/core/runtime/src/test/java/io/quarkiverse/langchain4j/runtime/tool/guardrails/ToolInputGuardrailResultTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/langchain4j/runtime/tool/guardrails/ToolInputGuardrailResultTest.java
@@ -1,0 +1,58 @@
+package io.quarkiverse.langchain4j.runtime.tool.guardrails;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailResult;
+
+class ToolInputGuardrailResultTest {
+
+    @Test
+    void testSuccess() {
+        ToolInputGuardrailResult result = ToolInputGuardrailResult.success();
+
+        assertTrue(result.isSuccess());
+        assertNull(result.modifiedRequest());
+        assertNull(result.errorMessage());
+        assertNull(result.cause());
+    }
+
+    @Test
+    void testSuccessWith() {
+        ToolExecutionRequest modifiedRequest = ToolExecutionRequest.builder()
+                .id("modified-id")
+                .name("modifiedTool")
+                .arguments("{\"modified\": true}")
+                .build();
+
+        ToolInputGuardrailResult result = ToolInputGuardrailResult.successWith(modifiedRequest);
+
+        assertTrue(result.isSuccess());
+        assertSame(modifiedRequest, result.modifiedRequest());
+        assertNull(result.errorMessage());
+        assertNull(result.cause());
+    }
+
+    @Test
+    void testFailure_withMessage() {
+        ToolInputGuardrailResult result = ToolInputGuardrailResult.failure("Validation failed");
+
+        assertFalse(result.isSuccess());
+        assertNull(result.modifiedRequest());
+        assertEquals("Validation failed", result.errorMessage());
+        assertNull(result.cause());
+    }
+
+    @Test
+    void testFailure_withMessageAndCause() {
+        Exception cause = new RuntimeException("Root cause");
+        ToolInputGuardrailResult result = ToolInputGuardrailResult.failure("Validation failed", cause);
+
+        assertFalse(result.isSuccess());
+        assertNull(result.modifiedRequest());
+        assertEquals("Validation failed", result.errorMessage());
+        assertSame(cause, result.cause());
+    }
+}

--- a/core/runtime/src/test/java/io/quarkiverse/langchain4j/runtime/tool/guardrails/ToolInvocationContextTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/langchain4j/runtime/tool/guardrails/ToolInvocationContextTest.java
@@ -1,0 +1,99 @@
+package io.quarkiverse.langchain4j.runtime.tool.guardrails;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.invocation.InvocationParameters;
+import io.quarkiverse.langchain4j.guardrails.ToolInvocationContext;
+
+class ToolInvocationContextTest {
+
+    @Test
+    void testConstruction_withNullParameters() {
+        ToolInvocationContext context = new ToolInvocationContext(
+                InvocationContext.builder().chatMemoryId("memory-123").build());
+
+        assertEquals("memory-123", context.memoryId());
+        assertNotNull(context.parameters());
+        assertTrue(context.parameters().isEmpty());
+    }
+
+    @Test
+    void testConstruction_withParameters() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("user", "alice");
+        params.put("tenant", "acme");
+
+        ToolInvocationContext context = new ToolInvocationContext(InvocationContext.builder().chatMemoryId("memory-123")
+                .invocationParameters(InvocationParameters.from(params))
+                .build());
+
+        assertEquals("memory-123", context.memoryId());
+        assertEquals(2, context.parameters().size());
+        assertEquals("alice", context.parameters().get("user"));
+        assertEquals("acme", context.parameters().get("tenant"));
+    }
+
+    @Test
+    void testParameters_immutable() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("user", "alice");
+
+        ToolInvocationContext context = new ToolInvocationContext(InvocationContext.builder().chatMemoryId("memory-123")
+                .invocationParameters(InvocationParameters.from(params))
+                .build());
+
+        // Original map can be modified
+        params.put("user", "bob");
+
+        // But context parameters remain unchanged
+        assertEquals("alice", context.parameters().get("user"));
+
+        // Cannot modify context parameters
+        assertThrows(UnsupportedOperationException.class,
+                () -> context.parameters().put("user", "charlie"));
+    }
+
+    @Test
+    void testParameter() {
+        Map<String, Object> params = Map.of(
+                "user", "alice",
+                "session", "session-456");
+
+        ToolInvocationContext context = new ToolInvocationContext(InvocationContext.builder().chatMemoryId("memory-123")
+                .invocationParameters(InvocationParameters.from(params))
+                .build());
+
+        assertEquals("alice", context.parameter("user"));
+        assertEquals("session-456", context.parameter("session"));
+        assertNull(context.parameter("nonexistent"));
+    }
+
+    @Test
+    void testHasParameter() {
+        Map<String, Object> params = Map.of("user", "alice");
+
+        ToolInvocationContext context = new ToolInvocationContext(InvocationContext.builder().chatMemoryId("memory-123")
+                .invocationParameters(InvocationParameters.from(params))
+                .build());
+
+        assertTrue(context.hasParameter("user"));
+        assertFalse(context.hasParameter("nonexistent"));
+    }
+
+    @Test
+    void testEmptyContext() {
+        ToolInvocationContext context = new ToolInvocationContext(InvocationContext.builder().build());
+
+        assertNull(context.memoryId());
+        assertNotNull(context.parameters());
+        assertTrue(context.parameters().isEmpty());
+        assertFalse(context.hasParameter("anything"));
+        assertNull(context.parameter("anything"));
+    }
+}

--- a/core/runtime/src/test/java/io/quarkiverse/langchain4j/runtime/tool/guardrails/ToolOutputGuardrailRequestTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/langchain4j/runtime/tool/guardrails/ToolOutputGuardrailRequestTest.java
@@ -1,0 +1,146 @@
+package io.quarkiverse.langchain4j.runtime.tool.guardrails;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.invocation.InvocationParameters;
+import dev.langchain4j.service.tool.ToolExecutionResult;
+import io.quarkiverse.langchain4j.guardrails.ToolInvocationContext;
+import io.quarkiverse.langchain4j.guardrails.ToolMetadata;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrailRequest;
+
+class ToolOutputGuardrailRequestTest {
+
+    @Test
+    void testConstruction() {
+        ToolExecutionResult executionResult = createToolExecutionResult();
+        ToolExecutionRequest executionRequest = createToolExecutionRequest();
+        ToolMetadata toolMetadata = createToolMetadata();
+        ToolInvocationContext context = new ToolInvocationContext(InvocationContext.builder().chatMemoryId("memory-123")
+                .invocationParameters(InvocationParameters.from(Map.of("user", "alice")))
+                .build());
+
+        ToolOutputGuardrailRequest request = new ToolOutputGuardrailRequest(
+                executionResult, executionRequest, toolMetadata, context);
+
+        assertSame(executionResult, request.executionResult());
+        assertSame(executionRequest, request.executionRequest());
+        assertSame(toolMetadata, request.toolMetadata());
+        assertSame(context, request.invocationContext());
+    }
+
+    @Test
+    void testConstruction_nullExecutionResult() {
+        ToolExecutionRequest executionRequest = createToolExecutionRequest();
+        ToolMetadata toolMetadata = createToolMetadata();
+        ToolInvocationContext context = new ToolInvocationContext(InvocationContext.builder().build());
+
+        assertThrows(IllegalArgumentException.class,
+                () -> new ToolOutputGuardrailRequest(null, executionRequest, toolMetadata, context));
+    }
+
+    @Test
+    void testConstruction_nullOptionalFields() {
+        // Execution request, metadata and context can be null
+        ToolExecutionResult executionResult = createToolExecutionResult();
+
+        ToolOutputGuardrailRequest request = new ToolOutputGuardrailRequest(executionResult, null, null, null);
+
+        assertSame(executionResult, request.executionResult());
+        assertNull(request.executionRequest());
+        assertNull(request.toolMetadata());
+        assertNull(request.invocationContext());
+    }
+
+    @Test
+    void testToolName() {
+        ToolExecutionResult executionResult = createToolExecutionResult();
+        ToolExecutionRequest executionRequest = createToolExecutionRequest();
+        ToolOutputGuardrailRequest request = new ToolOutputGuardrailRequest(executionResult, executionRequest, null, null);
+
+        assertEquals("testTool", request.toolName());
+    }
+
+    @Test
+    void testToolName_nullRequest() {
+        ToolExecutionResult executionResult = createToolExecutionResult();
+        ToolOutputGuardrailRequest request = new ToolOutputGuardrailRequest(executionResult, null, null, null);
+
+        assertNull(request.toolName());
+    }
+
+    @Test
+    void testResultText() {
+        ToolExecutionResult executionResult = createToolExecutionResult();
+        ToolOutputGuardrailRequest request = new ToolOutputGuardrailRequest(executionResult, null, null, null);
+
+        assertEquals("Success result", request.resultText());
+    }
+
+    @Test
+    void testIsError_false() {
+        ToolExecutionResult executionResult = ToolExecutionResult.builder()
+                .resultText("Success")
+                .build();
+        ToolOutputGuardrailRequest request = new ToolOutputGuardrailRequest(executionResult, null, null, null);
+
+        assertFalse(request.isError());
+    }
+
+    @Test
+    void testIsError_true() {
+        ToolExecutionResult executionResult = ToolExecutionResult.builder()
+                .isError(true)
+                .resultText("Error occurred")
+                .build();
+        ToolOutputGuardrailRequest request = new ToolOutputGuardrailRequest(executionResult, null, null, null);
+
+        assertTrue(request.isError());
+    }
+
+    @Test
+    void testMemoryId() {
+        ToolExecutionResult executionResult = createToolExecutionResult();
+        ToolInvocationContext context = new ToolInvocationContext(InvocationContext.builder().chatMemoryId("memory-123")
+                .build());
+        ToolOutputGuardrailRequest request = new ToolOutputGuardrailRequest(executionResult, null, null, context);
+
+        assertEquals("memory-123", request.memoryId());
+    }
+
+    @Test
+    void testMemoryId_nullContext() {
+        ToolExecutionResult executionResult = createToolExecutionResult();
+        ToolOutputGuardrailRequest request = new ToolOutputGuardrailRequest(executionResult, null, null, null);
+
+        assertNull(request.memoryId());
+    }
+
+    private ToolExecutionRequest createToolExecutionRequest() {
+        return ToolExecutionRequest.builder()
+                .id("test-id")
+                .name("testTool")
+                .arguments("{\"param\": \"value\"}")
+                .build();
+    }
+
+    private ToolExecutionResult createToolExecutionResult() {
+        return ToolExecutionResult.builder()
+                .resultText("Success result")
+                .build();
+    }
+
+    private ToolMetadata createToolMetadata() {
+        ToolSpecification spec = ToolSpecification.builder()
+                .name("testTool")
+                .description("Test tool")
+                .build();
+        return new ToolMetadata(spec, null);
+    }
+}

--- a/core/runtime/src/test/java/io/quarkiverse/langchain4j/runtime/tool/guardrails/ToolOutputGuardrailResultTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/langchain4j/runtime/tool/guardrails/ToolOutputGuardrailResultTest.java
@@ -1,0 +1,56 @@
+package io.quarkiverse.langchain4j.runtime.tool.guardrails;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import dev.langchain4j.service.tool.ToolExecutionResult;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrailResult;
+
+class ToolOutputGuardrailResultTest {
+
+    @Test
+    void testSuccess() {
+        ToolOutputGuardrailResult result = ToolOutputGuardrailResult.success();
+
+        assertTrue(result.isSuccess());
+        assertNull(result.modifiedResult());
+        assertNull(result.errorMessage());
+        assertNull(result.cause());
+    }
+
+    @Test
+    void testSuccessWith() {
+        ToolExecutionResult modifiedResult = ToolExecutionResult.builder()
+                .resultText("Modified output")
+                .build();
+
+        ToolOutputGuardrailResult result = ToolOutputGuardrailResult.successWith(modifiedResult);
+
+        assertTrue(result.isSuccess());
+        assertSame(modifiedResult, result.modifiedResult());
+        assertNull(result.errorMessage());
+        assertNull(result.cause());
+    }
+
+    @Test
+    void testFailure_withMessage() {
+        ToolOutputGuardrailResult result = ToolOutputGuardrailResult.failure("Validation failed");
+
+        assertFalse(result.isSuccess());
+        assertNull(result.modifiedResult());
+        assertEquals("Validation failed", result.errorMessage());
+        assertNull(result.cause());
+    }
+
+    @Test
+    void testFailure_withMessageAndCause() {
+        Exception cause = new RuntimeException("Root cause");
+        ToolOutputGuardrailResult result = ToolOutputGuardrailResult.failure("Validation failed", cause);
+
+        assertFalse(result.isSuccess());
+        assertNull(result.modifiedResult());
+        assertEquals("Validation failed", result.errorMessage());
+        assertSame(cause, result.cause());
+    }
+}

--- a/docs/modules/ROOT/pages/function-calling.adoc
+++ b/docs/modules/ROOT/pages/function-calling.adoc
@@ -410,6 +410,76 @@ public interface WeatherForecastService {
 }
 ----
 
+== Tool Guardrails
+
+Tool guardrails provide validation and control mechanisms for tool invocations, operating at both **input** (before tool execution) and **output** (after tool execution) stages.
+
+=== Basic Example
+
+[source,java]
+----
+@ApplicationScoped
+public class EmailTools {
+
+    @Tool("Send an email to a recipient")
+    @ToolInputGuardrails({ EmailFormatValidator.class })    // Input validation
+    @ToolOutputGuardrails({ SensitiveDataFilter.class })    // Output filtering
+    public String sendEmail(String to, String subject, String body) {
+        return "Email sent to " + to;
+    }
+}
+----
+
+[source,java]
+----
+@ApplicationScoped
+public class EmailFormatValidator implements ToolInputGuardrail {
+
+    @Override
+    public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+        // Parse and validate email format
+        JsonNode args = parseArguments(request.arguments());
+        String email = args.get("to").asText();
+
+        if (!isValidEmail(email)) {
+            return ToolInputGuardrailResult.failure("Invalid email format: " + email);
+        }
+
+        return ToolInputGuardrailResult.success();
+    }
+}
+----
+
+=== Common Use Cases
+
+Tool guardrails are useful for:
+
+* **Security**: Authorization checks before tool execution
+* **Validation**: Email format, parameter ranges, business rules
+* **Privacy**: Filter sensitive data (SSN, credit cards) from outputs
+* **Cost Control**: Rate limiting, output size limiting
+* **Compliance**: Audit logging, data classification
+
+=== Input vs. Output Guardrails
+
+**Input Guardrails** (`@ToolInputGuardrails`):
+
+* Execute **before** the tool
+* Can validate parameters, check authorization, enforce rate limits
+* If validation fails, the tool is **not executed**
+* Error message is returned to the LLM
+
+**Output Guardrails** (`@ToolOutputGuardrails`):
+
+* Execute **after** the tool
+* Can filter sensitive data, transform results, validate output format
+* Can modify the result before returning to the LLM
+
+[NOTE]
+====
+See xref:tool-guardrails.adoc[Tool Guardrails] for complete documentation.
+====
+
 == Summary
 
 Function calling enables the model to take actions and retrieve external information by invoking application-defined tools. Quarkus LangChain4j simplifies this process through annotations and automatic orchestration and execution.
@@ -424,11 +494,14 @@ Function calling enables the model to take actions and retrieve external informa
 |`@Blocking`, `@NonBlocking`, `@RunOnVirtualThread` | Control how tool execution is scheduled
 |`@UserMessage`, `@SystemMessage` | Provide instructions to guide tool use, depending on the model, the prompt should provide hints.
 |`toolProviderSupplier` | Allows dynamic tool provisioning via ToolProvider
+|`@ToolInputGuardrails` | Validates tool parameters before execution
+|`@ToolOutputGuardrails` | Validates or transforms tool results after execution
 |===
 
 == Going Further
 
 [.lead]
+* xref:tool-guardrails.adoc[Tool Guardrails] – Validate and control tool invocations
 * xref:ai-services.adoc[AI Service Configuration]
 * xref:messages-and-memory.adoc[Memory and Context Management]
 * xref:observability.adoc[Observability of Tool Invocations]

--- a/docs/modules/ROOT/pages/tool-guardrails.adoc
+++ b/docs/modules/ROOT/pages/tool-guardrails.adoc
@@ -1,0 +1,800 @@
+= Tool Guardrails - Protecting Your Function Calls
+
+include::./includes/attributes.adoc[]
+
+Tool guardrails provide validation and control mechanisms for tool (function) invocations in AI applications.
+Unlike LLM guardrails which validate prompts and responses from the LLM, tool guardrails operate on the **input parameters** and **output results** of tools that the LLM can invoke using xref:function-calling.adoc[function calling].
+
+[NOTE]
+====
+Tool guardrails are important for:
+
+* **Security**: Prevent unauthorized access to sensitive operations
+* **Data Validation**: Ensure parameters meet format and business rule requirements
+* **Privacy Protection**: Filter sensitive data from tool outputs
+* **Cost Control**: Limit expensive operations through rate limiting
+* **Reliability**: Prevent malformed requests from causing errors
+====
+
+== Overview
+
+Tool guardrails operate at two stages:
+
+1. **Input Guardrails** (`@ToolInputGuardrails`) - Execute **before** the tool, validating parameters and context
+2. **Output Guardrails** (`@ToolOutputGuardrails`) - Execute **after** the tool, validating or transforming results
+
+Both types can:
+
+* Allow execution to proceed (`success()`)
+* Block execution with an error message (`failure()`)
+* Transform requests/responses (`successWith()`)
+
+== Quick Start
+
+To create your first guardrail in 3 steps:
+
+1. **Create a CDI bean** implementing `ToolInputGuardrail` or `ToolOutputGuardrail`
+2. **Implement the `validate()` method** with your validation logic
+3. **Apply the annotation** to your tool method
+
+[source,java]
+----
+// Step 1 & 2: Create guardrail bean
+@ApplicationScoped  // <1>
+public class PositiveNumberGuardrail implements ToolInputGuardrail {  // <2>
+
+    @Override
+    public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {  // <3>
+        JsonObject args = request.argumentsAsJson();
+        int number = args.getInteger("amount");
+
+        if (number < 0) {
+            return ToolInputGuardrailResult.failure(  // <4>
+                "Amount must be positive, got: " + number);
+        }
+
+        return ToolInputGuardrailResult.success();  // <5>
+    }
+}
+
+// Step 3: Apply to tool
+@ApplicationScoped
+public class BankingTools {
+
+    @Tool("Transfer money between accounts")
+    @ToolInputGuardrails({ PositiveNumberGuardrail.class })  // <6>
+    public String transfer(int amount, String from, String to) {
+        // This only executes if amount is positive
+        return "Transferred $" + amount + " from " + from + " to " + to;
+    }
+}
+----
+<1> Make it a CDI bean with a scope annotation
+<2> Implement the appropriate guardrail interface
+<3> Override the validate method
+<4> Return failure if validation fails
+<5> Return success if validation passes
+<6> Apply the guardrail annotation to your tool
+
+== Basic Usage
+
+=== Input Guardrails
+
+Input guardrails validate tool parameters before execution:
+
+[source,java]
+----
+@ApplicationScoped
+public class EmailTools {
+
+    @Tool("Send an email to a recipient")
+    @ToolInputGuardrails({ EmailFormatValidator.class })
+    public String sendEmail(String to,
+                           String subject,
+                           String body) {
+        // This only executes if EmailFormatValidator passes
+        return "Email sent to " + to;
+    }
+}
+----
+
+The guardrail implementation:
+
+[source,java]
+----
+@ApplicationScoped
+public class EmailFormatValidator implements ToolInputGuardrail {
+
+    private static final Pattern EMAIL_PATTERN =
+        Pattern.compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$");
+
+    @Override
+    public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+        // Parse arguments as JsonObject for easy access
+        JsonObject args = request.argumentsAsJson();
+        String email = args.getString("to");
+
+        if (!EMAIL_PATTERN.matcher(email).matches()) {
+            return ToolInputGuardrailResult.failure(
+                "Invalid email format: " + email);
+        }
+
+        return ToolInputGuardrailResult.success();
+    }
+}
+----
+
+[IMPORTANT]
+====
+When an input guardrail fails:
+
+* The tool is **not executed**
+* The error message is returned to the LLM as the tool result
+* The LLM can retry with corrected parameters
+====
+
+=== Output Guardrails
+
+Output guardrails validate and transform tool results:
+
+[source,java]
+----
+@Tool("Get customer information")
+@ToolOutputGuardrails({ SensitiveDataFilter.class })
+public String getCustomerInfo(String customerId) {
+    // Returns customer data including SSN, credit cards, etc.
+    return customerDatabase.findById(customerId).toString();
+}
+----
+
+The guardrail implementation:
+
+[source,java]
+----
+@ApplicationScoped
+public class SensitiveDataFilter implements ToolOutputGuardrail {
+
+    private static final Pattern SSN_PATTERN =
+        Pattern.compile("\\b\\d{3}-\\d{2}-\\d{4}\\b");
+
+    @Override
+    public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+        String result = request.resultText();
+
+        // Filter sensitive data
+        String filtered = SSN_PATTERN.matcher(result)
+            .replaceAll("[REDACTED-SSN]");
+
+        if (!filtered.equals(result)) {
+            // Return modified result
+            return ToolOutputGuardrailResult.successWith(
+                ToolExecutionResult.builder()
+                    .toolName(request.toolName())
+                    .resultText(filtered)
+                    .build()
+            );
+        }
+
+        return ToolOutputGuardrailResult.success();
+    }
+}
+----
+
+[IMPORTANT]
+====
+When an output guardrail modifies the result:
+
+* The **modified** result is returned to the LLM
+* The original tool result is **never** seen by the LLM
+* Multiple output guardrails can chain transformations
+====
+
+== Guardrail Interfaces
+
+=== ToolInputGuardrail Interface
+
+[source,java]
+----
+public interface ToolInputGuardrail {
+    /**
+     * Validates tool input parameters before execution.
+     */
+    ToolInputGuardrailResult validate(ToolInputGuardrailRequest request);
+}
+----
+
+**Request Context:**
+
+[source,java]
+----
+// Access available context
+String toolName = request.toolName();
+String arguments = request.arguments();  // JSON string
+JsonObject args = request.argumentsAsJson();  // Parsed JSON for easy access
+Object memoryId = request.memoryId();
+ToolMetadata metadata = request.toolMetadata();
+ToolInvocationContext context = request.invocationContext();
+----
+
+**Result Options:**
+
+[source,java]
+----
+// Validation passed
+return ToolInputGuardrailResult.success();
+
+// Validation passed with modified request
+return ToolInputGuardrailResult.successWith(modifiedRequest);
+
+// Validation failed
+return ToolInputGuardrailResult.failure("Error message for LLM");
+
+// Critical failure with exception
+return ToolInputGuardrailResult.failure("Error", exception);
+----
+
+=== ToolOutputGuardrail Interface
+
+[source,java]
+----
+public interface ToolOutputGuardrail {
+    /**
+     * Validates tool output after execution.
+     */
+    ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request);
+}
+----
+
+**Request Context:**
+
+[source,java]
+----
+// Access tool result and context
+String resultText = request.resultText();
+JsonObject result = request.resultAsJson();  // Parsed result for JSON tools
+boolean isError = request.isError();
+String toolName = request.toolName();
+JsonObject args = request.argumentsAsJson();  // Original input arguments
+ToolExecutionRequest originalRequest = request.executionRequest();
+ToolExecutionResult executionResult = request.executionResult();
+----
+
+**Result Options:**
+
+[source,java]
+----
+// Output valid
+return ToolOutputGuardrailResult.success();
+
+// Output valid with transformation
+return ToolOutputGuardrailResult.successWith(modifiedResult);
+
+// Output invalid
+return ToolOutputGuardrailResult.failure("Error message");
+
+----
+
+== Multiple Guardrails
+
+Multiple guardrails can be applied to a single tool and execute them in **order**:
+
+[source,java]
+----
+@Tool("Send bulk emails")
+@ToolInputGuardrails({
+    EmailFormatValidator.class,      // Executes first
+    UserAuthorizationGuardrail.class, // Executes second
+    RateLimitGuardrail.class          // Executes third
+})
+@ToolOutputGuardrails({
+    OutputSizeLimiter.class,          // Executes first
+    SensitiveDataFilter.class         // Executes second
+})
+public String sendBulkEmail(String recipients, String subject, String body) {
+    // Implementation
+}
+----
+
+[TIP]
+====
+**Execution Order Best Practices:**
+
+* Place **fast, cheap** checks first (format validation)
+* Place **slow, expensive** checks last (database lookups)
+* For output guardrails, order by transformation dependencies
+====
+
+[IMPORTANT]
+====
+**Fail-Fast Behavior:**
+
+Input guardrails execute in order and **stop at the first failure**. If `EmailFormatValidator` fails, the subsequent guardrails are not executed and the tool does not run.
+====
+
+== Working with Parameters
+
+=== Accessing JSON Parameters
+
+Tool arguments are provided as JSON strings. Use `argumentsAsJson()` for easy parameter access:
+
+[source,java]
+----
+import io.vertx.core.json.JsonObject;  // <1>
+import io.vertx.core.json.JsonArray;
+
+@Override
+public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+    JsonObject args = request.argumentsAsJson();  // <2>
+
+    // Type-safe parameter access
+    int age = args.getInteger("age");
+    String name = args.getString("name");
+    boolean active = args.getBoolean("active", false);  // with default
+
+    // Check for parameter existence
+    if (args.containsKey("email")) {
+        String email = args.getString("email");
+    }
+
+    // Nested objects
+    JsonObject address = args.getJsonObject("address");
+    String city = address.getString("city");
+
+    // Arrays
+    JsonArray tags = args.getJsonArray("tags");
+
+    return ToolInputGuardrailResult.success();
+}
+----
+<1> Import Vert.x JSON classes (included with Quarkus)
+<2> Parse arguments to JsonObject for easy access
+
+[NOTE]
+====
+`JsonObject` is from Vert.x (`io.vertx.core.json.JsonObject`), which is included in Quarkus.
+It provides null-safe methods like `getString(key, default)` and convenient type conversions.
+====
+
+=== POJO Mapping
+
+For complex parameters, map JSON directly to Java objects:
+
+[source,java]
+----
+// Define parameter structure as a record
+record EmailParams(
+    String to,
+    String subject,
+    String body,
+    List<String> attachments
+) {}
+
+@Override
+public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+    // Map arguments to POJO
+    EmailParams params = request.argumentsAsJson().mapTo(EmailParams.class);
+
+    // Access strongly-typed parameters
+    if (params.to() == null || params.to().isEmpty()) {
+        return ToolInputGuardrailResult.failure("Email recipient is required");
+    }
+
+    if (params.attachments().size() > 5) {
+        return ToolInputGuardrailResult.failure("Maximum 5 attachments allowed");
+    }
+
+    return ToolInputGuardrailResult.success();
+}
+----
+
+=== Parsing Tool Output
+
+Output guardrails can also parse JSON results:
+
+[source,java]
+----
+record CustomerData(
+    String id,
+    String name,
+    String ssn,
+    String creditCard
+) {}
+
+@Override
+public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+    // Parse JSON output
+    CustomerData customer = request.resultAsJson().mapTo(CustomerData.class);
+
+    // Filter sensitive fields
+    CustomerData filtered = new CustomerData(
+        customer.id(),
+        customer.name(),
+        "[REDACTED]",
+        "[REDACTED]"
+    );
+
+    // Return filtered result as JSON
+    JsonObject filteredJson = JsonObject.mapFrom(filtered);
+    return ToolOutputGuardrailResult.successWith(
+        ToolExecutionResult.builder()
+            .toolName(request.toolName())
+            .resultText(filteredJson.encode())
+            .build()
+    );
+}
+----
+
+== Common Use Cases
+
+=== Security and Authorization
+
+[source,java]
+----
+@RequestScoped
+public class UserAuthorizationGuardrail implements ToolInputGuardrail {
+
+    @Inject
+    SecurityIdentity securityIdentity;
+
+    @Override
+    public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+        if (securityIdentity.isAnonymous()) {
+            return ToolInputGuardrailResult.failure(
+                "Authentication required to execute " + request.toolName());
+        }
+
+        if (!securityIdentity.hasRole("ADMIN")) {
+            return ToolInputGuardrailResult.failure(
+                "Insufficient permissions to execute " + request.toolName());
+        }
+
+        return ToolInputGuardrailResult.success();
+    }
+}
+----
+
+[NOTE]
+====
+Guardrails are CDI beans and can inject dependencies like `SecurityIdentity`, making them ideal for authorization checks.
+====
+
+=== Rate Limiting
+
+[source,java]
+----
+@ApplicationScoped
+public class RateLimitGuardrail implements ToolInputGuardrail {
+
+    @Inject
+    RateLimiterService rateLimiter;
+
+    @Override
+    public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+        String userId = getUserId(request);
+
+        if (!rateLimiter.tryAcquire(userId, request.toolName())) {
+            return ToolInputGuardrailResult.failure(
+                "Rate limit exceeded. Please try again later.");
+        }
+
+        return ToolInputGuardrailResult.success();
+    }
+}
+----
+
+=== Data Privacy and Filtering
+
+[source,java]
+----
+@ApplicationScoped
+public class PiiFilter implements ToolOutputGuardrail {
+
+    private static final List<Pattern> PII_PATTERNS = List.of(
+        Pattern.compile("\\b\\d{3}-\\d{2}-\\d{4}\\b"),  // SSN
+        Pattern.compile("\\b\\d{4}[- ]?\\d{4}[- ]?\\d{4}[- ]?\\d{4}\\b")  // Credit card
+    );
+
+    @Override
+    public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+        String result = request.resultText();
+        String filtered = result;
+
+        for (Pattern pattern : PII_PATTERNS) {
+            filtered = pattern.matcher(filtered).replaceAll("[REDACTED]");
+        }
+
+        if (!filtered.equals(result)) {
+            return ToolOutputGuardrailResult.successWith(
+                ToolExecutionResult.builder()
+                    .toolName(request.toolName())
+                    .resultText(filtered)
+                    .build()
+            );
+        }
+
+        return ToolOutputGuardrailResult.success();
+    }
+}
+----
+
+=== Cost Control (Output Size Limiting)
+
+[source,java]
+----
+@ApplicationScoped
+public class OutputSizeLimiter implements ToolOutputGuardrail {
+
+    private static final int MAX_CHARACTERS = 4000;
+
+    @Override
+    public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+        String result = request.resultText();
+
+        if (result.length() > MAX_CHARACTERS) {
+            String truncated = result.substring(0, MAX_CHARACTERS) +
+                "\n\n[Output truncated. Please refine your query.]";
+
+            return ToolOutputGuardrailResult.successWith(
+                ToolExecutionResult.builder()
+                    .toolName(request.toolName())
+                    .resultText(truncated)
+                    .build()
+            );
+        }
+
+        return ToolOutputGuardrailResult.success();
+    }
+}
+----
+
+== CDI Integration
+
+Guardrails are CDI beans and support all standard features:
+
+[source,java]
+----
+@RequestScoped  // Can use different scopes
+public class StatefulGuardrail implements ToolInputGuardrail {
+
+    @Inject
+    SecurityIdentity identity;  // Dependency injection
+
+    @Inject
+    AuditLogger auditLogger;    // Custom beans
+
+    @ConfigProperty(name = "app.max-retries", defaultValue = "3")
+    int maxRetries;  // Configuration injection
+
+    private int callCount = 0;  // Instance state
+
+    @Override
+    public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+        callCount++;
+        auditLogger.log(identity.getPrincipal().getName(),
+                       "Tool invocation #" + callCount);
+
+        // Validation logic
+        return ToolInputGuardrailResult.success();
+    }
+}
+----
+
+== Advanced Topics
+
+=== Important Limitation: Tool Guardrails and Event Loop Compatibility
+
+Tool guardrails (both `@ToolInputGuardrails` and `@ToolOutputGuardrails`) have synchronous, blocking APIs by design, as
+  they perform operations like JSON parsing, validation, and potentially database lookups or external API calls.
+
+Consequently, tools annotated with guardrails cannot execute on the Vert.x event loop and must be marked as blocking.
+If you attempt to use a tool with guardrails from the event loop (for example, in a reactive endpoint or streaming AI  service), the framework will throw a ToolExecutionException with the message "Cannot execute guardrails on the event  loop thread."
+
+To use guardrails with your tools, ensure the tool methods are properly detected or annotated as  blocking (e.g., using @Blocking annotation or by returning blocking types instead of `Uni/Multi`).
+
+Tools without guardrails can continue to use reactive execution models without any restrictions.
+This architectural decision ensures  application responsiveness by preventing blocking operations on the event loop.
+
+=== Request Modification
+
+Input guardrails can modify tool requests before execution:
+
+[source,java]
+----
+@ApplicationScoped
+public class ParameterNormalizer implements ToolInputGuardrail {
+
+    @Override
+    public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+        // Parse arguments as JsonObject
+        JsonObject args = request.argumentsAsJson();
+
+        // Normalize email to lowercase
+        String email = args.getString("email").toLowerCase();
+        args.put("email", email);
+
+        // Build modified request with normalized parameters
+        ToolExecutionRequest modified = ToolExecutionRequest.builder()
+            .id(request.executionRequest().id())
+            .name(request.executionRequest().name())
+            .arguments(args.encode())  // Convert back to JSON string
+            .build();
+
+        return ToolInputGuardrailResult.successWith(modified);
+    }
+}
+----
+
+=== Context and Metadata
+
+Guardrails have access to contextual information:
+
+[source,java]
+----
+@Override
+public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+    // Tool information
+    ToolMetadata metadata = request.toolMetadata();
+    String toolName = metadata.toolName();
+    String description = metadata.description();
+
+    // Invocation context
+    ToolInvocationContext context = request.invocationContext();
+    Object memoryId = context.memoryId();
+    Map<String, Object> params = context.parameters();
+
+    // Use context for validation...
+    return ToolInputGuardrailResult.success();
+}
+----
+
+=== Error Handling
+
+Guardrails should handle parsing and validation errors gracefully:
+
+[source,java]
+----
+@Override
+public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+    try {
+        JsonObject args = request.argumentsAsJson();
+        int value = args.getInteger("amount");
+
+        if (value < 0) {
+            return ToolInputGuardrailResult.failure(
+                "Amount must be positive, got: " + value);
+        }
+
+        return ToolInputGuardrailResult.success();
+
+    } catch (DecodeException e) {
+        // JSON parsing failed
+        return ToolInputGuardrailResult.failure(
+            "Invalid JSON arguments: " + e.getMessage());
+
+    } catch (ClassCastException e) {
+        // Type mismatch (e.g., string instead of integer)
+        return ToolInputGuardrailResult.failure(
+            "Invalid parameter type: " + e.getMessage());
+
+    } catch (Exception e) {
+        // Unexpected error - use fatal failure to stop execution
+        return ToolInputGuardrailResult.failure(
+            "Validation error: " + e.getMessage(), e);
+    }
+}
+----
+
+[IMPORTANT]
+====
+**Fatal vs Non-Fatal Failures:**
+
+* `failure(message)` - Non-fatal: error returned to LLM as tool result
+* `failure(message, cause)` - Fatal: throws exception, stops execution completely
+
+Use fatal failures only for critical errors that indicate bugs or system failures, not for validation errors that the LLM can potentially correct.
+====
+
+=== Best Practices
+
+Follow these guidelines when implementing guardrails:
+
+[source,java]
+----
+@ApplicationScoped
+public class WellDesignedGuardrail implements ToolInputGuardrail {
+
+    @Override
+    public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+        try {
+            // 1. Use argumentsAsJson() for easy parameter access
+            JsonObject args = request.argumentsAsJson();
+
+            // 2. Provide clear, actionable error messages for the LLM
+            int age = args.getInteger("age", -1);
+            if (age < 0) {
+                return ToolInputGuardrailResult.failure(
+                    "Parameter 'age' must be a non-negative integer. Got: " + age
+                );
+            }
+
+            // 3. Check required parameters exist
+            if (!args.containsKey("email")) {
+                return ToolInputGuardrailResult.failure(
+                    "Missing required parameter: 'email'"
+                );
+            }
+
+            // 4. Validate formats with helpful messages
+            String email = args.getString("email");
+            if (!isValidEmail(email)) {
+                return ToolInputGuardrailResult.failure(
+                    "Invalid email format: '" + email + "'. " +
+                    "Expected format: user@example.com"
+                );
+            }
+
+            return ToolInputGuardrailResult.success();
+
+        } catch (DecodeException e) {
+            // 5. Handle JSON parsing errors gracefully
+            return ToolInputGuardrailResult.failure(
+                "Arguments must be valid JSON. " + e.getMessage()
+            );
+        }
+    }
+}
+----
+
+== Testing
+
+Test guardrails as regular CDI beans:
+
+[source,java]
+----
+@QuarkusTest
+public class EmailValidatorTest {
+
+    @Inject
+    EmailFormatValidator validator;
+
+    @Test
+    public void testValidEmail() {
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+            .id("1")
+            .name("sendEmail")
+            .arguments("{\"to\":\"user@example.com\"}")
+            .build();
+
+        ToolInputGuardrailRequest guardrailRequest =
+            new ToolInputGuardrailRequest(request, null, null);
+
+        ToolInputGuardrailResult result = validator.validate(guardrailRequest);
+
+        assertThat(result.isSuccess()).isTrue();
+    }
+
+    @Test
+    public void testInvalidEmail() {
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+            .id("1")
+            .name("sendEmail")
+            .arguments("{\"to\":\"invalid-email\"}")
+            .build();
+
+        ToolInputGuardrailRequest guardrailRequest =
+            new ToolInputGuardrailRequest(request, null, null);
+
+        ToolInputGuardrailResult result = validator.validate(guardrailRequest);
+
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.errorMessage()).contains("Invalid email");
+    }
+}
+----
+
+== Going Further
+
+[.lead]
+* xref:function-calling.adoc[Function Calling] – Learn how to declare and use tools in AI services
+* xref:guardrails.adoc[LLM Guardrails] – Understand guardrails for prompts and responses
+* xref:ai-services.adoc[AI Services Reference] – Complete AI service configuration guide

--- a/samples/tool-guardrails/README.md
+++ b/samples/tool-guardrails/README.md
@@ -1,0 +1,101 @@
+# Tool Guardrails Demo
+
+This demo showcases the implementation of **guardrails for tool/function calling** in Quarkus LangChain4j. 
+Guardrails provide a mechanism to validate and control tool invocations at both input and output stages.
+
+## What are Tool Guardrails?
+
+Tool guardrails are validation and transformation mechanisms that:
+
+- **Input Guardrails**: Validate parameters and context before tool execution
+- **Output Guardrails**: Validate, filter, or transform tool results before returning to the LLM
+
+This enables:
+- Security controls (authorization, authentication)
+- Data validation (format checking, business rules)
+- Privacy protection (sensitive data filtering)
+- Cost control (rate limiting, output size limiting)
+- Compliance requirements
+
+## Demo Overview
+
+This demo includes 6 different guardrails demonstrating various use cases:
+
+### Input Guardrails
+
+1. **EmailFormatValidator** - Validates email address format
+   - Checks against regex pattern
+   - Prevents execution if email is invalid
+   - Returns helpful error message to LLM
+
+2. **UserAuthorizationGuardrail** - Checks user permissions
+   - Uses CDI injection (RequestScoped)
+   - Integrates with Quarkus Security
+   - Role-based access control
+
+3. **RateLimitGuardrail** - Prevents abuse through rate limiting
+   - Stateful (maintains counters)
+   - Per-user/session limits
+   - Time-window based (5 calls per minute)
+
+### Output Guardrails
+
+4. **SensitiveDataFilter** - Redacts sensitive information
+   - Filters SSN, credit card numbers
+   - Regex-based pattern matching
+   - Transforms output before returning to LLM
+
+5. **OutputSizeLimiter** - Controls output size
+   - Truncates large results
+   - Prevents excessive token usage
+   - Adds truncation notice
+
+6. **Combined Guardrails** - Multiple guardrails on one tool
+   - Demonstrates guardrail chaining
+   - Ordered execution
+
+## Running the Demo
+
+### Start the application in dev mode:
+
+```bash
+mvn quarkus:dev
+```
+
+The application will start on http://localhost:8080
+
+### Example Requests
+
+#### 1. Send Email (with input validation)
+
+```bash
+# Valid email - should succeed
+curl "http://localhost:8080/email?request=Send%20an%20email%20to%20john@quarkus.io%20with%20subject%20'Hello'%20and%20body%20'How%20are%20you?'"
+
+# Invalid email - guardrail will reject
+curl "http://localhost:8080/email?request=Send%20an%20email%20to%20invalid-email%20with%20subject%20'Test'"
+```
+
+#### 2. Get Customer Info (with output filtering)
+
+```bash
+# SSN and credit card numbers will be redacted
+curl "http://localhost:8080/email?request=Get%20customer%20information%20for%20customer%20ID%2012345"
+```
+
+#### 3. Bulk Email (with rate limiting)
+
+```bash
+# Send multiple requests quickly to trigger rate limit
+for i in {1..10}; do
+  curl "http://localhost:8080/email?request=Send%20bulk%20email%20to%20alice@example.com,bob@example.com%20with%20subject%20'Test%20$i'"
+  sleep 1
+done
+```
+
+#### 4. Search Customers (with output size limiting)
+
+```bash
+# Large result set will be truncated
+curl "http://localhost:8080/email?request=Search%20for%20all%20customers"
+```

--- a/samples/tool-guardrails/pom.xml
+++ b/samples/tool-guardrails/pom.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.quarkiverse.langchain4j</groupId>
+    <artifactId>quarkus-langchain4j-sample-tool-guardrails</artifactId>
+    <name>Quarkus LangChain4j - Sample - Tool Guardrails</name>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <compiler-plugin.version>3.13.0</compiler-plugin.version>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
+        <maven.compiler.release>17</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.version>3.27.1</quarkus.platform.version>
+        <skipITs>true</skipITs>
+        <surefire-plugin.version>3.2.5</surefire-plugin.version>
+        <quarkus-langchain4j.version>999-SNAPSHOT</quarkus-langchain4j.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.langchain4j</groupId>
+            <artifactId>quarkus-langchain4j-openai</artifactId>
+            <version>${quarkus-langchain4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-security</artifactId>
+        </dependency>
+
+        <!-- Minimal dependencies to constrain the build -->
+        <dependency>
+            <groupId>io.quarkiverse.langchain4j</groupId>
+            <artifactId>quarkus-langchain4j-openai-deployment</artifactId>
+            <version>${quarkus-langchain4j.version}</version>
+            <scope>test</scope>
+            <type>pom</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>3.5.1</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                                        <maven.home>${maven.home}</maven.home>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <properties>
+                <quarkus.package.type>native</quarkus.package.type>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/samples/tool-guardrails/src/main/java/io/quarkiverse/langchain4j/sample/guardrails/EmailFormatValidator.java
+++ b/samples/tool-guardrails/src/main/java/io/quarkiverse/langchain4j/sample/guardrails/EmailFormatValidator.java
@@ -1,0 +1,67 @@
+package io.quarkiverse.langchain4j.sample.guardrails;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailResult;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.regex.Pattern;
+
+/**
+ * Input guardrail that validates email addresses.
+ * This guardrail checks if the email parameter matches a valid email format.
+ * If validation fails, the tool execution is prevented and an error message is returned to the LLM.
+ */
+@ApplicationScoped
+public class EmailFormatValidator implements ToolInputGuardrail {
+
+    private static final Pattern EMAIL_PATTERN =
+            Pattern.compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$");
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+        try {
+            // Parse the JSON arguments
+            JsonNode args = objectMapper.readTree(request.arguments());
+
+            // Check for 'to' parameter (single email)
+            if (args.has("to")) {
+                String email = args.get("to").asText();
+                if (!isValidEmail(email)) {
+                    return ToolInputGuardrailResult.failure(
+                            "Invalid email format: '" + email +
+                                    "'. Please provide a valid email address in the format 'user@domain.com'.");
+                }
+            }
+
+            // Check for 'recipients' parameter (comma-separated emails)
+            if (args.has("recipients")) {
+                String recipients = args.get("recipients").asText();
+                String[] emails = recipients.split(",");
+                for (String email : emails) {
+                    String trimmed = email.trim();
+                    if (!isValidEmail(trimmed)) {
+                        return ToolInputGuardrailResult.failure(
+                                "Invalid email format in recipients list: '" + trimmed +
+                                        "'. Please provide valid email addresses separated by commas.");
+                    }
+                }
+            }
+
+            // Validation passed
+            return ToolInputGuardrailResult.success();
+
+        } catch (Exception e) {
+            return ToolInputGuardrailResult.failure(
+                    "Failed to validate email format: " + e.getMessage(), e);
+        }
+    }
+
+    private boolean isValidEmail(String email) {
+        return email != null && EMAIL_PATTERN.matcher(email).matches();
+    }
+}

--- a/samples/tool-guardrails/src/main/java/io/quarkiverse/langchain4j/sample/guardrails/EmailResource.java
+++ b/samples/tool-guardrails/src/main/java/io/quarkiverse/langchain4j/sample/guardrails/EmailResource.java
@@ -1,0 +1,33 @@
+package io.quarkiverse.langchain4j.sample.guardrails;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+
+/**
+ * REST endpoint demonstrating tool guardrails.
+ */
+@Path("/email")
+public class EmailResource {
+
+    private final EmailService emailService;
+
+    public EmailResource(EmailService emailService) {
+        this.emailService = emailService;
+    }
+
+    /**
+     * Process an email-related request.
+     * Examples:
+     * - "Send an email to john@example.com with subject 'Hello' and body 'How are you?'"
+     * - "Get customer information for customer ID 12345"
+     * - "Search for customers named Smith"
+     */
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String processRequest(@QueryParam("request") String request) {
+        return emailService.processRequest(request);
+    }
+}

--- a/samples/tool-guardrails/src/main/java/io/quarkiverse/langchain4j/sample/guardrails/EmailService.java
+++ b/samples/tool-guardrails/src/main/java/io/quarkiverse/langchain4j/sample/guardrails/EmailService.java
@@ -1,0 +1,31 @@
+package io.quarkiverse.langchain4j.sample.guardrails;
+
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.ToolBox;
+
+/**
+ * AI Service for email-related operations.
+ * This service demonstrates how tools with guardrails work in practice.
+ */
+@RegisterAiService
+public interface EmailService {
+
+    /**
+     * Process email-related requests.
+     * The LLM will use the available tools (with their guardrails) to fulfill the request.
+     */
+    @SystemMessage("""
+            You are an AI assistant that helps with email operations.
+            You have access to tools for sending emails and retrieving customer information.
+            
+            Important:
+            - Always provide valid email addresses when sending emails
+            - Follow rate limits and authorization requirements
+            - Be aware that sensitive data may be filtered from customer information
+            """)
+    @UserMessage("{userMessage}")
+    @ToolBox(EmailTools.class)
+    String processRequest(String userMessage);
+}

--- a/samples/tool-guardrails/src/main/java/io/quarkiverse/langchain4j/sample/guardrails/EmailTools.java
+++ b/samples/tool-guardrails/src/main/java/io/quarkiverse/langchain4j/sample/guardrails/EmailTools.java
@@ -1,0 +1,104 @@
+package io.quarkiverse.langchain4j.sample.guardrails;
+
+import dev.langchain4j.agent.tool.Tool;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrails;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrails;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Example tools demonstrating various guardrail configurations.
+ */
+@ApplicationScoped
+public class EmailTools {
+
+    /**
+     * Send email with input validation (email format and authorization).
+     * This tool demonstrates:
+     * - Email format validation (input guardrail)
+     * - User authorization check (input guardrail)
+     * - Multiple guardrails in chain
+     */
+    @Tool("Send an email to a recipient")
+    @ToolInputGuardrails({
+            EmailFormatValidator.class,
+            UserAuthorizationGuardrail.class
+    })
+    public String sendEmail(String to,
+                            String subject,
+                            String body) {
+        return "Email sent successfully to " + to +
+                " with subject '" + subject + "'. Message: " + body;
+    }
+
+    /**
+     * Send bulk email with rate limiting.
+     * This tool demonstrates:
+     * - Rate limiting (input guardrail)
+     * - Preventing abuse through guardrails
+     */
+    @Tool("Send bulk emails to multiple recipients")
+    @ToolInputGuardrails({RateLimitGuardrail.class})
+    public String sendBulkEmail(String recipients,
+                                String subject,
+                                String body) {
+        String[] emails = recipients.split(",");
+        return "Bulk email sent to " + emails.length + " recipients: " + recipients;
+    }
+
+    /**
+     * Get customer information with output filtering.
+     * This tool demonstrates:
+     * - Sensitive data filtering (output guardrail)
+     * - Output size limiting (output guardrail)
+     * - Protecting customer privacy
+     */
+    @Tool("Get customer information by customer ID")
+    @ToolOutputGuardrails({
+            SensitiveDataFilter.class,
+            OutputSizeLimiter.class
+    })
+    public String getCustomerInfo(String customerId) {
+        // Simulated customer data
+        return "Customer ID: " + customerId + "\n" +
+                "Name: John Doe\n" +
+                "Email: john.doe@example.com\n" +
+                "Phone: +1-555-123-4567\n" +
+                "SSN: 123-45-6789\n" +  // This will be filtered by SensitiveDataFilter
+                "Credit Card: 1234-5678-9012-3456\n" +  // This will be filtered
+                "Address: 123 Main St, Anytown, USA\n" +
+                "Account Balance: $15,234.56\n" +
+                "Last Login: 2025-11-25 10:30:00";
+    }
+
+    /**
+     * Search customer database (demonstrates output size limiting).
+     * This tool demonstrates:
+     * - Output size limiting to prevent token overuse
+     * - Automatic truncation of large results
+     */
+    @Tool("Search customer database by query")
+    @ToolOutputGuardrails({OutputSizeLimiter.class})
+    public String searchCustomers(String query) {
+        // Simulated search results (in real app, this would query a database)
+        StringBuilder results = new StringBuilder();
+        results.append("Search results for '").append(query).append("':\n\n");
+
+        for (int i = 1; i <= 50; i++) {
+            results.append("Customer ").append(i).append(":\n");
+            results.append("  Name: Customer ").append(i).append(" Name\n");
+            results.append("  Email: customer").append(i).append("@example.com\n");
+            results.append("  Phone: +1-555-").append(String.format("%03d", i)).append("-").append(String.format("%04d", i * 10)).append("\n");
+            results.append("  Status: Active\n\n");
+        }
+
+        return results.toString();
+    }
+
+    /**
+     * Simple tool without guardrails for comparison.
+     */
+    @Tool("Get current timestamp")
+    public String getCurrentTime() {
+        return "Current time: " + java.time.LocalDateTime.now();
+    }
+}

--- a/samples/tool-guardrails/src/main/java/io/quarkiverse/langchain4j/sample/guardrails/OutputSizeLimiter.java
+++ b/samples/tool-guardrails/src/main/java/io/quarkiverse/langchain4j/sample/guardrails/OutputSizeLimiter.java
@@ -1,0 +1,47 @@
+package io.quarkiverse.langchain4j.sample.guardrails;
+
+import dev.langchain4j.service.tool.ToolExecutionResult;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrailRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrailResult;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Output guardrail that limits the size of tool output.
+ */
+@ApplicationScoped
+public class OutputSizeLimiter implements ToolOutputGuardrail {
+
+    // Maximum characters allowed (roughly ~1000 tokens)
+    private static final int MAX_CHARACTERS = 4000;
+
+    @Override
+    public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+        String result = request.resultText();
+
+        if (result == null || result.isEmpty()) {
+            return ToolOutputGuardrailResult.success();
+        }
+
+        // Check if output exceeds limit
+        if (result.length() > MAX_CHARACTERS) {
+            // Truncate the output
+            String truncated = result.substring(0, MAX_CHARACTERS);
+
+            // Add truncation notice
+            truncated += "\n\n[Output truncated - " + (result.length() - MAX_CHARACTERS) +
+                    " characters omitted. Original length: " + result.length() + " characters. " +
+                    "Please refine your query to get more specific results.]";
+
+            // Return modified result
+            ToolExecutionResult modifiedResult = ToolExecutionResult.builder()
+                    .resultText(truncated)
+                    .build();
+
+            return ToolOutputGuardrailResult.successWith(modifiedResult);
+        }
+
+        // Output size is acceptable
+        return ToolOutputGuardrailResult.success();
+    }
+}

--- a/samples/tool-guardrails/src/main/java/io/quarkiverse/langchain4j/sample/guardrails/RateLimitGuardrail.java
+++ b/samples/tool-guardrails/src/main/java/io/quarkiverse/langchain4j/sample/guardrails/RateLimitGuardrail.java
@@ -1,0 +1,76 @@
+package io.quarkiverse.langchain4j.sample.guardrails;
+
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailResult;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Input guardrail that implements rate limiting for tool invocations.
+ */
+@ApplicationScoped
+public class RateLimitGuardrail implements ToolInputGuardrail {
+
+    // Simple rate limiter: max 5 calls per minute per user/session
+    private static final int MAX_CALLS_PER_MINUTE = 5;
+    private static final Duration WINDOW_DURATION = Duration.ofMinutes(1);
+
+    // In-memory storage (in production, use Redis or similar)
+    private final Map<String, RateLimitEntry> rateLimits = new ConcurrentHashMap<>();
+
+    @Override
+    public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+        // Get user/session identifier (use memory ID as a proxy for user session)
+        String userId = getUserIdentifier(request);
+        String toolName = request.toolName();
+        String key = userId + ":" + toolName;
+
+        // Get or create rate limit entry
+        RateLimitEntry entry = rateLimits.computeIfAbsent(key, k -> new RateLimitEntry());
+
+        // Check rate limit
+        long now = System.currentTimeMillis();
+        synchronized (entry) {
+            // Reset counter if window has expired
+            if (now - entry.windowStart.get() > WINDOW_DURATION.toMillis()) {
+                entry.windowStart.set(now);
+                entry.count.set(0);
+            }
+
+            // Check if limit exceeded
+            if (entry.count.get() >= MAX_CALLS_PER_MINUTE) {
+                long timeUntilReset = entry.windowStart.get() + WINDOW_DURATION.toMillis() - now;
+                return ToolInputGuardrailResult.failure(
+                        "Rate limit exceeded for tool '" + toolName + "'. " +
+                                "Maximum " + MAX_CALLS_PER_MINUTE + " calls per minute allowed. " +
+                                "Please wait " + (timeUntilReset / 1000) + " seconds before trying again.");
+            }
+
+            // Increment counter
+            entry.count.incrementAndGet();
+        }
+
+        // Rate limit check passed
+        return ToolInputGuardrailResult.success();
+    }
+
+    private String getUserIdentifier(ToolInputGuardrailRequest request) {
+        // Use memory ID as user identifier (in production, use actual user ID from security context)
+        Object memoryId = request.memoryId();
+        return memoryId != null ? memoryId.toString() : "anonymous";
+    }
+
+    /**
+     * Simple rate limit entry holder.
+     */
+    private static class RateLimitEntry {
+        final AtomicLong windowStart = new AtomicLong(System.currentTimeMillis());
+        final AtomicInteger count = new AtomicInteger(0);
+    }
+}

--- a/samples/tool-guardrails/src/main/java/io/quarkiverse/langchain4j/sample/guardrails/SensitiveDataFilter.java
+++ b/samples/tool-guardrails/src/main/java/io/quarkiverse/langchain4j/sample/guardrails/SensitiveDataFilter.java
@@ -1,0 +1,49 @@
+package io.quarkiverse.langchain4j.sample.guardrails;
+
+import dev.langchain4j.service.tool.ToolExecutionResult;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrailRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrailResult;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.regex.Pattern;
+
+/**
+ * Output guardrail that filters sensitive data from tool results.
+ */
+@ApplicationScoped
+public class SensitiveDataFilter implements ToolOutputGuardrail {
+
+    // Patterns for sensitive data
+    private static final Pattern SSN_PATTERN = Pattern.compile("\\b\\d{3}-\\d{2}-\\d{4}\\b");
+    private static final Pattern CREDIT_CARD_PATTERN =
+            Pattern.compile("\\b\\d{4}[- ]?\\d{4}[- ]?\\d{4}[- ]?\\d{4}\\b");
+    // Optionally filter phone numbers (commented out as they might be needed)
+    // private static final Pattern PHONE_PATTERN = Pattern.compile("\\+?1?[- ]?\\(?\\d{3}\\)?[- ]?\\d{3}[- ]?\\d{4}");
+
+    @Override
+    public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
+        String result = request.resultText();
+
+        if (result == null || result.isEmpty()) {
+            return ToolOutputGuardrailResult.success();
+        }
+
+        // Apply filters
+        String filtered = result;
+        filtered = SSN_PATTERN.matcher(filtered).replaceAll("[REDACTED-SSN]");
+        filtered = CREDIT_CARD_PATTERN.matcher(filtered).replaceAll("[REDACTED-CARD]");
+
+        // If content was modified, return the filtered version
+        if (!filtered.equals(result)) {
+            ToolExecutionResult modifiedResult = ToolExecutionResult.builder()
+                    .resultText(filtered)
+                    .build();
+
+            return ToolOutputGuardrailResult.successWith(modifiedResult);
+        }
+
+        // No sensitive data found
+        return ToolOutputGuardrailResult.success();
+    }
+}

--- a/samples/tool-guardrails/src/main/java/io/quarkiverse/langchain4j/sample/guardrails/UserAuthorizationGuardrail.java
+++ b/samples/tool-guardrails/src/main/java/io/quarkiverse/langchain4j/sample/guardrails/UserAuthorizationGuardrail.java
@@ -1,0 +1,52 @@
+package io.quarkiverse.langchain4j.sample.guardrails;
+
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailResult;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+
+/**
+ * Input guardrail that checks user authorization before executing tools.
+ * NOTE: This is a simplified example. In a production environment,
+ * you would configure proper Quarkus Security with authentication.
+ */
+@RequestScoped
+public class UserAuthorizationGuardrail implements ToolInputGuardrail {
+
+    @Inject
+    SecurityIdentity securityIdentity;
+
+    @Override
+    public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+        // In this example, we simulate authorization check
+        // In a real application, you would check actual roles and permissions
+
+        String toolName = request.toolName();
+
+        // For demonstration purposes, assume anonymous users cannot send emails
+        if (securityIdentity.isAnonymous()) {
+            return ToolInputGuardrailResult.failure(
+                    "User not authorized to execute '" + toolName +
+                            "'. Please authenticate to use this feature.");
+        }
+
+        // Check for required role (in a real app, this would be a real role check)
+        // For this demo, we'll assume all authenticated users have the right role
+        if (!hasRequiredRole(toolName)) {
+            return ToolInputGuardrailResult.failure(
+                    "User '" + securityIdentity.getPrincipal().getName() +
+                            "' does not have permission to execute '" + toolName + "'.");
+        }
+
+        // Authorization successful
+        return ToolInputGuardrailResult.success();
+    }
+
+    private boolean hasRequiredRole(String toolName) {
+        // For this demo, we'll simulate that all authenticated users have permission
+        // In production, use: securityIdentity.hasRole("REQUIRED_ROLE")
+        return true;
+    }
+}

--- a/samples/tool-guardrails/src/main/resources/application.properties
+++ b/samples/tool-guardrails/src/main/resources/application.properties
@@ -1,0 +1,19 @@
+# Quarkus Configuration
+quarkus.http.port=8080
+
+# OpenAI Configuration
+# Set your OpenAI API key here or as an environment variable
+quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
+quarkus.langchain4j.openai.chat-model.model-name=gpt-4
+quarkus.langchain4j.openai.chat-model.temperature=0.7
+quarkus.langchain4j.openai.timeout=60s
+
+# Logging
+quarkus.log.level=INFO
+quarkus.log.category."io.quarkiverse.langchain4j".level=DEBUG
+
+# Security (for demonstration purposes - in production, configure properly)
+quarkus.security.users.embedded.enabled=true
+quarkus.security.users.embedded.plain-text=true
+quarkus.security.users.embedded.users.alice=password
+quarkus.security.users.embedded.roles.alice=user,email-sender


### PR DESCRIPTION
Implement a guardrail system for tool invocations, providing input validation and output filtering capabilities.

Features:
- Input guardrails (@ToolInputGuardrails) validate parameters before execution
- Output guardrails (@ToolOutputGuardrails) filter/transform results after execution
- Guardrails can allow, block, modify, or request retry with custom logic
- Support for multiple chained guardrails with fail-fast behavior
- CDI integration with full dependency injection support
- JSON parameter access via argumentsAsJson() for easy validation
- Access to tool metadata, invocation context, and memory ID

Limitations:
- Guardrails cannot execute on Vert.x event loop due to synchronous API
- Tools with guardrails must use blocking execution model
- Clear error message guides users to mark tools as @Blocking

---

- Closes: https://github.com/quarkiverse/quarkus-langchain4j/issues/990
