### PR TITLE
Call an action after cloning the repo

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -25,9 +25,6 @@ jobs:
         run: git config --global core.autocrlf false
         if: startsWith(matrix.os, 'windows')
 
-      - name: Reclaim Disk Space
-        run: .github/ci-prerequisites.sh
-
       - uses: actions/checkout@v3
 
       - name: Reclaim Disk Space


### PR DESCRIPTION
Nightly build pipeline calls "Reclaim Disk Space" action first and clones a repository which contains it second.
This leads to failures in nightly builds.