### PR TITLE
Allow Gemini Schema detection to be null

### DIFF
--- a/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/BaseGeminiChatModel.java
+++ b/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/BaseGeminiChatModel.java
@@ -6,6 +6,8 @@ import org.jboss.logging.Logger;
 
 import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.chat.request.ResponseFormat;
+import dev.langchain4j.model.chat.request.ResponseFormatType;
+import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
 
 public class BaseGeminiChatModel {
 
@@ -34,5 +36,54 @@ public class BaseGeminiChatModel {
         this.thinkingBudget = thinkingBudget;
         this.includeThoughts = includeThoughts;
         this.useGoogleSearch = useGoogleSearch;
+    }
+
+    /**
+     * Detects and returns the schema based on the given response format.
+     * If the response format type is JSON or if a JSON schema is provided,
+     * a corresponding {@code Schema} object is created and returned. Otherwise, returns {@code null}.
+     *
+     * @param effectiveResponseFormat nullable detected {@code ResponseFormat}
+     * @return the detected {@code Schema} object; otherwise, {@code null}
+     */
+    protected Schema detectSchema(ResponseFormat effectiveResponseFormat) {
+        if (effectiveResponseFormat != null &&
+                (effectiveResponseFormat.type().equals(ResponseFormatType.JSON)
+                        || effectiveResponseFormat.jsonSchema() != null)) {
+            return SchemaMapper.fromJsonSchemaToSchema(effectiveResponseFormat.jsonSchema());
+        }
+        return null;
+    }
+
+    /**
+     * Computes the MIME type based on the provided response format.
+     * If the response format is null or of type TEXT, returns "text/plain".
+     * If the response format is of type JSON and contains a JSON schema with a root element
+     * that is an instance of JsonEnumSchema, returns "text/x.enum".
+     * If detected schema is null, logs a warning and defaults to "text/plain".
+     * Otherwise, returns "application/json".
+     *
+     * @param responseFormat nullable {@code ResponseFormat}
+     * @param schema nullable {@code Schema}
+     * @return the computed MIME type as a string
+     */
+    protected String computeMimeType(ResponseFormat responseFormat, Schema schema) {
+        if (responseFormat == null || ResponseFormatType.TEXT.equals(responseFormat.type())) {
+            return "text/plain";
+        }
+
+        if (ResponseFormatType.JSON.equals(responseFormat.type()) &&
+                responseFormat.jsonSchema() != null &&
+                responseFormat.jsonSchema().rootElement() != null &&
+                responseFormat.jsonSchema().rootElement() instanceof JsonEnumSchema) {
+            return "text/x.enum";
+        }
+
+        if (schema == null) {
+            log.warn("Schema is null while computing MIME type suggesting 'application/json'. Defaulting to 'text/plain'.");
+            return "text/plain";
+        }
+
+        return "application/json";
     }
 }

--- a/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/GeminiChatLanguageModel.java
+++ b/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/GeminiChatLanguageModel.java
@@ -1,9 +1,7 @@
 package io.quarkiverse.langchain4j.gemini.common;
 
-import static dev.langchain4j.data.message.AiMessage.aiMessage;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.model.chat.Capability.RESPONSE_FORMAT_JSON_SCHEMA;
-import static io.quarkiverse.langchain4j.gemini.common.BaseGeminiChatModel.log;
 
 import java.util.HashSet;
 import java.util.List;
@@ -26,7 +24,6 @@ import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.ResponseFormatType;
-import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.output.FinishReason;
@@ -58,12 +55,11 @@ public abstract class GeminiChatLanguageModel extends BaseGeminiChatModel implem
     public ChatResponse chat(ChatRequest chatRequest) {
         ChatRequestParameters requestParameters = chatRequest.parameters();
         ResponseFormat effectiveResponseFormat = getOrDefault(requestParameters.responseFormat(), responseFormat);
-        Schema schema = effectiveResponseFormat != null
-                ? SchemaMapper.fromJsonSchemaToSchema(effectiveResponseFormat.jsonSchema())
-                : null;
+        Schema schema = detectSchema(effectiveResponseFormat);
+
         GenerationConfig.Builder generationConfigBuilder = GenerationConfig.builder()
                 .maxOutputTokens(getOrDefault(requestParameters.maxOutputTokens(), this.maxOutputTokens))
-                .responseMimeType(schema != null ? computeMimeType(effectiveResponseFormat) : null)
+                .responseMimeType(computeMimeType(effectiveResponseFormat, schema))
                 .responseSchema(schema)
                 .stopSequences(requestParameters.stopSequences())
                 .temperature(getOrDefault(requestParameters.temperature(), this.temperature))
@@ -178,21 +174,6 @@ public abstract class GeminiChatLanguageModel extends BaseGeminiChatModel implem
                 .metadata(ChatResponseMetadata.builder().id(responseId).modelName(responseModel)
                         .tokenUsage(response.tokenUsage()).build())
                 .build();
-    }
-
-    private String computeMimeType(ResponseFormat responseFormat) {
-        if (responseFormat == null || ResponseFormatType.TEXT.equals(responseFormat.type())) {
-            return "text/plain";
-        }
-
-        if (ResponseFormatType.JSON.equals(responseFormat.type()) &&
-                responseFormat.jsonSchema() != null &&
-                responseFormat.jsonSchema().rootElement() != null &&
-                responseFormat.jsonSchema().rootElement() instanceof JsonEnumSchema) {
-            return "text/x.enum";
-        }
-
-        return "application/json";
     }
 
     @Override

--- a/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/SchemaMapper.java
+++ b/model-providers/google/gemini/gemini-common/runtime/src/main/java/io/quarkiverse/langchain4j/gemini/common/SchemaMapper.java
@@ -15,6 +15,9 @@ import dev.langchain4j.model.chat.request.json.JsonStringSchema;
 
 public class SchemaMapper {
     public static Schema fromJsonSchemaToSchema(JsonSchema jsonSchema) {
+        if (jsonSchema == null || jsonSchema.rootElement() == null) {
+            return null;
+        }
         var result = fromJsonSchemaToSchema(jsonSchema.rootElement());
         if ((result == null) || result.isEffectiveEmptyObject()) {
             return null;


### PR DESCRIPTION
Good afternoon everyone,

Here is a suggestion that allows the schema to be null in Gemini. This makes ResponseFormatType.Text possible.
Currently, a workaround is possible in which you set the format to null.
Like:
`AiGeminiChatLanguageModel.builder()
                .key(...)
                .modelId(...)
                .responseFormat(null)
`

However, to ensure that interfaces such as the following will work again in the future, I propose the change.
`
@SystemMessage(""".....
            """)
    @UserMessage("""
            QUESTION:
            {question}
            """)
    String answer(String question);
`
I have also moved two methods to the base class. In general, the existing base class could be used even more to avoid duplication.
