### PR TITLE
Show how to use quarkus-langchain4j-bom

### DIFF
--- a/docs/modules/ROOT/pages/anthropic-chat-model.adoc
+++ b/docs/modules/ROOT/pages/anthropic-chat-model.adoc
@@ -15,14 +15,7 @@ To use Anthropic models, you need an API key. Follow the steps on the https://do
 
 To enable Anthropic LLM integration in your project, add the following dependency:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-anthropic</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-anthropic]
 
 If no other LLM extension is installed, xref:ai-services.adoc[AI Services] will automatically use the configured Anthropic chat model.
 

--- a/docs/modules/ROOT/pages/azure-openai-chat-model.adoc
+++ b/docs/modules/ROOT/pages/azure-openai-chat-model.adoc
@@ -34,14 +34,7 @@ quarkus.langchain4j.azure-openai.ad-token=
 
 Add the `quarkus-langchain4j-azure-openai` extension to your project:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-azure-openai</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-azure-openai]
 
 If no other LLM extension is present, xref:ai-services.adoc[AI Services] will automatically use the configured Azure OpenAI chat model.
 

--- a/docs/modules/ROOT/pages/azure-openai-embedding-model.adoc
+++ b/docs/modules/ROOT/pages/azure-openai-embedding-model.adoc
@@ -14,14 +14,7 @@ include::./azure-openai-chat-model.adoc[tags=azure-openai-prerequisites]
 
 To use Azure OpenAI embedding models in your Quarkus application, add the `quarkus-langchain4j-azure-openai` extension:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-azure-openai</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-azure-openai]
 
 If no other LLM extension is present, xref:ai-services.adoc[AI Services] will automatically select the configured Azure OpenAI embedding model.
 

--- a/docs/modules/ROOT/pages/azure-openai-image-model.adoc
+++ b/docs/modules/ROOT/pages/azure-openai-image-model.adoc
@@ -16,14 +16,7 @@ include::./azure-openai-chat-model.adoc[tags=azure-openai-prerequisites]
 To use Azure OpenAI image models in your Quarkus application, add the following extension:
 
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-azure-openai</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-azure-openai]
 
 If no other LLM extension is installed, xref:ai-services.adoc[AI Services] will automatically use the configured Azure OpenAI image model.
 

--- a/docs/modules/ROOT/pages/gemini-chat-model.adoc
+++ b/docs/modules/ROOT/pages/gemini-chat-model.adoc
@@ -10,14 +10,7 @@ It is a good first step for developers to get started with Gemini models.
 
 To use Gemini chat models, add the following dependency to your project:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-ai-gemini</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-ai-gemini]
 
 If no other LLM extension is installed, xref:ai-services.adoc[AI Services] will automatically utilize the configured Gemini model.
 

--- a/docs/modules/ROOT/pages/gemini-embedding-model.adoc
+++ b/docs/modules/ROOT/pages/gemini-embedding-model.adoc
@@ -12,14 +12,7 @@ The Gemini platform also provides an embedding model suitable for transforming i
 
 To use it, first add the required dependency to your project:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-ai-gemini</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-ai-gemini]
 
 If no other embedding model is configured, xref:ai-services.adoc[AI Services] will automatically use the Gemini embedding model.
 

--- a/docs/modules/ROOT/pages/gpullama3-chat-model.adoc
+++ b/docs/modules/ROOT/pages/gpullama3-chat-model.adoc
@@ -64,14 +64,7 @@ The TornadoVM installation:
 
 To integrate the GPULlama3 chat model into your Quarkus application, add the following dependency:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-gpu-llama3</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-gpu-llama3]
 
 IMPORTANT: If no other LLM extension is configured, xref:ai-services.adoc[AI Services] will automatically use the GPU-accelerated GPULlama3!
 

--- a/docs/modules/ROOT/pages/guide-prompt-engineering.adoc
+++ b/docs/modules/ROOT/pages/guide-prompt-engineering.adoc
@@ -24,36 +24,15 @@ You can use any supported model provider by adding the appropriate extension to 
 
 For example, to use OpenAI:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-  <groupId>io.quarkiverse.langchain4j</groupId>
-  <artifactId>quarkus-langchain4j-openai</artifactId>
-  <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-openai]
 
 To use Anthropic (Claude):
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-  <groupId>io.quarkiverse.langchain4j</groupId>
-  <artifactId>quarkus-langchain4j-anthropic</artifactId>
-  <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-anthropic]
 
 To use Ollama:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-  <groupId>io.quarkiverse.langchain4j</groupId>
-  <artifactId>quarkus-langchain4j-ollama</artifactId>
-  <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-ollama]
 
 For other providers, see xref:models.adoc[Models Serving].
 

