### PR TITLE
Add a sample SkillsSystemMessageProvider

### DIFF
--- a/docs/modules/ROOT/pages/skills.adoc
+++ b/docs/modules/ROOT/pages/skills.adoc
@@ -73,12 +73,19 @@ Any `@RegisterAiService` that uses a `ToolProvider` will pick it up:
 
 [source,java]
 ----
-@RegisterAiService
+@RegisterAiService(systemMessageProviderSupplier = SkillsSystemMessageProvider.class)
 public interface PoemAiService {
 
     String chat(String message);
 }
 ----
+
+NOTE: The `SkillsSystemMessageProvider` (`io.quarkiverse.langchain4j.skills.SkillsSystemMessageProvider`) is a built-in
+sample implementation of `SystemMessageProvider` that generates a system message
+containing the descriptions of all loaded skills. You can implement your own `SystemMessageProvider` (and reuse parts of the
+`SkillsSystemMessageProvider`) if you need to customize the system message further. If you don't specify a system message provider,
+then the LLM might not be aware which skills are available and thus won't be able to use them unless the end user provides the exact
+skill name during the chat.
 
 [source,java]
 ----

--- a/samples/skills/pom.xml
+++ b/samples/skills/pom.xml
@@ -18,8 +18,7 @@
         <quarkus.platform.version>3.27.2</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.2.5</surefire-plugin.version>
-        <!-- TODO: update when we have a released version that supports skills -->
-        <quarkus-langchain4j.version>1.8.2</quarkus-langchain4j.version>
+        <quarkus-langchain4j.version>999-SNAPSHOT</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>

--- a/samples/skills/src/main/java/io/quarkiverse/langchain4j/sample/PoemResource.java
+++ b/samples/skills/src/main/java/io/quarkiverse/langchain4j/sample/PoemResource.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.langchain4j.sample;
 
+import io.quarkiverse.langchain4j.skills.SkillsSystemMessageProvider;
 import io.smallrye.common.annotation.Blocking;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -7,13 +8,12 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
-import dev.langchain4j.service.tool.ToolProvider;
 import io.quarkiverse.langchain4j.RegisterAiService;
 
 @Path("/poem")
 public class PoemResource {
 
-    @RegisterAiService
+    @RegisterAiService(systemMessageProviderSupplier = SkillsSystemMessageProvider.class)
     public interface PoemAiService {
 
         String chat(String message);
@@ -27,6 +27,6 @@ public class PoemResource {
     @Blocking
     public String poem() {
         return poemAiService.chat(
-                "First, activate the poem-writing skill and then write a poem following those instructions.");
+                "First, activate the skill for poem writing and then write a poem following those instructions.");
     }
 }

--- a/skills/deployment/src/test/java/io/quarkiverse/langchain4j/skills/deployment/SkillsTest.java
+++ b/skills/deployment/src/test/java/io/quarkiverse/langchain4j/skills/deployment/SkillsTest.java
@@ -3,6 +3,7 @@ package io.quarkiverse.langchain4j.skills.deployment;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Path;
+import java.util.Optional;
 
 import jakarta.inject.Inject;
 
@@ -16,6 +17,7 @@ import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.service.tool.ToolExecutionResult;
 import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.service.tool.ToolProviderResult;
+import io.quarkiverse.langchain4j.skills.SkillsSystemMessageProvider;
 import io.quarkiverse.langchain4j.skills.runtime.SkillsToolProvider;
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -68,5 +70,13 @@ public class SkillsTest {
 
         ToolExecutionResult resourceResult = readResource.executeWithContext(request, null);
         assertThat(resourceResult.resultText()).contains("This is the foobar guide resource content.");
+    }
+
+    @Test
+    void testSkillsSystemMessageProvider() {
+        Optional<String> systemMessage = new SkillsSystemMessageProvider().getSystemMessage(null);
+        assertThat(systemMessage).isPresent();
+        assertThat(systemMessage.get()).contains("You have access to the following skills");
+        assertThat(systemMessage.get()).contains("foobar-skill");
     }
 }

