### PR TITLE
Adjust several syntax typos and misuse in docs

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -64,7 +64,7 @@
 *** xref:azure-openai-embedding-model.adoc[Azure OpenAI]
 *** xref:gemini-embedding-model.adoc[Anthropic (Claude)]
 *** xref:huggingface-embedding-model.adoc[HuggingFace]
-*** xref:watsonx-chat-model.adoc[IBM watsonx.ai]
+*** xref:watsonx-embedding-model.adoc[IBM watsonx.ai]
 *** xref:in-process-embedding.adoc[In-Process Embeddings (ONNX)]
 *** xref:jlama-embedding-model.adoc[Jlama]
 *** xref:ollama-embedding-model.adoc[Ollama]

--- a/docs/modules/ROOT/pages/ai-services.adoc
+++ b/docs/modules/ROOT/pages/ai-services.adoc
@@ -202,6 +202,7 @@ See the <<Memory Management>> reference for detailed customization.
 AI Services map LLM responses to method return types:
 
 - Direct JSON mapping:
+
 [source,java]
 ----
 @UserMessage("Evaluate review: {review}. Respond in JSON.")
@@ -212,7 +213,8 @@ Quarkus automatically deserializes responses into `ReviewResponse`.
 Depending on the model, it forces the response format to match the expected type.
 It inserts the expected schema into the prompt automatically.
 
