### PR TITLE
Include the response body when MCP client receives an error

### DIFF
--- a/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/http/QuarkusStreamableHttpMcpTransport.java
+++ b/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/http/QuarkusStreamableHttpMcpTransport.java
@@ -268,8 +268,12 @@ public class QuarkusStreamableHttpMcpTransport implements McpTransport {
                                                 return null;
                                             });
                                 } else {
-                                    future.completeExceptionally(
-                                            new RuntimeException("Unexpected status code: " + response.result().statusCode()));
+                                    response.result().bodyHandler(bodyBuffer -> {
+                                        String responseString = bodyBuffer.toString();
+                                        future.completeExceptionally(
+                                                new RuntimeException("Unexpected status code: " + response.result().statusCode()
+                                                        + ", body: " + responseString));
+                                    });
                                 }
                             }
                         });


### PR DESCRIPTION
- Closes: https://github.com/quarkiverse/quarkus-langchain4j/issues/2169