### PR TITLE
Update dynamic-mcp-clients sample to support GitHub MCP server

### DIFF
--- a/samples/dynamic-mcp-clients/dynamic-mcp-clients-assistant/README.md
+++ b/samples/dynamic-mcp-clients/dynamic-mcp-clients-assistant/README.md
@@ -6,9 +6,9 @@ When you use the chat page, tools from the configured MCP clients will always be
 
 The application currently supports only a single application-scoped chat memory for simplicity.
 
-**NOTE**: The application currently does not store any persistent data. All information about configured MCP clients is lost after a restart. 
+**NOTE**: The application currently does not store any persistent data. All information about configured MCP clients is lost after a restart.
 
-If you would like, you can launch a Quarkus MCP Server with public and secured endpoints in the `dynamic-mcp-clients-server` folder.
+**NOTE**: Connections to both public and secured MCP servers can be added. Currently, secured MCP Servers can be imported only if they are compliant with the latest version of the MCP Authorization specification available at https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization.
 
 ## Running the Demo
 
@@ -39,3 +39,20 @@ and start the application in dev mode as follows:
 ```bash
 mvn quarkus:dev -Dquarkus.langchain4j.ai.gemini.api-key=$API_KEY
 ```
+
+### Quarkus MCP Server
+
+If you would like, you can launch a Quarkus MCP Server with public and secured endpoints in the `dynamic-mcp-clients-server` folder, follow README.md in that folder to add secured and public Quarkus MCP server connections.
+
+### Well-known MCP Servers
+
+To add connections to other well-known MCP servers, follow the corresponding instructions.
+
+For example, to add a GitHub Streamable HTTP MCP Server connection:
+
+* Create a GitHub OAuth2 application, see https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app
+* Set `GitHub` name, `https://api.githubcopilot.com/mcp/` URL, press `Add Connection`
+* Enter your GitHub OAuth2 application's client id, secret, and choose one or more scopes from https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps; starting with the `read:user` scope is reasonable
+* Press `Authenticate and Add Connection`, login to GitHub, a connection to the GitHub MCP server will be added
+* Ask the assistant a question such as `What is my profile name`
+

--- a/samples/dynamic-mcp-clients/dynamic-mcp-clients-assistant/pom.xml
+++ b/samples/dynamic-mcp-clients/dynamic-mcp-clients-assistant/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.31.1</quarkus.platform.version>
+        <quarkus.platform.version>3.34.0.CR1</quarkus.platform.version>
         <surefire-plugin.version>3.5.4</surefire-plugin.version>
     </properties>
 

--- a/samples/dynamic-mcp-clients/dynamic-mcp-clients-assistant/src/main/java/io/quarkiverse/langchain4j/sample/assistant/oauth2/McpAuthorizationServerResolver.java
+++ b/samples/dynamic-mcp-clients/dynamic-mcp-clients-assistant/src/main/java/io/quarkiverse/langchain4j/sample/assistant/oauth2/McpAuthorizationServerResolver.java
@@ -121,25 +121,19 @@ public class McpAuthorizationServerResolver implements TenantConfigResolver {
                     return null;
                 }
                 
-                if (!server.authorizationServerDiscoveryPath.endsWith("/.well-known/openid-configuration")) {
-                    Log.infof("Currently, a secured MCP server can only be imported if its authorization server's"
-                            + " metadata endpoint URL path ends with '/.well-known/openid-configuration'");
-                    return null;
-                }
-                
-                Log.infof("Creating OidcTenantConfig, authServerUrl: %s, discoveryPath: %s", 
+                Log.infof("Creating OidcTenantConfig, authServerUrl: %s, discoveryPath: %s",
                         server.authorizationServerBaseUri(), server.authorizationServerDiscoveryPath());
-                
+
                 ClientIdAndSecret clientIdAndSecret = getClientIdAndSecret(routingContext, formParams);
                 if (clientIdAndSecret == null) {
                     Log.warnf("OAuth2 client id is not available");
                     return null;
                 }
-                
+
                 OidcTenantConfigBuilder builder = OidcTenantConfig.builder()
                         .tenantId(tenantId)
                         .authServerUrl(server.authorizationServerBaseUri())
-                        //.discoveryPath(server.authorizationServerDiscoveryPath())
+                        .discoveryPath(server.authorizationServerDiscoveryPath())
                         .applicationType(ApplicationType.WEB_APP)
                         .clientId(clientIdAndSecret.clientId());
                 
@@ -151,7 +145,7 @@ public class McpAuthorizationServerResolver implements TenantConfigResolver {
                 AuthenticationConfigBuilder authBuilder =  builder.authentication();
                 
                 authBuilder.idTokenRequired(false);
-                //authBuilder.userInfoRequired(false);
+                authBuilder.userInfoRequired(false);
                 
                 if (server.resource() != null) {
                     // MCP Authorization expects that this resource will end up as the token audience value
@@ -194,17 +188,17 @@ public class McpAuthorizationServerResolver implements TenantConfigResolver {
                            String baseUri = authUri.getScheme() + "://" + authUri.getAuthority();
                            
                            return tryDiscoveryEndpoints(metadata.resource(), baseUri, path, List.of(
-                               path + "/.well-known/openid-configuration",    
                                "/.well-known/oauth-authorization-server/" + pathComponent,
-                               "/.well-known/openid-configuration/" + pathComponent
+                               "/.well-known/openid-configuration/" + pathComponent,
+                               path + "/.well-known/openid-configuration"
                            ));
                        } else {
                            // For issuer URLs without path components
                            String baseUri = authUri.getScheme() + "://" + authUri.getAuthority();
                            
                            return tryDiscoveryEndpoints(metadata.resource(), baseUri, null, List.of(
-                               "/.well-known/openid-configuration",
-                               "/.well-known/oauth-authorization-server"
+                               "/.well-known/oauth-authorization-server",
+                               "/.well-known/openid-configuration"
                            ));
                        }
                    }
@@ -305,7 +299,7 @@ public class McpAuthorizationServerResolver implements TenantConfigResolver {
     private ClientIdAndSecret checkFormParameters(MultiMap formParams) {
         String clientId = formParams.get("client_id");
         String clientSecret = formParams.get("client_secret");
-        Log.warnf("client id: %s, client secret:%s", clientId, clientSecret);
+        Log.debugf("client id: %s, client secret:%s", clientId, clientSecret);
         return clientId != null ? new ClientIdAndSecret(clientId, clientSecret) : null;
     }
 


### PR DESCRIPTION
This PR makes it possible to connect to GitHub MCP Server, @jmartisk, when you get a chance, have a look please.

MCP Authorization spec is also talking `MUST`  about PKCE and that MCP Clients must not connect if an associated authorization server does not indicate that it supports PKCE - GitHub does not indicate it.

The difference in our demo is that the authentication is driven by Quarkus OIDC as opposed to SPA which is where the risks are and what PKCE is meant to mitigate. So for now, I don't think we should worry about it - in any case, Quarkus OIDC supports PKCE with a single property, so would not be a problem to harden the flow with PKCE - perhaps we will make it optional...

Next from the the MCP Client OAuth2 perspective is adding one of the suggested options for the dynamic client registrations, implicit or explicit one.

@cescoffier FYI