### PR TITLE
Bedrock: add support for guardrail config

### DIFF
--- a/model-providers/bedrock/runtime/src/main/java/io/quarkiverse/langchain4j/bedrock/runtime/BedrockRecorder.java
+++ b/model-providers/bedrock/runtime/src/main/java/io/quarkiverse/langchain4j/bedrock/runtime/BedrockRecorder.java
@@ -17,6 +17,7 @@ import jakarta.enterprise.util.TypeLiteral;
 import dev.langchain4j.model.bedrock.BedrockChatModel;
 import dev.langchain4j.model.bedrock.BedrockChatRequestParameters;
 import dev.langchain4j.model.bedrock.BedrockCohereEmbeddingModel;
+import dev.langchain4j.model.bedrock.BedrockGuardrailConfiguration;
 import dev.langchain4j.model.bedrock.BedrockStreamingChatModel;
 import dev.langchain4j.model.bedrock.BedrockTitanEmbeddingModel;
 import dev.langchain4j.model.chat.ChatModel;
@@ -27,6 +28,7 @@ import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.embedding.DisabledEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import io.quarkiverse.langchain4j.bedrock.runtime.config.AwsClientConfig;
+import io.quarkiverse.langchain4j.bedrock.runtime.config.GuardrailConfig;
 import io.quarkiverse.langchain4j.bedrock.runtime.config.LangChain4jBedrockConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkiverse.langchain4j.runtime.config.LangChain4jConfig;
@@ -91,6 +93,10 @@ public class BedrockRecorder {
 
             if (modelConfig.reasoning().isPresent()) {
                 paramBuilder.enableReasoning(modelConfig.reasoning().getAsInt());
+            }
+
+            if (modelConfig.guardrail().guardrailIdentifier().isPresent()) {
+                paramBuilder.guardrailConfiguration(buildGuardrailConfiguration(modelConfig.guardrail()));
             }
 
             var clientBuilder = BedrockRuntimeClient.builder();
@@ -180,6 +186,10 @@ public class BedrockRecorder {
 
             if (modelConfig.reasoning().isPresent()) {
                 paramsBuilder.enableReasoning(modelConfig.reasoning().getAsInt());
+            }
+
+            if (modelConfig.guardrail().guardrailIdentifier().isPresent()) {
+                paramsBuilder.guardrailConfiguration(buildGuardrailConfiguration(modelConfig.guardrail()));
             }
 
             var builder = BedrockStreamingChatModel.builder()
@@ -280,6 +290,16 @@ public class BedrockRecorder {
             config = runtimeConfig.getValue().namedConfig().get(configName);
         }
         return config;
+    }
+
+    private static BedrockGuardrailConfiguration buildGuardrailConfiguration(GuardrailConfig guardrailConfig) {
+        var builder = BedrockGuardrailConfiguration.builder()
+                .guardrailIdentifier(guardrailConfig.guardrailIdentifier().get());
+
+        guardrailConfig.guardrailVersion().ifPresent(builder::guardrailVersion);
+        guardrailConfig.streamProcessingMode().ifPresent(builder::streamProcessingMode);
+
+        return builder.build();
     }
 
     private void configureClient(

--- a/model-providers/bedrock/runtime/src/main/java/io/quarkiverse/langchain4j/bedrock/runtime/config/ChatModelConfig.java
+++ b/model-providers/bedrock/runtime/src/main/java/io/quarkiverse/langchain4j/bedrock/runtime/config/ChatModelConfig.java
@@ -87,6 +87,13 @@ public interface ChatModelConfig extends AwsClientConfig {
     HttpClientConfig client();
 
     /**
+     * Guardrail configuration for the chat model.
+     *
+     * @see <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html">Amazon Bedrock Guardrails</a>
+     */
+    GuardrailConfig guardrail();
+
+    /**
      * Enables prompt caching to reduce latency and costs for requests with repeated content.
      * You can specify where to place the cache point in the prompt, possible values are {@code AFTER_SYSTEM},
      * {@code AFTER_USER_MESSAGE} or {@code AFTER_TOOLS}.

--- a/model-providers/bedrock/runtime/src/main/java/io/quarkiverse/langchain4j/bedrock/runtime/config/GuardrailConfig.java
+++ b/model-providers/bedrock/runtime/src/main/java/io/quarkiverse/langchain4j/bedrock/runtime/config/GuardrailConfig.java
@@ -1,0 +1,31 @@
+package io.quarkiverse.langchain4j.bedrock.runtime.config;
+
+import java.util.Optional;
+
+import dev.langchain4j.model.bedrock.BedrockGuardrailConfiguration;
+import io.quarkus.runtime.annotations.ConfigGroup;
+
+@ConfigGroup
+public interface GuardrailConfig {
+
+    /**
+     * The unique identifier of the guardrail that you want to use.
+     *
+     * @see <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html">Amazon Bedrock Guardrails</a>
+     */
+    Optional<String> guardrailIdentifier();
+
+    /**
+     * The version number for the guardrail.
+     */
+    Optional<String> guardrailVersion();
+
+    /**
+     * The processing mode for streaming requests. Possible values are {@code SYNC} or {@code ASYNC}.
+     *
+     * @see <a href=
+     *      "https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-streaming.html">Configure streaming response
+     *      behavior</a>
+     */
+    Optional<BedrockGuardrailConfiguration.ProcessingMode> streamProcessingMode();
+}


### PR DESCRIPTION
Following up on  https://github.com/langchain4j/langchain4j/pull/3988/ to be able to declaratively:

```
quarkus:
    langchain4j:
      bedrock:
        chat-model:
          guardrail:
            guardrail-identifier: my-guardrail-id
            guardrail-version: "1"
            stream-processing-mode: SYNC
```