### PR TITLE
Add Support for Anthropic Advanced Tool Use Features (#2258)

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/ToolProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/ToolProcessor.java
@@ -41,6 +41,9 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Opcodes;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import dev.langchain4j.agent.tool.ReturnBehavior;
 import dev.langchain4j.agent.tool.Tool;
@@ -102,6 +105,7 @@ import io.quarkus.gizmo.ResultHandle;
 public class ToolProcessor {
 
     private static final DotName TOOL = DotName.createSimple(Tool.class);
+
     private static final DotName TOOL_MEMORY_ID = DotName.createSimple(ToolMemoryId.class);
     private static final DotName JSON_IGNORE = DotName.createSimple(JsonIgnore.class);
     private static final DotName INVOCATION_PARAMETERS = DotName.createSimple(InvocationParameters.class);
@@ -340,6 +344,8 @@ public class ToolProcessor {
 
                     String toolName = getToolName(nameValue, toolMethod);
                     String toolDescription = getToolDescription(descriptionValue);
+
+                    AnnotationValue metadataValue = instance.value("metadata");
                     AnnotationValue returnBehavior = instance.value("returnBehavior");
                     ReturnBehavior returnBehaviorEnum = ReturnBehavior.TO_LLM;
                     if (returnBehavior != null) {
@@ -380,6 +386,20 @@ public class ToolProcessor {
                                     .addProperties(properties)
                                     .required(required)
                                     .build());
+
+                    if (metadataValue != null) {
+                        String metadataJson = metadataValue.asString();
+                        if (!metadataJson.isEmpty()) {
+                            try {
+                                Map<String, Object> toolMetadata = ObjectMapperHolder.OBJECT_MAPPER.readValue(metadataJson,
+                                        ObjectMapperHolder.MAP_TYPE_REF);
+                                builder.metadata(toolMetadata);
+                            } catch (JsonProcessingException e) {
+                                throw new ValidationException("Invalid metadata JSON for tool " + toolName + " in " + className,
+                                        e);
+                            }
+                        }
+                    }
 
                     Map<String, Integer> nameToParamPosition = toolMethod.parameters().stream().collect(
                             Collectors.toMap(MethodParameterInfo::name, i -> Integer.valueOf(i.position())));
@@ -1094,5 +1114,11 @@ public class ToolProcessor {
                 .map(type -> type.name().toString())
                 .distinct()
                 .toList();
+    }
+
+    private static class ObjectMapperHolder {
+        private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+        private static final TypeReference<Map<String, Object>> MAP_TYPE_REF = new TypeReference<>() {
+        };
     }
 }

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ToolMetadataValidationTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ToolMetadataValidationTest.java
@@ -1,0 +1,38 @@
+package io.quarkiverse.langchain4j.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ValidationException;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.Tool;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ToolMetadataValidationTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(InvalidMetadataTool.class))
+            .assertException(arg0 -> {
+                assertThat(arg0)
+                        .isInstanceOf(ValidationException.class)
+                        .hasMessageContaining("Invalid metadata JSON for tool invalidMetadataTool");
+            });
+
+    public static class InvalidMetadataTool {
+        @Tool(name = "invalidMetadataTool", value = "Tool with invalid metadata", metadata = "{invalid}")
+        public void toolCall() {
+
+        }
+    }
+
+    @Test
+    void test() {
+        // Should not be called
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ToolSpecificationTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ToolSpecificationTest.java
@@ -1,8 +1,8 @@
 package io.quarkiverse.langchain4j.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
@@ -50,11 +50,23 @@ public class ToolSpecificationTest {
         }
     }
 
+    public static class MetadataTool {
+        @Tool(name = "metadataTool", value = "Tool with metadata", metadata = "{\"foo\": \"bar\", \"baz\": 123}")
+        public void toolCall() {
+
+        }
+
+        @Tool(name = "emptyMetadataTool", value = "Tool with empty metadata", metadata = "")
+        public void toolCallEmptyMetadata() {
+
+        }
+    }
+
     @Test
-    public void testComplexSchema() {
+    void testComplexSchema() {
         List<ToolMethodCreateInfo> methodCreateInfos = ToolsRecorder.getMetadata().get(TestTool.class.getName());
         assertNotNull(methodCreateInfos);
-        assertTrue(methodCreateInfos.size() > 0);
+        assertFalse(methodCreateInfos.isEmpty());
         assertThat(methodCreateInfos).hasSize(1);
 
         ToolSpecification toolSpecification = methodCreateInfos.get(0).toolSpecification();
@@ -66,6 +78,20 @@ public class ToolSpecificationTest {
         assertThat(schema.properties().get("baseField")).isNotNull();
         assertThat(schema.properties().get("staticBaseField")).isNull();
         assertThat(schema.properties().get("ignoredBaseField")).isNull();
+    }
+
+    @Test
+    void testMetadata() {
+        List<ToolMethodCreateInfo> methodCreateInfos = ToolsRecorder.getMetadata().get(MetadataTool.class.getName());
+        assertNotNull(methodCreateInfos);
+        assertThat(methodCreateInfos).hasSize(2);
+
+        ToolSpecification metadataToolSpecification = methodCreateInfos.get(0).toolSpecification();
+        assertThat(metadataToolSpecification.metadata()).containsEntry("foo", "bar");
+        assertThat(metadataToolSpecification.metadata()).containsEntry("baz", 123);
+
+        ToolSpecification emptyMetadataToolSpecification = methodCreateInfos.get(1).toolSpecification();
+        assertThat(emptyMetadataToolSpecification.metadata()).isEmpty();
     }
 
 }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/ToolSpecificationObjectSubstitution.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/ToolSpecificationObjectSubstitution.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.langchain4j.runtime.tool;
 
+import java.util.Map;
+
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import io.quarkus.runtime.ObjectSubstitution;
@@ -10,7 +12,7 @@ public class ToolSpecificationObjectSubstitution
 
     @Override
     public Serialized serialize(ToolSpecification obj) {
-        return new Serialized(obj.name(), obj.description(), obj.parameters());
+        return new Serialized(obj.name(), obj.description(), obj.parameters(), obj.metadata());
     }
 
     @Override
@@ -21,6 +23,9 @@ public class ToolSpecificationObjectSubstitution
         if (obj.parameters != null) {
             builder.parameters(obj.parameters);
         }
+        if (obj.metadata != null) {
+            builder.metadata(obj.metadata);
+        }
         return builder.build();
     }
 
@@ -28,13 +33,16 @@ public class ToolSpecificationObjectSubstitution
         private final String name;
         private final String description;
         private final JsonObjectSchema parameters;
+        private final Map<String, Object> metadata;
 
         @RecordableConstructor
         public Serialized(String name, String description,
-                JsonObjectSchema parameters) {
+                JsonObjectSchema parameters,
+                Map<String, Object> metadata) {
             this.name = name;
             this.description = description;
             this.parameters = parameters;
+            this.metadata = metadata;
         }
 
         public String getName() {
@@ -47,6 +55,10 @@ public class ToolSpecificationObjectSubstitution
 
         public JsonObjectSchema getParameters() {
             return parameters;
+        }
+
+        public Map<String, Object> getMetadata() {
+            return metadata;
         }
 
     }

--- a/docs/modules/ROOT/pages/anthropic-chat-model.adoc
+++ b/docs/modules/ROOT/pages/anthropic-chat-model.adoc
@@ -68,6 +68,161 @@ public interface Assistant {
 }
 ----
 
+== Advanced Tool Use Features
+These features enable more efficient tool orchestration, improved accuracy, and reduced token consumption.
+
+All features are optional and can be enabled independently.
+
+=== Tool Search
+
+Anthropic's Tool Search Tool allows Claude to use search tools to access thousands of tools without consuming its context window
+
+The `Tool Search Tool` lets Claude dynamically discover tools instead of loading all definitions upfront. You provide all your tool definitions to the API, but mark tools with `defer_loading: true` to make them discoverable on-demand. Deferred tools aren't loaded into Claude's context initially. Claude only sees the `Tool Search Tool` itself plus any tools with `defer_loading: false` (your most critical, frequently-used tools).
+
+When Claude needs specific capabilities, it searches for relevant tools. The `Tool Search Tool` returns references to matching tools, which get expanded into full definitions in Claude's context.
+
+To enable this feature, set the following property:
+
+[source,properties]
+----
+quarkus.langchain4j.anthropic.chat-model.tool-search.enabled=true
+----
+
+You can optionally specify the search type (`regex` is the default, or `bm25`):
+
+[source,properties]
+----
+quarkus.langchain4j.anthropic.chat-model.tool-search.type=bm25
+----
+
+[NOTE]
+====
+Under the hood, when Tool Search is enabled, the Quarkus extension automatically:
+
+* Adds the `AnthropicServerTool` (either `regex` or `bm25` variant) to the model request.
+* Configures the `toolMetadataKeysToSend` to include `defer_loading`, allowing the model to see which tools can be discovered on-demand.
+* Includes the required `advanced-tool-use-2025-11-20` beta header in all requests.
+====
+
+When tool search is enabled, you can mark specific tools to be discovered on-demand using the `defer_loading` metadata:
+
+[source,java]
+----
+@Tool(name = "get_weather", value = "Get the weather for a city", metadata = "{\"defer_loading\": true}")
+public String getWeather(String city) {
+    // ...
+}
+----
+
+=== Programmatic Tool Calling
+
+Anthropic's Programmatic Tool Calling allows Claude to invoke tools in a code execution environment
+reducing the impact on the model’s context window.
+
+Programmatic Tool Calling enables Claude to orchestrate tools through code rather than through individual
+API round-trips. Instead of Claude requesting tools one at a time with each result being returned to its context,
+Claude writes code that calls multiple tools, processes their outputs, and controls what information actually
+enters its context window.
+
+Claude excels at writing code and by letting it express orchestration logic in Python rather than through natural
+language tool invocations, you get more reliable, precise control flow. Loops, conditionals,
+data transformations, and error handling are all explicit in code rather than implicit in Claude's reasoning.
+
+To enable this feature, set the following property:
+
+[source,properties]
+----
+quarkus.langchain4j.anthropic.chat-model.programmatic-tool-calling.enabled=true
+----
+
+[NOTE]
+====
+Under the hood, when Programmatic Tool Calling is enabled, the extension automatically:
+
+* Adds the Code Execution server tool
+* Sends the `"allowed_callers"` metadata key with tool definitions
+* Includes the required beta header in all requests
+====
+
+Tools that should be callable from generated code must include the
+`allowed_callers` metadata:
+
+[source,java]
+----
+@Tool(
+    name = "get_weather",
+    value = "Get the weather for a city",
+    metadata = "{\"allowed_callers\": [\"code_execution_20250825\"]}"
+)
+public String getWeather(String city) {
+    // ...
+}
+----
+
+=== Tool Use Examples
+This feature provides a universal standard for demonstrating how to effectively use a given tool.
+
+Tool Use Examples let you provide sample tool calls directly in your tool definitions.
+Instead of relying on schema alone, you show Claude concrete usage patterns.
+
+__ For example, format ambiguity: __
+__ if a date is passed as `string`, should it use "2024-11-06", "Nov 6, 2024", or "2024-11-06T00:00:00Z"?__
+
+To enable this feature, set the following property:
+
+[source,properties]
+----
+quarkus.langchain4j.anthropic.chat-model.tool-use-examples.enabled=true
+----
+
+[NOTE]
+====
+Under the hood, when Tool Use Examples is enabled, the extension automatically:
+
+* Sends the `"input_examples"` metadata key with tool definitions
+* Includes the required beta header in all requests
+====
+
+Tools that include examples must define the `input_examples` metadata:
+
+[source,java]
+----
+        private static final String METADATA = """
+                {
+                  "input_examples": [
+                    {
+                      "title": "Login page returns 500 error",
+                      "priority": "critical",
+                      "labels": ["bug", "authentication"],
+                      "date": "2024-11-06"
+                    },
+                    {
+                      "title": "Update API documentation",
+                      "date": "2024-12-01"
+                    },
+                    {
+                      "title": "Brainstorming session"
+                    }
+                  ]
+                }
+                """;
+
+        @Tool(name = "create_ticket", value = "Create a support ticket", metadata = METADATA)
+        public String createTicket(String title, String priority, String date) {
+            return "TICKET-123";
+        }
+----
+
+==== References
+
+For more details on Anthropic's Tool Search and advanced tool use, see:
+
+- https://www.anthropic.com/engineering/advanced-tool-use[Introducing advanced tool use on the Claude Developer Platform]
+- https://github.com/langchain4j/langchain4j/blob/main/docs/docs/integrations/language-models/anthropic.md#tool-search-tool[LangChain4j Anthropic Tool Search Tool Documentation]
+- https://github.com/langchain4j/langchain4j/blob/main/docs/docs/integrations/language-models/anthropic.md#programmatic-tool-calling[LangChain4j Anthropic Programmatic Tool Calling Documentation]
+- https://github.com/langchain4j/langchain4j/blob/main/docs/docs/integrations/language-models/anthropic.md#tool-use-examples[LangChain4j Anthropic Tool Use Examples Documentation]
+- https://github.com/langchain4j/langchain4j/blob/main/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java#L321[LangChain4j AnthropicChatModel Source Code]
+
 == Configuration Reference
 
 include::includes/quarkus-langchain4j-anthropic.adoc[leveloffset=+1,opts=optional]

--- a/model-providers/anthropic/deployment/src/test/java/io/quarkiverse/langchain4j/anthropic/deployment/AnthropicSmokeTest.java
+++ b/model-providers/anthropic/deployment/src/test/java/io/quarkiverse/langchain4j/anthropic/deployment/AnthropicSmokeTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 
-abstract class AnthropicSmokeTest {
+public abstract class AnthropicSmokeTest {
     protected static final int WIREMOCK_PORT = 8089;
     protected static final String CHAT_MODEL_ID = "claude-3-haiku-20240307";
     protected static final String API_KEY = "somekey";

--- a/model-providers/anthropic/deployment/src/test/java/io/quarkiverse/langchain4j/anthropic/deployment/advancedtooluse/AnthropicAllAdvancedToolFeaturesTest.java
+++ b/model-providers/anthropic/deployment/src/test/java/io/quarkiverse/langchain4j/anthropic/deployment/advancedtooluse/AnthropicAllAdvancedToolFeaturesTest.java
@@ -1,0 +1,159 @@
+package io.quarkiverse.langchain4j.anthropic.deployment.advancedtooluse;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.absent;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.not;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.ToolBox;
+import io.quarkiverse.langchain4j.anthropic.deployment.AnthropicSmokeTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+class AnthropicAllAdvancedToolFeaturesTest extends AnthropicSmokeTest {
+
+    private static final String MODEL_ID = "claude-sonnet-4-6";
+
+    private static final String EXPECTED_BETA_HEADER = "tools-2024-04-04,advanced-tool-use-2025-11-20";
+
+    private static final String MINIMAL_VALID_ANTHROPIC_RESPONSE = """
+            {
+              "type": "message",
+              "role": "assistant",
+              "content": [ { "type": "text", "text": "ok" } ],
+              "stop_reason": "end_turn",
+              "usage": { "input_tokens": 1, "output_tokens": 1 }
+            }
+            """;
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.anthropic.api-key", API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.anthropic.chat-model.model-name", MODEL_ID)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.anthropic.chat-model.tool-search.enabled", "true")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.anthropic.chat-model.programmatic-tool-calling.enabled", "true")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.anthropic.chat-model.tool-use-examples.enabled", "true")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.anthropic.base-url", "http://localhost:%d".formatted(WIREMOCK_PORT));
+
+    @Inject
+    TestAiService aiService;
+
+    @Test
+    void shouldContainAllAdvancedToolFeaturesWithDeduplicatedBetaHeader() throws Exception {
+        wireMockServer.stubFor(
+                post(urlPathEqualTo("/messages"))
+                        .withHeader("x-api-key", equalTo(API_KEY))
+                        .withHeader("anthropic-version", not(absent()))
+                        .withHeader("anthropic-beta", equalTo(EXPECTED_BETA_HEADER))
+                        .willReturn(okJson(MINIMAL_VALID_ANTHROPIC_RESPONSE)));
+
+        aiService.chat("Create a critical ticket for the login page failure");
+
+        assertThat(wireMockServer.getAllServeEvents()).hasSize(1);
+
+        var loggedRequest = wireMockServer.getAllServeEvents().get(0).getRequest();
+        var body = MAPPER.readTree(loggedRequest.getBodyAsString());
+        var tools = body.get("tools");
+
+        var betaHeader = loggedRequest.getHeader("anthropic-beta");
+        var advancedToolUseBetaCount = betaHeader.split("advanced-tool-use-2025-11-20", -1).length - 1;
+        assertThat(advancedToolUseBetaCount)
+                .as("advanced-tool-use beta should appear exactly once despite three features requiring it")
+                .isEqualTo(1);
+
+        System.out.println(tools);
+
+        var toolSearchTool = findTool(tools, "tool_search_tool_regex");
+        assertThat(toolSearchTool.path("type").asText())
+                .isEqualTo("tool_search_tool_regex_20251119");
+
+        var codeExecutionTool = findTool(tools, "code_execution");
+        assertThat(codeExecutionTool.path("type").asText())
+                .isEqualTo("code_execution_20250825");
+
+        var createTicketTool = findTool(tools, "create_ticket");
+
+        assertThat(createTicketTool.path("defer_loading").asBoolean())
+                .isTrue();
+
+        assertThat(createTicketTool.path("allowed_callers").get(0).asText())
+                .isEqualTo("code_execution_20250825");
+
+        var inputExamples = createTicketTool.get("input_examples");
+        assertThat(inputExamples).isNotNull();
+        assertThat(inputExamples.isArray()).isTrue();
+        assertThat(inputExamples.size()).isEqualTo(3);
+
+        assertThat(inputExamples.get(0).path("due_date").asText()).isEqualTo("2024-11-06");
+        assertThat(inputExamples.get(1).path("due_date").asText()).isEqualTo("2024-12-01");
+
+        assertThat(inputExamples.get(2).has("due_date")).isFalse();
+    }
+
+    private JsonNode findTool(JsonNode tools, String name) {
+        for (JsonNode tool : tools) {
+            if (name.equals(tool.path("name").asText())) {
+                return tool;
+            }
+        }
+        throw new AssertionError("Tool '" + name + "' not found in tools array");
+    }
+
+    @RegisterAiService
+    @ApplicationScoped
+    interface TestAiService {
+        @SystemMessage("You are a helpful assistant. Use tools when needed.")
+        @ToolBox(TestTicketService.class)
+        String chat(@UserMessage String question);
+    }
+
+    @ApplicationScoped
+    static class TestTicketService {
+        private static final String METADATA = """
+                {
+                  "defer_loading": true,
+                  "allowed_callers": ["code_execution_20250825"],
+                  "input_examples": [
+                    {
+                      "title": "Login page returns 500 error",
+                      "priority": "critical",
+                      "labels": ["bug", "authentication"],
+                      "due_date": "2024-11-06"
+                    },
+                    {
+                      "title": "Update API documentation",
+                      "due_date": "2024-12-01"
+                    },
+                    {
+                      "title": "Brainstorming session"
+                    }
+                  ]
+                }
+                """;
+
+        @Tool(name = "create_ticket", value = "Create a support ticket", metadata = METADATA)
+        public String createTicket(String title, String priority, String dueDate) {
+            return "TICKET-123";
+        }
+    }
+}

--- a/model-providers/anthropic/deployment/src/test/java/io/quarkiverse/langchain4j/anthropic/deployment/advancedtooluse/AnthropicProgrammaticToolCallingTest.java
+++ b/model-providers/anthropic/deployment/src/test/java/io/quarkiverse/langchain4j/anthropic/deployment/advancedtooluse/AnthropicProgrammaticToolCallingTest.java
@@ -1,0 +1,107 @@
+package io.quarkiverse.langchain4j.anthropic.deployment.advancedtooluse;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.absent;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.not;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.ToolBox;
+import io.quarkiverse.langchain4j.anthropic.deployment.AnthropicSmokeTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+class AnthropicProgrammaticToolCallingTest extends AnthropicSmokeTest {
+    private static final String MODEL_ID = "claude-sonnet-4-6";
+    private static final String EXPECTED_BETA_HEADER = "tools-2024-04-04,advanced-tool-use-2025-11-20";
+    private static final String MINIMAL_VALID_ANTHROPIC_RESPONSE = """
+            {
+              "type": "message",
+              "role": "assistant",
+              "content": [ { "type": "text", "text": "ok" } ],
+              "stop_reason": "end_turn",
+              "usage": { "input_tokens": 1, "output_tokens": 1 }
+            }
+            """;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.anthropic.api-key", API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.anthropic.chat-model.model-name", MODEL_ID)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.anthropic.chat-model.programmatic-tool-calling.enabled", "true")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.anthropic.base-url", "http://localhost:%d".formatted(WIREMOCK_PORT));
+
+    @Inject
+    TestAiService aiService;
+
+    @Test
+    void shouldContainCodeExecutionToolAndAllowedCallers() throws Exception {
+        wireMockServer.stubFor(
+                post(urlPathEqualTo("/messages"))
+                        .withHeader("x-api-key", equalTo(API_KEY))
+                        .withHeader("anthropic-version", not(absent()))
+                        .withHeader("anthropic-beta", equalTo(EXPECTED_BETA_HEADER))
+                        .willReturn(okJson(MINIMAL_VALID_ANTHROPIC_RESPONSE)));
+
+        aiService.chat("What was the average max temperature in Munich in the last 5 days?");
+
+        assertThat(wireMockServer.getAllServeEvents()).hasSize(1);
+
+        var loggedRequest = wireMockServer.getAllServeEvents().get(0).getRequest();
+        var body = MAPPER.readTree(loggedRequest.getBodyAsString());
+        var tools = body.get("tools");
+
+        var codeExecutionTool = findTool(tools, "code_execution");
+        assertThat(codeExecutionTool.path("type").asText())
+                .isEqualTo("code_execution_20250825");
+
+        var temperatureTool = findTool(tools, "get_daily_temperatures");
+        assertThat(temperatureTool.path("allowed_callers").get(0).asText())
+                .isEqualTo("code_execution_20250825");
+        assertThat(temperatureTool.path("description").asText())
+                .isEqualTo("Get daily temperatures for a city");
+    }
+
+    private JsonNode findTool(JsonNode tools, String name) {
+        for (JsonNode tool : tools) {
+            if (name.equals(tool.path("name").asText())) {
+                return tool;
+            }
+        }
+        throw new AssertionError("Tool '" + name + "' not found in tools array");
+    }
+
+    @RegisterAiService
+    @ApplicationScoped
+    interface TestAiService {
+        @SystemMessage("You are a helpful assistant. Use tools when needed.")
+        @ToolBox(TestTemperatureService.class)
+        String chat(@UserMessage String question);
+    }
+
+    @ApplicationScoped
+    static class TestTemperatureService {
+        @Tool(name = "get_daily_temperatures", value = "Get daily temperatures for a city", metadata = "{\"allowed_callers\": [\"code_execution_20250825\"]}")
+        public String getDailyTemperatures(String city, int days) {
+            return "[{\"min\":0.0,\"max\":5.0}]";
+        }
+    }
+}