--- a/docs/modules/ROOT/pages/huggingface-chat-model.adoc
+++ b/docs/modules/ROOT/pages/huggingface-chat-model.adoc
@@ -11,14 +11,7 @@ https://huggingface.co/[Hugging Face] is a leading platform in the field of natu
 
 To use Hugging Face chat models in your Quarkus application, add the following extension:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-hugging-face</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-hugging-face]
 
 If no other LLM extension is installed, xref:ai-services.adoc[AI Services] will automatically use the configured Hugging Face chat model.
 

--- a/docs/modules/ROOT/pages/huggingface-embedding-model.adoc
+++ b/docs/modules/ROOT/pages/huggingface-embedding-model.adoc
@@ -11,14 +11,7 @@ Hugging Face provides several pre-trained embedding models useful for semantic s
 
 To use Hugging Face embedding models in your Quarkus application, add the following extension:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-hugging-face</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-hugging-face]
 
 If no other LLM extension is installed, xref:ai-services.adoc[AI Services] will automatically use the configured Hugging Face embedding model.
 

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-maven-dependencies.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-maven-dependencies.adoc
@@ -1,0 +1,44 @@
+[source,xml,subs=attributes+]
+----
+<dependency>
+  <groupId>io.quarkiverse.langchain4j</groupId>
+  <artifactId>{provider-artifact}</artifactId>
+  <version>{project-version}</version>
+</dependency>
+----
+
+Even better, if you use the Quarkus platformn BOM (default for projects generated), add the Quarkus Langchain4J BOM and all dependency versions will align:
+
+[source,xml,subs=attributes+]
+----
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-langchain4j-bom</artifactId> <!--1-->
+                <version>${quarkus.platform.version}</version> <!--2-->
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+      <dependency>
+        <groupId>io.quarkiverse.langchain4j</groupId>
+        <artifactId>{provider-artifact}</artifactId>
+        <!--3-->
+      </dependency>
+    </dependencies>
+----
+
+<1> In your `dependencyManagement` section, add the `quarkus-langchain4j-bom`
+<2> Inherit the version from your platform version
+<3> Voilà, no need for version alignment anymore

--- a/docs/modules/ROOT/pages/jlama-chat-model.adoc
+++ b/docs/modules/ROOT/pages/jlama-chat-model.adoc
@@ -41,14 +41,7 @@ Jlama models can be large (several GB) and may take time to download and initial
 
 To integrate Jlama into your Quarkus project, add the following dependency:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-jlama</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-jlama]
 
 If no other LLM extension is installed, xref:ai-services.adoc[AI Services] will automatically use the configured Jlama chat model.
 

--- a/docs/modules/ROOT/pages/jlama-embedding-model.adoc
+++ b/docs/modules/ROOT/pages/jlama-embedding-model.adoc
@@ -20,14 +20,7 @@ See xref:jlama-chat-model.adoc[Jlama Chat Models] for Dev Mode details and model
 
 To enable embedding model support, include:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-jlama</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-jlama]
 
 == Default Model
 

--- a/docs/modules/ROOT/pages/llama3-chat-model.adoc
+++ b/docs/modules/ROOT/pages/llama3-chat-model.adoc
@@ -53,14 +53,7 @@ quarkus.native.additional-build-args=-O3,-march=native
 
 To integrate the Llama3.java chat model into your Quarkus application, add:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-llama3-java</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-llama3-java]
 
 If no other LLM extension is installed, xref:ai-services.adoc[AI Services] will automatically use the configured Llama3.java chat model.
 

--- a/docs/modules/ROOT/pages/mistral-chat-model.adoc
+++ b/docs/modules/ROOT/pages/mistral-chat-model.adoc
@@ -11,14 +11,7 @@ To use Mistral models, you need an API key from the https://docs.mistral.ai/plat
 
 Add the following dependency:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-mistral-ai</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-mistral-ai]
 
 [NOTE]
 ====

--- a/docs/modules/ROOT/pages/mistral-embedding-model.adoc
+++ b/docs/modules/ROOT/pages/mistral-embedding-model.adoc
@@ -11,14 +11,7 @@ See xref:mistral-chat-model.adoc[Mistral Chat Models] for prerequisites, includi
 
 Add this dependency:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-mistral-ai</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-mistral-ai]
 
 == Configuration
 

--- a/docs/modules/ROOT/pages/mistral-moderation-model.adoc
+++ b/docs/modules/ROOT/pages/mistral-moderation-model.adoc
@@ -9,14 +9,7 @@ Mistral provides moderation models to detect harmful or unsafe content in user i
 
 Same setup as chat/embedding models. You must provide a valid API key.
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-mistral-ai</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-mistral-ai]
 
 == Configuration
 

