### PR TITLE
Add CLAUDE.md to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ bin/
 .idea/
 
 .claude/
+CLAUDE.md
 
 # NetBeans
 nb-configuration.xml


### PR DESCRIPTION
This is what Claude Code creates when you run the `/init` command and it contains deduced information about the project. Everybody should have their own independent CLAUDE.md...