--- a/model-providers/anthropic/deployment/src/test/java/io/quarkiverse/langchain4j/anthropic/deployment/advancedtooluse/AnthropicToolSearchToolBm25DeferLoadingTest.java
+++ b/model-providers/anthropic/deployment/src/test/java/io/quarkiverse/langchain4j/anthropic/deployment/advancedtooluse/AnthropicToolSearchToolBm25DeferLoadingTest.java
@@ -1,0 +1,32 @@
+package io.quarkiverse.langchain4j.anthropic.deployment.advancedtooluse;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.langchain4j.anthropic.deployment.AnthropicSmokeTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+class AnthropicToolSearchToolBm25DeferLoadingTest extends AnthropicToolSearchToolDeferLoadingTest {
+    private static final String MODEL_ID = "claude-sonnet-4-6"; // model that supports tools calling
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.anthropic.api-key", AnthropicSmokeTest.API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.anthropic.chat-model.model-name", MODEL_ID)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.anthropic.chat-model.tool-search.enabled", "true")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.anthropic.chat-model.tool-search.type", "bm25")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.anthropic.base-url",
+                    "http://localhost:%d".formatted(AnthropicSmokeTest.WIREMOCK_PORT));
+
+    @Override
+    String expectedToolName() {
+        return "tool_search_tool_bm25";
+    }
+
+    @Override
+    String expectedToolType() {
+        return "tool_search_tool_bm25_20251119";
+    }
+}

