### PR TITLE
Fix config mapping registration in gpu-llama3 runtime module

### DIFF
--- a/model-providers/gpu-llama3/runtime/pom.xml
+++ b/model-providers/gpu-llama3/runtime/pom.xml
@@ -77,6 +77,13 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                     <release combine.self="override" />
                     <compilerArgs>
                         <arg>--enable-preview</arg>


### PR DESCRIPTION
## Fix config mapping registration in gpu-llama3 runtime module

This PR adds `quarkus-extension-processor` to `annotationProcessorPaths` in the gpu-llama3 runtime module's compiler configuration.

Without this processor, `@ConfigMapping` classes were compiled but never registered, causing `SRCFG00027: Could not find a mapping` errors during integration test builds.

The processor was present in the deployment module but missing from runtime, preventing proper config discovery for `BUILD_AND_RUN_TIME_FIXED` phase configs.