### PR TITLE
Add :diataxis-type: attributes to 49 single-type doc files

### DIFF
--- a/docs/modules/ROOT/pages/anthropic-chat-model.adoc
+++ b/docs/modules/ROOT/pages/anthropic-chat-model.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 https://www.anthropic.com/[Anthropic] is an AI safety and research company. It provides the _Claude_ family of Large Language Models, designed with constitutional AI principles for safe and controllable output.
 

--- a/docs/modules/ROOT/pages/azure-openai-chat-model.adoc
+++ b/docs/modules/ROOT/pages/azure-openai-chat-model.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 Azure OpenAI is a managed service provided by Microsoft that gives developers access to OpenAI’s Large Language Models (LLMs) via the Azure cloud platform.
 

--- a/docs/modules/ROOT/pages/azure-openai-embedding-model.adoc
+++ b/docs/modules/ROOT/pages/azure-openai-embedding-model.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 Azure OpenAI supports the development of Retrieval-Augmented Generation (RAG) applications by offering embedding models that transform text into high-dimensional vector representations. These embeddings enable similarity search, semantic retrieval, and other vector-based operations.
 

--- a/docs/modules/ROOT/pages/azure-openai-image-model.adoc
+++ b/docs/modules/ROOT/pages/azure-openai-image-model.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 Azure OpenAI provides image generation models that can create or modify images based on natural language prompts. These models enable use cases such as visual storytelling, creative content generation, and image editing workflows.
 

--- a/docs/modules/ROOT/pages/dev-ui.adoc
+++ b/docs/modules/ROOT/pages/dev-ui.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: reference
 
 If you use the Dev mode, the `quarkus-langchain4j` project provides several pages
 in the Dev UI to facilitate development:

--- a/docs/modules/ROOT/pages/enable-disable-integrations.adoc
+++ b/docs/modules/ROOT/pages/enable-disable-integrations.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 By default, all AI provider integrations (e.g., OpenAI, HuggingFace, Azure OpenAI) are enabled. This means that live API calls are made to the respective providers when an AI service is invoked.
 

--- a/docs/modules/ROOT/pages/gemini-chat-model.adoc
+++ b/docs/modules/ROOT/pages/gemini-chat-model.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 https://gemini.google.com/[Gemini] is a simpler platform designed for a broader audience than Vertex AI Gemini, including non-technical users.
 It is a good first step for developers to get started with Gemini models.

--- a/docs/modules/ROOT/pages/gemini-embedding-model.adoc
+++ b/docs/modules/ROOT/pages/gemini-embedding-model.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 https://gemini.google.com/[Gemini] is a simpler platform designed for a broader audience than Vertex AI Gemini, including non-technical users.
 It is a good first step for developers to get started with Gemini models.

--- a/docs/modules/ROOT/pages/gpullama3-chat-model.adoc
+++ b/docs/modules/ROOT/pages/gpullama3-chat-model.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 https://github.com/beehive-lab/GPULlama3.java[GPULlama3.java] provides a *Java-native implementation* of LLMs that runs entirely in Java and executes automatically on GPUs via https://github.com/beehive-lab/TornadoVM[TornadoVM].
 

--- a/docs/modules/ROOT/pages/guide-fault-tolerance.adoc
+++ b/docs/modules/ROOT/pages/guide-fault-tolerance.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 Quarkus Fault Tolerance helps you make your AI service interactions more robust and resilient to failure.
 This is particularly useful when working with external model providers that may be unavailable or experience latency.

--- a/docs/modules/ROOT/pages/guide-few-shots.adoc
+++ b/docs/modules/ROOT/pages/guide-few-shots.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: tutorial
 
 Few-shot prompting lets you guide an LLM by embedding a handful of input–output examples directly in the prompt—no fine-tuning required.
 It strikes a balance between zero-shot and one-shot prompting, boosting accuracy on tasks like classification, extraction, and summarization while keeping your code simple.

--- a/docs/modules/ROOT/pages/guide-generating-image.adoc
+++ b/docs/modules/ROOT/pages/guide-generating-image.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: tutorial
 
 Text completions are powerful, but many modern AI use cases also demand image generation.
 With Quarkus LangChain4j’s Image model support, you can declare a service method that returns a `dev.langchain4j.data.image.Image` instance, letting your microservice request, receive, and expose AI‐generated visuals seamlessly.