-- Dynamic schema with `{response_schema}` placeholder:
+- Dynamic schema with `\{response_schema}` placeholder:
+
 [source,java]
 ----
 @UserMessage("""
@@ -223,6 +225,7 @@ Classify text: {text}. Schema: {response_schema}
 In this case, the schema is not automatically inserted.
 
 You can disable automatic schema insertion via configuration:
+
 [source,properties]
 ----
 quarkus.langchain4j.response-schema=false
@@ -304,6 +307,7 @@ quarkus.langchain4j.openai.m3.embedding-model.model-name=text-emb...
 Integrate function calling (methods) callable by the LLM:
 
 - Define tools with `@Tool`:
++
 [source,java]
 ----
 @ApplicationScoped
@@ -313,15 +317,16 @@ public class CustomerService {
     public String getName(long id) { /*...*/ }
 }
 ----
-
++
 - Configure tools:
++
 [source,java]
 ----
 @RegisterAiService(tools = CustomerService.class)
 ----
-
-or, (recommended) use a toolbox:
-
++
+- or, (recommended) use a toolbox:
++
 [source,java]
 ----
 @RegisterAiService
@@ -466,12 +471,14 @@ Limitations for image generation:
 To summarize:
 
 - Image description:
++
 [source,java]
 ----
 String describe(@ImageUrl String imageUrl);
 ----
-
++
 - Image generation:
++
 [source,java]
 ----
 Image generate(String prompt);

--- a/docs/modules/ROOT/pages/anthropic-chat-model.adoc
+++ b/docs/modules/ROOT/pages/anthropic-chat-model.adoc
@@ -51,9 +51,9 @@ quarkus.langchain4j.anthropic.chat-model.model-name=claude-opus-4-20250514
 
 Refer to https://docs.anthropic.com/claude/docs/models-overview[Anthropic's model catalog] for available versions, such as:
 
-- `claude-sonnet-4-20250514	`
+- `claude-sonnet-4-20250514`
 - `claude-3-opus-20240229`
-- `claude-3-haiku-20240307	`
+- `claude-3-haiku-20240307`
 
 == Usage
 

--- a/docs/modules/ROOT/pages/azure-openai-chat-model.adoc
+++ b/docs/modules/ROOT/pages/azure-openai-chat-model.adoc
@@ -18,7 +18,7 @@ To use Azure OpenAI models in your Quarkus application, configure your Azure cre
 
 1.	Obtain your Azure OpenAI endpoint, resource name, deployment name, and either an api-key or an Azure AD access token from the https://portal.azure.com/[Azure Portal].
 2.	Configure your application.properties with the necessary details:
-
++
 [source,properties,subs=attributes+]
 ----
 quarkus.langchain4j.azure-openai.resource-name=

--- a/docs/modules/ROOT/pages/azure-openai-image-model.adoc
+++ b/docs/modules/ROOT/pages/azure-openai-image-model.adoc
@@ -5,7 +5,7 @@ include::./includes/customization.adoc[]
 
 Azure OpenAI provides image generation models that can create or modify images based on natural language prompts. These models enable use cases such as visual storytelling, creative content generation, and image editing workflows.
 
-For an overview of how image models fit into AI workflows, refer to the xref:models.adoc#_image_models_[Image Models] section of the Models documentation.
+For an overview of how image models fit into AI workflows, refer to the xref:models.adoc#_image_models[Image Models] section of the Models documentation.
 
 == Prerequisites
 
@@ -62,7 +62,7 @@ import jakarta.inject.Inject;
 == Related Topics
 
 [.lead]
-* xref:models.adoc#_image_models_[Image Models Overview]
+* xref:models.adoc#_image_models[Image Models Overview]
 * xref:ai-services.adoc[AI Services Reference]
 
 

--- a/docs/modules/ROOT/pages/function-calling.adoc
+++ b/docs/modules/ROOT/pages/function-calling.adoc
@@ -349,7 +349,8 @@ The previous AI service is the one that will reason about the user question and 
 
 The tool _implementations_ are very simple:
 
-1) The city extractor agent just extracts the city from the user question. It's implemented as an AI service.
+1. The city extractor agent just extracts the city from the user question. It's implemented as an AI service.
++
 [source, java]
 ----
 @ApplicationScoped
@@ -366,13 +367,13 @@ public interface CityExtractorAgent {
     String extractCity(String question); // <3>
 }
 ----
-
++
 <1> This service does not require memory.
 <2> The tool description, the LLM can use it to decide when to call this tool.
 <3> The method signature, the LLM use it to know how to call this tool.
-
-2) The geocoding tool is a REST client that provide the _GeoResult_ for a given city:
-
++
+2. The geocoding tool is a REST client that provide the _GeoResult_ for a given city:
++
 [source, java]
 ----
 @RegisterRestClient(configKey = "geocoding")
@@ -386,9 +387,9 @@ public interface GeoCodingService {
     GeoResults findCity(@RestQuery String name);
 }
 ----
-
-3) The weather forecast tools is also implemented as a REST client:
-
++
+3. The weather forecast tools is also implemented as a REST client:
++
 [source, java]
 ----
 @RegisterRestClient(configKey = "openmeteo")

--- a/docs/modules/ROOT/pages/gemini-embedding-model.adoc
+++ b/docs/modules/ROOT/pages/gemini-embedding-model.adoc
@@ -31,7 +31,7 @@ To inject the embedding model:
 EmbeddingModel embeddingModel;
 ----
 
-=== Configuration
+== Configuration
 
 Set the API key in your `application.properties`:
 

--- a/docs/modules/ROOT/pages/gpullama3-chat-model.adoc
+++ b/docs/modules/ROOT/pages/gpullama3-chat-model.adoc
@@ -73,7 +73,7 @@ To integrate the GPULlama3 chat model into your Quarkus application, add the fol
 </dependency>
 ----
 
-Important: If no other LLM extension is configured, xref:ai-services.adoc[AI Services] will automatically use the GPU-accelerated GPULlama3!
+IMPORTANT: If no other LLM extension is configured, xref:ai-services.adoc[AI Services] will automatically use the GPU-accelerated GPULlama3!
 
 Sample implementation for ChatModel:
 [source,java]
@@ -167,16 +167,16 @@ To run your Quarkus application in **dev mode** with TornadoVM:
 1. Ensure your `pom.xml` contains the `quarkus-langchain4j-gpu-llama3` dependency (shown earlier).
 
 2. Add the TornadoVM argfile as a Maven property:
-
++
 [source,xml]
 ----
 <properties>
     <tornado.argfile>/path/to/tornado-argfile</tornado.argfile>
 </properties>
 ----
-
++
 3. Pass the argfile to the JVM in the plugin configuration for dev mode:
-
++
 [source,xml]
 ----
 <plugin>
@@ -187,9 +187,9 @@ To run your Quarkus application in **dev mode** with TornadoVM:
     </configuration>
 </plugin>
 ----
-
++
 4. Launch dev mode explicitly:
-
++
 [source,shell]
 ----
 mvn quarkus:dev
@@ -202,29 +202,31 @@ mvn quarkus:dev
 To build and run your application in **production mode**:
 
 1. Build the Quarkus application:
-
++
 [source,shell]
 ----
 mvn clean package
 ----
-
++
 2. Run the generated jar with the TornadoVM argfile:
-
++
 [source,shell]
 ----
 java @$TORNADOVM_HOME/tornado-argfile -jar target/quarkus-app/quarkus-run.jar
 ----
 
-⚠ **Important:** Ensure `TORNADOVM_SDK` and the `tornado-argfile` path are correctly set.
+IMPORTANT: Ensure `TORNADOVM_SDK` and the `tornado-argfile` path are correctly set.
 
 
 == Supported Models and Quantizations
 
 The following models have been tested with GPULlama3.java and can be found in link:++https://huggingface.co/beehive-lab/collections[Beehive Lab's HuggingFace Collections].
 
-⚠️ **Important:**
+[IMPORTANT]
+====
 Quantization format names are model-dependent. Some models require `F16`, others `fp16` (lowercase), as defined in their GGUF files.
 Use **exactly** the spelling listed below, or the model may fail to load.
+====
 
 [cols="2a,1,3a", options="header"]
 |===

--- a/docs/modules/ROOT/pages/guide-fault-tolerance.adoc
+++ b/docs/modules/ROOT/pages/guide-fault-tolerance.adoc
@@ -9,7 +9,7 @@ This is particularly useful when working with external model providers that may 
 To enable fault tolerance for AI services, follow these steps:
 
 * Add the `quarkus-smallrye-fault-tolerance` extension to your project:
-
++
 [source,xml]
 ----
 <dependency>
@@ -17,9 +17,9 @@ To enable fault tolerance for AI services, follow these steps:
     <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
 </dependency>
 ----
-
++
 * Use fault tolerance annotations such as `@Fallback`, `@Timeout`, or `@Retry` on your AI service methods:
-
++
 [source,java]
 ----
 include::{examples-dir}/io/quarkiverse/langchain4j/samples/AiServiceWithFaultTolerance.java[]

--- a/docs/modules/ROOT/pages/guide-generating-image.adoc
+++ b/docs/modules/ROOT/pages/guide-generating-image.adoc
@@ -11,15 +11,15 @@ With Quarkus LangChain4j’s Image model support, you can declare a service meth
 * A Quarkus project with the `quarkus-langchain4j-openai` extension on the classpath (or another model provider that supports image models)
 * OpenAI (or another provider) API Key configured in `application.properties` or via `QUARKUS_LANGCHAIN4J_OPENAI_API_KEY`
 * An **Image Model** enabled (e.g. `dall-e-3` or `GPT-Image-1`) in your config:
-
++
 [source,properties]
 ----
 quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 quarkus.langchain4j.openai.image-model.model-name=dall-e-3 # This is the default model, but you can specify another one if needed
 ----
-
++
 * Extended timeout for image generation, which can take longer than text completions. For example:
-
++
 [source,properties]
 ----
 quarkus.langchain4j.openai.timeout=60s

--- a/docs/modules/ROOT/pages/guide-passing-image.adoc
+++ b/docs/modules/ROOT/pages/guide-passing-image.adoc
@@ -11,15 +11,15 @@ This guide shows you how to build a Quarkus microservice that sends image dataâ€
 * A Quarkus project with the `quarkus-langchain4j-openai` extension (or another model provider that supports a model with vision capabilities)
 * `quarkus.langchain4j.openai.api-key` set in `application.properties`
 * A vision-capable model (for example: `gpt-4.1-mini`, `o3`. The default model has vision capabilities, but you can specify a different one if needed)
-
++
 [source,properties]
 ----
 quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 quarkus.langchain4j.openai.chat-model.model-name=gpt-4.1-mini
 ----
-
++
 * Set the temperature to 0.0 for deterministic outputs, especially for tasks like OCR or object detection where precision matters:
-
++
 [source,properties]
 ----
 quarkus.langchain4j.openai.chat-model.temperature=0

--- a/docs/modules/ROOT/pages/guide-prompt-engineering.adoc
+++ b/docs/modules/ROOT/pages/guide-prompt-engineering.adoc
@@ -541,10 +541,10 @@ ANSWER: <final_answer>
 """)
 public interface MathSolver {
 
-@UserMessage("""
-If Alice has 4 apples and Bob gives her 3 more, how many apples does Alice have?
-""")
-String solve();
+    @UserMessage("""
+    If Alice has 4 apples and Bob gives her 3 more, how many apples does Alice have?
+    """)
+    String solve();
 
 }
 ----
