### PR TITLE
Restructure tool-guardrails.adoc into Diataxis-aligned files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ release.properties
 /docs/node_modules/
 node_modules/
 antora-cache/
+diataxis-audit-*.md

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -42,6 +42,11 @@
 ** xref:messages-and-memory.adoc[Messages and Memory]
 ** xref:function-calling.adoc[Function Calling]
 ** xref:guardrails.adoc[Guardrails]
+** Tool Guardrails
+*** xref:tool-guardrails-concept.adoc[Understand tool guardrails]
+*** xref:tool-guardrails-tutorial.adoc[Create your first tool guardrail]
+*** xref:tool-guardrails-howto.adoc[Validate tool invocations]
+*** xref:tool-guardrails-reference.adoc[Tool guardrails reference]
 ** xref:response-augmenter.adoc[Response Augmenter]
 * xref:models.adoc[Models]
 ** Chat Models

--- a/docs/modules/ROOT/pages/function-calling.adoc
+++ b/docs/modules/ROOT/pages/function-calling.adoc
@@ -478,7 +478,7 @@ Tool guardrails are useful for:
 
 [NOTE]
 ====
-See xref:tool-guardrails.adoc[Tool Guardrails] for complete documentation.
+See xref:tool-guardrails-concept.adoc[Tool Guardrails] for complete documentation.
 ====
 
 == Summary
@@ -502,7 +502,7 @@ Function calling enables the model to take actions and retrieve external informa
 == Going Further
 
 [.lead]
-* xref:tool-guardrails.adoc[Tool Guardrails] – Validate and control tool invocations
+* xref:tool-guardrails-concept.adoc[Tool Guardrails] – Validate and control tool invocations
 * xref:ai-services.adoc[AI Service Configuration]
 * xref:messages-and-memory.adoc[Memory and Context Management]
 * xref:observability.adoc[Observability of Tool Invocations]

--- a/docs/modules/ROOT/pages/tool-guardrails-concept.adoc
+++ b/docs/modules/ROOT/pages/tool-guardrails-concept.adoc
@@ -1,0 +1,53 @@
+= Understand Tool Guardrails
+
+include::./includes/attributes.adoc[]
+:diataxis-type: concept
+
+Tool guardrails provide validation and control mechanisms for tool (function) invocations in AI applications.
+Unlike LLM guardrails which validate prompts and responses from the LLM, tool guardrails operate on the **input parameters** and **output results** of tools that the LLM can invoke using xref:function-calling.adoc[function calling].
+
+[NOTE]
+====
+Tool guardrails are important for:
+
+* **Security**: Prevent unauthorized access to sensitive operations
+* **Data Validation**: Ensure parameters meet format and business rule requirements
+* **Privacy Protection**: Filter sensitive data from tool outputs
+* **Cost Control**: Limit expensive operations through rate limiting
+* **Reliability**: Prevent malformed requests from causing errors
+====
+
+== How Tool Guardrails Work
+
+Tool guardrails operate at two stages:
+
+1. **Input Guardrails** (`@ToolInputGuardrails`) - Execute **before** the tool, validating parameters and context
+2. **Output Guardrails** (`@ToolOutputGuardrails`) - Execute **after** the tool, validating or transforming results
+
+Both types can:
+
+* Allow execution to proceed (`success()`)
+* Block execution with an error message (`failure()`)
+* Transform requests/responses (`successWith()`)
+
+When an input guardrail fails, the tool is **not executed**. The error message is returned to the LLM as the tool result, and the LLM can retry with corrected parameters.
+
+When an output guardrail modifies the result, the **modified** result is returned to the LLM. The original tool result is **never** seen by the LLM. Multiple output guardrails can chain transformations.
+
+== Event Loop Compatibility
+
+Tool guardrails (both `@ToolInputGuardrails` and `@ToolOutputGuardrails`) have synchronous, blocking APIs by design, as they perform operations like JSON parsing, validation, and potentially database lookups or external API calls.
+
+Consequently, tools annotated with guardrails cannot execute on the Vert.x event loop and must be marked as blocking. If you attempt to use a tool with guardrails from the event loop (for example, in a reactive endpoint or streaming AI service), the framework throws a `ToolExecutionException` with the message "Cannot execute guardrails on the event loop thread."
+
+To use guardrails with your tools, ensure the tool methods are properly detected or annotated as blocking (e.g., using `@Blocking` annotation or by returning blocking types instead of `Uni/Multi`).
+
+Tools without guardrails can continue to use reactive execution models without any restrictions. This architectural decision ensures application responsiveness by preventing blocking operations on the event loop.
+
+== Related Resources
+
+* xref:tool-guardrails-tutorial.adoc[Create your first tool guardrail] -- A step-by-step tutorial
+* xref:tool-guardrails-howto.adoc[Validate tool invocations] -- Task-oriented recipes for common guardrail patterns
+* xref:tool-guardrails-reference.adoc[Tool guardrails reference] -- API interfaces, metrics, and CDI integration details
+* xref:function-calling.adoc[Function Calling] -- How to declare and use tools in AI services
+* xref:guardrails.adoc[LLM Guardrails] -- Guardrails for prompts and responses

--- a/docs/modules/ROOT/pages/tool-guardrails-concept.adoc
+++ b/docs/modules/ROOT/pages/tool-guardrails-concept.adoc
@@ -4,17 +4,17 @@ include::./includes/attributes.adoc[]
 :diataxis-type: concept
 
 Tool guardrails provide validation and control mechanisms for tool (function) invocations in AI applications.
