### PR TITLE
Temporarily hard-code the versions of various testcontainers

### DIFF
--- a/embedding-stores/chroma/deployment/pom.xml
+++ b/embedding-stores/chroma/deployment/pom.xml
@@ -28,6 +28,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>chromadb</artifactId>
+            <version>1.21.3</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>

--- a/embedding-stores/milvus/deployment/pom.xml
+++ b/embedding-stores/milvus/deployment/pom.xml
@@ -34,6 +34,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>milvus</artifactId>
+            <version>1.21.3</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>

--- a/embedding-stores/qdrant/deployment/pom.xml
+++ b/embedding-stores/qdrant/deployment/pom.xml
@@ -34,6 +34,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>qdrant</artifactId>
+            <version>1.21.3</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>

--- a/embedding-stores/weaviate/deployment/pom.xml
+++ b/embedding-stores/weaviate/deployment/pom.xml
@@ -20,6 +20,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>weaviate</artifactId>
+            <version>1.21.3</version>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.langchain4j</groupId>

--- a/model-providers/ollama/deployment/pom.xml
+++ b/model-providers/ollama/deployment/pom.xml
@@ -34,6 +34,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>ollama</artifactId>
+            <version>1.21.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>junit</groupId>


### PR DESCRIPTION
This is done in order to make the project build with the latest Quarkus from `main` which has been bumped to TestContainers 2