### PR TITLE
fix: AiServiceMethodImplementationSupport.doImplement0 redundantly fetches the messages from the ChatMemoryStore

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ChatMemoryStoreHitCountTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ChatMemoryStoreHitCountTest.java
@@ -128,8 +128,6 @@ public class ChatMemoryStoreHitCountTest {
         var hitCounts = CustomChatMemoryStore.measureHitCounts(() -> {
             service.chat("123", "Say hello");
         });
-        // The extra hits will likely be eliminated once https://github.com/langchain4j/langchain4j/pull/4416 goes
-        // in, and we update DefaultCommittableChatMemory.commit to use the set method to commit the changes.
-        assertThat(hitCounts).isEqualTo(new HitCounts(3, 2, 1));
+        assertThat(hitCounts).isEqualTo(new HitCounts(1, 1, 0));
     }
 }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/DefaultCommittableChatMemory.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/DefaultCommittableChatMemory.java
@@ -62,9 +62,6 @@ class DefaultCommittableChatMemory implements CommittableChatMemory {
 
     @Override
     public void commit() {
-        delegate.clear(); // remove the original messages as this class keeps the entire state
-        for (ChatMessage newMessage : newMessages) {
-            delegate.add(newMessage);
-        }
+        delegate.set(newMessages);
     }
 }


### PR DESCRIPTION
This change reduces the number of times `ChatMemoryStore.getMessages` gets called to just 1 time. This change depends the new ChatMemory.set method introduced in langchain4j 1.11.0

fixes: #2062