-Unlike LLM guardrails which validate prompts and responses from the LLM, tool guardrails operate on the **input parameters** and **output results** of tools that the LLM can invoke using xref:function-calling.adoc[function calling].
+Unlike LLM guardrails, which validate prompts and responses from the LLM, tool guardrails operate on the **input parameters** and **output results** of tools that the LLM can invoke using xref:function-calling.adoc[function calling].
 
 [NOTE]
 ====
 Tool guardrails are important for:
 
-* **Security**: Prevent unauthorized access to sensitive operations
-* **Data Validation**: Ensure parameters meet format and business rule requirements
-* **Privacy Protection**: Filter sensitive data from tool outputs
-* **Cost Control**: Limit expensive operations through rate limiting
-* **Reliability**: Prevent malformed requests from causing errors
+* **Security**: Prevent unauthorized access to sensitive operations.
+* **Data Validation**: Ensure parameters meet format and business rule requirements.
+* **Privacy Protection**: Filter sensitive data from tool outputs.
+* **Cost Control**: Limit expensive operations through rate limiting.
+* **Reliability**: Prevent malformed requests from causing errors.
 ====
 
 == How Tool Guardrails Work

--- a/docs/modules/ROOT/pages/tool-guardrails-howto.adoc
+++ b/docs/modules/ROOT/pages/tool-guardrails-howto.adoc
@@ -1,86 +1,15 @@
-= Tool Guardrails - Protecting Your Function Calls
+= Validate Tool Invocations
 
 include::./includes/attributes.adoc[]
+:diataxis-type: howto
 
-Tool guardrails provide validation and control mechanisms for tool (function) invocations in AI applications.
-Unlike LLM guardrails which validate prompts and responses from the LLM, tool guardrails operate on the **input parameters** and **output results** of tools that the LLM can invoke using xref:function-calling.adoc[function calling].
+This guide provides task-oriented recipes for implementing tool guardrails.
+For background on what tool guardrails are and how they work, see xref:tool-guardrails-concept.adoc[Understand tool guardrails].
+For the full API reference, see xref:tool-guardrails-reference.adoc[Tool guardrails reference].
 
-[NOTE]
-====
-Tool guardrails are important for:
+== Validate Input Parameters
 
-* **Security**: Prevent unauthorized access to sensitive operations
-* **Data Validation**: Ensure parameters meet format and business rule requirements
-* **Privacy Protection**: Filter sensitive data from tool outputs
-* **Cost Control**: Limit expensive operations through rate limiting
-* **Reliability**: Prevent malformed requests from causing errors
-====
-
-== Overview
-
-Tool guardrails operate at two stages:
-
-1. **Input Guardrails** (`@ToolInputGuardrails`) - Execute **before** the tool, validating parameters and context
-2. **Output Guardrails** (`@ToolOutputGuardrails`) - Execute **after** the tool, validating or transforming results
-
-Both types can:
-
-* Allow execution to proceed (`success()`)
-* Block execution with an error message (`failure()`)
-* Transform requests/responses (`successWith()`)
-
-== Quick Start
-
-To create your first guardrail in 3 steps:
-
-1. **Create a CDI bean** implementing `ToolInputGuardrail` or `ToolOutputGuardrail`
-2. **Implement the `validate()` method** with your validation logic
-3. **Apply the annotation** to your tool method
-
-[source,java]
-----
-// Step 1 & 2: Create guardrail bean
-@ApplicationScoped  // <1>
-public class PositiveNumberGuardrail implements ToolInputGuardrail {  // <2>
-
-    @Override
-    public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {  // <3>
-        JsonObject args = request.argumentsAsJson();
-        int number = args.getInteger("amount");
-
-        if (number < 0) {
-            return ToolInputGuardrailResult.failure(  // <4>
-                "Amount must be positive, got: " + number);
-        }
-
-        return ToolInputGuardrailResult.success();  // <5>
-    }
-}
-
-// Step 3: Apply to tool
-@ApplicationScoped
-public class BankingTools {
-
-    @Tool("Transfer money between accounts")
-    @ToolInputGuardrails({ PositiveNumberGuardrail.class })  // <6>
-    public String transfer(int amount, String from, String to) {
-        // This only executes if amount is positive
-        return "Transferred $" + amount + " from " + from + " to " + to;
-    }
-}
-----
-<1> Make it a CDI bean with a scope annotation
-<2> Implement the appropriate guardrail interface
-<3> Override the validate method
-<4> Return failure if validation fails
-<5> Return success if validation passes
-<6> Apply the guardrail annotation to your tool
-
-== Basic Usage
-
-=== Input Guardrails
-
-Input guardrails validate tool parameters before execution:
+To validate tool parameters before execution, create a CDI bean that implements `ToolInputGuardrail` and annotate your tool with `@ToolInputGuardrails`:
 
 [source,java]
 ----
@@ -98,7 +27,7 @@ public class EmailTools {
 }
 ----
 
-The guardrail implementation:
+Implement the guardrail:
 
 [source,java]
 ----
@@ -133,9 +62,9 @@ When an input guardrail fails:
 * The LLM can retry with corrected parameters
 ====
 
-=== Output Guardrails
+== Filter Sensitive Data from Output
 
