### PR TITLE
Fix `asMethodShouldThrowExceptionIfValueCannotBeConverted` for Quarkus main

### DIFF
--- a/testing/evaluation/evaluation-core/src/test/java/io/quarkiverse/langchain4j/testing/evaluation/ParameterTest.java
+++ b/testing/evaluation/evaluation-core/src/test/java/io/quarkiverse/langchain4j/testing/evaluation/ParameterTest.java
@@ -45,7 +45,7 @@ class ParameterTest {
         Parameter parameter = new Parameter.UnnamedParameter("notANumber");
         assertThatThrownBy(() -> parameter.as(Integer.class))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("SRCFG00020");
+                .hasMessageContaining("SRCFG");
     }
 
     @Test


### PR DESCRIPTION
Related to: https://github.com/quarkiverse/quarkiverse/issues/195#issuecomment-3821810735