### PR TITLE
Avoid Quarkus version confusion in ITs and other modules

### DIFF
--- a/integration-tests/ai-gemini/pom.xml
+++ b/integration-tests/ai-gemini/pom.xml
@@ -67,7 +67,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>io.quarkus</groupId>
+        <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <executions>
           <execution>

--- a/integration-tests/anthropic/pom.xml
+++ b/integration-tests/anthropic/pom.xml
@@ -67,7 +67,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.quarkus</groupId>
+                <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/integration-tests/azure-openai/pom.xml
+++ b/integration-tests/azure-openai/pom.xml
@@ -59,7 +59,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.quarkus</groupId>
+                <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/integration-tests/devui/pom.xml
+++ b/integration-tests/devui/pom.xml
@@ -45,7 +45,6 @@
             <plugin>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/integration-tests/gpu-llama3/pom.xml
+++ b/integration-tests/gpu-llama3/pom.xml
@@ -64,7 +64,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.quarkus</groupId>
+                <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/integration-tests/hugging-face/pom.xml
+++ b/integration-tests/hugging-face/pom.xml
@@ -59,7 +59,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.quarkus</groupId>
+                <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/integration-tests/in-process-embedding-models/embed-all-minilm-l6-v2-q/pom.xml
+++ b/integration-tests/in-process-embedding-models/embed-all-minilm-l6-v2-q/pom.xml
@@ -51,7 +51,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.quarkus</groupId>
+                <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/integration-tests/in-process-embedding-models/embed-all-minilm-l6-v2/pom.xml
+++ b/integration-tests/in-process-embedding-models/embed-all-minilm-l6-v2/pom.xml
@@ -51,7 +51,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.quarkus</groupId>
+                <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/integration-tests/in-process-embedding-models/embed-bge-small-en-q/pom.xml
+++ b/integration-tests/in-process-embedding-models/embed-bge-small-en-q/pom.xml
@@ -51,7 +51,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.quarkus</groupId>
+                <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/integration-tests/in-process-embedding-models/embed-bge-small-en-v15-and-ollama/pom.xml
+++ b/integration-tests/in-process-embedding-models/embed-bge-small-en-v15-and-ollama/pom.xml
@@ -66,7 +66,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.quarkus</groupId>
+                <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/integration-tests/in-process-embedding-models/embed-bge-small-en-v15-q/pom.xml
+++ b/integration-tests/in-process-embedding-models/embed-bge-small-en-v15-q/pom.xml
@@ -51,7 +51,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.quarkus</groupId>
+                <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/integration-tests/in-process-embedding-models/embed-bge-small-en-v15/pom.xml
+++ b/integration-tests/in-process-embedding-models/embed-bge-small-en-v15/pom.xml
@@ -51,7 +51,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.quarkus</groupId>
+                <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/integration-tests/in-process-embedding-models/embed-bge-small-en/pom.xml
+++ b/integration-tests/in-process-embedding-models/embed-bge-small-en/pom.xml
@@ -52,7 +52,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.quarkus</groupId>
+                <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/integration-tests/in-process-embedding-models/embed-e5-small-v2-q/pom.xml
+++ b/integration-tests/in-process-embedding-models/embed-e5-small-v2-q/pom.xml
@@ -66,7 +66,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.quarkus</groupId>
+                <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/integration-tests/in-process-embedding-models/embed-e5-small-v2/pom.xml
+++ b/integration-tests/in-process-embedding-models/embed-e5-small-v2/pom.xml
@@ -66,7 +66,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.quarkus</groupId>
+                <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/integration-tests/jlama/pom.xml
+++ b/integration-tests/jlama/pom.xml
@@ -11,7 +11,6 @@
     <properties>
         <skipITs>true</skipITs>
         <maven.compiler.release>21</maven.compiler.release>
-        <quarkus.version>3.18.0</quarkus.version>
     </properties>
     <dependencies>
         <dependency>
@@ -73,7 +72,7 @@
         </extensions>
         <plugins>
             <plugin>
-                <groupId>io.quarkus</groupId>
+                <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/integration-tests/llama3-java/pom.xml
+++ b/integration-tests/llama3-java/pom.xml
@@ -11,7 +11,6 @@
     <properties>
         <skipITs>true</skipITs>
         <maven.compiler.release>21</maven.compiler.release>
-        <quarkus.version>3.18.0</quarkus.version>
     </properties>
     <dependencies>
         <dependency>
@@ -61,7 +60,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.quarkus</groupId>
+                <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/integration-tests/mcp-conformance/pom.xml
+++ b/integration-tests/mcp-conformance/pom.xml
@@ -17,9 +17,6 @@
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.27.2</quarkus.platform.version>
         <skipITs>true</skipITs>
         <skipTests>true</skipTests>
         <surefire-plugin.version>3.2.5</surefire-plugin.version>
@@ -33,7 +30,6 @@
             <plugin>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -74,17 +70,6 @@
                     <name>!platform-deps</name>
                 </property>
             </activation>
-            <dependencyManagement>
-                <dependencies>
-                    <dependency>
-                        <groupId>${quarkus.platform.group-id}</groupId>
-                        <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                        <version>${quarkus.platform.version}</version>
-                        <type>pom</type>
-                        <scope>import</scope>
-                    </dependency>
-                </dependencies>
-            </dependencyManagement>
             <dependencies>
                 <dependency>
                     <groupId>io.quarkiverse.langchain4j</groupId>
@@ -100,24 +85,6 @@
                     <name>platform-deps</name>
                 </property>
             </activation>