--- a/docs/modules/ROOT/pages/guide-ollama.adoc
+++ b/docs/modules/ROOT/pages/guide-ollama.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: tutorial
 
 This guide shows how to use local Ollama models with the Quarkus LangChain4j extension.
 You'll learn how to:

--- a/docs/modules/ROOT/pages/guide-web-search.adoc
+++ b/docs/modules/ROOT/pages/guide-web-search.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 The Quarkus LangChain4j extension supports integrating the https://tavily.com/[Tavily] web search engine to enrich your AI services with up-to-date external knowledge.
 

--- a/docs/modules/ROOT/pages/huggingface-chat-model.adoc
+++ b/docs/modules/ROOT/pages/huggingface-chat-model.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 https://huggingface.co/[Hugging Face] is a leading platform in the field of natural language processing (NLP) that provides a wide collection of pre-trained language models. It facilitates easy access to cutting-edge models for various NLP tasks through hosted APIs or local inference.
 

--- a/docs/modules/ROOT/pages/huggingface-embedding-model.adoc
+++ b/docs/modules/ROOT/pages/huggingface-embedding-model.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 Hugging Face provides several pre-trained embedding models useful for semantic search, document retrieval, and Retrieval-Augmented Generation (RAG) workflows.
 

--- a/docs/modules/ROOT/pages/in-process-embedding.adoc
+++ b/docs/modules/ROOT/pages/in-process-embedding.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 In Retrieval-Augmented Generation (RAG) and other semantic search scenarios, embedding models are used to convert documents into vector representations. These vectors are stored in a vector database and used for similarity search.
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -3,6 +3,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: concept
 
 [.lead]
 **Build intelligent, AI-infused applications by integrating Large Language Models into your Quarkus services with a declarative, developer-friendly API.**

--- a/docs/modules/ROOT/pages/jlama-chat-model.adoc
+++ b/docs/modules/ROOT/pages/jlama-chat-model.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 https://github.com/tjake/Jlama[Jlama] provides a way to run Large Language Models (LLMs) *locally and in pure Java*, embedded within your Quarkus application.
 It supports a growing set of models available on Hugging Face: https://huggingface.co/tjake[https://huggingface.co/tjake].

--- a/docs/modules/ROOT/pages/jlama-embedding-model.adoc
+++ b/docs/modules/ROOT/pages/jlama-embedding-model.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 Jlama provides local embedding models suitable for RAG (Retriever-Augmented Generation), semantic search, and document classification—all without leaving the Java process.
 

--- a/docs/modules/ROOT/pages/llama3-chat-model.adoc
+++ b/docs/modules/ROOT/pages/llama3-chat-model.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 https://github.com/mukel/llama3.java[Llama3.java] enables running Large Language Models (LLMs) *locally and purely in Java*, embedded in your Quarkus application.
 It supports a growing collection of models available on Hugging Face under https://huggingface.co/mukel[https://huggingface.co/mukel], such as *Llama3* and *Mistral* variants.

--- a/docs/modules/ROOT/pages/mcp.adoc
+++ b/docs/modules/ROOT/pages/mcp.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 Quarkus LangChain4j supports the Model Context Protocol (MCP) for interacting with MCP-compliant servers that provide and execute tools dynamically.
 

--- a/docs/modules/ROOT/pages/mistral-chat-model.adoc
+++ b/docs/modules/ROOT/pages/mistral-chat-model.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 https://mistral.ai/[Mistral] is a French AI company offering high-performance open-weight LLMs. This extension allows seamless integration of Mistral's chat models into Quarkus applications.
 

--- a/docs/modules/ROOT/pages/mistral-embedding-model.adoc
+++ b/docs/modules/ROOT/pages/mistral-embedding-model.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 Mistral provides highly efficient embedding models that can be used to build RAG systems and perform vector similarity search.
 

--- a/docs/modules/ROOT/pages/mistral-moderation-model.adoc
+++ b/docs/modules/ROOT/pages/mistral-moderation-model.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 Mistral provides moderation models to detect harmful or unsafe content in user inputs before processing them.
 

--- a/docs/modules/ROOT/pages/ollama-chat-model.adoc
+++ b/docs/modules/ROOT/pages/ollama-chat-model.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 https://ollama.com/[Ollama] allows developers to run large language models (LLMs) locally on their machines, with support for both CPU and GPU execution.
 It supports many popular open models such as DeepSeek R1, Llama3, Mistral, and CodeLlama, which can be pulled from the https://ollama.com/library[Ollama model library].

