### PR TITLE
Allow multiple McpClientName annotations on McpClientAuthProvider beans

### DIFF
--- a/docs/modules/ROOT/pages/mcp.adoc
+++ b/docs/modules/ROOT/pages/mcp.adoc
@@ -79,6 +79,16 @@ public class MyMcpAuthProvider implements McpClientAuthProvider {
 
 TIP: The `Input` object gives you access to the HTTP request context (URI, method, headers).
 
+If you have multiple MCP clients, you may need to control which client uses which `McpClientAuthProvider`.
+For that, you can apply the `@McpClientName` qualifier on beans that implement `McpClientAuthProvider`, and
+that provider will only be used for the specified MCP client (or clients, if you repeat the annotation multiple times).
+
+When resolving which client will use which auth provider, these rules are followed:
+- If there is a provider with the matching `@McpClientName`, it will be used. If there are multiple, it's not defined which one will be used.
+- Otherwise, if there is a provider without `@McpClientName`, it will be used.
+- If neither of the above is true, no authorization will be applied.
+
+
 === Propagating OIDC Access Tokens
 
 If your application uses OpenID Connect (OIDC) and the user has authenticated, you can **automatically propagate** the user's access token to the MCP server by adding:

--- a/integration-tests/mcp/src/test/java/io/quarkiverse/langchain4j/mcp/test/McpTokenTest.java
+++ b/integration-tests/mcp/src/test/java/io/quarkiverse/langchain4j/mcp/test/McpTokenTest.java
@@ -1,0 +1,119 @@
+package io.quarkiverse.langchain4j.mcp.test;
+
+import static io.quarkiverse.langchain4j.mcp.test.McpServerHelper.skipTestsIfJbangNotAvailable;
+import static io.quarkiverse.langchain4j.mcp.test.McpServerHelper.startServerHttp;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.mcp.client.McpClient;
+import io.quarkiverse.langchain4j.mcp.auth.McpClientAuthProvider;
+import io.quarkiverse.langchain4j.mcp.runtime.McpClientName;
+import io.quarkus.test.QuarkusUnitTest;
+
+class McpTokenTest {
+
+    private static final Logger log = LoggerFactory.getLogger(McpTokenTest.class);
+    private static Process process;
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(McpServerHelper.class))
+            .overrideConfigKey("quarkus.langchain4j.mcp.client1.transport-type", "streamable-http")
+            .overrideConfigKey("quarkus.langchain4j.mcp.client1.url", "http://localhost:8082/mcp")
+            .overrideConfigKey("quarkus.langchain4j.mcp.client2.transport-type", "streamable-http")
+            .overrideConfigKey("quarkus.langchain4j.mcp.client2.url", "http://localhost:8082/mcp")
+            .overrideConfigKey("quarkus.langchain4j.mcp.client4.transport-type", "streamable-http")
+            .overrideConfigKey("quarkus.langchain4j.mcp.client4.url", "http://localhost:8082/mcp");
+
+    @BeforeAll
+    static void setup() throws Exception {
+        skipTestsIfJbangNotAvailable();
+        process = startServerHttp("auth_mcp_server.java");
+    }
+
+    @AfterAll
+    static void teardown() throws Exception {
+        if (process != null && process.isAlive()) {
+            process.destroyForcibly();
+        }
+    }
+
+    @Inject
+    @McpClientName("client1")
+    McpClient client1;
+
+    @Inject
+    @McpClientName("client2")
+    McpClient client2;
+
+    @Inject
+    @McpClientName("client4")
+    McpClient client4;
+
+    @Test
+    public void client1() throws Exception {
+        assertThat(getToken(client1)).isEqualTo("Bearer token1");
+    }
+
+    @Test
+    public void client2() throws Exception {
+        assertThat(getToken(client2)).isEqualTo("Bearer token2");
+    }
+
+    @Test
+    public void client4() throws Exception {
+        // there is no McpClientAuthProvider specific for client4, so the global one (without any McpClientName qualifier) should be used
+        assertThat(getToken(client4)).isEqualTo("Bearer token-global");
+    }
+
+    private String getToken(McpClient client) {
+        return client.executeTool(ToolExecutionRequest.builder().name("getToken").build()).resultText();
+    }
+
+    @ApplicationScoped
+    @McpClientName("client1")
+    public static class AuthProviderForClient1 implements McpClientAuthProvider {
+
+        @Override
+        public String getAuthorization(Input input) {
+            return "Bearer token1";
+        }
+
+    }
+
+    @ApplicationScoped
+    @McpClientName("client2")
+    @McpClientName("client3")
+    public static class AuthProviderForClient2and3 implements McpClientAuthProvider {
+
+        @Override
+        public String getAuthorization(Input input) {
+            return "Bearer token2";
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class AuthProviderGlobal implements McpClientAuthProvider {
+
+        @Override
+        public String getAuthorization(Input input) {
+            return "Bearer token-global";
+        }
+
+    }
+
+}

--- a/integration-tests/mcp/src/test/resources/auth_mcp_server.java
+++ b/integration-tests/mcp/src/test/resources/auth_mcp_server.java
@@ -1,0 +1,32 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS io.quarkus:quarkus-bom:${quarkus.version:3.27.0}@pom
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.7.2
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.7.2
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-websocket:1.7.2
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import io.quarkiverse.mcp.server.Cancellation;
+import io.quarkiverse.mcp.server.ImageContent;
+import io.quarkiverse.mcp.server.TextContent;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.ToolResponse;
+import jakarta.inject.Inject;
+
+import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
+
+public class auth_mcp_server {
+
+    @Inject
+    CurrentVertxRequest request;
+
+    @Tool(description = "Returns the client's authentication token")
+    public String getToken() {
+        return request.getCurrent().request().headers().get("Authorization");
+    }
+
+}

--- a/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/McpClientName.java
+++ b/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/McpClientName.java
@@ -4,6 +4,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -11,12 +12,17 @@ import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
 /**
- * Used as a qualifier to denote a particular MCP client by its name.
+ * This annotation has two uses:
+ * - On an injection point of type McpClient, this can be used as a qualifier to pick a particular MCP client by its name.
+ * - When applied on a bean that implements McpClientAuthProvider, it indicates that this provider is associated with the named
+ * MCP client. In this case,
+ * it's allowed to add multiple McpClientName annotations to say that the provider should be used for multiple MCP clients.
  */
 @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
 @Retention(RUNTIME)
 @Documented
 @Qualifier
+@Repeatable(McpClientNames.class)
 public @interface McpClientName {
 
     String value();

--- a/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/McpClientNames.java
+++ b/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/McpClientNames.java
@@ -1,0 +1,17 @@
+package io.quarkiverse.langchain4j.mcp.runtime;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RUNTIME)
+@Documented
+public @interface McpClientNames {
+
+    McpClientName[] value();
+
+}


### PR DESCRIPTION
- Closes: https://github.com/quarkiverse/quarkus-langchain4j/issues/2028