--- a/model-providers/anthropic/deployment/src/test/java/io/quarkiverse/langchain4j/anthropic/deployment/advancedtooluse/AnthropicToolSearchToolDeferLoadingTest.java
+++ b/model-providers/anthropic/deployment/src/test/java/io/quarkiverse/langchain4j/anthropic/deployment/advancedtooluse/AnthropicToolSearchToolDeferLoadingTest.java
@@ -1,0 +1,100 @@
+package io.quarkiverse.langchain4j.anthropic.deployment.advancedtooluse;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.absent;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.not;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.ToolBox;
+import io.quarkiverse.langchain4j.anthropic.deployment.AnthropicSmokeTest;
+
+abstract class AnthropicToolSearchToolDeferLoadingTest extends AnthropicSmokeTest {
+    abstract String expectedToolName();
+
+    abstract String expectedToolType();
+
+    private static final String EXPECTED_BETA_HEADER = "tools-2024-04-04,advanced-tool-use-2025-11-20";
+    private static final String MINIMAL_VALID_ANTHROPIC_RESPONSE = """
+            {
+              "type": "message",
+              "role": "assistant",
+              "content": [ { "type": "text", "text": "ok" } ],
+              "stop_reason": "end_turn",
+              "usage": { "input_tokens": 1, "output_tokens": 1 }
+            }
+            """;
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Inject
+    TestAiService aiService;
+
+    @Test
+    void shouldContainSearchToolAndDeferLoading() throws Exception {
+        wireMockServer.stubFor(
+                post(urlPathEqualTo("/messages"))
+                        .withHeader("x-api-key", equalTo(API_KEY))
+                        .withHeader("anthropic-version", not(absent()))
+                        .withHeader("anthropic-beta", equalTo(EXPECTED_BETA_HEADER))
+                        .willReturn(okJson(MINIMAL_VALID_ANTHROPIC_RESPONSE)));
+
+        aiService.chat("Can you tell me the status of order 1002?");
+
+        assertThat(wireMockServer.getAllServeEvents()).hasSize(1);
+
+        var loggedRequest = wireMockServer.getAllServeEvents().get(0).getRequest();
+        var body = MAPPER.readTree(loggedRequest.getBodyAsString());
+        var tools = body.get("tools");
+
+        var toolSearchTool = findTool(tools, expectedToolName());
+        assertThat(toolSearchTool.path("type").asText())
+                .isEqualTo(expectedToolType());
+
+        var orderTool = findTool(tools, "get_order_status_by_order_id");
+        assertThat(orderTool.get("defer_loading").asBoolean()).isTrue();
+        assertThat(orderTool.path("description").asText()).isEqualTo("Get order status by order id");
+        assertThat(orderTool.path("input_schema").path("properties").has("orderId")).isTrue();
+        assertThat(orderTool.path("input_schema").path("required").toString()).contains("orderId");
+    }
+
+    private JsonNode findTool(JsonNode tools, String name) {
+        for (JsonNode tool : tools) {
+            if (name.equals(tool.path("name").asText())) {
+                return tool;
+            }
+        }
+        throw new AssertionError("Tool '" + name + "' not found in tools array");
+    }
+
+    @RegisterAiService
+    @ApplicationScoped
+    interface TestAiService {
+        @SystemMessage("You are a helpful assistant. Use tools when needed.")
+        @ToolBox(TestOrderService.class)
+        String chat(@UserMessage String question);
+    }
+
+    @ApplicationScoped
+    static class TestOrderService {
+        @Tool(name = "get_order_status_by_order_id", value = "Get order status by order id", metadata = "{\"defer_loading\": true}")
+        public String getOrderStatus(String orderId) {
+            // never called - WireMock intercepts before tool invocation
+            return "SHIPPED";
+        }
+    }
+}

