### PR TITLE
enhance: return exception to include err message and type

### DIFF
--- a/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/QuarkusAnthropicClient.java
+++ b/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/QuarkusAnthropicClient.java
@@ -33,6 +33,7 @@ import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateMessageRespon
 import dev.langchain4j.model.anthropic.internal.api.AnthropicMessage;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicMessageContent;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicStreamingData;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicStreamingException;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicToolResultContent;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicToolUseContent;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicUsage;
@@ -430,7 +431,7 @@ public class QuarkusAnthropicClient extends AnthropicClient {
         }
 
         private void handleError(AnthropicStreamingData data) {
-            onFailure(new RuntimeException("Got error processing data (%s)".formatted(data)));
+            onFailure(new AnthropicStreamingException(data.error.message, data.error.type));
         }
 
         @Override


### PR DESCRIPTION
Currently, when an error event occurs in the Anthropic streaming chat model, we throw a generic RuntimeException. This results in a vague message like the following:

```
Got error processing data (dev.langchain4j.model.anthropic.internal.api.AnthropicStreamingData@1d18dd73)
```

The downstream consumer is unable to figure out what the actual error.

We recently updated  `AnthropicStreamingData` to include the error field https://github.com/langchain4j/langchain4j/issues/4571

In this pull request, we will throw the specific exception so the downstream consumer can handle the error accordingly.