--- a/docs/modules/ROOT/pages/ollama-chat-model.adoc
+++ b/docs/modules/ROOT/pages/ollama-chat-model.adoc
@@ -51,14 +51,7 @@ Model pulls can take several minutes depending on the model size and connection 
 
 To enable Ollama support in your Quarkus project, add the following dependency:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-ollama</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-ollama]
 
 If no other LLM extension is present, xref:ai-services.adoc[AI Services] will default to using the configured Ollama chat model.
 

--- a/docs/modules/ROOT/pages/ollama-embedding-model.adoc
+++ b/docs/modules/ROOT/pages/ollama-embedding-model.adoc
@@ -16,14 +16,7 @@ To use embedding models, you must have a working Ollama setup. Refer to xref:./o
 
 To enable embedding support, include the following extension:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-ollama</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-ollama]
 
 == Default Model
 

--- a/docs/modules/ROOT/pages/openai-chat-model.adoc
+++ b/docs/modules/ROOT/pages/openai-chat-model.adoc
@@ -53,14 +53,7 @@ quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 
 To enable OpenAI chat model support, add the following dependency to your `pom.xml`:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-openai</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-openai]
 
 [NOTE]
 ====

--- a/docs/modules/ROOT/pages/openai-embedding-model.adoc
+++ b/docs/modules/ROOT/pages/openai-embedding-model.adoc
@@ -15,14 +15,7 @@ include::./openai-chat-model.adoc[tags=openai-prerequisites]
 
 To use OpenAI’s embedding models in your Quarkus application, add the `quarkus-langchain4j-openai` extension:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-openai</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-openai]
 
 If no other LLM extension is present, xref:ai-services.adoc[AI Services] will automatically use the configured OpenAI embedding model.
 

--- a/docs/modules/ROOT/pages/openai-image-model.adoc
+++ b/docs/modules/ROOT/pages/openai-image-model.adoc
@@ -16,14 +16,7 @@ include::./openai-chat-model.adoc[tags=openai-prerequisites]
 
 To use OpenAI image models in your Quarkus application, add the `quarkus-langchain4j-openai` extension:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-openai</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-openai]
 
 If no other LLM extension is present, xref:ai-services.adoc[AI Services] will automatically use the configured OpenAI image model.
 

--- a/docs/modules/ROOT/pages/openai-moderation-model.adoc
+++ b/docs/modules/ROOT/pages/openai-moderation-model.adoc
@@ -15,14 +15,7 @@ include::./openai-chat-model.adoc[tags=openai-prerequisites]
 === OpenAI Quarkus Extension
 
 To use OpenAI moderation models in your Quarkus application, add the following dependency:
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-openai</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-openai]
 
 If no other LLM extension is installed, xref:ai-services.adoc[AI Services] will automatically use the configured OpenAI moderation model.
 Note that to enable moderation, the method must be annotated with `@Moderate`.

--- a/docs/modules/ROOT/pages/podman.adoc
+++ b/docs/modules/ROOT/pages/podman.adoc
@@ -22,14 +22,7 @@ See https://github.com/containers/podman-desktop-extension-ai-lab?tab=readme-ov-
 
 Add the OpenAI extension to your project:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-openai</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-openai]
 
 Even though this is not an actual OpenAI deployment, the API is compatible and works seamlessly with this extension.
 

--- a/docs/modules/ROOT/pages/quickstart-summarization.adoc
+++ b/docs/modules/ROOT/pages/quickstart-summarization.adoc
@@ -11,14 +11,7 @@ The service reads a plain text file (such as an article or report), sends the co
 
 Make sure you’ve added your preferred LLM provider to your `pom.xml`. For example, to use OpenAI:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-  <groupId>io.quarkiverse.langchain4j</groupId>
-  <artifactId>quarkus-langchain4j-openai</artifactId>
-  <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-openai]
 
 Then configure your API key in `application.properties`:
 

--- a/docs/modules/ROOT/pages/quickstart.adoc
+++ b/docs/modules/ROOT/pages/quickstart.adoc
@@ -12,14 +12,7 @@ To use the extension, add the dependency for your preferred model provider.
 
 For example, to use OpenAI:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-  <groupId>io.quarkiverse.langchain4j</groupId>
-  <artifactId>quarkus-langchain4j-openai</artifactId>
-  <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-openai]
 
 [NOTE]
 .Want to use another model serving?

--- a/docs/modules/ROOT/pages/rag-chroma-store.adoc
+++ b/docs/modules/ROOT/pages/rag-chroma-store.adoc
@@ -12,14 +12,7 @@ This guide explains how to configure and use Chroma as an embedding-aware docume
 
 To enable Chroma integration in your Quarkus project, add the following Maven dependency:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-chroma</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-chroma]
 
 == Dev Services Support
 