-            <dependencyManagement>
-                <dependencies>
-                    <dependency>
-                        <groupId>${quarkus.platform.group-id}</groupId>
-                        <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                        <version>${quarkus.platform.version}</version>
-                        <type>pom</type>
-                        <scope>import</scope>
-                    </dependency>
-                    <dependency>
-                        <groupId>${quarkus.platform.group-id}</groupId>
-                        <artifactId>quarkus-langchain4j-bom</artifactId>
-                        <version>${quarkus.platform.version}</version>
-                        <type>pom</type>
-                        <scope>import</scope>
-                    </dependency>
-                </dependencies>
-            </dependencyManagement>
             <dependencies>
                 <dependency>
                     <groupId>io.quarkiverse.langchain4j</groupId>

--- a/integration-tests/mcp-native/pom.xml
+++ b/integration-tests/mcp-native/pom.xml
@@ -43,7 +43,6 @@
             <plugin>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/integration-tests/mcp/pom.xml
+++ b/integration-tests/mcp/pom.xml
@@ -59,7 +59,6 @@
             <plugin>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/integration-tests/mistralai/pom.xml
+++ b/integration-tests/mistralai/pom.xml
@@ -67,7 +67,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.quarkus</groupId>
+                <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/integration-tests/multiple-providers/pom.xml
+++ b/integration-tests/multiple-providers/pom.xml
@@ -87,7 +87,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.quarkus</groupId>
+                <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/integration-tests/ollama/pom.xml
+++ b/integration-tests/ollama/pom.xml
@@ -59,7 +59,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.quarkus</groupId>
+                <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/integration-tests/openai/pom.xml
+++ b/integration-tests/openai/pom.xml
@@ -63,7 +63,6 @@
       <plugin>
         <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <version>${quarkus.platform.version}</version>
         <executions>
           <execution>
             <goals>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -9,11 +9,11 @@
   <artifactId>quarkus-langchain4j-integration-tests-parent</artifactId>
   <name>Quarkus LangChain4j - Integration Tests - Parent</name>
   <packaging>pom</packaging>
-    <properties>
-        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.26.3</quarkus.platform.version>
-    </properties>
+  <properties>
+    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+    <quarkus.platform.version>${quarkus.version}</quarkus.platform.version>
+  </properties>
   <modules>
     <module>anthropic</module>
     <module>openai</module>
@@ -203,6 +203,9 @@
                   <name>platform-deps</name>
               </property>
           </activation>
+          <properties>
+              <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+          </properties>
           <dependencyManagement>
               <dependencies>
                   <dependency>
@@ -232,6 +235,15 @@
 
 <!-- we need test jars for inclusion in the Quarkus Platform -->
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>${quarkus.platform.group-id}</groupId>
+          <artifactId>quarkus-maven-plugin</artifactId>
+          <version>${quarkus.platform.version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/integration-tests/rag-pgvector-flyway/pom.xml
+++ b/integration-tests/rag-pgvector-flyway/pom.xml
@@ -61,7 +61,6 @@
       <plugin>
         <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <version>${quarkus.platform.version}</version>
         <executions>
           <execution>
             <goals>

--- a/integration-tests/rag-pgvector/pom.xml
+++ b/integration-tests/rag-pgvector/pom.xml
@@ -56,7 +56,6 @@
       <plugin>
         <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <version>${quarkus.platform.version}</version>
         <executions>
           <execution>
             <goals>

--- a/integration-tests/rag/pom.xml
+++ b/integration-tests/rag/pom.xml
@@ -52,7 +52,6 @@
       <plugin>
         <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <version>${quarkus.platform.version}</version>
         <executions>
           <execution>
             <goals>

--- a/integration-tests/secure-mcp/pom.xml
+++ b/integration-tests/secure-mcp/pom.xml
@@ -62,7 +62,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.quarkus</groupId>
+                <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/integration-tests/simple-ollama/pom.xml
+++ b/integration-tests/simple-ollama/pom.xml
@@ -60,7 +60,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>io.quarkus</groupId>
+        <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <executions>
           <execution>

--- a/integration-tests/tools/pom.xml
+++ b/integration-tests/tools/pom.xml
@@ -52,7 +52,6 @@
       <plugin>
         <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <version>${quarkus.platform.version}</version>
         <executions>
           <execution>
             <goals>

--- a/integration-tests/vertex-ai-gemini/pom.xml
+++ b/integration-tests/vertex-ai-gemini/pom.xml
@@ -67,7 +67,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>io.quarkus</groupId>
+        <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <executions>
           <execution>

--- a/quarkus-integrations/websockets-next/pom.xml
+++ b/quarkus-integrations/websockets-next/pom.xml
@@ -12,11 +12,6 @@
     <name>Quarkus LangChain4j - WebSockets Next - Parent</name>
     <packaging>pom</packaging>
 
-    <properties>
-        <!-- Quarkus LangChain4j Websockets Next works with 3.9.0 or higher -->
-        <quarkus.version>3.20.0</quarkus.version>
-    </properties>
-
     <modules>
         <module>deployment</module>
         <module>runtime</module>


### PR DESCRIPTION
There has been quite a confusion growing with the config in integration-tests/pom.xml and this had led to some problems when productizing the platform.

We shouldn't override the Quarkus version in integration-tests/pom.xml and we should be careful as to which plugin we use.

I think this commit will make everything consistent and make sure we are using a consistent Quarkus version, while allowing to override Platform and version for specific testing.

I think we should backport this to 1.7.x too so that it can be fixed for the 3.33 platform.

Following a discussion with Roberto Oliveira today.

Note: I don't know the project that well so I did what looked right to me but feel free to push back if something looks odd.