### PR TITLE
Added disabling for mcp clients

### DIFF
--- a/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/McpClientDisabledTest.java
+++ b/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/McpClientDisabledTest.java
@@ -1,0 +1,43 @@
+package io.quarkiverse.langchain4j.mcp.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.service.tool.ToolProvider;
+import io.quarkiverse.langchain4j.mcp.runtime.McpClientName;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class McpClientDisabledTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset("""
+                            quarkus.langchain4j.openai.api-key=whatever
+                            quarkus.langchain4j.mcp.client1.enabled=false
+                            quarkus.langchain4j.mcp.client1.transport-type=http
+                            """),
+                            "application.properties"));
+
+    @Inject
+    @McpClientName("client1")
+    Instance<McpClient> clientCDIInstance;
+
+    @Inject
+    Instance<ToolProvider> toolProviderCDIInstance;
+
+    @Test
+    public void test() {
+        assertThat(clientCDIInstance.isResolvable()).isFalse();
+        assertThat(toolProviderCDIInstance.isResolvable()).isFalse();
+    }
+}

--- a/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/McpDisabledTest.java
+++ b/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/McpDisabledTest.java
@@ -1,0 +1,43 @@
+package io.quarkiverse.langchain4j.mcp.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.service.tool.ToolProvider;
+import io.quarkiverse.langchain4j.mcp.runtime.McpClientName;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class McpDisabledTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset("""
+                            quarkus.langchain4j.openai.api-key=whatever
+                            quarkus.langchain4j.mcp.enabled=false
+                            quarkus.langchain4j.mcp.client1.transport-type=http
+                            """),
+                            "application.properties"));
+
+    @Inject
+    @McpClientName("client1")
+    Instance<McpClient> clientCDIInstance;
+
+    @Inject
+    Instance<ToolProvider> toolProviderCDIInstance;
+
+    @Test
+    public void test() {
+        assertThat(clientCDIInstance.isResolvable()).isFalse();
+        assertThat(toolProviderCDIInstance.isResolvable()).isFalse();
+    }
+}

--- a/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/McpHealthSectionNotAClientTest.java
+++ b/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/McpHealthSectionNotAClientTest.java
@@ -1,0 +1,45 @@
+package io.quarkiverse.langchain4j.mcp.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.mcp.client.McpClient;
+import io.quarkiverse.langchain4j.mcp.runtime.McpClientName;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class McpHealthSectionNotAClientTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(AbstractMockHttpMcpServer.class, MockHttpMcpServer.class)
+                    .addAsResource(new StringAsset("""
+                            quarkus.langchain4j.openai.api-key=whatever
+                            quarkus.langchain4j.mcp.health.enabled=true
+                            quarkus.langchain4j.mcp.client1.transport-type=http
+                            quarkus.langchain4j.mcp.client1.url=http://localhost:8081/mock-mcp/sse
+                            """),
+                            "application.properties"));
+
+    @Inject
+    @McpClientName("client1")
+    Instance<McpClient> client1Instance;
+
+    @Inject
+    @McpClientName("health")
+    Instance<McpClient> healthInstance;
+
+    @Test
+    public void test() {
+        assertThat(client1Instance.isResolvable()).isTrue();
+        assertThat(healthInstance.isResolvable()).isFalse();
+    }
+}

--- a/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/MultipleMcpClientsOneDisabledTest.java
+++ b/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/MultipleMcpClientsOneDisabledTest.java
@@ -1,0 +1,63 @@
+package io.quarkiverse.langchain4j.mcp.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIterable;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.service.tool.ToolProvider;
+import dev.langchain4j.service.tool.ToolProviderResult;
+import io.quarkiverse.langchain4j.mcp.runtime.McpClientName;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MultipleMcpClientsOneDisabledTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(AbstractMockHttpMcpServer.class, MockHttpMcpServer.class, Mock2HttpMcpServer.class)
+                    .addAsResource(new StringAsset("""
+                            quarkus.langchain4j.openai.api-key=whatever
+                            quarkus.langchain4j.mcp.client1.transport-type=http
+                            quarkus.langchain4j.mcp.client1.url=http://localhost:8081/mock-mcp/sse
+                            quarkus.langchain4j.mcp.client2.enabled=false
+                            quarkus.langchain4j.mcp.client2.transport-type=http
+                            quarkus.langchain4j.mcp.client2.url=http://localhost:8081/mock2-mcp/sse
+                            """),
+                            "application.properties"));
+
+    @Inject
+    @McpClientName("client1")
+    Instance<McpClient> client1Instance;
+
+    @Inject
+    @McpClientName("client2")
+    Instance<McpClient> client2Instance;
+
+    @Inject
+    ToolProvider toolProvider;
+
+    @Test
+    public void oneClientDisabled() {
+        assertThat(client1Instance.isResolvable()).isTrue();
+        assertThat(client2Instance.isResolvable()).isFalse();
+
+        ToolProviderResult result = toolProvider.provideTools(null);
+        Set<String> toolNames = result.tools().keySet().stream()
+                .map(ToolSpecification::name)
+                .collect(Collectors.toSet());
+        assertThatIterable(toolNames).containsExactlyInAnyOrder("add", "longRunningOperation", "logging");
+    }
+}