--- a/model-providers/anthropic/deployment/src/test/java/io/quarkiverse/langchain4j/anthropic/deployment/advancedtooluse/AnthropicToolSearchToolRegexDeferLoadingTest.java
+++ b/model-providers/anthropic/deployment/src/test/java/io/quarkiverse/langchain4j/anthropic/deployment/advancedtooluse/AnthropicToolSearchToolRegexDeferLoadingTest.java
@@ -1,0 +1,30 @@
+package io.quarkiverse.langchain4j.anthropic.deployment.advancedtooluse;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class AnthropicToolSearchToolRegexDeferLoadingTest extends AnthropicToolSearchToolDeferLoadingTest {
+    private static final String MODEL_ID = "claude-sonnet-4-6"; // model that supports tools calling
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.anthropic.api-key", API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.anthropic.chat-model.model-name", MODEL_ID)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.anthropic.chat-model.tool-search.enabled", "true")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.anthropic.chat-model.tool-search.type", "regex")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.anthropic.base-url", "http://localhost:%d".formatted(WIREMOCK_PORT));
+
+    @Override
+    String expectedToolName() {
+        return "tool_search_tool_regex";
+    }
+
+    @Override
+    String expectedToolType() {
+        return "tool_search_tool_regex_20251119";
+    }
+}

