### PR TITLE
Don't register an operation when sending a response to a server-initiated operation

### DIFF
--- a/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/http/QuarkusStreamableHttpMcpTransport.java
+++ b/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/http/QuarkusStreamableHttpMcpTransport.java
@@ -90,11 +90,12 @@ public class QuarkusStreamableHttpMcpTransport implements McpTransport {
     public CompletableFuture<JsonNode> initialize(McpInitializeRequest request) {
         this.initializeRequest = request;
         McpCallContext ctx = new McpCallContext(null, request);
-        return execute(ctx)
+        return execute(ctx, false, true)
                 .emitOn(Infrastructure.getDefaultWorkerPool())
                 .onItem()
                 .transformToUni(
-                        response -> execute(new McpInitializationNotification()).onItem().transform(ignored -> response))
+                        response -> execute(new McpInitializationNotification(), false, true).onItem()
+                                .transform(ignored -> response))
                 .subscribeAsCompletionStage();
     }
 
@@ -111,44 +112,36 @@ public class QuarkusStreamableHttpMcpTransport implements McpTransport {
     @Override
     public CompletableFuture<JsonNode> executeOperationWithResponse(McpClientMessage operation) {
         McpCallContext context = new McpCallContext(null, operation);
-        return execute(context).subscribeAsCompletionStage();
+        return execute(context, false, true).subscribeAsCompletionStage();
     }
 
     @Override
     public CompletableFuture<JsonNode> executeOperationWithResponse(McpCallContext context) {
-        return execute(context).subscribeAsCompletionStage();
+        return execute(context, false, true).subscribeAsCompletionStage();
     }
 
     @Override
     public void executeOperationWithoutResponse(McpClientMessage operation) {
-        execute(operation).subscribe().with(ignored -> {
+        execute(new McpCallContext(null, operation), false, false).subscribe().with(ignored -> {
         });
     }
 
     @Override
     public void executeOperationWithoutResponse(McpCallContext context) {
-        execute(context).subscribe().with(ignored -> {
+        execute(context, false, false).subscribe().with(ignored -> {
         });
     }
 
-    private Uni<JsonNode> execute(McpClientMessage request) {
-        return execute(new McpCallContext(null, request), false);
+    private Uni<JsonNode> execute(McpClientMessage operation, boolean isRetry, boolean expectsResponse) {
+        return execute(new McpCallContext(null, operation), isRetry, expectsResponse);
     }
 
-    private Uni<JsonNode> execute(McpClientMessage request, boolean retry) {
-        return execute(new McpCallContext(null, request), retry);
-    }
-
-    private Uni<JsonNode> execute(McpCallContext context) {
-        return execute(context, false);
-    }
-
-    private Uni<JsonNode> execute(McpCallContext context, boolean isRetry) {
+    private Uni<JsonNode> execute(McpCallContext context, boolean isRetry, boolean expectsResponse) {
         CompletableFuture<JsonNode> future = new CompletableFuture<>();
         Uni<JsonNode> uni = Uni.createFrom().completionStage(future);
         Long id = context.message().getId();
         McpClientMessage request = context.message();
-        if (id != null) {
+        if (expectsResponse && id != null) {
             operationHandler.startOperation(id, future);
         }
         String body = null;
@@ -256,7 +249,7 @@ public class QuarkusStreamableHttpMcpTransport implements McpTransport {
                                         return;
                                     }
                                     initialize(initReq).thenAccept(node -> {
-                                        execute(request, true)
+                                        execute(request, true, true)
                                                 .subscribeAsCompletionStage()
                                                 .thenAccept(future::complete)
                                                 .exceptionally(t -> {


### PR DESCRIPTION
- Closes: https://github.com/quarkiverse/quarkus-langchain4j/issues/2234

The problem only arises in a very specific scenario: when in the middle of a client-initiated operation with a specific ID, the server starts a server-initiated operation that has exactly the same ID - in that case, the client mistakenly, when sending a response to the server-initiated operation, overwrites the original Future that represents the result to the client-initiated operation with a new Future that represents a result of the server-initiated operation, and later when the client-initiated operation completes, it completes the wrong Future (the one for the server-initiated operation), so the original one stays hanging forever.