### PR TITLE
[1.2] Backport of Update the filesystem MCP server version #1969

### DIFF
--- a/samples/mcp-tools/src/main/resources/application.properties
+++ b/samples/mcp-tools/src/main/resources/application.properties
@@ -1,8 +1,9 @@
 quarkus.langchain4j.timeout=60s
-quarkus.log.category.\"dev.langchain4j\".level=DEBUG
-quarkus.log.category.\"io.quarkiverse\".level=DEBUG
+
+# uncomment the following to see more logging related to MCP
+#quarkus.log.category.\"MCP\".level=DEBUG
+#quarkus.langchain4j.log-requests=true
+#quarkus.langchain4j.log-responses=true
 
 quarkus.langchain4j.mcp.filesystem.transport-type=stdio
-quarkus.langchain4j.mcp.filesystem.command=npm,exec,@modelcontextprotocol/server-filesystem@0.6.2,playground
-quarkus.langchain4j.mcp.filesystem.log-requests=true
-quarkus.langchain4j.mcp.filesystem.log-responses=true
+quarkus.langchain4j.mcp.filesystem.command=npm,exec,@modelcontextprotocol/server-filesystem@2025.11.25,playground


### PR DESCRIPTION
Backport of:
- https://github.com/quarkiverse/quarkus-langchain4j/pull/1969


Context:
Testing the release 3.27.2.CR1 we are hitting issues described in [1964](https://github.com/quarkiverse/quarkus-langchain4j/issues/1964) the `MCPToolTest`. The `read_file` tool is being invoked with empty arguments (`{}`), causing the tests to fail and blocking the release validation.

cc: @jmartisk 