--- a/docs/modules/ROOT/pages/ollama-embedding-model.adoc
+++ b/docs/modules/ROOT/pages/ollama-embedding-model.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 Ollama supports embedding models suitable for semantic search, document retrieval, and RAG-style workflows.
 These models run locally, just like chat models.

--- a/docs/modules/ROOT/pages/openai-chat-model.adoc
+++ b/docs/modules/ROOT/pages/openai-chat-model.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 OpenAI is a leading AI research organization known for its groundbreaking Large Language Models (LLMs) like GPT-4.
 

--- a/docs/modules/ROOT/pages/openai-embedding-model.adoc
+++ b/docs/modules/ROOT/pages/openai-embedding-model.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 OpenAI is a leading AI research organization known for its groundbreaking Large Language Models (LLMs) such as GPT-4.
 

--- a/docs/modules/ROOT/pages/openai-image-model.adoc
+++ b/docs/modules/ROOT/pages/openai-image-model.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 OpenAI provides various image models capable of generating or editing images based on textual prompts.
 These models are ideal for use cases involving content creation, design assistance, or visual storytelling.

--- a/docs/modules/ROOT/pages/openai-moderation-model.adoc
+++ b/docs/modules/ROOT/pages/openai-moderation-model.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 OpenAI provides a dedicated moderation model designed to detect and filter harmful, offensive, or otherwise inappropriate content in user-generated text.
 These models are particularly useful in public-facing applications where user safety and content compliance are essential.

--- a/docs/modules/ROOT/pages/podman.adoc
+++ b/docs/modules/ROOT/pages/podman.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 https://developers.redhat.com/products/podman-desktop/podman-ai-lab/[Podman AI Lab] is a local AI development environment provided as an extension to Podman Desktop.
 It simplifies experimentation with AI by providing a curated catalog of models and recipes, all runnable on your local machine via containerized infrastructure.

--- a/docs/modules/ROOT/pages/quickstart-function-calling.adoc
+++ b/docs/modules/ROOT/pages/quickstart-function-calling.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: tutorial
 
 Function calling allows Large Language Models (LLMs) to invoke application-specific methods based on user prompts.
 Rather than returning free-form text, the model is instructed to identify when an application-defined *function* (called a *tool*) should be used, and to call it with structured arguments.

--- a/docs/modules/ROOT/pages/quickstart-image.adoc
+++ b/docs/modules/ROOT/pages/quickstart-image.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: tutorial
 
 This guide demonstrates how to use Quarkus LangChain4j to extract text from an image using a Large Language Model (LLM). You will create a simple CLI application that loads an image, converts it to a base64 payload, and sends it to a model for text extraction and translation.
 

--- a/docs/modules/ROOT/pages/quickstart-summarization.adoc
+++ b/docs/modules/ROOT/pages/quickstart-summarization.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: tutorial
 
 This guide shows you how to implement a simple text summarization service using Quarkus LangChain4j and run it as a standalone CLI application.
 The service reads a plain text file (such as an article or report), sends the content to a Large Language Model, and receives a structured Markdown summary in return.

--- a/docs/modules/ROOT/pages/quickstart.adoc
+++ b/docs/modules/ROOT/pages/quickstart.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: tutorial
 
 This guide shows you how to get started with Quarkus LangChain4j by building a simple CLI application that generates poems using an AI model.
 

--- a/docs/modules/ROOT/pages/rag-chroma-store.adoc
+++ b/docs/modules/ROOT/pages/rag-chroma-store.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 Chroma is a lightweight, open-source vector database designed for embedding-based search.
 It can be used as a document store in Retrieval-Augmented Generation (RAG) pipelines with Quarkus LangChain4j.

--- a/docs/modules/ROOT/pages/rag-infinispan-store.adoc
+++ b/docs/modules/ROOT/pages/rag-infinispan-store.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 Quarkus LangChain4j integrates with Infinispan Server to provide a scalable, distributed vector store for Retrieval-Augmented Generation (RAG).
 This extension enables you to persist and query embedding vectors for document retrieval.

--- a/docs/modules/ROOT/pages/rag-milvus-store.adoc
+++ b/docs/modules/ROOT/pages/rag-milvus-store.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 Milvus is a scalable and high-performance vector database optimized for AI and semantic search use cases.
 This guide explains how to use Milvus as an embedding store in Quarkus LangChain4j for RAG applications.

