### PR TITLE
Make quarkus-langchain4j-openai aware of Quarkus Proxy Registry

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-all-config.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-all-config.adoc
@@ -10710,6 +10710,27 @@ h|[.extension-name]##Quarkus LangChain4j - Chroma##
 h|Type
 h|Default
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-default-store-enabled]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-default-store-enabled[`+++quarkus.langchain4j.chroma.default-store-enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chroma.default-store-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the default (unnamed) Chroma embedding store should be enabled. Set to `false` when you only want to use named stores.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHROMA_DEFAULT_STORE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA_DEFAULT_STORE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-devservices-enabled]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-devservices-enabled[`+++quarkus.langchain4j.chroma.devservices.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.chroma.devservices.enabled+++[]
@@ -10865,7 +10886,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA_URL+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|required icon:exclamation-circle[title=Configuration property is required]
+|
 
 a| [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-collection-name]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-collection-name[`+++quarkus.langchain4j.chroma.collection-name+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -10971,6 +10992,158 @@ endif::add-copy-button-to-env-var[]
 --
 a|`v1`, `v2`
 |`+++v2+++`
+
+h|[[quarkus-langchain4j-chroma_section_quarkus-langchain4j-chroma]] [.section-name.section-level0]##link:#quarkus-langchain4j-chroma_section_quarkus-langchain4j-chroma[Named store configurations]##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-collection-name]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-collection-name[`+++quarkus.langchain4j.chroma."store-name".collection-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chroma."store-name".collection-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The collection name for this named store. This property serves as the build-time key that enables named store discovery. If not set, the collection name from the runtime configuration will be used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__COLLECTION_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__COLLECTION_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++<default>+++`
+
+a| [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-url]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-url[`+++quarkus.langchain4j.chroma."store-name".url+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chroma."store-name".url+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+URL where the Chroma database is listening for requests
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__URL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__URL+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-collection-name]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-collection-name[`+++quarkus.langchain4j.chroma."store-name".collection-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chroma."store-name".collection-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The collection name.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__COLLECTION_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__COLLECTION_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++default+++`
+
+a| [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-timeout]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-timeout[`+++quarkus.langchain4j.chroma."store-name".timeout+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chroma."store-name".timeout+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The timeout duration for the Chroma client. If not specified, 5 seconds will be used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__TIMEOUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__TIMEOUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-all-config[icon:question-circle[title=More information about the Duration format]]
+|
+
+a| [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-log-requests]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-log-requests[`+++quarkus.langchain4j.chroma."store-name".log-requests+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chroma."store-name".log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether requests to Chroma should be logged
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-log-responses]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-log-responses[`+++quarkus.langchain4j.chroma."store-name".log-responses+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chroma."store-name".log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether responses from Chroma should be logged
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-api-version]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-api-version[`+++quarkus.langchain4j.chroma."store-name".api-version+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chroma."store-name".api-version+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The Chroma API version to use. V1 is deprecated (Chroma 0.x) and its support will be removed in the future. Please use Chroma 1.x which uses the V2 API.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__API_VERSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__API_VERSION+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`v1`, `v2`
+|`+++v2+++`
+
 
 
 h|[.extension-name]##Quarkus LangChain4j - Cohere##
@@ -14318,6 +14491,27 @@ h|[.extension-name]##Quarkus LangChain4j - Milvus embedding store##
 h|Type
 h|Default
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-default-store-enabled]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-default-store-enabled[`+++quarkus.langchain4j.milvus.default-store-enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus.default-store-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the default (unnamed) Milvus embedding store should be enabled. Set to `false` when you only want to use named stores.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS_DEFAULT_STORE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS_DEFAULT_STORE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-devservices-enabled]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-devservices-enabled[`+++quarkus.langchain4j.milvus.devservices.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.milvus.devservices.enabled+++[]
@@ -14442,7 +14636,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS_HOST+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|required icon:exclamation-circle[title=Configuration property is required]
+|`+++localhost+++`
 
 a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-port]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-port[`+++quarkus.langchain4j.milvus.port+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -14463,7 +14657,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS_PORT+++`
 endif::add-copy-button-to-env-var[]
 --
 |int
-|required icon:exclamation-circle[title=Configuration property is required]
+|`+++19530+++`
 
 a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-token]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-token[`+++quarkus.langchain4j.milvus.token+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -14800,6 +14994,410 @@ endif::add-copy-button-to-env-var[]
 --
 a|`strong`, `session`, `bounded`, `eventually`
 |`+++eventually+++`
+
+h|[[quarkus-langchain4j-milvus_section_quarkus-langchain4j-milvus]] [.section-name.section-level0]##link:#quarkus-langchain4j-milvus_section_quarkus-langchain4j-milvus[Named store configurations]##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-host]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-host[`+++quarkus.langchain4j.milvus."store-name".host+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".host+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The host of the Milvus server to use for this named store. If set to `<default>`, the default Milvus server will be used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__HOST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__HOST+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++<default>+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-host]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-host[`+++quarkus.langchain4j.milvus."store-name".host+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".host+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The URL of the Milvus server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__HOST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__HOST+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++localhost+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-port]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-port[`+++quarkus.langchain4j.milvus."store-name".port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The port of the Milvus server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++19530+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-token]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-token[`+++quarkus.langchain4j.milvus."store-name".token+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".token+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The authentication token for the Milvus server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__TOKEN+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__TOKEN+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-username]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-username[`+++quarkus.langchain4j.milvus."store-name".username+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".username+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The username for the Milvus server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__USERNAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__USERNAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-password]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-password[`+++quarkus.langchain4j.milvus."store-name".password+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".password+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The password for the Milvus server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-timeout]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-timeout[`+++quarkus.langchain4j.milvus."store-name".timeout+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".timeout+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The timeout duration for the Milvus client. If not specified, 5 seconds will be used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__TIMEOUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__TIMEOUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-all-config[icon:question-circle[title=More information about the Duration format]]
+|
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-db-name]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-db-name[`+++quarkus.langchain4j.milvus."store-name".db-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".db-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the database.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__DB_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__DB_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++default+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-create-collection]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-create-collection[`+++quarkus.langchain4j.milvus."store-name".create-collection+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".create-collection+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Create the collection if it does not exist yet.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__CREATE_COLLECTION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__CREATE_COLLECTION+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-collection-name]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-collection-name[`+++quarkus.langchain4j.milvus."store-name".collection-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".collection-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the collection.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__COLLECTION_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__COLLECTION_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++embeddings+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-dimension]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-dimension[`+++quarkus.langchain4j.milvus."store-name".dimension+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".dimension+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Dimension of the vectors. Only applicable when the collection yet has to be created.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__DIMENSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__DIMENSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-primary-field]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-primary-field[`+++quarkus.langchain4j.milvus."store-name".primary-field+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".primary-field+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the field that contains the ID of the vector.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__PRIMARY_FIELD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__PRIMARY_FIELD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++id+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-text-field]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-text-field[`+++quarkus.langchain4j.milvus."store-name".text-field+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".text-field+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the field that contains the text from which the vector was calculated.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__TEXT_FIELD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__TEXT_FIELD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++text+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-metadata-field]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-metadata-field[`+++quarkus.langchain4j.milvus."store-name".metadata-field+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".metadata-field+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the field that contains JSON metadata associated with the text.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__METADATA_FIELD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__METADATA_FIELD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++metadata+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-vector-field]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-vector-field[`+++quarkus.langchain4j.milvus."store-name".vector-field+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".vector-field+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the field to store the vector in.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__VECTOR_FIELD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__VECTOR_FIELD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++vector+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-description]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-description[`+++quarkus.langchain4j.milvus."store-name".description+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".description+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Description of the collection.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__DESCRIPTION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__DESCRIPTION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-index-type]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-index-type[`+++quarkus.langchain4j.milvus."store-name".index-type+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".index-type+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The index type to use for the collection.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__INDEX_TYPE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__INDEX_TYPE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`none`, `flat`, `ivf-flat`, `ivf-sq8`, `ivf-pq`, `hnsw`, `hnsw-sq`, `hnsw-pq`, `hnsw-prq`, `diskann`, `autoindex`, `scann`, `gpu-ivf-flat`, `gpu-ivf-pq`, `gpu-brute-force`, `gpu-cagra`, `bin-flat`, `bin-ivf-flat`, `trie`, `stl-sort`, `inverted`, `bitmap`, `sparse-inverted-index`, `sparse-wand`
+|`+++flat+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-metric-type]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-metric-type[`+++quarkus.langchain4j.milvus."store-name".metric-type+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".metric-type+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The metric type to use for searching.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__METRIC_TYPE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__METRIC_TYPE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`none`, `l2`, `ip`, `cosine`, `hamming`, `jaccard`
+|`+++cosine+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-consistency-level]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-consistency-level[`+++quarkus.langchain4j.milvus."store-name".consistency-level+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".consistency-level+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The consistency level.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__CONSISTENCY_LEVEL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__CONSISTENCY_LEVEL+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`strong`, `session`, `bounded`, `eventually`
+|`+++eventually+++`
+
 
 
 h|[.extension-name]##Quarkus LangChain4j - Mistral AI##
@@ -18141,68 +18739,33 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-type]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-type[`+++quarkus.langchain4j.openai.proxy-type+++`]##
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-configuration-name]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-configuration-name[`+++quarkus.langchain4j.openai.proxy-configuration-name+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.openai.proxy-type+++[]
+config_property_copy_button:+++quarkus.langchain4j.openai.proxy-configuration-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-The Proxy type
+Proxy configuration name.
+
+There are some rules for using Quarkus Proxy Registry configuration:
+
+ - If `quarkus.langchain4j.openai.proxy-configuration-name` is set, it takes precedence over `proxy-host` configuration.
+ - If not set and the default proxy configuration is configured (`quarkus.proxy.++*++`) then that will be used.
+ - If the proxy configuration name is set, the configuration from `quarkus.proxy.<name>.++*++` will be used.
+ - If the proxy configuration name is set, but no proxy configuration is found with that name, then an error will be thrown at runtime.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_TYPE+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_CONFIGURATION_NAME+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_TYPE+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++HTTP+++`
-
-a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-host]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-host[`+++quarkus.langchain4j.openai.proxy-host+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.openai.proxy-host+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The Proxy host
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_HOST+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_HOST+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_CONFIGURATION_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
 |
-
-a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-port]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-port[`+++quarkus.langchain4j.openai.proxy-port+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.openai.proxy-port+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The Proxy port
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_PORT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_PORT+++`
-endif::add-copy-button-to-env-var[]
---
-|int
-|`+++3128+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-model-name]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-model-name[`+++quarkus.langchain4j.openai.chat-model.model-name+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -18879,6 +19442,75 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-type]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-type[[.line-through]#`+++quarkus.langchain4j.openai.proxy-type+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.proxy-type+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `quarkus.langchain4j.openai.proxy-configuration-name` instead._
+
+The Proxy type
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_TYPE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_TYPE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++HTTP+++`
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-host]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-host[[.line-through]#`+++quarkus.langchain4j.openai.proxy-host+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.proxy-host+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `quarkus.langchain4j.openai.proxy-configuration-name` instead._
+
+The Proxy host
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_HOST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_HOST+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-port]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-port[[.line-through]#`+++quarkus.langchain4j.openai.proxy-port+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.proxy-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `quarkus.langchain4j.openai.proxy-configuration-name` instead._
+
+The Proxy port
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++3128+++`
+
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-max-tokens]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-max-tokens[[.line-through]#`+++quarkus.langchain4j.openai.chat-model.max-tokens+++`#]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.max-tokens+++[]
@@ -19116,68 +19748,33 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-proxy-type]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-proxy-type[`+++quarkus.langchain4j.openai."model-name".proxy-type+++`]##
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-proxy-configuration-name]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-proxy-configuration-name[`+++quarkus.langchain4j.openai."model-name".proxy-configuration-name+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.openai."model-name".proxy-type+++[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".proxy-configuration-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-The Proxy type
+Proxy configuration name.
+
+There are some rules for using Quarkus Proxy Registry configuration:
+
+ - If `quarkus.langchain4j.openai.proxy-configuration-name` is set, it takes precedence over `proxy-host` configuration.
+ - If not set and the default proxy configuration is configured (`quarkus.proxy.++*++`) then that will be used.
+ - If the proxy configuration name is set, the configuration from `quarkus.proxy.<name>.++*++` will be used.
+ - If the proxy configuration name is set, but no proxy configuration is found with that name, then an error will be thrown at runtime.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__PROXY_TYPE+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__PROXY_CONFIGURATION_NAME+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__PROXY_TYPE+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++HTTP+++`
-
-a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-proxy-host]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-proxy-host[`+++quarkus.langchain4j.openai."model-name".proxy-host+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.openai."model-name".proxy-host+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The Proxy host
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__PROXY_HOST+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__PROXY_HOST+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__PROXY_CONFIGURATION_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
 |
-
-a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-proxy-port]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-proxy-port[`+++quarkus.langchain4j.openai."model-name".proxy-port+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.openai."model-name".proxy-port+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The Proxy port
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__PROXY_PORT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__PROXY_PORT+++`
-endif::add-copy-button-to-env-var[]
---
-|int
-|`+++3128+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-model-name]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-model-name[`+++quarkus.langchain4j.openai."model-name".chat-model.model-name+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-chroma.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-chroma.adoc
@@ -302,7 +302,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The collection name for this named store. This property serves as the build-time key that enables named store discovery. If not set, the default collection name will be used.
+The collection name for this named store. This property serves as the build-time key that enables named store discovery. If not set, the collection name from the runtime configuration will be used.
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-chroma_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-chroma_quarkus.langchain4j.adoc
@@ -302,7 +302,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The collection name for this named store. This property serves as the build-time key that enables named store discovery. If not set, the default collection name will be used.
+The collection name for this named store. This property serves as the build-time key that enables named store discovery. If not set, the collection name from the runtime configuration will be used.
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai.adoc
@@ -301,68 +301,33 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-type]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-type[`+++quarkus.langchain4j.openai.proxy-type+++`]##
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-configuration-name]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-configuration-name[`+++quarkus.langchain4j.openai.proxy-configuration-name+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.openai.proxy-type+++[]
+config_property_copy_button:+++quarkus.langchain4j.openai.proxy-configuration-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-The Proxy type
+Proxy configuration name.
+
+There are some rules for using Quarkus Proxy Registry configuration:
+
+ - If `quarkus.langchain4j.openai.proxy-configuration-name` is set, it takes precedence over `proxy-host` configuration.
+ - If not set and the default proxy configuration is configured (`quarkus.proxy.++*++`) then that will be used.
+ - If the proxy configuration name is set, the configuration from `quarkus.proxy.<name>.++*++` will be used.
+ - If the proxy configuration name is set, but no proxy configuration is found with that name, then an error will be thrown at runtime.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_TYPE+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_CONFIGURATION_NAME+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_TYPE+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++HTTP+++`
-
-a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-host]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-host[`+++quarkus.langchain4j.openai.proxy-host+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.openai.proxy-host+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The Proxy host
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_HOST+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_HOST+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_CONFIGURATION_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
 |
-
-a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-port]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-port[`+++quarkus.langchain4j.openai.proxy-port+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.openai.proxy-port+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The Proxy port
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_PORT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_PORT+++`
-endif::add-copy-button-to-env-var[]
---
-|int
-|`+++3128+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-model-name]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-model-name[`+++quarkus.langchain4j.openai.chat-model.model-name+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -1039,6 +1004,75 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-type]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-type[[.line-through]#`+++quarkus.langchain4j.openai.proxy-type+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.proxy-type+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `quarkus.langchain4j.openai.proxy-configuration-name` instead._
+
+The Proxy type
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_TYPE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_TYPE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++HTTP+++`
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-host]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-host[[.line-through]#`+++quarkus.langchain4j.openai.proxy-host+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.proxy-host+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `quarkus.langchain4j.openai.proxy-configuration-name` instead._
+
+The Proxy host
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_HOST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_HOST+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-port]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-port[[.line-through]#`+++quarkus.langchain4j.openai.proxy-port+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.proxy-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `quarkus.langchain4j.openai.proxy-configuration-name` instead._
+
+The Proxy port
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++3128+++`
+
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-max-tokens]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-max-tokens[[.line-through]#`+++quarkus.langchain4j.openai.chat-model.max-tokens+++`#]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.max-tokens+++[]
@@ -1276,68 +1310,33 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-proxy-type]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-proxy-type[`+++quarkus.langchain4j.openai."model-name".proxy-type+++`]##
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-proxy-configuration-name]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-proxy-configuration-name[`+++quarkus.langchain4j.openai."model-name".proxy-configuration-name+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.openai."model-name".proxy-type+++[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".proxy-configuration-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-The Proxy type
+Proxy configuration name.
+
+There are some rules for using Quarkus Proxy Registry configuration:
+
+ - If `quarkus.langchain4j.openai.proxy-configuration-name` is set, it takes precedence over `proxy-host` configuration.
+ - If not set and the default proxy configuration is configured (`quarkus.proxy.++*++`) then that will be used.
+ - If the proxy configuration name is set, the configuration from `quarkus.proxy.<name>.++*++` will be used.
+ - If the proxy configuration name is set, but no proxy configuration is found with that name, then an error will be thrown at runtime.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__PROXY_TYPE+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__PROXY_CONFIGURATION_NAME+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__PROXY_TYPE+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++HTTP+++`
-
-a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-proxy-host]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-proxy-host[`+++quarkus.langchain4j.openai."model-name".proxy-host+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.openai."model-name".proxy-host+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The Proxy host
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__PROXY_HOST+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__PROXY_HOST+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__PROXY_CONFIGURATION_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
 |
-
-a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-proxy-port]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-proxy-port[`+++quarkus.langchain4j.openai."model-name".proxy-port+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.openai."model-name".proxy-port+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The Proxy port
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__PROXY_PORT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__PROXY_PORT+++`
-endif::add-copy-button-to-env-var[]
---
-|int
-|`+++3128+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-model-name]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-model-name[`+++quarkus.langchain4j.openai."model-name".chat-model.model-name+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai_quarkus.langchain4j.adoc
@@ -301,68 +301,33 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-type]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-type[`+++quarkus.langchain4j.openai.proxy-type+++`]##
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-configuration-name]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-configuration-name[`+++quarkus.langchain4j.openai.proxy-configuration-name+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.openai.proxy-type+++[]
+config_property_copy_button:+++quarkus.langchain4j.openai.proxy-configuration-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-The Proxy type
+Proxy configuration name.
+
+There are some rules for using Quarkus Proxy Registry configuration:
+
+ - If `quarkus.langchain4j.openai.proxy-configuration-name` is set, it takes precedence over `proxy-host` configuration.
+ - If not set and the default proxy configuration is configured (`quarkus.proxy.++*++`) then that will be used.
+ - If the proxy configuration name is set, the configuration from `quarkus.proxy.<name>.++*++` will be used.
+ - If the proxy configuration name is set, but no proxy configuration is found with that name, then an error will be thrown at runtime.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_TYPE+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_CONFIGURATION_NAME+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_TYPE+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++HTTP+++`
-
-a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-host]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-host[`+++quarkus.langchain4j.openai.proxy-host+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.openai.proxy-host+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The Proxy host
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_HOST+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_HOST+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_CONFIGURATION_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
 |
-
-a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-port]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-port[`+++quarkus.langchain4j.openai.proxy-port+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.openai.proxy-port+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The Proxy port
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_PORT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_PORT+++`
-endif::add-copy-button-to-env-var[]
---
-|int
-|`+++3128+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-model-name]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-model-name[`+++quarkus.langchain4j.openai.chat-model.model-name+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -1039,6 +1004,75 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-type]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-type[[.line-through]#`+++quarkus.langchain4j.openai.proxy-type+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.proxy-type+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `quarkus.langchain4j.openai.proxy-configuration-name` instead._
+
+The Proxy type
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_TYPE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_TYPE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++HTTP+++`
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-host]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-host[[.line-through]#`+++quarkus.langchain4j.openai.proxy-host+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.proxy-host+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `quarkus.langchain4j.openai.proxy-configuration-name` instead._
+
+The Proxy host
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_HOST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_HOST+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-port]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-proxy-port[[.line-through]#`+++quarkus.langchain4j.openai.proxy-port+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.proxy-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `quarkus.langchain4j.openai.proxy-configuration-name` instead._
+
+The Proxy port
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_PROXY_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++3128+++`
+
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-max-tokens]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-max-tokens[[.line-through]#`+++quarkus.langchain4j.openai.chat-model.max-tokens+++`#]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.max-tokens+++[]
@@ -1276,68 +1310,33 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-proxy-type]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-proxy-type[`+++quarkus.langchain4j.openai."model-name".proxy-type+++`]##
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-proxy-configuration-name]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-proxy-configuration-name[`+++quarkus.langchain4j.openai."model-name".proxy-configuration-name+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.openai."model-name".proxy-type+++[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".proxy-configuration-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-The Proxy type
+Proxy configuration name.
+
+There are some rules for using Quarkus Proxy Registry configuration:
+
+ - If `quarkus.langchain4j.openai.proxy-configuration-name` is set, it takes precedence over `proxy-host` configuration.
+ - If not set and the default proxy configuration is configured (`quarkus.proxy.++*++`) then that will be used.
+ - If the proxy configuration name is set, the configuration from `quarkus.proxy.<name>.++*++` will be used.
+ - If the proxy configuration name is set, but no proxy configuration is found with that name, then an error will be thrown at runtime.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__PROXY_TYPE+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__PROXY_CONFIGURATION_NAME+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__PROXY_TYPE+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++HTTP+++`
-
-a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-proxy-host]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-proxy-host[`+++quarkus.langchain4j.openai."model-name".proxy-host+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.openai."model-name".proxy-host+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The Proxy host
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__PROXY_HOST+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__PROXY_HOST+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__PROXY_CONFIGURATION_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
 |
-
-a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-proxy-port]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-proxy-port[`+++quarkus.langchain4j.openai."model-name".proxy-port+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.openai."model-name".proxy-port+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The Proxy port
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__PROXY_PORT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__PROXY_PORT+++`
-endif::add-copy-button-to-env-var[]
---
-|int
-|`+++3128+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-model-name]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-model-name[`+++quarkus.langchain4j.openai."model-name".chat-model.model-name+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/model-providers/openai/openai-vanilla/deployment/pom.xml
+++ b/model-providers/openai/openai-vanilla/deployment/pom.xml
@@ -20,6 +20,10 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-proxy-registry-deployment</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkiverse.langchain4j</groupId>
             <artifactId>quarkus-langchain4j-openai-testing-internal</artifactId>
             <scope>test</scope>

--- a/model-providers/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/OpenAiProcessor.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/OpenAiProcessor.java
@@ -53,6 +53,7 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
+import io.quarkus.proxy.ProxyConfigurationRegistry;
 
 public class OpenAiProcessor {
 
@@ -117,6 +118,7 @@ public class OpenAiProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
+                        .addInjectionPoint(Type.create(ProxyConfigurationRegistry.class))
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
@@ -132,6 +134,7 @@ public class OpenAiProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
+                        .addInjectionPoint(Type.create(ProxyConfigurationRegistry.class))
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
@@ -153,6 +156,7 @@ public class OpenAiProcessor {
                         .defaultBean()
                         .unremovable()
                         .scope(ApplicationScoped.class)
+                        .addInjectionPoint(Type.create(ProxyConfigurationRegistry.class))
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
                                         new Type[] { ClassType.create(OPENAI_EMBEDDING_MODEL_BUILDER) }, null) },
@@ -171,6 +175,7 @@ public class OpenAiProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
+                        .addInjectionPoint(Type.create(ProxyConfigurationRegistry.class))
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
                                         new Type[] { ClassType.create(OPENAI_MODERATION_MODEL_BUILDER) }, null) },
@@ -189,6 +194,7 @@ public class OpenAiProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
+                        .addInjectionPoint(Type.create(ProxyConfigurationRegistry.class))
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
                                         new Type[] { ClassType.create(OPENAI_IMAGE_MODEL_BUILDER) }, null) },

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/proxy/BothProxyConfigsSetTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/proxy/BothProxyConfigsSetTest.java
@@ -1,0 +1,66 @@
+package io.quarkiverse.langchain4j.openai.test.proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.logging.LogRecord;
+
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.SoftAssertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class BothProxyConfigsSetTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.proxy-configuration-name", "local")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.proxy-host", "proxy.example.com")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.proxy-port", "8080")
+            .overrideRuntimeConfigKey("quarkus.proxy.local.host", "localhost")
+            .overrideRuntimeConfigKey("quarkus.proxy.local.port", "${quarkus.wiremock.devservices.port}")
+            .setLogRecordPredicate(record -> true)
+            .assertLogRecords(BothProxyConfigsSetTest::verifyLogRecords);
+
+    private static void verifyLogRecords(List<LogRecord> logRecords) {
+        assertThat(logRecords.stream().map(LogRecord::getMessage))
+                .contains(
+                        "Both 'proxy-configuration-name' (%s) and deprecated 'proxy-host' (%s) are set. The 'proxy-host' configuration will be ignored. Please remove 'proxy-host' and 'proxy-port' from your configuration.");
+    }
+
+    @Inject
+    ChatModel chatModel;
+
+    @BeforeEach
+    void reset() {
+        resetRequests();
+    }
+
+    @Test
+    void shouldPrioritizeProxyConfigurationNameOverDeprecated() {
+        SoftAssertions softly = new SoftAssertions();
+
+        setChatCompletionMessageContent("response");
+        String response = chatModel.chat("hello");
+        softly.assertThat(response).isEqualTo("response");
+        LoggedRequest loggedRequest = singleLoggedRequest();
+
+        softly.assertThat(loggedRequest.getHost()).contains("localhost");
+
+        softly.assertAll();
+    }
+}

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/proxy/DefaultProxyAvailableTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/proxy/DefaultProxyAvailableTest.java
@@ -45,6 +45,7 @@ public class DefaultProxyAvailableTest extends OpenAiBaseTest {
         // The fact that WireMock received this request proves the proxy was used,
         // since nothing is actually listening on localhost:8282.
         softly.assertThat(loggedRequest.getHeader("User-Agent")).isEqualTo("langchain4j-openai");
+        softly.assertThat(loggedRequest.getHeader("Host")).isEqualTo("localhost:8282");
         softly.assertAll();
     }
 

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/proxy/DefaultProxyAvailableTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/proxy/DefaultProxyAvailableTest.java
@@ -1,0 +1,51 @@
+package io.quarkiverse.langchain4j.openai.test.proxy;
+
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.SoftAssertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DefaultProxyAvailableTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    "http://localhost:8282/v1") // nothing listens here — proxy must be used
+            .overrideRuntimeConfigKey("quarkus.proxy.host", "localhost")
+            .overrideRuntimeConfigKey("quarkus.proxy.port", "${quarkus.wiremock.devservices.port}");
+
+    @Inject
+    ChatModel chatModel;
+
+    @BeforeEach
+    void reset() {
+        resetRequests();
+    }
+
+    @Test
+    void shouldUseDefaultProxyFromRegistry() {
+        setChatCompletionMessageContent("response");
+        String response = chatModel.chat("hello");
+
+        SoftAssertions softly = new SoftAssertions();
+        softly.assertThat(response).isEqualTo("response");
+        LoggedRequest loggedRequest = singleLoggedRequest();
+        // Host header reflects the target (base-url), not the proxy.
+        // The fact that WireMock received this request proves the proxy was used,
+        // since nothing is actually listening on localhost:8282.
+        softly.assertThat(loggedRequest.getHeader("User-Agent")).isEqualTo("langchain4j-openai");
+        softly.assertAll();
+    }
+
+}

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/proxy/NoProxyConfiguredTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/proxy/NoProxyConfiguredTest.java
@@ -1,0 +1,44 @@
+package io.quarkiverse.langchain4j.openai.test.proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class NoProxyConfiguredTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    ChatModel chatModel;
+
+    @BeforeEach
+    void reset() {
+        resetRequests();
+    }
+
+    @Test
+    void shouldWorkWithoutProxy() {
+        setChatCompletionMessageContent("response");
+        String response = chatModel.chat("hello");
+        assertThat(response).isEqualTo("response");
+        LoggedRequest loggedRequest = singleLoggedRequest();
+        assertThat(loggedRequest.getHeader("User-Agent")).isEqualTo("langchain4j-openai");
+    }
+}

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/proxy/OpenAiProxyConfigurationTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/proxy/OpenAiProxyConfigurationTest.java
@@ -1,0 +1,62 @@
+package io.quarkiverse.langchain4j.openai.test.proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.logging.LogRecord;
+
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.SoftAssertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OpenAiProxyConfigurationTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.proxy-host", "localhost")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.proxy-port", "${quarkus.wiremock.devservices.port}")
+            .setLogRecordPredicate(record -> true)
+            .assertLogRecords(OpenAiProxyConfigurationTest::verifyLogRecords);
+
+    private static void verifyLogRecords(List<LogRecord> logRecords) {
+        assertThat(logRecords.stream().map(LogRecord::getMessage))
+                .contains(
+                        "Using deprecated 'proxy-host' configuration. Please migrate to 'proxy-configuration-name' using Quarkus Proxy Registry. The 'proxy-host', 'proxy-port', and 'proxy-type' properties will be removed in a future version.");
+    }
+
+    @Inject
+    ChatModel chatModel;
+
+    @BeforeEach
+    void reset() {
+        resetRequests();
+    }
+
+    @Test
+    void shouldUseDeprecatedProxyHost() {
+        setChatCompletionMessageContent("response");
+        String response = chatModel.chat("hello");
+
+        SoftAssertions softly = new SoftAssertions();
+        softly.assertThat(response).isEqualTo("response");
+        LoggedRequest loggedRequest = singleLoggedRequest();
+        softly.assertThat(loggedRequest.getHeader("User-Agent")).isEqualTo("langchain4j-openai");
+
+        softly.assertAll();
+    }
+}

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/proxy/ProxyConfigurationNameFoundTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/proxy/ProxyConfigurationNameFoundTest.java
@@ -1,0 +1,41 @@
+package io.quarkiverse.langchain4j.openai.test.proxy;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ProxyConfigurationNameFoundTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.proxy-configuration-name", "my-proxy");
+
+    @Inject
+    ChatModel chatModel;
+
+    @BeforeEach
+    void reset() {
+        resetRequests();
+    }
+
+    @Test
+    void shouldUseProxyFromRegistry() {
+        assertThatThrownBy(() -> chatModel.chat("hello"))
+                .hasMessageContaining(
+                        "Proxy configuration with name my-proxy was requested but quarkus.proxy.\"my-proxy\".host is not defined");
+    }
+}

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/proxy/ProxyImageModelTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/proxy/ProxyImageModelTest.java
@@ -1,0 +1,56 @@
+package io.quarkiverse.langchain4j.openai.test.proxy;
+
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.SoftAssertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+
+import dev.langchain4j.data.image.Image;
+import dev.langchain4j.model.image.ImageModel;
+import dev.langchain4j.model.output.Response;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ProxyImageModelTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.proxy-configuration-name", "local")
+            .overrideRuntimeConfigKey("quarkus.proxy.local.host", "localhost")
+            .overrideRuntimeConfigKey("quarkus.proxy.local.port", "${quarkus.wiremock.devservices.port}");
+
+    @Inject
+    ImageModel imageModel;
+
+    @BeforeEach
+    void reset() {
+        resetRequests();
+    }
+
+    @Test
+    public void shouldLoadImageModel() {
+
+        Response<Image> response = imageModel.generate("whatever");
+        SoftAssertions softly = new SoftAssertions();
+        softly.assertThat(response).isNotNull();
+        softly.assertThat(response.content().url().getHost()).isEqualTo("somewhere.com");
+
+        LoggedRequest loggedRequest = singleLoggedRequest();
+        softly.assertThat(loggedRequest.getHost()).isEqualTo("localhost");
+        softly.assertThat(loggedRequest.getPort()).isEqualTo(getResolvedWiremockPort());
+        softly.assertThat(loggedRequest.getHeader("User-Agent")).isEqualTo("Quarkus REST Client");
+
+        softly.assertAll();
+    }
+}

