### PR TITLE
Tracks cache token count for anthropic request

### DIFF
--- a/model-providers/anthropic/deployment/src/test/java/io/quarkiverse/langchain4j/anthropic/deployment/AnthropicStreamingChatLanguageModelSmokeTest.java
+++ b/model-providers/anthropic/deployment/src/test/java/io/quarkiverse/langchain4j/anthropic/deployment/AnthropicStreamingChatLanguageModelSmokeTest.java
@@ -223,7 +223,7 @@ class AnthropicStreamingChatLanguageModelSmokeTest extends AnthropicSmokeTest {
 
         var tokenUsage = (AnthropicTokenUsage) streamingResponse.get().tokenUsage();
         assertThat(tokenUsage.inputTokenCount()).isEqualTo(14);
-        assertThat(tokenUsage.outputTokenCount()).isEqualTo(42);
+        assertThat(tokenUsage.outputTokenCount()).isEqualTo(41);
         assertThat(tokenUsage.cacheCreationInputTokens()).isEqualTo(100);
         assertThat(tokenUsage.cacheReadInputTokens()).isEqualTo(50);
 

--- a/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/QuarkusAnthropicClient.java
+++ b/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/QuarkusAnthropicClient.java
@@ -250,19 +250,19 @@ public class QuarkusAnthropicClient extends AnthropicClient {
 
         private void handleUsage(AnthropicUsage usage) {
             if (usage.inputTokens != null) {
-                inputTokenCount.addAndGet(usage.inputTokens);
+                inputTokenCount.set(usage.inputTokens);
             }
 
             if (usage.outputTokens != null) {
-                outputTokenCount.addAndGet(usage.outputTokens);
+                outputTokenCount.set(usage.outputTokens);
             }
 
             if (usage.cacheCreationInputTokens != null) {
-                cacheCreationInputTokens.addAndGet(usage.cacheCreationInputTokens);
+                cacheCreationInputTokens.set(usage.cacheCreationInputTokens);
             }
 
             if (usage.cacheReadInputTokens != null) {
-                cacheReadInputTokens.addAndGet(usage.cacheReadInputTokens);
+                cacheReadInputTokens.set(usage.cacheReadInputTokens);
             }
         }
 


### PR DESCRIPTION
Track cache token counts we can better estimate the cost of a request and how effective we are caching our input tokens.

Langchain4j default anthropic client track this already.

https://github.com/langchain4j/langchain4j/blob/731ec59ba1e40d9a04933376562cc9cd6c604ea7/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClient.java#L353-L358

Then comparing the langchain4j client, I noticed we used `addAndGet` instead of `set`. Investigating further `addAndGet` is incorrect because the value aren't incremental delta but the current cumulative value. So `set` is more appropriate.