@@ -569,10 +569,10 @@ You will receive a task. First decompose it into smaller steps. Then solve each 
 """)
 public interface TaskDecomposer {
 
-@UserMessage("""
-Analyze this article and produce a summary and a list of 5 follow-up actions.
-""")
-String execute(String article);
+    @UserMessage("""
+    Analyze this article and produce a summary and a list of 5 follow-up actions.
+    """)
+    String execute(String article);
 
 }
 ----
@@ -591,18 +591,20 @@ Use when integrating tools, agents, or APIs where decisions depend on intermedia
 
 [source,java]
 ----
-import io.quarkiverse.langchain4j.ToolBox;@RegisterAiService
+import io.quarkiverse.langchain4j.ToolBox;
+
+@RegisterAiService
 @ApplicationScoped
 @SystemMessage("""
 You are a reasoning agent. For each problem, reason about the solution, and when necessary, use available tools.
 """)
 public interface AgentService {
 
-@UserMessage("""
+    @UserMessage("""
     What’s the weather like in Tokyo tomorrow?
-""")
-@ToolBox(WeatherForecastTool.class)
-String answer();
+    """)
+    @ToolBox(WeatherForecastTool.class)
+    String answer();
 
 }
 ----
@@ -634,7 +636,7 @@ public interface ReflectiveAI {
     STEP 1: Provide a first version.
     STEP 2: Reflect on and improve the answer.
     """)
