### PR TITLE
Add default auth model provider

### DIFF
--- a/docs/modules/ROOT/pages/azure-openai-chat-model.adoc
+++ b/docs/modules/ROOT/pages/azure-openai-chat-model.adoc
@@ -91,6 +91,32 @@ import jakarta.inject.Inject;
 @Inject @ModelName("some-name") ChatModel chatModel;
 ----
 
+== Default Azure Credential
+
+Quarkus LangChain4j supports Azure OpenAI authentication using Azure AD via https://learn.microsoft.com/en-us/java/api/com.azure.identity.defaultazurecredential?view=azure-java-stable[`DefaultAzureCredential`].
+
+To enable it, add the Azure Identity extension:
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.quarkiverse.azureservices</groupId>
+    <artifactId>quarkus-azure-identity</artifactId>
+    <version>1.2.2</version>
+</dependency>
+----
+
+Then enable DefaultAzureCredential authentication in your configuration:
+
+[source,properties]
+----
+quarkus.langchain4j.azure-openai.use-azure-credential-model-auth-provider=true
+----
+
+When enabled, the SDK automatically authenticates using `DefaultAzureCredential`.
+
+It supports Azure Managed Identity and local developer credentials (Azure CLI, IDE login).
+
 == Advanced usage
 
 Please refer to https://docs.quarkiverse.io/quarkus-langchain4j/dev/openai-chat-model.html#_advanced_usage[Open AI].

--- a/model-providers/openai/azure-openai/deployment/pom.xml
+++ b/model-providers/openai/azure-openai/deployment/pom.xml
@@ -20,6 +20,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.quarkiverse.azureservices</groupId>
+            <artifactId>quarkus-azure-identity</artifactId>
+            <version>${io.quarkiverse.azureservices-quarkus-azure-identity.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>

--- a/model-providers/openai/azure-openai/deployment/src/main/java/io/quarkiverse/langchain4j/azure/openai/deployment/AzureOpenAiProcessor.java
+++ b/model-providers/openai/azure-openai/deployment/src/main/java/io/quarkiverse/langchain4j/azure/openai/deployment/AzureOpenAiProcessor.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.spi.DeploymentException;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassType;
@@ -17,6 +18,7 @@ import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 
 import io.quarkiverse.langchain4j.ModelName;
+import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
 import io.quarkiverse.langchain4j.azure.openai.AzureOpenAiChatModel;
 import io.quarkiverse.langchain4j.azure.openai.AzureOpenAiEmbeddingModel;
 import io.quarkiverse.langchain4j.azure.openai.AzureOpenAiImageModel;
@@ -59,6 +61,32 @@ public class AzureOpenAiProcessor {
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    public void registerDefaultModelAuthProvider(
+            AzureOpenAiRecorder recorder,
+            BuildProducer<SyntheticBeanBuildItem> producer,
+            LangChain4jAzureOpenAiBuildConfig config) {
+        if (!config.useAzureCredentialModelAuthProvider())
+            return;
+
+        try {
+            Class.forName("com.azure.identity.DefaultAzureCredentialBuilder");
+        } catch (ClassNotFoundException e) {
+            throw new DeploymentException(
+                    "use-azure-credential-model-auth-provider=true requires io.quarkiverse.azureservices:quarkus-azure-identity on the classpath. Add it to your project dependencies.");
+        }
+
+        producer.produce(
+                SyntheticBeanBuildItem
+                        .configure(ModelAuthProvider.class)
+                        .scope(ApplicationScoped.class)
+                        .setRuntimeInit()
+                        .defaultBean()
+                        .createWith(recorder.defaultAzureCredentialModelAuthProvider())
+                        .done());
     }
 
     @BuildStep

--- a/model-providers/openai/azure-openai/deployment/src/main/java/io/quarkiverse/langchain4j/azure/openai/deployment/LangChain4jAzureOpenAiBuildConfig.java
+++ b/model-providers/openai/azure-openai/deployment/src/main/java/io/quarkiverse/langchain4j/azure/openai/deployment/LangChain4jAzureOpenAiBuildConfig.java
@@ -4,6 +4,7 @@ import static io.quarkus.runtime.annotations.ConfigPhase.BUILD_TIME;
 
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
 @ConfigRoot(phase = BUILD_TIME)
 @ConfigMapping(prefix = "quarkus.langchain4j.azure-openai")
@@ -28,4 +29,10 @@ public interface LangChain4jAzureOpenAiBuildConfig {
      * Image model related settings
      */
     ImageModelBuildConfig imageModel();
+
+    /**
+     * If true, provides model auth provider, which uses Default Azure Credential for authentication.
+     */
+    @WithDefault("false")
+    boolean useAzureCredentialModelAuthProvider();
 }

--- a/model-providers/openai/azure-openai/deployment/src/test/java/io/quarkiverse/langchain4j/azure/openai/test/DefaultAzureCredentialModelAuthProviderDisabledTest.java
+++ b/model-providers/openai/azure-openai/deployment/src/test/java/io/quarkiverse/langchain4j/azure/openai/test/DefaultAzureCredentialModelAuthProviderDisabledTest.java
@@ -1,0 +1,33 @@
+package io.quarkiverse.langchain4j.azure.openai.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
+import io.quarkiverse.langchain4j.azure.openai.runtime.AzureOpenAiRecorder;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DefaultAzureCredentialModelAuthProviderDisabledTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey(
+                    "quarkus.langchain4j.azure-openai.endpoint", WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Test
+    void defaultAzureCredentialProviderBeanIsNotRegistered() {
+        var instance = Arc.container().instance(ModelAuthProvider.class);
+        if (instance.isAvailable()) {
+            assertThat(instance.get())
+                    .isNotInstanceOf(AzureOpenAiRecorder.DefaultAzureCredentialModelAuthProvider.class);
+        }
+    }
+}

--- a/model-providers/openai/azure-openai/deployment/src/test/java/io/quarkiverse/langchain4j/azure/openai/test/DefaultAzureCredentialModelAuthProviderTest.java
+++ b/model-providers/openai/azure-openai/deployment/src/test/java/io/quarkiverse/langchain4j/azure/openai/test/DefaultAzureCredentialModelAuthProviderTest.java
@@ -1,0 +1,62 @@
+package io.quarkiverse.langchain4j.azure.openai.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DefaultAzureCredentialModelAuthProviderTest extends OpenAiBaseTest {
+
+    private static final String MOCK_TOKEN = "mock-azure-bearer-token";
+
+    @ApplicationScoped
+    public static class MockModelAuthProvider implements ModelAuthProvider {
+        @Override
+        public String getAuthorization(Input input) {
+            return "Bearer " + MOCK_TOKEN;
+        }
+    }
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MockModelAuthProvider.class))
+            .overrideConfigKey(
+                    "quarkus.langchain4j.azure-openai.use-azure-credential-model-auth-provider", "true")
+            .overrideRuntimeConfigKey(
+                    "quarkus.langchain4j.azure-openai.endpoint", WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    ChatModel chatModel;
+
+    @Inject
+    ModelAuthProvider modelAuthProvider;
+
+    @Test
+    void authProviderBeanIsRegisteredAndResolvable() {
+        assertThat(modelAuthProvider).isInstanceOf(MockModelAuthProvider.class);
+    }
+
+    @Test
+    void chatUsesAuthProviderBearerToken() {
+        String response = chatModel.chat("hello");
+        assertThat(response).isNotBlank();
+
+        LoggedRequest loggedRequest = singleLoggedRequest();
+        assertThat(loggedRequest.getHeader("Authorization"))
+                .isEqualTo("Bearer " + MOCK_TOKEN);
+    }
+}

--- a/model-providers/openai/azure-openai/runtime/pom.xml
+++ b/model-providers/openai/azure-openai/runtime/pom.xml
@@ -15,6 +15,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.quarkiverse.azureservices</groupId>
+            <artifactId>quarkus-azure-identity</artifactId>
+            <version>${io.quarkiverse.azureservices-quarkus-azure-identity.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
@@ -19,6 +19,11 @@ import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.util.TypeLiteral;
 
+import com.azure.core.credential.AccessToken;
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.credential.TokenRequestContext;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.DisabledChatModel;
 import dev.langchain4j.model.chat.DisabledStreamingChatModel;
@@ -307,6 +312,16 @@ public class AzureOpenAiRecorder {
         }
     }
 
+    public Function<SyntheticCreationalContext<ModelAuthProvider>, ModelAuthProvider> defaultAzureCredentialModelAuthProvider() {
+        return new Function<>() {
+            @Override
+            public ModelAuthProvider apply(
+                    SyntheticCreationalContext<ModelAuthProvider> modelAuthProviderSyntheticCreationalContext) {
+                return new DefaultAzureCredentialModelAuthProvider();
+            }
+        };
+    }
+
     static String getEndpoint(LangChain4jAzureOpenAiConfig.AzureAiConfig azureAiConfig, String configName, EndpointType type) {
         var endpoint = azureAiConfig.endPointFor(type);
 
@@ -393,4 +408,24 @@ public class AzureOpenAiRecorder {
         });
     }
 
