### PR TITLE
Fix: Persist ChatMemory when Tool ReturnBehavior is IMMEDIATE (#2017)

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
@@ -468,6 +468,7 @@ public class AiServiceMethodImplementationSupport {
                 committableChatMemory.add(toolResult);
             }
             if (immediateToolReturn) {
+                committableChatMemory.commit();
                 if (!TypeUtil.isResult(returnType)) {
                     throw IllegalConfigurationException
                             .illegalConfiguration("@Tool with IMMEDIATE return behavior must return a Result");


### PR DESCRIPTION
- Fixes: #2017 