--- a/model-providers/anthropic/deployment/src/test/java/io/quarkiverse/langchain4j/anthropic/deployment/advancedtooluse/AnthropicToolUseExamplesTest.java
+++ b/model-providers/anthropic/deployment/src/test/java/io/quarkiverse/langchain4j/anthropic/deployment/advancedtooluse/AnthropicToolUseExamplesTest.java
@@ -1,0 +1,141 @@
+package io.quarkiverse.langchain4j.anthropic.deployment.advancedtooluse;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.absent;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.not;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.ToolBox;
+import io.quarkiverse.langchain4j.anthropic.deployment.AnthropicSmokeTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+class AnthropicToolUseExamplesTest extends AnthropicSmokeTest {
+    private static final String MODEL_ID = "claude-sonnet-4-6";
+    private static final String EXPECTED_BETA_HEADER = "tools-2024-04-04,advanced-tool-use-2025-11-20";
+    private static final String MINIMAL_VALID_ANTHROPIC_RESPONSE = """
+            {
+              "type": "message",
+              "role": "assistant",
+              "content": [ { "type": "text", "text": "ok" } ],
+              "stop_reason": "end_turn",
+              "usage": { "input_tokens": 1, "output_tokens": 1 }
+            }
+            """;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.anthropic.api-key", API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.anthropic.chat-model.model-name", MODEL_ID)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.anthropic.chat-model.tool-use-examples.enabled", "true")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.anthropic.base-url", "http://localhost:%d".formatted(WIREMOCK_PORT));
+
+    @Inject
+    TestAiService aiService;
+
+    @Test
+    void shouldContainInputExamplesInToolDefinition() throws Exception {
+        wireMockServer.stubFor(
+                post(urlPathEqualTo("/messages"))
+                        .withHeader("x-api-key", equalTo(API_KEY))
+                        .withHeader("anthropic-version", not(absent()))
+                        .withHeader("anthropic-beta", equalTo(EXPECTED_BETA_HEADER))
+                        .willReturn(okJson(MINIMAL_VALID_ANTHROPIC_RESPONSE)));
+
+        aiService.chat("Create a critical bug ticket for the login page");
+
+        assertThat(wireMockServer.getAllServeEvents()).hasSize(1);
+
+        var loggedRequest = wireMockServer.getAllServeEvents().get(0).getRequest();
+        var body = MAPPER.readTree(loggedRequest.getBodyAsString());
+        var tools = body.get("tools");
+
+        var createTicketTool = findTool(tools, "create_ticket");
+        var inputExamples = createTicketTool.get("input_examples");
+
+        assertThat(inputExamples).isNotNull();
+        assertThat(inputExamples.isArray()).isTrue();
+        assertThat(inputExamples.size()).isEqualTo(3);
+
+        assertThat(inputExamples.get(0).path("title").asText())
+                .isEqualTo("Login page returns 500 error");
+        assertThat(inputExamples.get(0).path("priority").asText())
+                .isEqualTo("critical");
+        assertThat(inputExamples.get(0).path("date").asText())
+                .isEqualTo("2024-11-06");
+
+        assertThat(inputExamples.get(1).path("title").asText())
+                .isEqualTo("Update API documentation");
+        assertThat(inputExamples.get(1).has("priority")).isFalse();
+        assertThat(inputExamples.get(1).path("date").asText())
+                .isEqualTo("2024-12-01");
+
+        assertThat(inputExamples.get(2).path("title").asText())
+                .isEqualTo("Brainstorming session");
+        assertThat(inputExamples.get(2).has("date")).isFalse();
+    }
+
+    private JsonNode findTool(JsonNode tools, String name) {
+        for (JsonNode tool : tools) {
+            if (name.equals(tool.path("name").asText())) {
+                return tool;
+            }
+        }
+        throw new AssertionError("Tool '" + name + "' not found in tools array");
+    }
+
+    @RegisterAiService
+    @ApplicationScoped
+    interface TestAiService {
+        @SystemMessage("You are a helpful assistant. Use tools when needed.")
+        @ToolBox(TestTicketService.class)
+        String chat(@UserMessage String question);
+    }
+
+    @ApplicationScoped
+    static class TestTicketService {
+        private static final String METADATA = """
+                {
+                  "input_examples": [
+                    {
+                      "title": "Login page returns 500 error",
+                      "priority": "critical",
+                      "labels": ["bug", "authentication"],
+                      "date": "2024-11-06"
+                    },
+                    {
+                      "title": "Update API documentation",
+                      "date": "2024-12-01"
+                    },
+                    {
+                      "title": "Brainstorming session"
+                    }
+                  ]
+                }
+                """;
+
+        @Tool(name = "create_ticket", value = "Create a support ticket", metadata = METADATA)
+        public String createTicket(String title, String priority, String date) {
+            return "TICKET-123";
+        }
+    }
+}