+    public static class DefaultAzureCredentialModelAuthProvider implements ModelAuthProvider {
+        private static final String SCOPE = "https://cognitiveservices.azure.com/.default";
+        private static final TokenCredential credential = new DefaultAzureCredentialBuilder().build();
+        private static final TokenRequestContext context = new TokenRequestContext().addScopes(SCOPE);
+        private static volatile AccessToken currentToken;
+
+        @Override
+        public String getAuthorization(Input input) {
+            AccessToken token = currentToken;
+            if (token == null || token.isExpired()) {
+                synchronized (this) {
+                    token = currentToken;
+                    if (token == null || token.isExpired()) {
+                        currentToken = credential.getTokenSync(context);
+                    }
+                }
+            }
+            return "Bearer " + currentToken.getToken();
+        }
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
     <google-auth-library-oauth2-http.version>1.42.1</google-auth-library-oauth2-http.version>
     <gpu-llama3.version>0.4.0</gpu-llama3.version>
     <smallrye-certificate-generator.version>0.9.2</smallrye-certificate-generator.version>
+    <io.quarkiverse.azureservices-quarkus-azure-identity.version>1.2.2</io.quarkiverse.azureservices-quarkus-azure-identity.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
My solution for default azure auth model provider. Please note that Azure advises to use different authentication method for production https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet.

> Simplifies authentication while developing apps that deploy to Azure by combining credentials used in Azure hosting environments with credentials used in local development. In production, it's better to use something else. See [Usage guidance for DefaultAzureCredential](https://aka.ms/azsdk/net/identity/credential-chains#usage-guidance-for-defaultazurecredential).

However it should be sufficient for development purposes and further collaboration. 

- Fixes: https://github.com/quarkiverse/quarkus-langchain4j/issues/1995