-Output guardrails validate and transform tool results:
+To filter or transform tool output before the LLM sees it, implement `ToolOutputGuardrail` and annotate your tool with `@ToolOutputGuardrails`:
 
 [source,java]
 ----
@@ -147,7 +76,7 @@ public String getCustomerInfo(String customerId) {
 }
 ----
 
-The guardrail implementation:
+Implement the guardrail:
 
 [source,java]
 ----
@@ -189,102 +118,9 @@ When an output guardrail modifies the result:
 * Multiple output guardrails can chain transformations
 ====
 
-== Guardrail Interfaces
+== Chain Multiple Guardrails
 
-=== ToolInputGuardrail Interface
-
-[source,java]
-----
-public interface ToolInputGuardrail {
-    /**
-     * Validates tool input parameters before execution.
-     */
-    ToolInputGuardrailResult validate(ToolInputGuardrailRequest request);
-}
-----
-
-**Request Context:**
-
-[source,java]
-----
-// Access available context
-String toolName = request.toolName();
-String arguments = request.arguments();  // JSON string
-JsonObject args = request.argumentsAsJson();  // Parsed JSON for easy access
-Object memoryId = request.memoryId();
-ToolMetadata metadata = request.toolMetadata();
-ToolInvocationContext context = request.invocationContext();
-----
-
-**Result Options:**
-
-[source,java]
-----
-// Validation passed
-return ToolInputGuardrailResult.success();
-
-// Validation passed with modified request
-return ToolInputGuardrailResult.successWith(modifiedRequest);
-
-// Validation failed - error returned to LLM
-return ToolInputGuardrailResult.failure("Error message for LLM");
-
-// Fatal failure - stops execution immediately
-return ToolInputGuardrailResult.fatal("Critical error", exception);
-
-// Fatal failure - uses exception message
-return ToolInputGuardrailResult.fatal(exception);
-----
-
-=== ToolOutputGuardrail Interface
-
-[source,java]
-----
-public interface ToolOutputGuardrail {
-    /**
-     * Validates tool output after execution.
-     */
-    ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request);
-}
-----
-
-**Request Context:**
-
-[source,java]
-----
-// Access tool result and context
-String resultText = request.resultText();
-JsonObject result = request.resultAsJson();  // Parsed result for JSON tools
-boolean isError = request.isError();
-String toolName = request.toolName();
-JsonObject args = request.argumentsAsJson();  // Original input arguments
-ToolExecutionRequest originalRequest = request.executionRequest();
-ToolExecutionResult executionResult = request.executionResult();
-----
-
-**Result Options:**
-
-[source,java]
-----
-// Output valid
-return ToolOutputGuardrailResult.success();
-
-// Output valid with transformation
-return ToolOutputGuardrailResult.successWith(modifiedResult);
-
-// Output invalid - error returned to LLM
-return ToolOutputGuardrailResult.failure("Error message");
-
-// Fatal failure - stops execution immediately
-return ToolOutputGuardrailResult.fatal("Critical error", exception);
-
-// Fatal failure - uses exception message
-return ToolOutputGuardrailResult.fatal(exception);
-----
-
-== Multiple Guardrails
-
-Multiple guardrails can be applied to a single tool and execute them in **order**:
+To apply multiple guardrails to a single tool, list them in the annotation array. They execute in **order**:
 
 [source,java]
 ----
@@ -319,11 +155,9 @@ public String sendBulkEmail(String recipients, String subject, String body) {
 Input guardrails execute in order and **stop at the first failure**. If `EmailFormatValidator` fails, the subsequent guardrails are not executed and the tool does not run.
 ====
 
-== Working with Parameters
+== Access JSON Parameters
 
-=== Accessing JSON Parameters
-
-Tool arguments are provided as JSON strings. Use `argumentsAsJson()` for easy parameter access:
+Tool arguments are provided as JSON strings. Use `argumentsAsJson()` for type-safe parameter access:
 
 [source,java]
 ----
@@ -363,7 +197,7 @@ public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
 It provides null-safe methods like `getString(key, default)` and convenient type conversions.
 ====
 
-=== POJO Mapping
+== Map Parameters to POJOs
 
 For complex parameters, map JSON directly to Java objects:
 
@@ -395,9 +229,9 @@ public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
 }
 ----
 
-=== Parsing Tool Output
+== Parse and Filter JSON Output
 
-Output guardrails can also parse JSON results:
+Output guardrails can parse JSON results and return filtered data:
 
 [source,java]
 ----
@@ -432,9 +266,9 @@ public ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request) {
 }
 ----
 
-== Common Use Cases
+== Enforce Authorization
 
-=== Security and Authorization
+Use CDI injection to access security context in guardrails:
 
 [source,java]
 ----
