### PR TITLE
Have `NoopChatMemory` maintain a local copy of messages

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionWithNoopChatMemoryTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionWithNoopChatMemoryTest.java
@@ -1,0 +1,159 @@
+package io.quarkiverse.langchain4j.test.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.ToolBox;
+import io.quarkiverse.langchain4j.runtime.aiservice.NoopChatMemory;
+import io.quarkiverse.langchain4j.test.Lists;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests that tool execution works correctly with NoopChatMemory (agents without memory).
+ * <p>
+ * This test validates the fix for the issue where tool execution would fail with NoopChatMemory
+ * because the messages list would be empty during subsequent chat requests.
+ * The fix maintains a local copy of messages during the tool execution loop.
+ * <p>
+ * Note: We use a custom ChatMemoryProviderSupplier (not NoChatMemoryProviderSupplier) to bypass
+ * the build-time validation while still testing the runtime behavior with NoopChatMemory.
+ */
+public class ToolExecutionWithNoopChatMemoryTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyAiService.class, MyTools.class, Lists.class));
+
+    @Inject
+    MyAiService aiService;
+
+    /**
+     * Tests that tool execution works correctly with NoopChatMemory.
+     * The fix ensures messages are accumulated in a local list during the tool loop,
+     * so the second chat request receives the proper message history.
+     */
+    @Test
+    @ActivateRequestContext
+    void testToolExecutionWithNoopChatMemory() {
+        String response = aiService.chat("memoryId", "call tool");
+        assertThat(response).isEqualTo("Tool returned: \"bar\"");
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = NullChatMemoryProviderSupplier.class)
+    public interface MyAiService {
+
+        @ToolBox(MyTools.class)
+        String chat(@MemoryId String memoryId, @UserMessage String userMessage);
+    }
+
+    public static class NullChatMemoryProviderSupplier implements Supplier<ChatMemoryProvider> {
+
+        @Override
+        public ChatMemoryProvider get() {
+            return null;
+        }
+    }
+
+    @Singleton
+    public static class MyTools {
+
+        @Tool("A simple tool for testing")
+        public String simpleTool() {
+            return "bar";
+        }
+    }
+
+    public static class MyChatModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new MyChatModel();
+        }
+    }
+
+    /**
+     * Mock ChatModel that simulates tool execution flow.
+     * - First call (1 message): returns tool execution request
+     * - Second call (3 messages): validates fix worked and returns final response
+     */
+    public static class MyChatModel implements ChatModel {
+
+        @Override
+        public ChatResponse chat(List<ChatMessage> messages) {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            List<ChatMessage> messages = chatRequest.messages();
+
+            if (messages.size() == 1) {
+                // First request: only user message - return tool execution request
+                return ChatResponse.builder()
+                        .aiMessage(new AiMessage("Calling tool", List.of(
+                                ToolExecutionRequest.builder()
+                                        .id("tool-1")
+                                        .name("simpleTool")
+                                        .arguments("{}")
+                                        .build())))
+                        .tokenUsage(new TokenUsage(0, 0))
+                        .finishReason(FinishReason.TOOL_EXECUTION)
+                        .build();
+            } else if (messages.size() == 3) {
+                // Second request: should have user + AI + tool result
+                // This validates the fix - with NoopChatMemory, without the fix this would be empty
+                ToolExecutionResultMessage toolResult = (ToolExecutionResultMessage) Lists.last(messages);
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.from("Tool returned: " + toolResult.text()))
+                        .finishReason(FinishReason.STOP)
+                        .build();
+            }
+
+            throw new IllegalStateException("Unexpected message count: " + messages.size());
+        }
+    }
+
+    /**
+     * Custom ChatMemoryProviderSupplier that provides NoopChatMemory.
+     * This bypasses the build-time validation (which checks for NoChatMemoryProviderSupplier)
+     * while still testing the runtime behavior with NoopChatMemory.
+     */
+    @Singleton
+    public static class CustomNoopChatMemoryProviderSupplier implements Supplier<ChatMemoryProvider> {
+        @Override
+        public ChatMemoryProvider get() {
+            return new ChatMemoryProvider() {
+                @Override
+                public ChatMemory get(Object memoryId) {
+                    return new NoopChatMemory();
+                }
+            };
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
@@ -420,6 +420,9 @@ public class AiServiceMethodImplementationSupport {
                         : getMaxSequentialToolExecutions();
         int executionsLeft = maxSequentialToolExecutions;
         List<ChatResponse> intermediateResponses = new ArrayList<>();
+        // Maintain a local copy of messages for the tool execution loop
+        // This is needed because NoopChatMemory (used by AgentWithoutMemory) discards all messages
+        List<ChatMessage> currentMessages = new ArrayList<>(messagesToSend);
         while (true) {
             if (executionsLeft-- == 0) {
                 throw runtime("Something is wrong, exceeded %s sequential tool executions",
@@ -428,6 +431,7 @@ public class AiServiceMethodImplementationSupport {
 
             AiMessage aiMessage = response.aiMessage();
             committableChatMemory.add(aiMessage);
+            currentMessages.add(aiMessage);
 
             if (!aiMessage.hasToolExecutionRequests()) {
                 break;
@@ -472,6 +476,7 @@ public class AiServiceMethodImplementationSupport {
             }
             for (ToolExecutionResultMessage toolResult : toolResults) {
                 committableChatMemory.add(toolResult);
+                currentMessages.add(toolResult);
             }
             if (immediateToolReturn) {
                 if (!TypeUtil.isResult(returnType)) {
@@ -500,7 +505,7 @@ public class AiServiceMethodImplementationSupport {
 
             log.debug("Attempting to obtain AI response");
             ChatModel effectiveChatModel = context.effectiveChatModel(methodCreateInfo, methodArgs);
-            ChatRequest.Builder chatRequestBuilder = ChatRequest.builder().messages(committableChatMemory.messages());
+            ChatRequest.Builder chatRequestBuilder = ChatRequest.builder().messages(currentMessages);
             DefaultChatRequestParameters.Builder<?> parametersBuilder = ChatRequestParameters.builder();
             if (supportsJsonSchema(effectiveChatModel)) {
                 Optional<JsonSchema> jsonSchema = methodCreateInfo.getResponseSchemaInfo().structuredOutputSchema();

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/NoopChatMemory.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/NoopChatMemory.java
@@ -1,6 +1,6 @@
 package io.quarkiverse.langchain4j.runtime.aiservice;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 
 import dev.langchain4j.data.message.ChatMessage;
@@ -23,7 +23,7 @@ public class NoopChatMemory implements CommittableChatMemory {
 
     @Override
     public List<ChatMessage> messages() {
-        return Collections.emptyList();
+        return new ArrayList<>();
     }
 
     @Override


### PR DESCRIPTION
  Tool execution failed when using NoopChatMemory (agents without persistent chat memory) because the
   second chat request in the tool execution loop received an empty messages list, causing the error:
   "messages cannot be null or empty".                                                               
                  
  NoopChatMemory is intentionally designed to discard all messages (no-op implementation), but the   
  code was relying on committableChatMemory.messages() to build subsequent chat requests during tool
  execution loops.                                                                                   
                  
  Implemented fix:                                                                                           
  
  - Add messages to both committableChatMemory (for agents with memory) AND the local list           
  - Use the local list when building chat requests instead of calling                                
  committableChatMemory.messages()                                   
  - This ensures tool execution works correctly with both stateful and stateless agents 
  - Messages list in NoopChatMemory is changed from unmodifiable list to ArrayList to avoid issue during ative compilation with camel-quarkus-langchain4j on classpath

Test `ToolExecutionWithNoopChatMemoryTest` covers the scenario.

- Fixes: https://github.com/quarkiverse/quarkus-langchain4j/issues/2344