--- a/docs/modules/ROOT/pages/rag-infinispan-store.adoc
+++ b/docs/modules/ROOT/pages/rag-infinispan-store.adoc
@@ -24,14 +24,7 @@ It automatically registers the required schema on startup.
 
 To enable Infinispan support in your Quarkus project, add the following dependency:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-infinispan</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-infinispan]
 
 This extension builds upon the https://quarkus.io/guides/infinispan-client[Quarkus Infinispan client].
 Ensure that the default Infinispan client is correctly configured* For more details, see:

--- a/docs/modules/ROOT/pages/rag-milvus-store.adoc
+++ b/docs/modules/ROOT/pages/rag-milvus-store.adoc
@@ -16,14 +16,7 @@ Milvus supports approximate nearest neighbor (ANN) search with various indexing 
 
 To enable Milvus integration in your Quarkus project, add the following dependency:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-milvus</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-milvus]
 
 == Dev Services Support
 

--- a/docs/modules/ROOT/pages/rag-neo4j.adoc
+++ b/docs/modules/ROOT/pages/rag-neo4j.adoc
@@ -16,14 +16,7 @@ Ensure your Neo4j deployment supports this feature.
 
 To enable Neo4j vector store support, add the following dependency:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-neo4j</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-neo4j]
 
 This extension depends on the https://github.com/quarkiverse/quarkus-neo4j[`quarkus-neo4j`] extension for Neo4j driver configuration, Dev Services support, and reactive client integration.
 

--- a/docs/modules/ROOT/pages/rag-pgvector-store.adoc
+++ b/docs/modules/ROOT/pages/rag-pgvector-store.adoc
@@ -26,14 +26,7 @@ NOTE: In dev mode, the `quarkus-langchain4j-pgvector` extension will automatical
 
 To enable PGVector integration in your Quarkus project, add the following Maven dependency:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-pgvector</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-pgvector]
 
 This extension requires a configured Quarkus datasource.
 For configuration details, refer to the https://quarkus.io/guides/datasource[Quarkus DataSource Guide].

--- a/docs/modules/ROOT/pages/rag-pinecone-store.adoc
+++ b/docs/modules/ROOT/pages/rag-pinecone-store.adoc
@@ -22,14 +22,7 @@ For more details, visit: https://docs.pinecone.io/docs/quickstart
 
 Add the following dependency to your `pom.xml`:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-pinecone</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-pinecone]
 
 == Configuration
 

--- a/docs/modules/ROOT/pages/rag-qdrant-store.adoc
+++ b/docs/modules/ROOT/pages/rag-qdrant-store.adoc
@@ -14,14 +14,7 @@ The `quarkus-langchain4j-qdrant` extension allows you to connect to a Qdrant ins
 
 To enable Qdrant integration, add the following dependency to your Quarkus project:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-qdrant</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-qdrant]
 
 == Dev Services Support
 

--- a/docs/modules/ROOT/pages/rag-redis.adoc
+++ b/docs/modules/ROOT/pages/rag-redis.adoc
@@ -40,14 +40,7 @@ quarkus.redis.devservices.image-name=your/custom/image
 
 To enable Redis integration in your Quarkus project, add the following Maven dependency:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-redis</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-redis]
 
 This extension builds on top of the https://quarkus.io/guides/redis[Quarkus Redis client].
 Ensure the default Redis data source is properly configured* For more details, refer to:

--- a/docs/modules/ROOT/pages/rag-weaviate.adoc
+++ b/docs/modules/ROOT/pages/rag-weaviate.adoc
@@ -15,14 +15,7 @@ With Quarkus LangChain4j, you can ingest documents and perform vector-based retr
 
 To enable Weaviate support in your Quarkus application, add the following dependency:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-weaviate</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-weaviate]
 
 == Dev Services Support
 

--- a/docs/modules/ROOT/pages/watsonx-chat-model.adoc
+++ b/docs/modules/ROOT/pages/watsonx-chat-model.adoc
@@ -59,14 +59,7 @@ TIP: You can also use the `QUARKUS_LANGCHAIN4J_WATSONX_API_KEY` environment vari
 
 Add the following dependency to your project:
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-watsonx</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-watsonx]
 
 If no other extension is installed, xref:ai-services.adoc[AI Services] will automatically use this provider.
 

--- a/docs/modules/ROOT/pages/watsonx-embedding-model.adoc
+++ b/docs/modules/ROOT/pages/watsonx-embedding-model.adoc
@@ -11,14 +11,7 @@ include::./watsonx-chat-model.adoc[tags=watsonx-prerequisites]
 
 == Dependency
 
-[source,xml,subs=attributes+]
-----
-<dependency>
-    <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-watsonx</artifactId>
-    <version>{project-version}</version>
-</dependency>
-----
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[provider-artifact=quarkus-langchain4j-watsonx]
 
 == Default Configuration
 


### PR DESCRIPTION
Update the doc so that we show how to use the quarkus langchain4j BOM.
The docu is in an include so we can reuse it across various dependency usage in the doc
