### PR TITLE
Add `thinking.display` config for Anthropic chat model

### DIFF
--- a/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/AnthropicRecorder.java
+++ b/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/AnthropicRecorder.java
@@ -127,6 +127,10 @@ public class AnthropicRecorder {
                 builder.sendThinking(thinkingConfig.sendThinking().get());
             }
 
+            if (thinkingConfig.display().isPresent()) {
+                builder.thinkingDisplay(thinkingConfig.display().get());
+            }
+
             // Pass caching configuration to builder
             builder.cacheSystemMessages(chatModelConfig.cacheSystemMessages());
             builder.cacheTools(chatModelConfig.cacheTools());
@@ -270,6 +274,10 @@ public class AnthropicRecorder {
 
             if (thinkingConfig.sendThinking().isPresent()) {
                 builder.sendThinking(thinkingConfig.sendThinking().get());
+            }
+
+            if (thinkingConfig.display().isPresent()) {
+                builder.thinkingDisplay(thinkingConfig.display().get());
             }
 
             // Pass caching configuration to builder

--- a/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/AnthropicRecorder.java
+++ b/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/AnthropicRecorder.java
@@ -118,6 +118,10 @@ public class AnthropicRecorder {
                 builder.sendThinking(thinkingConfig.sendThinking().get());
             }
 
+            if (thinkingConfig.display().isPresent()) {
+                builder.thinkingDisplay(thinkingConfig.display().get());
+            }
+
             // Pass caching configuration to builder
             builder.cacheSystemMessages(chatModelConfig.cacheSystemMessages());
             builder.cacheTools(chatModelConfig.cacheTools());
@@ -258,6 +262,10 @@ public class AnthropicRecorder {
 
             if (thinkingConfig.sendThinking().isPresent()) {
                 builder.sendThinking(thinkingConfig.sendThinking().get());
+            }
+
+            if (thinkingConfig.display().isPresent()) {
+                builder.thinkingDisplay(thinkingConfig.display().get());
             }
 
             // Pass caching configuration to builder

--- a/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/config/ChatModelConfig.java
+++ b/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/config/ChatModelConfig.java
@@ -148,6 +148,17 @@ public interface ChatModelConfig {
         Optional<Boolean> sendThinking();
 
         /**
+         * Controls how thinking content is returned by the Anthropic API.
+         * <p>
+         * Valid values: {@code "summarized"} and {@code "omitted"}. On Claude Opus 4.7
+         * the server default is {@code "omitted"} (thinking blocks are empty in the
+         * response). On earlier Opus/Sonnet models the default is {@code "summarized"}.
+         * Set to {@code "summarized"} explicitly on Opus 4.7+ if your product renders
+         * thinking text to users.
+         */
+        Optional<String> display();
+
+        /**
          * Enable interleaved thinking for Claude 4 models, allowing reasoning between tool calls.
          * Requires Claude 4 model (e.g., claude-opus-4-20250514) and thinking.type: enabled.
          */


### PR DESCRIPTION
Exposes the Anthropic API's thinking `display` parameter so users can opt into `summarized` thinking output on Claude Opus 4.7+, where the server default is `omitted`.

DRAFT: depends on [langchain4j PR](https://github.com/langchain4j/langchain4j/pull/4950)