--- a/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/McpRecorder.java
+++ b/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/McpRecorder.java
@@ -74,6 +74,10 @@ public class McpRecorder {
             public McpClient apply(SyntheticCreationalContext<McpClient> context) {
                 McpTransport transport;
                 McpClientRuntimeConfig runtimeConfig = mcpRuntimeConfiguration.getValue().clients().get(key);
+                if (runtimeConfig == null) {
+                    throw new ConfigurationException(
+                            "MCP client configuration named " + key + " has no runtime configuration");
+                }
                 List<McpRoot> initialRoots = new ArrayList<>();
                 if (runtimeConfig.roots().isPresent()) {
                     for (String kvPair : runtimeConfig.roots().get()) {

--- a/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/config/McpBuildTimeConfiguration.java
+++ b/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/config/McpBuildTimeConfiguration.java
@@ -19,6 +19,13 @@ import io.smallrye.config.WithParentName;
 public interface McpBuildTimeConfiguration {
 
     /**
+     * Whether MCP integration is enabled.
+     * If disabled, no MCP clients, registry clients, ToolProvider or MCP health check will be registered.
+     */
+    @WithDefault("true")
+    boolean enabled();
+
+    /**
      * Configured MCP clients
      */
     @ConfigDocSection

--- a/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/config/McpClientBuildTimeConfig.java
+++ b/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/config/McpClientBuildTimeConfig.java
@@ -8,6 +8,12 @@ import io.smallrye.config.WithName;
 public interface McpClientBuildTimeConfig {
 
     /**
+     * Whether this MCP client is enabled.
+     */
+    @WithDefault("true")
+    boolean enabled();
+
+    /**
      * Transport type
      */
     @WithDefault("stdio")


### PR DESCRIPTION
We were running into an issue with non disabled mcp clients. 

Our mcp is just running in the dev stage, not in staging or production, so it is not configured there. But, when the mcp.client.url is not correctly provided the application is always returning an exception. 

```
2026-01-09 09:06:55,259 WARN  [dev.lan.mcp.McpToolProvider] (executor-thread-119) Failed to retrieve tools from MCP server: jakarta.enterprise.inject.CreationException: Error creating synthetic bean [TXcHCWKJH9oZZuK8tzHUXT3lDy8]: io.quarkus.runtime.configuration.ConfigurationException: MCP client configuration named bi is missing the 'url' property
	at dev.langchain4j.mcp.client.McpClient_TXcHCWKJH9oZZuK8tzHUXT3lDy8_Synthetic_Bean.doCreate(Unknown Source)
	at dev.langchain4j.mcp.client.McpClient_TXcHCWKJH9oZZuK8tzHUXT3lDy8_Synthetic_Bean.create(Unknown Source)
	at dev.langchain4j.mcp.client.McpClient_TXcHCWKJH9oZZuK8tzHUXT3lDy8_Synthetic_Bean.create(Unknown Source)
	at io.quarkus.arc.impl.AbstractSharedContext.createInstanceHandle(AbstractSharedContext.java:119)
	at io.quarkus.arc.impl.AbstractSharedContext$1.get(AbstractSharedContext.java:38)
	at io.quarkus.arc.impl.AbstractSharedContext$1.get(AbstractSharedContext.java:35)
	at io.quarkus.arc.generator.Default_jakarta_enterprise_context_ApplicationScoped_ContextInstances.c173(Unknown Source)
	at io.quarkus.arc.generator.Default_jakarta_enterprise_context_ApplicationScoped_ContextInstances.computeIfAbsent(Unknown Source)
	at io.quarkus.arc.impl.AbstractSharedContext.get(AbstractSharedContext.java:35)
	at io.quarkus.arc.impl.ClientProxies.getApplicationScopedDelegate(ClientProxies.java:23)
	at dev.langchain4j.mcp.client.McpClient_TXcHCWKJH9oZZuK8tzHUXT3lDy8_Synthetic_ClientProxy.arc$delegate(Unknown Source)
	at dev.langchain4j.mcp.client.McpClient_TXcHCWKJH9oZZuK8tzHUXT3lDy8_Synthetic_ClientProxy.listTools(Unknown Source)
	at dev.langchain4j.mcp.McpToolProvider.provideTools(McpToolProvider.java:112)
	at io.quarkiverse.langchain4j.mcp.runtime.QuarkusMcpToolProvider.provideTools(QuarkusMcpToolProvider.java:38)
	at dev.langchain4j.service.tool.ToolProvider_XijGBi814_1fDyr5SACAv287COI_Synthetic_ClientProxy.provideTools(Unknown Source)
	at io.quarkiverse.langchain4j.runtime.aiservice.AiServiceMethodImplementationSupport.doImplement(AiServiceMethodImplementationSupport.java:207)
```


So this pr gives us the ability to enable/disable also the complete mcp or just single mcp clients. 