--- a/skills/runtime/src/main/java/io/quarkiverse/langchain4j/skills/SkillsSystemMessageProvider.java
+++ b/skills/runtime/src/main/java/io/quarkiverse/langchain4j/skills/SkillsSystemMessageProvider.java
@@ -1,0 +1,33 @@
+package io.quarkiverse.langchain4j.skills;
+
+import java.util.Optional;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
+
+import io.quarkiverse.langchain4j.runtime.aiservice.SystemMessageProvider;
+import io.quarkiverse.langchain4j.skills.runtime.SkillsToolProvider;
+
+/**
+ * A simple system message provider that describes which skills are available to the model.
+ * If you need the system message to contain some more information apart from that, you can reuse the part
+ * that retrieves skill descriptions and add it to your own SystemMessageProvider.
+ */
+@ApplicationScoped
+public class SkillsSystemMessageProvider implements SystemMessageProvider {
+
+    @Override
+    public Optional<String> getSystemMessage(Object memoryId) {
+        Instance<SkillsToolProvider> skillsToolProvider = CDI.current().select(SkillsToolProvider.class);
+        if (skillsToolProvider.isResolvable()) {
+            return Optional.of("""
+                    You have access to the following skills:
+                    %s
+                    """.formatted(skillsToolProvider.get().getSkills().formatAvailableSkills()));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+}

--- a/skills/runtime/src/main/java/io/quarkiverse/langchain4j/skills/runtime/SkillsRecorder.java
+++ b/skills/runtime/src/main/java/io/quarkiverse/langchain4j/skills/runtime/SkillsRecorder.java
@@ -35,7 +35,7 @@ public class SkillsRecorder {
                 if (config.directories().isEmpty() || config.directories().get().isEmpty()) {
                     log.warn("No skills directories configured (quarkus.langchain4j.skills.directories). "
                             + "The skills ToolProvider will provide no tools.");
-                    return new SkillsToolProvider(request -> ToolProviderResult.builder().build());
+                    return new SkillsToolProvider(request -> ToolProviderResult.builder().build(), null);
                 }
                 List<String> directories = config.directories().get();
                 List<FileSystemSkill> allSkills = new ArrayList<>();
@@ -57,10 +57,10 @@ public class SkillsRecorder {
                 if (allSkills.isEmpty()) {
                     log.warn("No skills were loaded from any configured directory. "
                             + "The skills ToolProvider will provide no tools.");
-                    return new SkillsToolProvider(request -> ToolProviderResult.builder().build());
+                    return new SkillsToolProvider(request -> ToolProviderResult.builder().build(), null);
                 }
                 Skills skills = Skills.from(allSkills);
-                return new SkillsToolProvider(skills.toolProvider());
+                return new SkillsToolProvider(skills.toolProvider(), skills);
             }
         };
     }

--- a/skills/runtime/src/main/java/io/quarkiverse/langchain4j/skills/runtime/SkillsToolProvider.java
+++ b/skills/runtime/src/main/java/io/quarkiverse/langchain4j/skills/runtime/SkillsToolProvider.java
@@ -3,6 +3,7 @@ package io.quarkiverse.langchain4j.skills.runtime;
 import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.service.tool.ToolProviderRequest;
 import dev.langchain4j.service.tool.ToolProviderResult;
+import dev.langchain4j.skills.Skills;
 
 /**
  * A tool provider that delegates to a skills ToolProvider created by upstream langchain4j code.
@@ -11,14 +12,20 @@ import dev.langchain4j.service.tool.ToolProviderResult;
  */
 public class SkillsToolProvider implements ToolProvider {
 
-    private ToolProvider delegate;
+    private final ToolProvider delegate;
+    private final Skills skills;
 
-    public SkillsToolProvider(ToolProvider delegate) {
+    public SkillsToolProvider(ToolProvider delegate, Skills skills) {
         this.delegate = delegate;
+        this.skills = skills;
     }
 
     @Override
     public ToolProviderResult provideTools(ToolProviderRequest request) {
         return delegate.provideTools(request);
+    }
+
+    public Skills getSkills() {
+        return skills;
     }
 }


### PR DESCRIPTION
The goal is to allow injecting information about available skills into the system message. This PR adds a sample `SystemMessageProvider` that can do it. This way, the user no longer has to provide the exact skill name because the LLM will be aware of the skills that are available.