### PR TITLE
Add promptCaching / enableReasoning config to Bedrock model

### DIFF
--- a/model-providers/bedrock/runtime/src/main/java/io/quarkiverse/langchain4j/bedrock/runtime/BedrockRecorder.java
+++ b/model-providers/bedrock/runtime/src/main/java/io/quarkiverse/langchain4j/bedrock/runtime/BedrockRecorder.java
@@ -15,6 +15,7 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.util.TypeLiteral;
 
 import dev.langchain4j.model.bedrock.BedrockChatModel;
+import dev.langchain4j.model.bedrock.BedrockChatRequestParameters;
 import dev.langchain4j.model.bedrock.BedrockCohereEmbeddingModel;
 import dev.langchain4j.model.bedrock.BedrockStreamingChatModel;
 import dev.langchain4j.model.bedrock.BedrockTitanEmbeddingModel;
@@ -23,7 +24,6 @@ import dev.langchain4j.model.chat.DisabledChatModel;
 import dev.langchain4j.model.chat.DisabledStreamingChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
-import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.embedding.DisabledEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import io.quarkiverse.langchain4j.bedrock.runtime.config.AwsClientConfig;
@@ -63,7 +63,7 @@ public class BedrockRecorder {
         if (config.enableIntegration()) {
             var modelConfig = config.chatModel();
 
-            var paramBuilder = ChatRequestParameters.builder()
+            var paramBuilder = BedrockChatRequestParameters.builder()
                     .maxOutputTokens(modelConfig.maxTokens());
 
             if (modelConfig.temperature().isPresent()) {
@@ -83,6 +83,14 @@ public class BedrockRecorder {
                 if (!stopSequences.isEmpty()) {
                     paramBuilder.stopSequences(stopSequences.toArray(new String[0]));
                 }
+            }
+
+            if (modelConfig.promptCaching().isPresent()) {
+                paramBuilder.promptCaching(modelConfig.promptCaching().get());
+            }
+
+            if (modelConfig.reasoning().isPresent()) {
+                paramBuilder.enableReasoning(modelConfig.reasoning().getAsInt());
             }
 
             var clientBuilder = BedrockRuntimeClient.builder();
@@ -147,7 +155,7 @@ public class BedrockRecorder {
 
             var modelId = modelConfig.modelId().orElse("anthropic.claude-v2");
 
-            var paramsBuilder = ChatRequestParameters.builder()
+            var paramsBuilder = BedrockChatRequestParameters.builder()
                     .maxOutputTokens(modelConfig.maxTokens());
 
             if (modelConfig.temperature().isPresent()) {
@@ -164,6 +172,14 @@ public class BedrockRecorder {
 
             if (modelConfig.stopSequences().isPresent()) {
                 paramsBuilder.stopSequences(modelConfig.stopSequences().get().toArray(new String[0]));
+            }
+
+            if (modelConfig.promptCaching().isPresent()) {
+                paramsBuilder.promptCaching(modelConfig.promptCaching().get());
+            }
+
+            if (modelConfig.reasoning().isPresent()) {
+                paramsBuilder.enableReasoning(modelConfig.reasoning().getAsInt());
             }
 
             var builder = BedrockStreamingChatModel.builder()

--- a/model-providers/bedrock/runtime/src/main/java/io/quarkiverse/langchain4j/bedrock/runtime/config/ChatModelConfig.java
+++ b/model-providers/bedrock/runtime/src/main/java/io/quarkiverse/langchain4j/bedrock/runtime/config/ChatModelConfig.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 
+import dev.langchain4j.model.bedrock.BedrockCachePointPlacement;
 import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
@@ -84,5 +85,22 @@ public interface ChatModelConfig extends AwsClientConfig {
      * Http client related configurations for chat models
      */
     HttpClientConfig client();
+
+    /**
+     * Enables prompt caching to reduce latency and costs for requests with repeated content.
+     * You can specify where to place the cache point in the prompt, possible values are {@code AFTER_SYSTEM},
+     * {@code AFTER_USER_MESSAGE} or {@code AFTER_TOOLS}.
+     *
+     * @see <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html">AWS Bedrock Prompt Caching</a>
+     */
+    Optional<BedrockCachePointPlacement> promptCaching();
+
+    /**
+     * Enables reasoning capabilities of the model. It requires to set the maximum number of tokens to allocate for reasoning.
+     *
+     * @see <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/inference-reasoning.html">AWS Bedrock inference
+     *      reasoning</a>.
+     */
+    OptionalInt reasoning();
 
 }


### PR DESCRIPTION
See https://github.com/quarkiverse/quarkus-langchain4j/discussions/2073 and https://github.com/langchain4j/langchain4j/pull/3664.

Adding prompt caching configurability. Configuration would look like this:

```yaml
  quarkus:
    langchain4j:
      bedrock:
        chat-model:
          model-id: "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
          prompt-caching: AFTER_SYSTEM
          enable-reasoning: 5000
```

- Closes: #2073