-String summarize(String article);
+    String summarize(String article);
 
 }
 ----

--- a/docs/modules/ROOT/pages/guide-streamed-responses.adoc
+++ b/docs/modules/ROOT/pages/guide-streamed-responses.adoc
@@ -48,7 +48,7 @@ Add the following dependencies in your `pom.xml`:
 </dependency>
 ----
 
-IF you are using Ollama, configure your model in `application.properties`:
+If you are using Ollama, configure your model in `application.properties`:
 
 [source,properties]
 ----

--- a/docs/modules/ROOT/pages/guide-web-search.adoc
+++ b/docs/modules/ROOT/pages/guide-web-search.adoc
@@ -111,6 +111,6 @@ include::includes/quarkus-langchain4j-tavily.adoc[leveloffset=+1,opts=optional]
 == Going Further
 
 [.lead]
-xref:function-calling.adoc[Function Calling with Tools] +
-xref:rag.adoc[Retrieval-Augmented Generation (RAG)] +
-xref:ai-services.adoc[AI Service Reference]
+* xref:function-calling.adoc[Function Calling with Tools] +
+* xref:rag.adoc[Retrieval-Augmented Generation (RAG)] +
+* xref:ai-services.adoc[AI Service Reference]

--- a/docs/modules/ROOT/pages/jlama-chat-model.adoc
+++ b/docs/modules/ROOT/pages/jlama-chat-model.adoc
@@ -26,7 +26,7 @@ When using Dev Mode:
 - The extension will automatically pull the configured model.
 - JVM flags are set up automatically to enable the C2 compiler, which is required for proper inference performance.
 - Disk space is required for downloaded models. The model directory can be customized via:
-
++
 [source,properties]
 ----
 quarkus.langchain4j.jlama.models-path=/path/to/model/storage