--- a/docs/modules/ROOT/pages/rag-neo4j.adoc
+++ b/docs/modules/ROOT/pages/rag-neo4j.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 Neo4j is a graph database that also supports vector search starting from version 5.x.
 With Quarkus LangChain4j, you can use Neo4j as a vector-capable document store for implementing Retrieval-Augmented Generation (RAG) pipelines.

--- a/docs/modules/ROOT/pages/rag-pgvector-store.adoc
+++ b/docs/modules/ROOT/pages/rag-pgvector-store.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 The PGVector extension allows you to use PostgreSQL as a vector database for Retrieval-Augmented Generation (RAG) with Quarkus LangChain4j.
 It leverages the `pgvector` extension in PostgreSQL to store and search vector embeddings efficiently.

--- a/docs/modules/ROOT/pages/rag-pinecone-store.adoc
+++ b/docs/modules/ROOT/pages/rag-pinecone-store.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 Pinecone is a fully managed, scalable vector database optimized for similarity search.
 With Quarkus LangChain4j, you can use Pinecone as a vector store to implement Retrieval-Augmented Generation (RAG) pipelines.

--- a/docs/modules/ROOT/pages/rag-qdrant-store.adoc
+++ b/docs/modules/ROOT/pages/rag-qdrant-store.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 Qdrant is a high-performance vector database optimized for semantic search and Retrieval-Augmented Generation (RAG) workloads.
 This guide explains how to use Qdrant as a vector-capable document store in Quarkus LangChain4j.

--- a/docs/modules/ROOT/pages/rag-redis.adoc
+++ b/docs/modules/ROOT/pages/rag-redis.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 Redis can serve as an efficient document store for Retrieval-Augmented Generation (RAG) applications using Quarkus LangChain4j.
 This guide explains how to configure and use Redis as a vector-capable document store.

--- a/docs/modules/ROOT/pages/rag-weaviate.adoc
+++ b/docs/modules/ROOT/pages/rag-weaviate.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 Weaviate is a scalable vector-native database designed for semantic search and Retrieval-Augmented Generation (RAG) use cases.
 This guide explains how to use Weaviate as an embedding store in Quarkus LangChain4j.

--- a/docs/modules/ROOT/pages/rag.adoc
+++ b/docs/modules/ROOT/pages/rag.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: concept
 
 == Overview
 

--- a/docs/modules/ROOT/pages/watsonx-chat-model.adoc
+++ b/docs/modules/ROOT/pages/watsonx-chat-model.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 https://www.ibm.com/products/watsonx-ai/foundation-models[IBM watsonx.ai] enables the development of generative AI applications using foundation models from IBM and Hugging Face.
 

--- a/docs/modules/ROOT/pages/watsonx-embedding-model.adoc
+++ b/docs/modules/ROOT/pages/watsonx-embedding-model.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 IBM watsonx.ai also provides access to embedding models that can be used for vector-based similarity search, semantic retrieval, and RAG scenarios.
 

--- a/docs/modules/ROOT/pages/websockets.adoc
+++ b/docs/modules/ROOT/pages/websockets.adoc
@@ -2,6 +2,7 @@
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
+:diataxis-type: howto
 
 Using a chatbot in a WebSockets environment is quite common, which is why the extension provides a few facilities to make such usages as easy as possible.
 


### PR DESCRIPTION
Add a `:diataxis-type:` attribute to 49 documentation files that are primarily one Diataxis content type. Each file gets a single line inserted after the `include::` lines in the AsciiDoc header:

```asciidoc
= Page Title
include::./includes/attributes.adoc[]
include::./includes/customization.adoc[]
:diataxis-type: howto
```

### Breakdown by type

| Type | Count | Description |
|------|-------|-------------|
| `howto` | 39 | Model provider config pages, embedding store setup, and task-oriented guides |
| `tutorial` | 7 | Quickstarts and step-by-step learning guides |
| `concept` | 2 | Landing page (`index.adoc`) and RAG overview (`rag.adoc`) |
| `reference` | 1 | Dev UI feature catalog (`dev-ui.adoc`) |
| **Total** | **49** | |

### What this enables

The `:diataxis-type:` attribute provides machine-readable metadata for documentation tooling and audits. It marks each file's primary content purpose without changing any visible content.

### Files not included (25 mixed-type files)

26 additional files have significant mixing of 2+ Diataxis types and need restructuring before they can receive a single type label. These are tracked in `docs/diataxis-categorization-plan.md` under Step 2.

### Validation

An independent Diataxis audit verified each attribute against the actual file content. 7 initially misclassified files were corrected (attributes removed, files moved to the mixed-type category for future restructuring).