### PR TITLE
Fix the reminder about Quarkus platform update

### DIFF
--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -31,6 +31,9 @@ jobs:
   send-notifications:
     needs: perform-release
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Currently it fails with insufficient permissions: https://github.com/quarkiverse/quarkus-langchain4j/actions/runs/23192705943/job/67393657667