--- a/model-providers/openai/openai-vanilla/runtime/pom.xml
+++ b/model-providers/openai/openai-vanilla/runtime/pom.xml
@@ -16,6 +16,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-proxy-registry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>
         </dependency>

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/QuarkusOpenAiImageModel.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/QuarkusOpenAiImageModel.java
@@ -5,6 +5,7 @@ import static dev.langchain4j.internal.RetryUtils.withRetry;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.net.Proxy;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -65,6 +66,7 @@ public class QuarkusOpenAiImageModel implements ImageModel {
                 .logRequests(builder.logRequests)
                 .logResponses(builder.logResponses)
                 .logCurl(builder.logCurl != null && builder.logCurl)
+                .proxy(builder.proxy)
                 .build();
     }
 
@@ -154,6 +156,7 @@ public class QuarkusOpenAiImageModel implements ImageModel {
         private Boolean logResponses;
         private Boolean logCurl;
         private Optional<Path> persistDirectory;
+        private Proxy proxy;
 
         public Builder baseUrl(String baseUrl) {
             this.baseUrl = baseUrl;
@@ -237,6 +240,11 @@ public class QuarkusOpenAiImageModel implements ImageModel {
 
         public Builder persistDirectory(Optional<Path> persistDirectory) {
             this.persistDirectory = persistDirectory;
+            return this;
+        }
+
+        public Builder proxy(Proxy proxy) {
+            this.proxy = proxy;
             return this;
         }
 

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
@@ -17,6 +17,8 @@ import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.util.TypeLiteral;
 
+import org.jboss.logging.Logger;
+
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.DisabledChatModel;
 import dev.langchain4j.model.chat.DisabledStreamingChatModel;
@@ -48,6 +50,8 @@ import io.quarkiverse.langchain4j.openai.runtime.config.LangChain4jOpenAiConfig;
 import io.quarkiverse.langchain4j.openai.runtime.config.ModerationModelConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.proxy.ProxyConfiguration;
+import io.quarkus.proxy.ProxyConfigurationRegistry;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
@@ -55,6 +59,8 @@ import io.smallrye.config.ConfigValidationException;
 
 @Recorder
 public class OpenAiRecorder {
+
+    private static final Logger log = Logger.getLogger(OpenAiRecorder.class);
 
     private static final TypeLiteral<Instance<ChatModelListener>> CHAT_MODEL_LISTENER_TYPE_LITERAL = new TypeLiteral<>() {
     };
@@ -120,10 +126,6 @@ public class OpenAiRecorder {
                     .stop(chatModelConfig.stop().orElse(null));
 
             openAiConfig.organizationId().ifPresent(builder::organizationId);
-            openAiConfig.proxyHost().ifPresent(host -> {
-                builder.proxy(new Proxy(Type.valueOf(openAiConfig.proxyType()),
-                        new InetSocketAddress(host, openAiConfig.proxyPort())));
-            });
 
             if (chatModelConfig.maxTokens().isPresent()) {
                 builder.maxTokens(chatModelConfig.maxTokens().get());
@@ -137,9 +139,17 @@ public class OpenAiRecorder {
                 public ChatModel apply(SyntheticCreationalContext<ChatModel> context) {
                     builder.listeners(context.getInjectedReference(CHAT_MODEL_LISTENER_TYPE_LITERAL).stream()
                             .collect(Collectors.toList()));
+
+                    ProxyConfigurationRegistry proxyRegistry = context.getInjectedReference(ProxyConfigurationRegistry.class);
+                    Optional<Proxy> chatProxy = resolveProxy(openAiConfig, proxyRegistry);
+                    if (chatProxy.isPresent()) {
+                        builder.proxy(chatProxy.get());
+                    }
+
                     ModelBuilderCustomizer.applyCustomizers(
                             context.getInjectedReference(CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
                             builder, configName);
+
                     return builder.build();
                 }
             };
@@ -184,10 +194,6 @@ public class OpenAiRecorder {
                     .stop(chatModelConfig.stop().orElse(null));
 
             openAiConfig.organizationId().ifPresent(builder::organizationId);
-            openAiConfig.proxyHost().ifPresent(host -> {
-                builder.proxy(new Proxy(Type.valueOf(openAiConfig.proxyType()),
-                        new InetSocketAddress(host, openAiConfig.proxyPort())));
-            });
 
             if (chatModelConfig.maxTokens().isPresent()) {
                 builder.maxTokens(chatModelConfig.maxTokens().get());
@@ -202,6 +208,13 @@ public class OpenAiRecorder {
                         SyntheticCreationalContext<StreamingChatModel> context) {
                     builder.listeners(context.getInjectedReference(CHAT_MODEL_LISTENER_TYPE_LITERAL).stream()
                             .collect(Collectors.toList()));
+
+                    ProxyConfigurationRegistry proxyRegistry = context.getInjectedReference(ProxyConfigurationRegistry.class);
+                    Optional<Proxy> streamingProxy = resolveProxy(openAiConfig, proxyRegistry);
+                    if (streamingProxy.isPresent()) {
+                        builder.proxy(streamingProxy.get());
+                    }
+
                     ModelBuilderCustomizer.applyCustomizers(
                             context.getInjectedReference(STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
                             builder, configName);
@@ -248,17 +261,20 @@ public class OpenAiRecorder {
             }
 
             openAiConfig.organizationId().ifPresent(builder::organizationId);
-            openAiConfig.proxyHost().ifPresent(host -> {
-                builder.proxy(new Proxy(Type.valueOf(openAiConfig.proxyType()),
-                        new InetSocketAddress(host, openAiConfig.proxyPort())));
-            });
 
             return new Function<>() {
                 @Override
                 public EmbeddingModel apply(SyntheticCreationalContext<EmbeddingModel> context) {
+                    ProxyConfigurationRegistry proxyRegistry = context.getInjectedReference(ProxyConfigurationRegistry.class);
+                    Optional<Proxy> embeddingProxy = resolveProxy(openAiConfig, proxyRegistry);
+                    if (embeddingProxy.isPresent()) {
+                        builder.proxy(embeddingProxy.get());
+                    }
+
                     ModelBuilderCustomizer.applyCustomizers(
                             context.getInjectedReference(EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
                             builder, configName);
+
                     return builder.build();
                 }
             };
@@ -298,10 +314,6 @@ public class OpenAiRecorder {
                     .modelName(moderationModelConfig.modelName());
 
             openAiConfig.organizationId().ifPresent(builder::organizationId);
-            openAiConfig.proxyHost().ifPresent(host -> {
-                builder.proxy(new Proxy(Type.valueOf(openAiConfig.proxyType()),
-                        new InetSocketAddress(host, openAiConfig.proxyPort())));
-            });
 
             return new Function<>() {
                 @Override
@@ -309,6 +321,11 @@ public class OpenAiRecorder {
                     ModelBuilderCustomizer.applyCustomizers(
                             context.getInjectedReference(MODERATION_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
                             builder, configName);
+                    ProxyConfigurationRegistry proxyRegistry = context.getInjectedReference(ProxyConfigurationRegistry.class);
+                    Optional<Proxy> moderationProxy = resolveProxy(openAiConfig, proxyRegistry);
+                    if (moderationProxy.isPresent()) {
+                        builder.proxy(moderationProxy.get());
+                    }
                     return builder.build();
                 }
             };
@@ -376,6 +393,11 @@ public class OpenAiRecorder {
                     ModelBuilderCustomizer.applyCustomizers(
                             context.getInjectedReference(IMAGE_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
                             builder, configName);
+                    ProxyConfigurationRegistry proxyRegistry = context.getInjectedReference(ProxyConfigurationRegistry.class);
+                    Optional<Proxy> imageProxy = resolveProxy(openAiConfig, proxyRegistry);
+                    if (imageProxy.isPresent()) {
+                        builder.proxy(imageProxy.get());
+                    }
                     return builder.build();
                 }
             };
@@ -388,6 +410,52 @@ public class OpenAiRecorder {
             };
         }
 
+    }
+
+    @SuppressWarnings({ "removal" })
+    private Optional<Proxy> resolveProxy(LangChain4jOpenAiConfig.OpenAiConfig openAiConfig,
+            ProxyConfigurationRegistry proxyRegistry) {
+
+        if (openAiConfig.proxyConfigurationName().isPresent()) {
+            String configName = openAiConfig.proxyConfigurationName().get();
+
+            if (openAiConfig.proxyHost().isPresent()) {
+                log.warnf("Both 'proxy-configuration-name' (%s) and deprecated 'proxy-host' (%s) are set. " +
+                        "The 'proxy-host' configuration will be ignored. " +
+                        "Please remove 'proxy-host' and 'proxy-port' from your configuration.",
+                        configName, openAiConfig.proxyHost().get());
+            }
+
+            return proxyRegistry.get(openAiConfig.proxyConfigurationName())
+                    .map(new Function<ProxyConfiguration, Proxy>() {
+                        @Override
+                        public Proxy apply(ProxyConfiguration pc) {
+                            return new Proxy(
+                                    Type.valueOf(pc.type().name()),
+                                    new InetSocketAddress(pc.host(), pc.port()));
+                        }
+                    });
+        }
+
+        if (openAiConfig.proxyHost().isPresent()) {
+            log.warnf("Using deprecated 'proxy-host' configuration. " +
+                    "Please migrate to 'proxy-configuration-name' using Quarkus Proxy Registry. " +
+                    "The 'proxy-host', 'proxy-port', and 'proxy-type' properties will be removed in a future version.");
+
+            return Optional.of(new Proxy(
+                    Type.valueOf(openAiConfig.proxyType()),
+                    new InetSocketAddress(openAiConfig.proxyHost().get(), openAiConfig.proxyPort())));
+        }
+
+        return proxyRegistry.get(Optional.empty())
+                .map(new Function<ProxyConfiguration, Proxy>() {
+                    @Override
+                    public Proxy apply(ProxyConfiguration pc) {
+                        return new Proxy(
+                                Type.valueOf(pc.type().name()),
+                                new InetSocketAddress(pc.host(), pc.port()));
+                    }
+                });
     }
 
     private LangChain4jOpenAiConfig.OpenAiConfig correspondingOpenAiConfig(LangChain4jOpenAiConfig runtimeConfig,

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/LangChain4jOpenAiConfig.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/LangChain4jOpenAiConfig.java
@@ -107,20 +107,46 @@ public interface LangChain4jOpenAiConfig {
 
         /**
          * The Proxy type
+         *
+         * @deprecated Use {@code quarkus.langchain4j.openai.proxy-configuration-name} instead.
          */
         @WithDefault("HTTP")
+        @Deprecated(forRemoval = true)
         String proxyType();
 
         /**
          * The Proxy host
+         *
+         * @deprecated Use {@code quarkus.langchain4j.openai.proxy-configuration-name} instead.
          */
+        @Deprecated(forRemoval = true)
         Optional<String> proxyHost();
 
         /**
          * The Proxy port
+         *
+         * @deprecated Use {@code quarkus.langchain4j.openai.proxy-configuration-name} instead.
          */
+        @Deprecated(forRemoval = true)
         @WithDefault("3128")
         Integer proxyPort();
+
+        /**
+         * Proxy configuration name.
+         * <p>
+         * There are some rules for using Quarkus Proxy Registry configuration:
+         * <ul>
+         * <li>If {@code quarkus.langchain4j.openai.proxy-configuration-name} is set, it takes precedence over
+         * <code>proxy-host</code>
+         * configuration.</li>
+         * <li>If not set and the default proxy configuration is configured ({@code quarkus.proxy.*}) then that will be
+         * used.</li>
+         * <li>If the proxy configuration name is set, the configuration from {@code quarkus.proxy.<name>.*} will be used.</li>
+         * <li>If the proxy configuration name is set, but no proxy configuration is found with that name, then an error will be
+         * thrown at runtime.</li>
+         * </ul>
+         */
+        Optional<String> proxyConfigurationName();
 
         /**
          * Chat model related settings

--- a/model-providers/openai/openai-vanilla/runtime/src/test/java/io/quarkiverse/langchain4j/openai/runtime/DisabledModelsOpenAiRecorderTest.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/test/java/io/quarkiverse/langchain4j/openai/runtime/DisabledModelsOpenAiRecorderTest.java
@@ -1,19 +1,26 @@
 package io.quarkiverse.langchain4j.openai.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.DisabledChatModel;
 import dev.langchain4j.model.chat.DisabledStreamingChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.embedding.DisabledEmbeddingModel;
+import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.image.DisabledImageModel;
+import dev.langchain4j.model.image.ImageModel;
 import dev.langchain4j.model.moderation.DisabledModerationModel;
+import dev.langchain4j.model.moderation.ModerationModel;
 import io.quarkiverse.langchain4j.openai.runtime.config.LangChain4jOpenAiConfig;
 import io.quarkiverse.langchain4j.openai.runtime.config.LangChain4jOpenAiConfig.OpenAiConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
+import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.runtime.RuntimeValue;
 
 class DisabledModelsOpenAiRecorderTest {
@@ -32,35 +39,41 @@ class DisabledModelsOpenAiRecorderTest {
 
     @Test
     void disabledChatModel() {
-        assertThat(recorder.chatModel(NamedConfigUtil.DEFAULT_NAME).apply(null))
+        SyntheticCreationalContext<ChatModel> mock = mock(SyntheticCreationalContext.class);
+
+        assertThat(recorder.chatModel(NamedConfigUtil.DEFAULT_NAME).apply(mock))
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledChatModel.class);
     }
 
     @Test
     void disabledStreamingChatModel() {
-        assertThat(recorder.streamingChatModel(NamedConfigUtil.DEFAULT_NAME).apply(null))
+        SyntheticCreationalContext<StreamingChatModel> mock = mock(SyntheticCreationalContext.class);
+        assertThat(recorder.streamingChatModel(NamedConfigUtil.DEFAULT_NAME).apply(mock))
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledStreamingChatModel.class);
     }
 
     @Test
     void disabledEmbeddingModel() {
-        assertThat(recorder.embeddingModel(NamedConfigUtil.DEFAULT_NAME).apply(null))
+        SyntheticCreationalContext<EmbeddingModel> mock = mock(SyntheticCreationalContext.class);
+        assertThat(recorder.embeddingModel(NamedConfigUtil.DEFAULT_NAME).apply(mock))
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledEmbeddingModel.class);
     }
 
     @Test
     void disabledImageModel() {
-        assertThat(recorder.imageModel(NamedConfigUtil.DEFAULT_NAME).apply(null))
+        SyntheticCreationalContext<ImageModel> mock = mock(SyntheticCreationalContext.class);
+        assertThat(recorder.imageModel(NamedConfigUtil.DEFAULT_NAME).apply(mock))
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledImageModel.class);
     }
 
     @Test
     void disabledModerationModel() {
-        assertThat(recorder.moderationModel(NamedConfigUtil.DEFAULT_NAME).apply(null))
+        SyntheticCreationalContext<ModerationModel> mock = mock(SyntheticCreationalContext.class);
+        assertThat(recorder.moderationModel(NamedConfigUtil.DEFAULT_NAME).apply(mock))
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledModerationModel.class);
     }


### PR DESCRIPTION
# Description 

This pull request updates the OpenAI provider to use the Quarkus Proxy Registry for proxy configuration, deprecating the older individual proxy properties. 

**Proxy configuration improvements:**

* Introduced support for specifying a proxy configuration by name using the new `quarkus.langchain4j.openai.proxy-configuration-name` and `quarkus.langchain4j.openai."model-name".proxy-configuration-name` properties, with clear rules on precedence and error handling if the named configuration is missing. [[1]](diffhunk://#diff-5edf81e3a6af30b800b5b7d1b46a83cd19ff0527bb5426d5b573442ea06da134L304-L366) [[2]](diffhunk://#diff-5edf81e3a6af30b800b5b7d1b46a83cd19ff0527bb5426d5b573442ea06da134L1279-L1341)
* Deprecated the old proxy properties (`proxy-type`, `proxy-host`, `proxy-port`) in favor of the new proxy registry-based configuration, and updated documentation to reflect this change, including deprecation notices and migration instructions.

**Code integration:**

* Imported `ProxyConfigurationRegistry` and related Quarkus classes in `OpenAiRecorder.java` to prepare for proxy registry integration in the runtime logic.

- Closes: #2309 