@@ -466,7 +300,7 @@ public class UserAuthorizationGuardrail implements ToolInputGuardrail {
 Guardrails are CDI beans and can inject dependencies like `SecurityIdentity`, making them ideal for authorization checks.
 ====
 
-=== Rate Limiting
+== Implement Rate Limiting
 
 [source,java]
 ----
@@ -490,7 +324,7 @@ public class RateLimitGuardrail implements ToolInputGuardrail {
 }
 ----
 
-=== Data Privacy and Filtering
+== Filter PII from Output
 
 [source,java]
 ----
@@ -525,7 +359,7 @@ public class PiiFilter implements ToolOutputGuardrail {
 }
 ----
 
-=== Cost Control (Output Size Limiting)
+== Limit Output Size
 
 [source,java]
 ----
@@ -555,56 +389,9 @@ public class OutputSizeLimiter implements ToolOutputGuardrail {
 }
 ----
 
-== CDI Integration
+== Modify Tool Requests
 
-Guardrails are CDI beans and support all standard features:
-
-[source,java]
-----
-@RequestScoped  // Can use different scopes
-public class StatefulGuardrail implements ToolInputGuardrail {
-
-    @Inject
-    SecurityIdentity identity;  // Dependency injection
-
-    @Inject
-    AuditLogger auditLogger;    // Custom beans
-
-    @ConfigProperty(name = "app.max-retries", defaultValue = "3")
-    int maxRetries;  // Configuration injection
-
-    private int callCount = 0;  // Instance state
-
-    @Override
-    public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
-        callCount++;
-        auditLogger.log(identity.getPrincipal().getName(),
-                       "Tool invocation #" + callCount);
-
-        // Validation logic
-        return ToolInputGuardrailResult.success();
-    }
-}
-----
-
-== Advanced Topics
-
-=== Important Limitation: Tool Guardrails and Event Loop Compatibility
-
-Tool guardrails (both `@ToolInputGuardrails` and `@ToolOutputGuardrails`) have synchronous, blocking APIs by design, as
-  they perform operations like JSON parsing, validation, and potentially database lookups or external API calls.
-
-Consequently, tools annotated with guardrails cannot execute on the Vert.x event loop and must be marked as blocking.
-If you attempt to use a tool with guardrails from the event loop (for example, in a reactive endpoint or streaming AI  service), the framework will throw a ToolExecutionException with the message "Cannot execute guardrails on the event  loop thread."
-
-To use guardrails with your tools, ensure the tool methods are properly detected or annotated as  blocking (e.g., using @Blocking annotation or by returning blocking types instead of `Uni/Multi`).
-
-Tools without guardrails can continue to use reactive execution models without any restrictions.
-This architectural decision ensures  application responsiveness by preventing blocking operations on the event loop.
-
-=== Request Modification
-
-Input guardrails can modify tool requests before execution:
+Input guardrails can modify tool requests before execution using `successWith()`:
 
 [source,java]
 ----
@@ -632,32 +419,9 @@ public class ParameterNormalizer implements ToolInputGuardrail {
 }
 ----
 
-=== Context and Metadata
+== Handle Errors Gracefully
 
-Guardrails have access to contextual information:
-
-[source,java]
-----
-@Override
-public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
-    // Tool information
-    ToolMetadata metadata = request.toolMetadata();
-    String toolName = metadata.toolName();
-    String description = metadata.description();
-
-    // Invocation context
-    ToolInvocationContext context = request.invocationContext();
-    Object memoryId = context.memoryId();
-    Map<String, Object> params = context.parameters();
-
-    // Use context for validation...
-    return ToolInputGuardrailResult.success();
-}
-----
-
-=== Error Handling
-
-Guardrails should handle parsing and validation errors gracefully:
+Guardrails should handle parsing and validation errors without crashing:
 
 [source,java]
 ----
@@ -703,9 +467,9 @@ public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
 Use fatal failures only for critical errors that indicate bugs or system failures (e.g., authorization failures, system errors), not for validation errors that the LLM can potentially correct.
 ====
 
-=== Best Practices
+== Write Clear Validation Messages
 
-Follow these guidelines when implementing guardrails:
+Follow these guidelines when writing guardrail validation logic:
 
 [source,java]
 ----
@@ -754,9 +518,9 @@ public class WellDesignedGuardrail implements ToolInputGuardrail {
 }
 ----
 
-== Testing
+== Test Guardrails
 
-Test guardrails as regular CDI beans:
+Test guardrails as regular CDI beans using `@QuarkusTest`:
 
 [source,java]
 ----
@@ -800,81 +564,3 @@ public class EmailValidatorTest {
     }
 }
 ----
-
-== Observability and Metrics
-
-Tool guardrail execution can be monitored using Micrometer metrics when the `quarkus-micrometer` extension is present.
-
-=== Metrics
-
-Two metrics are automatically recorded for each guardrail execution:
-
-**Counter Metric: `tool-guardrail.invoked`**
-
-Counts the number of times a tool guardrail is invoked, with tags:
-
-* `aiservice` - Fully qualified AI service interface name
-* `operation` - AI service method name
-* `tool.name` - Name of the tool being validated
-* `guardrail` - Guardrail class name
-* `guardrail.type` - `input` or `output`
-* `outcome` - `success`, `failure`, or `fatal`
-
-**Timer Metric: `tool-guardrail.timed`**
-
-Records execution time of guardrails with the same tags as the counter, plus percentiles (75th, 95th, 99th).
-
-=== Events
-
-For custom observability, you can observe CDI events fired during guardrail execution:
-
-[source,java]
-----
-@ApplicationScoped
-public class GuardrailMonitor {
-
-    public void onInputGuardrailExecuted(
-            @Observes ToolInputGuardrailExecutedEvent event) {
-
-        String toolName = event.toolName();
-        Class<?> guardrailClass = event.toolClass();
-        ToolGuardrailOutcome outcome = event.outcome(); // SUCCESS, FAILURE, FATAL
-        long durationNanos = event.duration();
-
-        // Custom monitoring logic
-        if (outcome == ToolGuardrailOutcome.FATAL) {
-            logger.error("Fatal guardrail failure for tool: {}", toolName);
-        }
-    }
-
-    public void onOutputGuardrailExecuted(
-            @Observes ToolOutputGuardrailExecutedEvent event) {
-        // Similar monitoring for output guardrails
-    }
-}
-----
-
-These events provide access to:
-
-* `toolName()` - The tool being validated
-* `toolClass()` - The guardrail class
-* `outcome()` - SUCCESS, FAILURE, or FATAL
-* `duration()` - Execution time in nanoseconds
-* `toolInvocationContext()` - Full invocation context including memory ID and parameters
-
-[TIP]
-====
-Use these metrics to:
-
-* Monitor guardrail success rates and identify problematic tools
-* Track performance and identify slow guardrails
-* Set up alerts for fatal failures indicating system issues
-* Analyze which guardrails are most frequently triggered
-====
-
-== Going Further
-
-[.lead]
-* xref:function-calling.adoc[Function Calling] – Learn how to declare and use tools in AI services
-* xref:guardrails.adoc[LLM Guardrails] – Understand guardrails for prompts and responses
-* xref:ai-services.adoc[AI Services Reference] – Complete AI service configuration guide