--- a/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/AnthropicRecorder.java
+++ b/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/AnthropicRecorder.java
@@ -3,6 +3,10 @@ package io.quarkiverse.langchain4j.anthropic.runtime;
 import static io.quarkiverse.langchain4j.runtime.OptionalUtil.firstOrDefault;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -12,6 +16,7 @@ import jakarta.enterprise.util.TypeLiteral;
 import org.jboss.logging.Logger;
 
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
+import dev.langchain4j.model.anthropic.AnthropicServerTool;
 import dev.langchain4j.model.anthropic.AnthropicStreamingChatModel;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.DisabledChatModel;
@@ -21,6 +26,7 @@ import dev.langchain4j.model.chat.listener.ChatModelListener;
 import io.quarkiverse.langchain4j.anthropic.QuarkusAnthropicClient;
 import io.quarkiverse.langchain4j.anthropic.runtime.config.ChatModelConfig;
 import io.quarkiverse.langchain4j.anthropic.runtime.config.LangChain4jAnthropicConfig;
+import io.quarkiverse.langchain4j.anthropic.runtime.config.ToolSearchType;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.runtime.RuntimeValue;
@@ -35,6 +41,8 @@ public class AnthropicRecorder {
     };
 
     private static final String DUMMY_KEY = "dummy";
+    public static final String ADVANCED_TOOL_USE = "advanced-tool-use-2025-11-20";
+    public static final String INTERLEAVED_THINKING = "interleaved-thinking-2025-05-14";
 
     private final RuntimeValue<LangChain4jAnthropicConfig> runtimeConfig;
 
