### PR TITLE
Ignore null SSE mesages

### DIFF
--- a/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/http/SseSubscriber.java
+++ b/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/http/SseSubscriber.java
@@ -33,18 +33,18 @@ public class SseSubscriber implements Consumer<SseEvent<String>> {
     @Override
     public void accept(SseEvent<String> s) {
         // some servers send empty messages as pings
-        if (s.data().isEmpty() || s.data().isBlank()) {
+        String data = s.data();
+        if (data == null || data.isEmpty() || data.isBlank()) {
             return;
         }
         if (logEvents) {
-            log.debug("< " + s.data());
+            log.debug("< " + data);
         }
         String name = s.name();
         if (name == null) {
             log.debug("Received event with null name, default it to 'message'");
             name = "message";
         }
-        String data = s.data();
         if (name.equals("message")) {
             try {
                 JsonNode jsonNode = OBJECT_MAPPER.readTree(data);


### PR DESCRIPTION
Fixes this error when SSE message is not present in server response
```
[ERROR] io.quarkus.vertx.core.runtime.VertxCoreRecorder - Uncaught exception received by Vert.x: java.lang.NullPointerException: Cannot invoke "String.isEmpty()" because the return value of "org.jboss.resteasy.reactive.client.SseEvent.data()" is null
	at io.quarkiverse.langchain4j.mcp.runtime.http.SseSubscriber.accept(SseSubscriber.java:36)
	at io.quarkiverse.langchain4j.mcp.runtime.http.QuarkusStreamableHttpMcpTransport$1.handle(QuarkusStreamableHttpMcpTransport.java:169)
	at io.quarkiverse.langchain4j.mcp.runtime.http.QuarkusStreamableHttpMcpTransport$1.handle(QuarkusStreamableHttpMcpTransport.java:156)
	at io.vertx.core.impl.ContextInternal.dispatch(ContextInternal.java:270)
	at io.vertx.core.http.impl.HttpEventHandler.handleChunk(HttpEventHandler.java:51)
...
```
@jmartisk I encountered this error, looks like you fixed some things there but apparently the value can also be null:
https://github.com/quarkiverse/quarkus-langchain4j/commit/1a53136c7b02990b13c3f9a86a7b4a6a7700f597#diff-fc362ec2be46d62eab0a2a730c593dcf5101602baefa120d5613b60174431dd0