--- a/docs/modules/ROOT/pages/llama3-chat-model.adoc
+++ b/docs/modules/ROOT/pages/llama3-chat-model.adoc
@@ -27,7 +27,7 @@ When using Dev Mode, the extension:
 - Automatically pulls and configures the selected model.
 - Ensures the *C2 JIT compiler* is enabled for optimal runtime performance.
 - Allows you to configure the model directory via:
-
++
 [source,properties]
 ----
 quarkus.langchain4j.llama3.models-path=/your/custom/location

--- a/docs/modules/ROOT/pages/models.adoc
+++ b/docs/modules/ROOT/pages/models.adoc
@@ -93,7 +93,7 @@ In Quarkus LangChain4j, streaming responses are exposed as `Multi<String>` seque
 include::{examples-dir}/io/quarkiverse/langchain4j/samples/ModelExamples.java[tag=streaming-ai-service,indent=0]
 ----
 
-[#_embedding_models]== Embedding Models
+== Embedding Models
 
 Embedding models convert #unstructured input (text or images) into numerical vectors known as _embeddings_#.
 An embedding is a high-dimensional representation that captures semantic similarity: items with similar meaning are close together in vector space.
@@ -140,7 +140,7 @@ The output is generally an image URL, byte stream, or base64-encoded representat
 include::{examples-dir}/io/quarkiverse/langchain4j/samples/ModelExamples.java[tag=image-service,indent=0]
 ----
 
-[#_reasoning_models]== Reasoning Models
+== Reasoning Models
 
 Reasoning models go beyond plain generation by supporting structured planning, problem-solving, and tool invocation. They are commonly used when the model needs to make decisions, call external tools, or follow multi-step workflows.
 They are the base for building complex AI agents that can reason about tasks, invoke APIs, and produce structured outputs, paving the way for #agentic architectures#.

--- a/docs/modules/ROOT/pages/observability.adoc
+++ b/docs/modules/ROOT/pages/observability.adoc
@@ -254,11 +254,16 @@ public class Startup {
 
 == Auditing
 
-IMPORTANT: The Quarkus-specific auditing features have been deprecated and removed. They have been replaced by https://docs.langchain4j.dev/tutorials/observability#ai-service-observability. You can observe the https://docs.langchain4j.dev/tutorials/observability#types-of-events[LangChain4j observability events] as CDI events.
+:langchain4j-observability-url: https://docs.langchain4j.dev/tutorials/observability
+:ai-service-observability-link: {langchain4j-observability-url}#ai-service-observability[LangChain4j AI Service Observability^]
+:event-types-observability-link: {langchain4j-observability-url}#types-of-events[LangChain4j observability events^]
+:cdi-observer-pattern-link: https://docs.oracle.com/javaee/6/tutorial/doc/gkhic.html[CDI observer pattern^]
 
-The extension allows users to audit the process of implementing an AiService by observing normal CDI events. See the https://docs.langchain4j.dev/tutorials/observability#ai-service-observability[LangChain4j AI Service Observability] tutorial for more information about the types of events that can be observed.
+IMPORTANT: The Quarkus-specific auditing features have been deprecated and removed. They have been replaced by {ai-service-observability-link}. You can observe the {event-types-observability-link} as CDI events.
 
-The main difference is that in Quarkus, you do not need to create an implementation of an `AiServiceListener`. Instead, just create a bean class (or multiple bean classes) and observe them using the https://docs.oracle.com/javaee/6/tutorial/doc/gkhic.html[CDI observer pattern].
+The extension allows users to audit the process of implementing an AiService by observing normal CDI events. See the {ai-service-observability-link} tutorial for more information about the types of events that can be observed.
+
+The main difference is that in Quarkus, you do not need to create an implementation of an `AiServiceListener`. Instead, just create a bean class (or multiple bean classes) and observe them using the {cdi-observer-pattern-link}.
 
 All the events for a single invocation can be correlated by `event.invocationContext().invocationId()`.
 

--- a/docs/modules/ROOT/pages/ollama-chat-model.adoc
+++ b/docs/modules/ROOT/pages/ollama-chat-model.adoc
@@ -27,7 +27,7 @@ The Dev Service bundled with this extension simplifies local setup:
 - It will *automatically pull* any model configured in your application.
 - If Ollama is not already running, it will *start an Ollama container* using your installed container runtime (Podman or Docker).
 - If, running in a container, the container will be exposed via configuration properties:
-
++
 [source,properties,subs=attributes+]
 ----
 langchain4j-ollama-dev-service.ollama.host=host

--- a/docs/modules/ROOT/pages/openai-chat-model.adoc
+++ b/docs/modules/ROOT/pages/openai-chat-model.adoc
@@ -20,14 +20,12 @@ If you’re using a provider other than OpenAI, ensure that the authentication a
 // tag::openai-prerequisites[]
 === OpenAI Account and API Key
 
-=== OpenAI Account and API Key
-
 To use OpenAI models in your Quarkus application:
 
 1.	https://auth.openai.com/create-account[Create an OpenAI account].
 2.	https://platform.openai.com/api-keys[Generate an API key] from the API Keys page.
 3.	Add the following to your `application.properties`:
-
++
 [source,properties,subs=attributes+]
 ----
 quarkus.langchain4j.openai.api-key=sk-...
@@ -43,12 +41,14 @@ You can use the environment variable `QUARKUS_LANGCHAIN4J_OPENAI_API_KEY` instea
 .Using configuration placeholders
 ====
 You can also reference an environment variable directly in your properties file:
-[source,properties,subs=attributes+]
+
+[source,properties]
 ----
 quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 ----
 ====
 // end::openai-prerequisites[]
+
 === OpenAI Quarkus Extension
 
 To enable OpenAI chat model support, add the following dependency to your `pom.xml`:
@@ -256,6 +256,6 @@ This approach is ideal for multi-tenant setups or dynamic token rotation.
 * xref:ai-services.adoc[AI Services]
 * xref:./models.adoc#_embedding_models[Embedding Models]
 * xref:./models.adoc#_moderation_models[Moderation Models]
-* xref:./models.adoc#_image_models_[Image Models]
+* xref:./models.adoc#_image_models[Image Models]
 
 

--- a/docs/modules/ROOT/pages/openai-image-model.adoc
+++ b/docs/modules/ROOT/pages/openai-image-model.adoc
@@ -6,7 +6,7 @@ include::./includes/customization.adoc[]
 OpenAI provides various image models capable of generating or editing images based on textual prompts.
 These models are ideal for use cases involving content creation, design assistance, or visual storytelling.
 
-For an overview of how image models fit into AI-infused applications, see the xref:models.adoc#_image_models_[Image Models] section in the Models reference guide.
+For an overview of how image models fit into AI-infused applications, see the xref:models.adoc#_image_models[Image Models] section in the Models reference guide.
 
 == Prerequisites
 
@@ -75,7 +75,7 @@ Image image = imageModel.generate("A majestic dragon flying over a medieval cast
 == Additional Resources
 
 [.lead]
-* Learn more about xref:models.adoc#_image_models_[Image Models]
+* Learn more about xref:models.adoc#_image_models[Image Models]
 * Explore xref:ai-services.adoc[AI Services] for orchestrating multiple models
 
 

--- a/docs/modules/ROOT/pages/quickstart-summarization.adoc
+++ b/docs/modules/ROOT/pages/quickstart-summarization.adoc
@@ -69,7 +69,7 @@ This interface defines a system message to guide the model's behavior and a meth
 
 Let's look at the `summarize` method.
 The `@UserMessage` annotation specifies how the input should be formatted when sent to the model.
-The `{input}` placeholder will be replaced with the actual content passed to the method.
+The `\{input}` placeholder will be replaced with the actual content passed to the method.
 
 [#main-app]
 == Writing the Main Application

--- a/docs/modules/ROOT/pages/rag-pgvector-store.adoc
+++ b/docs/modules/ROOT/pages/rag-pgvector-store.adoc
@@ -112,7 +112,7 @@ The PGVector extension maps each ingested document to a row in a PostgreSQL tabl
 * Optional metadata
 * The vector embedding (stored as a `vector` type column)
 
-During retrieval, a similarity search (e.g., cosine distance) is performed using a `SELECT` query with `ORDER BY embedding <=> :query_vector LIMIT N`.
+During retrieval, a similarity search (e.g., cosine distance) is performed using a `SELECT` query with `ORDER BY embedding +<=>+ :query_vector LIMIT N`.
 
 The extension manages schema creation and indexing automatically unless overridden.
 

--- a/docs/modules/ROOT/pages/reranking.adoc
+++ b/docs/modules/ROOT/pages/reranking.adoc
@@ -12,6 +12,8 @@ When using RAG, a scoring model can be used to rerank the top-k documents retrie
   mutually incomparable, so using the raw https://learn.microsoft.com/en-us/azure/search/hybrid-search-ranking[Reciprocal Rank Fusion] for merging the lists of documents retrieved by these retrievers is suboptimal.
 
 Quarkus-langchain4j currently supports scoring through `Cohere`. Configure a scoring model:
+
+[source,properties]
 ----
 quarkus.langchain4j.cohere.api-key=YOUR_COHERE_API_KEY
 quarkus.langchain4j.cohere.scoring-model.model-name=MODEL_ID

--- a/docs/modules/ROOT/pages/security.adoc
+++ b/docs/modules/ROOT/pages/security.adoc
@@ -47,7 +47,7 @@ A malicious user might craft a prompt that manipulates the LLM to ignore its ori
 
 * *Sanitize User Input*: Before adding user input to a prompt, sanitize it to neutralize any characters or instructions that could alter the prompt's meaning.
 * *Use Delimiters and Context*: Clearly separate instructions from user-provided data in your prompts. For example:
-
++
 [source,java]
 ----
 // User input is clearly demarcated.

--- a/docs/modules/ROOT/pages/watsonx-chat-model.adoc
+++ b/docs/modules/ROOT/pages/watsonx-chat-model.adoc
@@ -9,6 +9,7 @@ IMPORTANT: This extension supports IBM watsonx as a service on IBM Cloud only.
 
 == Prerequisites
 
+// tag::watsonx-prerequisites[]
 To use watsonx.ai models, configure the following required values in your `application.properties` file:
 
 === Base URL
@@ -51,7 +52,8 @@ Create an API key by visiting https://cloud.ibm.com/iam/apikeys and clicking Cre
 quarkus.langchain4j.watsonx.api-key=your-api-key
 ----
 
-TIP: You can also use the QUARKUS_LANGCHAIN4J_WATSONX_API_KEY environment variable.
+TIP: You can also use the `QUARKUS_LANGCHAIN4J_WATSONX_API_KEY` environment variable.
+// end::watsonx-prerequisites[]
 
 == Dependency
 
@@ -89,7 +91,7 @@ Each mode has its own configuration namespace:
 
 === Chat Mode Example
 
-[source,properties,subs=attributes+]
+[source,properties]
 ----
 quarkus.langchain4j.watsonx.base-url=${BASE_URL}
 quarkus.langchain4j.watsonx.api-key=${API_KEY}
@@ -109,7 +111,7 @@ public interface AiService {
 
 === Generation Mode Example
 
-[source,properties,subs=attributes+]
+[source,properties]
 ----
 quarkus.langchain4j.watsonx.base-url=${BASE_URL}
 quarkus.langchain4j.watsonx.api-key=${API_KEY}

--- a/docs/modules/ROOT/pages/watsonx-embedding-model.adoc
+++ b/docs/modules/ROOT/pages/watsonx-embedding-model.adoc
@@ -7,15 +7,7 @@ IBM watsonx.ai also provides access to embedding models that can be used for vec
 
 == Prerequisites
 
-Same as for the chat model. Ensure:
-
-- base-url
-- project-id
-- api-key
-
-are configured.
-
-See xref:watsonx-chat-model.adoc[IBM watsonx.ai Chat Models] for details on setting up the service and obtaining an API key.
+include::./watsonx-chat-model.adoc[tags=watsonx-prerequisites]
 
 == Dependency
 


### PR DESCRIPTION
After identifying a broken section and links to it, I performed a thorough review of the documentation for incorrect details, such as code presentation, list continuation, syntax escaping, code indentation, and other issues that were triggering alerts during documentation generation.