@@ -103,9 +111,55 @@ public class AnthropicRecorder {
             builder.cacheSystemMessages(chatModelConfig.cacheSystemMessages());
             builder.cacheTools(chatModelConfig.cacheTools());
 
-            // Add beta header for interleaved thinking if enabled
+            // Collect beta headers from features that need them
+            Set<String> betas = new LinkedHashSet<>();
             if (thinkingConfig.interleaved().orElse(false)) {
-                builder.beta("interleaved-thinking-2025-05-14");
+                betas.add(INTERLEAVED_THINKING);
+            }
+
+            Set<String> metadataKeys = new LinkedHashSet<>();
+            List<AnthropicServerTool> serverTools = new ArrayList<>();
+
+            // Configure tool search if enabled
+            ChatModelConfig.ToolSearchConfig toolSearchConfig = chatModelConfig.toolSearch();
+            if (Boolean.TRUE.equals(toolSearchConfig.enabled())) {
+                ToolSearchType type = ToolSearchType.from(toolSearchConfig.type());
+                serverTools.add(AnthropicServerTool.builder()
+                        .type(type.getToolType())
+                        .name(type.getToolName())
+                        .build());
+                metadataKeys.add("defer_loading");
+                betas.add(ADVANCED_TOOL_USE);
+            }
+
+            // Configure programmatic tool calling if enabled
+            ChatModelConfig.ProgrammaticToolCallingConfig ptcConfig = chatModelConfig.programmaticToolCalling();
+            if (Boolean.TRUE.equals(ptcConfig.enabled())) {
+                serverTools.add(AnthropicServerTool.builder()
+                        .type("code_execution_20250825")
+                        .name("code_execution")
+                        .build());
+                metadataKeys.add("allowed_callers");
+                betas.add(ADVANCED_TOOL_USE);
+            }
+
+            // Configure tool use examples if enabled
+            ChatModelConfig.ToolUseExamplesConfig toolUseExamplesConfig = chatModelConfig.toolUseExamples();
+            if (Boolean.TRUE.equals(toolUseExamplesConfig.enabled())) {
+                metadataKeys.add("input_examples");
+                betas.add(ADVANCED_TOOL_USE);
+            }
+
+            if (!betas.isEmpty()) {
+                builder.beta(String.join(",", betas));
+            }
+
+            if (!metadataKeys.isEmpty()) {
+                builder.toolMetadataKeysToSend(metadataKeys);
+            }
+
+            if (!serverTools.isEmpty()) {
+                builder.serverTools(serverTools);
             }
 
             var logCurl = firstOrDefault(false, anthropicConfig.logRequestsCurl());
@@ -191,9 +245,55 @@ public class AnthropicRecorder {
             builder.cacheSystemMessages(chatModelConfig.cacheSystemMessages());
             builder.cacheTools(chatModelConfig.cacheTools());
 
-            // Add beta header for interleaved thinking if enabled
+            // Collect beta headers from features that need them
+            List<String> betas = new ArrayList<>();
             if (thinkingConfig.interleaved().orElse(false)) {
-                builder.beta("interleaved-thinking-2025-05-14");
+                betas.add(INTERLEAVED_THINKING);
+            }
+
+            Set<String> metadataKeys = new LinkedHashSet<>();
+            List<AnthropicServerTool> serverTools = new ArrayList<>();
+
+            // Configure tool search if enabled
+            ChatModelConfig.ToolSearchConfig toolSearchConfig = chatModelConfig.toolSearch();
+            if (Boolean.TRUE.equals(toolSearchConfig.enabled())) {
+                ToolSearchType type = ToolSearchType.from(toolSearchConfig.type());
+                serverTools.add(AnthropicServerTool.builder()
+                        .type(type.getToolType())
+                        .name(type.getToolName())
+                        .build());
+                metadataKeys.add("defer_loading");
+                betas.add(ADVANCED_TOOL_USE);
+            }
+
+            // Configure programmatic tool calling if enabled
+            ChatModelConfig.ProgrammaticToolCallingConfig ptcConfig = chatModelConfig.programmaticToolCalling();
+            if (Boolean.TRUE.equals(ptcConfig.enabled())) {
+                serverTools.add(AnthropicServerTool.builder()
+                        .type("code_execution_20250825")
+                        .name("code_execution")
+                        .build());
+                metadataKeys.add("allowed_callers");
+                betas.add(ADVANCED_TOOL_USE);
+            }
+
+            // Configure tool use examples if enabled
+            ChatModelConfig.ToolUseExamplesConfig toolUseExamplesConfig = chatModelConfig.toolUseExamples();
+            if (Boolean.TRUE.equals(toolUseExamplesConfig.enabled())) {
+                metadataKeys.add("input_examples");
+                betas.add(ADVANCED_TOOL_USE);
+            }
+
+            if (!betas.isEmpty()) {
+                builder.beta(String.join(",", betas));
+            }
+
+            if (!metadataKeys.isEmpty()) {
+                builder.toolMetadataKeysToSend(metadataKeys);
+            }
+
+            if (!serverTools.isEmpty()) {
+                builder.serverTools(serverTools);
             }
 
             var logCurl = firstOrDefault(false, anthropicConfig.logRequestsCurl());

--- a/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/config/ChatModelConfig.java
+++ b/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/config/ChatModelConfig.java
@@ -98,6 +98,23 @@ public interface ChatModelConfig {
      */
     ThinkingConfig thinking();
 
+    /**
+     * Tool Search Tool, which allows Claude to use search tools to access thousands of tools without consuming its context
+     * window
+     */
+    ToolSearchConfig toolSearch();
+
+    /**
+     * Programmatic tool calling configuration, which allows Claude to invoke tools in a code execution environment reducing the
+     * impact on the model’s context window
+     */
+    ProgrammaticToolCallingConfig programmaticToolCalling();
+
+    /**
+     * Tool Use Examples, which provides a universal standard for demonstrating how to effectively use a given tool
+     */
+    ToolUseExamplesConfig toolUseExamples();
+
     @ConfigGroup
     interface ThinkingConfig {
 
@@ -129,5 +146,59 @@ public interface ChatModelConfig {
          */
         @WithDefault("false")
         Optional<Boolean> interleaved();
+    }
+
+    @ConfigGroup
+    interface ToolSearchConfig {
+
+        /**
+         * Enable Anthropic's Tool Search Tool for on-demand tool discovery.
+         * When enabled, this automatically adds the tool search server tool, sets the
+         * required beta header, and enables the "defer_loading" tool metadata key.
+         * Tools annotated with {@code @Tool(metadata = "{\"defer_loading\": true}")}
+         * will be discovered on demand instead of loaded upfront.
+         */
+        @WithDefault("false")
+        Boolean enabled();
+
+        /**
+         * The type of tool search to use.
+         * Available types: "regex" (default) or "bm25".
+         */
+        @WithDefault("regex")
+        String type();
+    }
+
+    @ConfigGroup
+    interface ProgrammaticToolCallingConfig {
+        /**
+         * Enable Anthropic's Programmatic Tool Calling via the Code Execution server tool.
+         * When enabled, this automatically adds the code execution server tool, the {@code "allowed_callers"}
+         * key is sent with tool definitions, and the required beta header is set.
+         * Claude can orchestrate multiple tool calls from within generated Python code,
+         * keeping intermediate results out of the context window rather than accumulating
+         * them in the conversation, significantly reducing token consumption.
+         * <p>
+         * Tools that should be callable from code must include:
+         * {@code @Tool(metadata = "{\"allowed_callers\": [\"code_execution_20250825\"]}")}
+         */
+        @WithDefault("false")
+        Boolean enabled();
+    }
+
+    @ConfigGroup
+    interface ToolUseExamplesConfig {
+        /**
+         * Enable Anthropic's Tool Use Examples feature.
+         * When enabled, the {@code "input_examples"} key is sent with tool definitions,
+         * and the required beta header is set. Providing concrete input examples alongside
+         * tool schemas helps Claude learn correct parameter usage, formats, and conventions
+         * that cannot be expressed in JSON Schema alone.
+         * <p>
+         * Tools with examples must include:
+         * {@code @Tool(metadata = "{\"input_examples\": [{...}, ...]}")}
+         */
+        @WithDefault("false")
+        Boolean enabled();
     }
 }

--- a/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/config/ToolSearchType.java
+++ b/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/config/ToolSearchType.java
@@ -1,0 +1,39 @@
+package io.quarkiverse.langchain4j.anthropic.runtime.config;
+
+import java.util.Arrays;
+
+/**
+ * Anthropic tool search type.
+ * <p>
+ * For more details, see the <a href=
+ * "https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool">Anthropic
+ * documentation</a>.
+ */
+public enum ToolSearchType {
+    BM25("tool_search_tool_bm25", "tool_search_tool_bm25_20251119"),
+    REGEX("tool_search_tool_regex", "tool_search_tool_regex_20251119");
+
+    private final String toolName;
+    private final String toolType;
+
+    ToolSearchType(String toolName, String toolType) {
+        this.toolName = toolName;
+        this.toolType = toolType;
+    }
+
+    public String getToolName() {
+        return toolName;
+    }
+
+    public String getToolType() {
+        return toolType;
+    }
+
+    public static ToolSearchType from(String value) {
+        return Arrays.stream(values())
+                .filter(type -> type.name().equalsIgnoreCase(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Unknown tool search type: " + value));
+    }
+}


### PR DESCRIPTION
## Support for Anthropic Advanced Tool Use Features #2258

In November 2025, Anthropic introduced [Advanced Tool Use](https://www.anthropic.com/engineering/advanced-tool-use), a set of capabilities that allow tools to be used more efficiently without bloating the context window. This PR implements support for all three features, plus the underlying metadata plumbing needed to make them work.

### Added configuration for the following application properties:
```
# Tool Search — on-demand tool discovery
quarkus.langchain4j.anthropic.tool-search.enabled=true
quarkus.langchain4j.anthropic.tool-search.type=bm25  # Optional: bm25, regex (default)

# Programmatic Tool Calling — tools invoked from Claude-generated code
quarkus.langchain4j.anthropic.programmatic-tool-calling.enabled=true

# Tool Use Examples — concrete input examples alongside tool schemas
quarkus.langchain4j.anthropic.tool-use-examples.enabled=true
```

---

### Tool Search Tool

Allows Claude to discover tools on demand instead of loading all of them upfront into the context window — essential when working with large tool sets.

When enabled, this automatically:
- Adds the tool search server tool (`bm25` or `regex`, defaulting to `regex`)
- Sets the required `anthropic-beta` header
- Enables the `defer_loading` tool metadata key

Tools that should be deferred must be annotated with:
```java
@Tool(metadata = "{\"defer_loading\": true}")
```

---

### Programmatic Tool Calling

Allows Claude to orchestrate multiple tool calls from within generated Python code, keeping intermediate results out of the context window rather than accumulating them in the conversation.

When enabled, this automatically:
- Adds the `code_execution_20250825` server tool
- Sets the required `anthropic-beta` header
- Enables the `allowed_callers` tool metadata key

Tools that should be callable from code must be annotated with:
```java
@Tool(metadata = "{\"allowed_callers\": [\"code_execution_20250825\"]}")
```

---

### Tool Use Examples

Provides a standard way to attach concrete input examples to tool definitions, helping Claude learn correct parameter usage, formats, and conventions that JSON Schema alone can't express.

When enabled, this automatically:
- Sets the required `anthropic-beta` header
- Enables the `input_examples` tool metadata key

Tools with examples must be annotated with:
```java
@Tool(metadata = "{\"input_examples\": [{...}, ...]}")
```

---

### Tool Metadata Handling (prerequisite fix)

While implementing the above, I noticed that the `metadata` field on `@Tool` was never actually being passed through. Fixed that as a prerequisite:

- Updated `ToolProcessor` to extract the `defer_loading` (and other) metadata properties from the `@Tool` annotation
- Adjusted `ToolSpecificationObjectSubstitution` to properly handle tool metadata

All three features share the same `anthropic-beta: advanced-tool-use` header and the metadata key forwarding mechanism introduced by this fix.

- fixes https://github.com/quarkiverse/quarkus-langchain4j/issues/2258