--- a/docs/modules/ROOT/pages/tool-guardrails-howto.adoc
+++ b/docs/modules/ROOT/pages/tool-guardrails-howto.adoc
@@ -3,7 +3,7 @@
 include::./includes/attributes.adoc[]
 :diataxis-type: howto
 
-This guide provides task-oriented recipes for implementing tool guardrails.
+Use these recipes to add validation and control to your tool invocations.
 For background on what tool guardrails are and how they work, see xref:tool-guardrails-concept.adoc[Understand tool guardrails].
 For the full API reference, see xref:tool-guardrails-reference.adoc[Tool guardrails reference].
 
@@ -57,9 +57,9 @@ public class EmailFormatValidator implements ToolInputGuardrail {
 ====
 When an input guardrail fails:
 
-* The tool is **not executed**
-* The error message is returned to the LLM as the tool result
-* The LLM can retry with corrected parameters
+* The tool is **not executed**.
+* The error message is returned to the LLM as the tool result.
+* The LLM can retry with corrected parameters.
 ====
 
 == Filter Sensitive Data from Output
@@ -113,9 +113,9 @@ public class SensitiveDataFilter implements ToolOutputGuardrail {
 ====
 When an output guardrail modifies the result:
 
-* The **modified** result is returned to the LLM
-* The original tool result is **never** seen by the LLM
-* Multiple output guardrails can chain transformations
+* The **modified** result is returned to the LLM.
+* The original tool result is **never** seen by the LLM.
+* Multiple output guardrails can chain transformations.
 ====
 
 == Chain Multiple Guardrails
@@ -143,9 +143,9 @@ public String sendBulkEmail(String recipients, String subject, String body) {
 ====
 **Execution Order Best Practices:**
 
-* Place **fast, cheap** checks first (format validation)
-* Place **slow, expensive** checks last (database lookups)
-* For output guardrails, order by transformation dependencies
+* Place **fast, cheap** checks first (format validation).
+* Place **slow, expensive** checks last (database lookups).
+* For output guardrails, order by transformation dependencies.
 ====
 
 [IMPORTANT]
@@ -302,6 +302,8 @@ Guardrails are CDI beans and can inject dependencies like `SecurityIdentity`, ma
 
 == Implement Rate Limiting
 
+To throttle tool invocations per user, inject a rate limiter service:
+
 [source,java]
 ----
 @ApplicationScoped
@@ -325,6 +327,8 @@ public class RateLimitGuardrail implements ToolInputGuardrail {
 ----
 
 == Filter PII from Output
+
+To redact personally identifiable information such as SSNs and credit card numbers from tool output:
 
 [source,java]
 ----
@@ -360,6 +364,8 @@ public class PiiFilter implements ToolOutputGuardrail {
 ----
 
 == Limit Output Size
+
+To prevent oversized tool responses from consuming excessive tokens:
 
 [source,java]
 ----

--- a/docs/modules/ROOT/pages/tool-guardrails-reference.adoc
+++ b/docs/modules/ROOT/pages/tool-guardrails-reference.adoc
@@ -1,0 +1,231 @@
+= Tool Guardrails Reference
+
+include::./includes/attributes.adoc[]
+:diataxis-type: reference
+
+This page documents the tool guardrail API: interfaces, request/result objects, CDI integration, and observability.
+For an introduction to tool guardrails, see xref:tool-guardrails-concept.adoc[Understand tool guardrails].
+For task-oriented usage, see xref:tool-guardrails-howto.adoc[Validate tool invocations].
+
+== ToolInputGuardrail Interface
+
+[source,java]
+----
+public interface ToolInputGuardrail {
+    /**
+     * Validates tool input parameters before execution.
+     */
+    ToolInputGuardrailResult validate(ToolInputGuardrailRequest request);
+}
+----
+
+=== ToolInputGuardrailRequest
+
+[source,java]
+----
+// Access available context
+String toolName = request.toolName();
+String arguments = request.arguments();  // JSON string
+JsonObject args = request.argumentsAsJson();  // Parsed JSON for easy access
+Object memoryId = request.memoryId();
+ToolMetadata metadata = request.toolMetadata();
+ToolInvocationContext context = request.invocationContext();
+----
+
+=== ToolInputGuardrailResult
+
+[source,java]
+----
+// Validation passed
+return ToolInputGuardrailResult.success();
+
+// Validation passed with modified request
+return ToolInputGuardrailResult.successWith(modifiedRequest);
+
+// Validation failed - error returned to LLM
+return ToolInputGuardrailResult.failure("Error message for LLM");
+
+// Fatal failure - stops execution immediately
+return ToolInputGuardrailResult.fatal("Critical error", exception);
+
+// Fatal failure - uses exception message
+return ToolInputGuardrailResult.fatal(exception);
+----
+
+== ToolOutputGuardrail Interface
+
+[source,java]
+----
+public interface ToolOutputGuardrail {
+    /**
+     * Validates tool output after execution.
+     */
+    ToolOutputGuardrailResult validate(ToolOutputGuardrailRequest request);
+}
+----
+
+=== ToolOutputGuardrailRequest
+
+[source,java]
+----
+// Access tool result and context
+String resultText = request.resultText();
+JsonObject result = request.resultAsJson();  // Parsed result for JSON tools
+boolean isError = request.isError();
+String toolName = request.toolName();
+JsonObject args = request.argumentsAsJson();  // Original input arguments
+ToolExecutionRequest originalRequest = request.executionRequest();
+ToolExecutionResult executionResult = request.executionResult();
+----
+
+=== ToolOutputGuardrailResult
+
+[source,java]
+----
+// Output valid
+return ToolOutputGuardrailResult.success();
+
+// Output valid with transformation
+return ToolOutputGuardrailResult.successWith(modifiedResult);
+
+// Output invalid - error returned to LLM
+return ToolOutputGuardrailResult.failure("Error message");
+
+// Fatal failure - stops execution immediately
+return ToolOutputGuardrailResult.fatal("Critical error", exception);
+
+// Fatal failure - uses exception message
+return ToolOutputGuardrailResult.fatal(exception);
+----
+
+== Context and Metadata
+
+Guardrails have access to tool metadata and invocation context:
+
+[source,java]
+----
+@Override
+public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+    // Tool information
+    ToolMetadata metadata = request.toolMetadata();
+    String toolName = metadata.toolName();
+    String description = metadata.description();
+
+    // Invocation context
+    ToolInvocationContext context = request.invocationContext();
+    Object memoryId = context.memoryId();
+    Map<String, Object> params = context.parameters();
+
+    // Use context for validation...
+    return ToolInputGuardrailResult.success();
+}
+----
+
+== CDI Integration
+
+Guardrails are CDI beans and support all standard features:
+
+[source,java]
+----
+@RequestScoped  // Can use different scopes
+public class StatefulGuardrail implements ToolInputGuardrail {
+
+    @Inject
+    SecurityIdentity identity;  // Dependency injection
+
+    @Inject
+    AuditLogger auditLogger;    // Custom beans
+
+    @ConfigProperty(name = "app.max-retries", defaultValue = "3")
+    int maxRetries;  // Configuration injection
+
+    private int callCount = 0;  // Instance state
+
+    @Override
+    public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+        callCount++;
+        auditLogger.log(identity.getPrincipal().getName(),
+                       "Tool invocation #" + callCount);
+
+        // Validation logic
+        return ToolInputGuardrailResult.success();
+    }
+}
+----
+
+== Observability and Metrics
+
+Tool guardrail execution can be monitored using Micrometer metrics when the `quarkus-micrometer` extension is present.
+
+=== Metrics
+
+Two metrics are automatically recorded for each guardrail execution:
+
+**Counter Metric: `tool-guardrail.invoked`**
+
+Counts the number of times a tool guardrail is invoked, with tags:
+
+* `aiservice` - Fully qualified AI service interface name
+* `operation` - AI service method name
+* `tool.name` - Name of the tool being validated
+* `guardrail` - Guardrail class name
+* `guardrail.type` - `input` or `output`
+* `outcome` - `success`, `failure`, or `fatal`
+
+**Timer Metric: `tool-guardrail.timed`**
+
+Records execution time of guardrails with the same tags as the counter, plus percentiles (75th, 95th, 99th).
+
+=== Events
+
+For custom observability, observe CDI events fired during guardrail execution:
+
+[source,java]
+----
+@ApplicationScoped
+public class GuardrailMonitor {
+
+    public void onInputGuardrailExecuted(
+            @Observes ToolInputGuardrailExecutedEvent event) {
+
+        String toolName = event.toolName();
+        Class<?> guardrailClass = event.toolClass();
+        ToolGuardrailOutcome outcome = event.outcome(); // SUCCESS, FAILURE, FATAL
+        long durationNanos = event.duration();
+
+        // Custom monitoring logic
+        if (outcome == ToolGuardrailOutcome.FATAL) {
+            logger.error("Fatal guardrail failure for tool: {}", toolName);
+        }
+    }
+
+    public void onOutputGuardrailExecuted(
+            @Observes ToolOutputGuardrailExecutedEvent event) {
+        // Similar monitoring for output guardrails
+    }
+}
+----
+
+Event objects provide access to:
+
+* `toolName()` - The tool being validated
+* `toolClass()` - The guardrail class
+* `outcome()` - SUCCESS, FAILURE, or FATAL
+* `duration()` - Execution time in nanoseconds
+* `toolInvocationContext()` - Full invocation context including memory ID and parameters
+
+[TIP]
+====
+Use these metrics to:
+
+* Monitor guardrail success rates and identify problematic tools
+* Track performance and identify slow guardrails
+* Set up alerts for fatal failures indicating system issues
+* Analyze which guardrails are most frequently triggered
+====
+
+== Related Resources
+
+* xref:function-calling.adoc[Function Calling] -- How to declare and use tools in AI services
+* xref:guardrails.adoc[LLM Guardrails] -- Guardrails for prompts and responses
+* xref:ai-services.adoc[AI Services] -- Complete AI service configuration

--- a/docs/modules/ROOT/pages/tool-guardrails-reference.adoc
+++ b/docs/modules/ROOT/pages/tool-guardrails-reference.adoc
@@ -218,10 +218,10 @@ Event objects provide access to:
 ====
 Use these metrics to:
 
-* Monitor guardrail success rates and identify problematic tools
-* Track performance and identify slow guardrails
-* Set up alerts for fatal failures indicating system issues
-* Analyze which guardrails are most frequently triggered
+* Monitor guardrail success rates and identify problematic tools.
+* Track performance and identify slow guardrails.
+* Set up alerts for fatal failures indicating system issues.
+* Analyze which guardrails are most frequently triggered.
 ====
 
 == Related Resources

--- a/docs/modules/ROOT/pages/tool-guardrails-tutorial.adoc
+++ b/docs/modules/ROOT/pages/tool-guardrails-tutorial.adoc
@@ -1,0 +1,85 @@
+= Create Your First Tool Guardrail
+
+include::./includes/attributes.adoc[]
+:diataxis-type: tutorial
+
+In this tutorial, you create a tool input guardrail that validates a parameter before a tool executes.
+By the end, you will have a working guardrail that rejects negative numbers and returns a clear error message to the LLM.
+
+== Prerequisites
+
+* A Quarkus project with the `quarkus-langchain4j` extension
+* Familiarity with xref:function-calling.adoc[function calling] in Quarkus LangChain4j
+
+== Step 1: Create the Guardrail Bean
+
+Create a CDI bean that implements `ToolInputGuardrail`. This bean contains your validation logic.
+
+[source,java]
+----
+@ApplicationScoped  // <1>
+public class PositiveNumberGuardrail implements ToolInputGuardrail {  // <2>
+
+    @Override
+    public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {  // <3>
+        JsonObject args = request.argumentsAsJson();
+        int number = args.getInteger("amount");
+
+        if (number < 0) {
+            return ToolInputGuardrailResult.failure(  // <4>
+                "Amount must be positive, got: " + number);
+        }
+
+        return ToolInputGuardrailResult.success();  // <5>
+    }
+}
+----
+<1> Make it a CDI bean with a scope annotation
+<2> Implement the `ToolInputGuardrail` interface
+<3> Override the `validate` method
+<4> Return failure if validation fails -- the error message goes back to the LLM
+<5> Return success if validation passes -- the tool proceeds normally
+
+== Step 2: Apply the Guardrail to a Tool
+
+Annotate your tool method with `@ToolInputGuardrails` and reference your guardrail class:
+
+[source,java]
+----
+@ApplicationScoped
+public class BankingTools {
+
+    @Tool("Transfer money between accounts")
+    @ToolInputGuardrails({ PositiveNumberGuardrail.class })  // <1>
+    public String transfer(int amount, String from, String to) {
+        // This only executes if amount is positive
+        return "Transferred $" + amount + " from " + from + " to " + to;
+    }
+}
+----
+<1> The guardrail runs before every call to `transfer()`
+
+== Step 3: Verify the Behavior
+
+When the LLM invokes `transfer` with a negative amount, the guardrail intercepts the call:
+
+1. The `validate()` method receives the tool arguments as JSON
+2. It detects that `amount` is negative
+3. It returns a failure message: `"Amount must be positive, got: -50"`
+4. The tool method **does not execute**
+5. The LLM receives the error message and can retry with a corrected value
+
+Notice that the guardrail message is written for the LLM, not the end user. Clear, actionable messages help the LLM correct its parameters on the next attempt.
+
+== What You Learned
+
+* Tool guardrails are CDI beans that implement `ToolInputGuardrail` or `ToolOutputGuardrail`
+* The `validate()` method inspects tool arguments and returns `success()` or `failure()`
+* Apply guardrails to tools using the `@ToolInputGuardrails` annotation
+* When a guardrail fails, the tool does not execute and the error message goes to the LLM
+
+== Next Steps
+
+* xref:tool-guardrails-howto.adoc[Validate tool invocations] -- Recipes for email validation, authorization, rate limiting, and more
+* xref:tool-guardrails-reference.adoc[Tool guardrails reference] -- Full API reference for both input and output guardrail interfaces
+* xref:tool-guardrails-concept.adoc[Understand tool guardrails] -- Architecture and design rationale

--- a/docs/modules/ROOT/pages/tool-guardrails-tutorial.adoc
+++ b/docs/modules/ROOT/pages/tool-guardrails-tutorial.adoc
@@ -34,11 +34,11 @@ public class PositiveNumberGuardrail implements ToolInputGuardrail {  // <2>
     }
 }
 ----
-<1> Make it a CDI bean with a scope annotation
-<2> Implement the `ToolInputGuardrail` interface
-<3> Override the `validate` method
-<4> Return failure if validation fails -- the error message goes back to the LLM
-<5> Return success if validation passes -- the tool proceeds normally
+<1> Make it a CDI bean with a scope annotation.
+<2> Implement the `ToolInputGuardrail` interface.
+<3> Override the `validate` method.
+<4> Return failure if validation fails. The error message goes back to the LLM.
+<5> Return success if validation passes. The tool proceeds normally.
 
 == Step 2: Apply the Guardrail to a Tool
 
@@ -57,26 +57,26 @@ public class BankingTools {
     }
 }
 ----
-<1> The guardrail runs before every call to `transfer()`
+<1> The guardrail runs before every call to `transfer()`.
 
 == Step 3: Verify the Behavior
 
 When the LLM invokes `transfer` with a negative amount, the guardrail intercepts the call:
 
-1. The `validate()` method receives the tool arguments as JSON
-2. It detects that `amount` is negative
-3. It returns a failure message: `"Amount must be positive, got: -50"`
-4. The tool method **does not execute**
-5. The LLM receives the error message and can retry with a corrected value
+1. The `validate()` method receives the tool arguments as JSON.
+2. It detects that `amount` is negative.
+3. It returns a failure message: `"Amount must be positive, got: -50"`.
+4. The tool method **does not execute**.
+5. The LLM receives the error message and can retry with a corrected value.
 
 Notice that the guardrail message is written for the LLM, not the end user. Clear, actionable messages help the LLM correct its parameters on the next attempt.
 
 == What You Learned
 
-* Tool guardrails are CDI beans that implement `ToolInputGuardrail` or `ToolOutputGuardrail`
-* The `validate()` method inspects tool arguments and returns `success()` or `failure()`
-* Apply guardrails to tools using the `@ToolInputGuardrails` annotation
-* When a guardrail fails, the tool does not execute and the error message goes to the LLM
+* Tool guardrails are CDI beans that implement `ToolInputGuardrail` or `ToolOutputGuardrail`.
+* The `validate()` method inspects tool arguments and returns `success()` or `failure()`.
+* Apply guardrails to tools using the `@ToolInputGuardrails` annotation.
+* When a guardrail fails, the tool does not execute and the error message goes to the LLM.
 
 == Next Steps
 


### PR DESCRIPTION
This restructuring applies the [Diataxis](https://diataxis.fr/) content architecture to `tool-guardrails.adoc`, splitting a single mixed-content file into focused pages that each serve one user need.

### Why Diataxis?

Diataxis organizes documentation along two axes — *action vs. cognition* and *learning vs. working* — producing four content types that each serve a distinct user need:

| | **Learning** | **Working** |
|---|---|---|
| **Practical** | Tutorial | How-to guide |
| **Theoretical** | Explanation | Reference |

**For users:** When content types are mixed in a single page, every need is served poorly: a digression into explanation interrupts a how-to guide, tutorial hand-holding frustrates a practitioner looking for a quick recipe, and reference details buried in prose are hard to scan. Separating them keeps each page focused on one user mode, so readers find the right content at the right moment. As the [Diataxis docs](https://diataxis.fr/quality/) put it, separating content also makes quality gaps "apparent that were obscured before" — missing information becomes visible when each type stands on its own.

**For documentation systems:** Separating content types into distinct files produces the file-level modularity that documentation toolchains depend on. Single-purpose files can be composed into different navigation structures for different audiences, included or excluded by product variant without surgical editing, and translated as coherent units. When a how-to guide changes, the stable concept explanation that used to live on the same page no longer needs retranslation.

### What this PR does

Splits the single 881-line `tool-guardrails.adoc` into four focused files:

User-focused titles replace the single generic "Tool Guardrails" link, so readers can jump directly to the page that matches their intent.

| File | Type | Title | Intent |
|------|------|-------|-------|
| `tool-guardrails-concept.adoc` | Explanation | Understand tool guardrails | Conceptual overview of why and how guardrails work |
| `tool-guardrails-tutorial.adoc` | Tutorial | Create your first tool guardrail | Hands-on walkthrough for building one from scratch |
| `tool-guardrails-howto.adoc` | How-to | Validate tool invocations | Task-oriented recipes for common validation patterns |
| `tool-guardrails-reference.adoc` | Reference | Tool guardrails reference | API and configuration details for quick lookup |


**Navigation** — The four files are grouped under a single "Tool Guardrails" heading in `nav.adoc`, so from the reader's perspective the navigation is *more* structured, not more sprawling. The titles are user-oriented: "Understand...", "Create your first...", "Validate...", which help developers identify the page that matches their current need at a glance.

**Cross-references** — Updated `function-calling.adoc` xrefs to point to the new concept page. Each new file cross-references the others in a "Related Resources" section.

**Content preservation** — Verified via a 4-check content comparison (code block line-by-line diff, callout annotation verification, prose passage diff, structural element verification). Zero content losses; all differences are intentional editorial changes from the split.

### Commits

1. **Restructure tool-guardrails.adoc into four Diataxis-aligned files** — New files, nav update, xref update, `.gitignore` pattern for audit artifacts, original file removal.
2. **Copyedit tool guardrails docs** — Fixed anthropomorphic language, added missing intro sentences, corrected punctuation.
