### PR TITLE
Add support for additional model options in Ollama extension

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/devservice/DevServicesOllamaProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/devservice/DevServicesOllamaProcessor.java
@@ -3,6 +3,7 @@ package io.quarkiverse.langchain4j.deployment.devservice;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -190,6 +191,19 @@ public class DevServicesOllamaProcessor {
             for (var bi : allOllamaModels) {
                 modelBaseUrls.put(bi.getBaseUrlProperty(), ollamaBaseUrl);
             }
+
+            Map<String, String> modelOptions = ollamaDevServicesConfig
+                    .map(DevServicesOllamaConfigBuildItem::getModelOptions)
+                    .orElse(Collections.emptyMap());
+
+            if (!modelOptions.isEmpty()) {
+                LOGGER.infof("Applying model options from Dev Services: %s", modelOptions);
+                for (Map.Entry<String, String> entry : modelOptions.entrySet()) {
+                    modelBaseUrls.put("quarkus.langchain4j.ollama.chat-model.model-options." + entry.getKey(),
+                            entry.getValue());
+                }
+            }
+
             producer.produce(new DevServicesResultBuildItem("ollama", null, modelBaseUrls));
 
         } catch (OllamaClient.ServerUnavailableException e) {

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/items/DevServicesOllamaConfigBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/items/DevServicesOllamaConfigBuildItem.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.langchain4j.deployment.items;
 
+import java.util.Collections;
 import java.util.Map;
 
 import io.quarkus.builder.item.SimpleBuildItem;
@@ -10,13 +11,23 @@ import io.quarkus.builder.item.SimpleBuildItem;
 public final class DevServicesOllamaConfigBuildItem extends SimpleBuildItem {
 
     private final Map<String, String> config;
+    private final Map<String, String> modelOptions;
 
     public DevServicesOllamaConfigBuildItem(Map<String, String> config) {
+        this(config, Collections.emptyMap());
+    }
+
+    public DevServicesOllamaConfigBuildItem(Map<String, String> config, Map<String, String> modelOptions) {
         this.config = config;
+        this.modelOptions = modelOptions != null ? modelOptions : Collections.emptyMap();
     }
 
     public Map<String, String> getConfig() {
         return config;
+    }
+
+    public Map<String, String> getModelOptions() {
+        return modelOptions;
     }
 
 }

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-ollama.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-ollama.adoc
@@ -114,6 +114,27 @@ endif::add-copy-button-to-env-var[]
 |int
 |
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-devservices-model-options-model-options]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-devservices-model-options-model-options[`+++quarkus.langchain4j.ollama.devservices.model-options."model-options"+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama.devservices.model-options."model-options"+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Additional model options to apply when pulling/loading the model. These options will be propagated to the chat-model configuration. For example: `quarkus.langchain4j.ollama.devservices.model-options.think=true`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA_DEVSERVICES_MODEL_OPTIONS__MODEL_OPTIONS_+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA_DEVSERVICES_MODEL_OPTIONS__MODEL_OPTIONS_+++`
+endif::add-copy-button-to-env-var[]
+--
+|Map<String,String>
+|`+++{}+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-id]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-id[`+++quarkus.langchain4j.ollama.chat-model.model-id+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.ollama.chat-model.model-id+++[]
@@ -496,6 +517,195 @@ endif::add-copy-button-to-env-var[]
 --
 |boolean
 |`+++false+++`
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-think]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-think[`+++quarkus.langchain4j.ollama.chat-model.model-options.think+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama.chat-model.model-options.think+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enable thinking mode for models that support it (e.g., Qwen3). When enabled, the model will output its reasoning process.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_THINK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_THINK+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-return-thinking]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-return-thinking[`+++quarkus.langchain4j.ollama.chat-model.model-options.return-thinking+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama.chat-model.model-options.return-thinking+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to return thinking/reasoning content in the response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_RETURN_THINKING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_RETURN_THINKING+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-num-ctx]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-num-ctx[`+++quarkus.langchain4j.ollama.chat-model.model-options.num-ctx+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama.chat-model.model-options.num-ctx+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Sets the size of the context window used to generate the next token.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_NUM_CTX+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_NUM_CTX+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-repeat-last-n]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-repeat-last-n[`+++quarkus.langchain4j.ollama.chat-model.model-options.repeat-last-n+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama.chat-model.model-options.repeat-last-n+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The last N tokens to penalize. Higher values will penalize more.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_REPEAT_LAST_N+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_REPEAT_LAST_N+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-repeat-penalty]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-repeat-penalty[`+++quarkus.langchain4j.ollama.chat-model.model-options.repeat-penalty+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama.chat-model.model-options.repeat-penalty+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The penalty for repeated tokens. Higher values will penalize repetition more.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_REPEAT_PENALTY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_REPEAT_PENALTY+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-mirostat]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-mirostat[`+++quarkus.langchain4j.ollama.chat-model.model-options.mirostat+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama.chat-model.model-options.mirostat+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enable Mirostat sampling for controlling perplexity. 0 = disabled, 1 = Mirostat, 2 = Mirostat 2.0.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_MIROSTAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_MIROSTAT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-mirostat-eta]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-mirostat-eta[`+++quarkus.langchain4j.ollama.chat-model.model-options.mirostat-eta+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama.chat-model.model-options.mirostat-eta+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Controls the learning rate of Mirostat. Lower values result in slower adjustments.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_MIROSTAT_ETA+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_MIROSTAT_ETA+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-mirostat-tau]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-mirostat-tau[`+++quarkus.langchain4j.ollama.chat-model.model-options.mirostat-tau+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama.chat-model.model-options.mirostat-tau+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Controls the target perplexity for Mirostat. Lower values produce more focused outputs.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_MIROSTAT_TAU+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_MIROSTAT_TAU+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-min-p]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-min-p[`+++quarkus.langchain4j.ollama.chat-model.model-options.min-p+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama.chat-model.model-options.min-p+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Sets the minimum probability relative to the most likely token. Lower values will result in more diverse outputs.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_MIN_P+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_MIN_P+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
 
 a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-embedding-model-temperature]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-embedding-model-temperature[`+++quarkus.langchain4j.ollama.embedding-model.temperature+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -1030,6 +1240,195 @@ endif::add-copy-button-to-env-var[]
 --
 |boolean
 |`+++false+++`
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-think]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-think[`+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.think+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.think+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enable thinking mode for models that support it (e.g., Qwen3). When enabled, the model will output its reasoning process.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_THINK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_THINK+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-return-thinking]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-return-thinking[`+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.return-thinking+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.return-thinking+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to return thinking/reasoning content in the response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_RETURN_THINKING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_RETURN_THINKING+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-num-ctx]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-num-ctx[`+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.num-ctx+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.num-ctx+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Sets the size of the context window used to generate the next token.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_NUM_CTX+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_NUM_CTX+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-repeat-last-n]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-repeat-last-n[`+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.repeat-last-n+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.repeat-last-n+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The last N tokens to penalize. Higher values will penalize more.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_REPEAT_LAST_N+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_REPEAT_LAST_N+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-repeat-penalty]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-repeat-penalty[`+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.repeat-penalty+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.repeat-penalty+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The penalty for repeated tokens. Higher values will penalize repetition more.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_REPEAT_PENALTY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_REPEAT_PENALTY+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-mirostat]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-mirostat[`+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.mirostat+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.mirostat+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enable Mirostat sampling for controlling perplexity. 0 = disabled, 1 = Mirostat, 2 = Mirostat 2.0.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_MIROSTAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_MIROSTAT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-mirostat-eta]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-mirostat-eta[`+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.mirostat-eta+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.mirostat-eta+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Controls the learning rate of Mirostat. Lower values result in slower adjustments.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_MIROSTAT_ETA+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_MIROSTAT_ETA+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-mirostat-tau]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-mirostat-tau[`+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.mirostat-tau+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.mirostat-tau+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Controls the target perplexity for Mirostat. Lower values produce more focused outputs.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_MIROSTAT_TAU+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_MIROSTAT_TAU+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-min-p]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-min-p[`+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.min-p+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.min-p+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Sets the minimum probability relative to the most likely token. Lower values will result in more diverse outputs.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_MIN_P+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_MIN_P+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
 
 a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-embedding-model-temperature]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-embedding-model-temperature[`+++quarkus.langchain4j.ollama."model-name".embedding-model.temperature+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-ollama_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-ollama_quarkus.langchain4j.adoc
@@ -114,6 +114,27 @@ endif::add-copy-button-to-env-var[]
 |int
 |
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-devservices-model-options-model-options]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-devservices-model-options-model-options[`+++quarkus.langchain4j.ollama.devservices.model-options."model-options"+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama.devservices.model-options."model-options"+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Additional model options to apply when pulling/loading the model. These options will be propagated to the chat-model configuration. For example: `quarkus.langchain4j.ollama.devservices.model-options.think=true`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA_DEVSERVICES_MODEL_OPTIONS__MODEL_OPTIONS_+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA_DEVSERVICES_MODEL_OPTIONS__MODEL_OPTIONS_+++`
+endif::add-copy-button-to-env-var[]
+--
+|Map<String,String>
+|`+++{}+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-id]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-id[`+++quarkus.langchain4j.ollama.chat-model.model-id+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.ollama.chat-model.model-id+++[]
@@ -496,6 +517,195 @@ endif::add-copy-button-to-env-var[]
 --
 |boolean
 |`+++false+++`
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-think]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-think[`+++quarkus.langchain4j.ollama.chat-model.model-options.think+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama.chat-model.model-options.think+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enable thinking mode for models that support it (e.g., Qwen3). When enabled, the model will output its reasoning process.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_THINK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_THINK+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-return-thinking]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-return-thinking[`+++quarkus.langchain4j.ollama.chat-model.model-options.return-thinking+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama.chat-model.model-options.return-thinking+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to return thinking/reasoning content in the response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_RETURN_THINKING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_RETURN_THINKING+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-num-ctx]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-num-ctx[`+++quarkus.langchain4j.ollama.chat-model.model-options.num-ctx+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama.chat-model.model-options.num-ctx+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Sets the size of the context window used to generate the next token.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_NUM_CTX+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_NUM_CTX+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-repeat-last-n]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-repeat-last-n[`+++quarkus.langchain4j.ollama.chat-model.model-options.repeat-last-n+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama.chat-model.model-options.repeat-last-n+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The last N tokens to penalize. Higher values will penalize more.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_REPEAT_LAST_N+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_REPEAT_LAST_N+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-repeat-penalty]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-repeat-penalty[`+++quarkus.langchain4j.ollama.chat-model.model-options.repeat-penalty+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama.chat-model.model-options.repeat-penalty+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The penalty for repeated tokens. Higher values will penalize repetition more.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_REPEAT_PENALTY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_REPEAT_PENALTY+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-mirostat]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-mirostat[`+++quarkus.langchain4j.ollama.chat-model.model-options.mirostat+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama.chat-model.model-options.mirostat+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enable Mirostat sampling for controlling perplexity. 0 = disabled, 1 = Mirostat, 2 = Mirostat 2.0.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_MIROSTAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_MIROSTAT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-mirostat-eta]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-mirostat-eta[`+++quarkus.langchain4j.ollama.chat-model.model-options.mirostat-eta+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama.chat-model.model-options.mirostat-eta+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Controls the learning rate of Mirostat. Lower values result in slower adjustments.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_MIROSTAT_ETA+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_MIROSTAT_ETA+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-mirostat-tau]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-mirostat-tau[`+++quarkus.langchain4j.ollama.chat-model.model-options.mirostat-tau+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama.chat-model.model-options.mirostat-tau+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Controls the target perplexity for Mirostat. Lower values produce more focused outputs.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_MIROSTAT_TAU+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_MIROSTAT_TAU+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-min-p]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-chat-model-model-options-min-p[`+++quarkus.langchain4j.ollama.chat-model.model-options.min-p+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama.chat-model.model-options.min-p+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Sets the minimum probability relative to the most likely token. Lower values will result in more diverse outputs.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_MIN_P+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_OPTIONS_MIN_P+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
 
 a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-embedding-model-temperature]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-embedding-model-temperature[`+++quarkus.langchain4j.ollama.embedding-model.temperature+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -1030,6 +1240,195 @@ endif::add-copy-button-to-env-var[]
 --
 |boolean
 |`+++false+++`
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-think]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-think[`+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.think+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.think+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enable thinking mode for models that support it (e.g., Qwen3). When enabled, the model will output its reasoning process.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_THINK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_THINK+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-return-thinking]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-return-thinking[`+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.return-thinking+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.return-thinking+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to return thinking/reasoning content in the response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_RETURN_THINKING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_RETURN_THINKING+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-num-ctx]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-num-ctx[`+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.num-ctx+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.num-ctx+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Sets the size of the context window used to generate the next token.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_NUM_CTX+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_NUM_CTX+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-repeat-last-n]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-repeat-last-n[`+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.repeat-last-n+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.repeat-last-n+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The last N tokens to penalize. Higher values will penalize more.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_REPEAT_LAST_N+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_REPEAT_LAST_N+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-repeat-penalty]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-repeat-penalty[`+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.repeat-penalty+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.repeat-penalty+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The penalty for repeated tokens. Higher values will penalize repetition more.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_REPEAT_PENALTY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_REPEAT_PENALTY+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-mirostat]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-mirostat[`+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.mirostat+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.mirostat+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enable Mirostat sampling for controlling perplexity. 0 = disabled, 1 = Mirostat, 2 = Mirostat 2.0.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_MIROSTAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_MIROSTAT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-mirostat-eta]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-mirostat-eta[`+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.mirostat-eta+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.mirostat-eta+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Controls the learning rate of Mirostat. Lower values result in slower adjustments.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_MIROSTAT_ETA+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_MIROSTAT_ETA+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-mirostat-tau]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-mirostat-tau[`+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.mirostat-tau+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.mirostat-tau+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Controls the target perplexity for Mirostat. Lower values produce more focused outputs.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_MIROSTAT_TAU+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_MIROSTAT_TAU+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-min-p]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-chat-model-model-options-min-p[`+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.min-p+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.ollama."model-name".chat-model.model-options.min-p+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Sets the minimum probability relative to the most likely token. Lower values will result in more diverse outputs.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_MIN_P+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OLLAMA__MODEL_NAME__CHAT_MODEL_MODEL_OPTIONS_MIN_P+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
 
 a| [[quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-embedding-model-temperature]] [.property-path]##link:#quarkus-langchain4j-ollama_quarkus-langchain4j-ollama-model-name-embedding-model-temperature[`+++quarkus.langchain4j.ollama."model-name".embedding-model.temperature+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/model-providers/ollama/deployment/src/main/java/io/quarkiverse/langchain4j/ollama/deployment/devservices/OllamaDevServicesBuildConfig.java
+++ b/model-providers/ollama/deployment/src/main/java/io/quarkiverse/langchain4j/ollama/deployment/devservices/OllamaDevServicesBuildConfig.java
@@ -1,7 +1,9 @@
 package io.quarkiverse.langchain4j.ollama.deployment.devservices;
 
+import java.util.Map;
 import java.util.OptionalInt;
 
+import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
@@ -35,4 +37,12 @@ public interface OllamaDevServicesBuildConfig {
      * </p>
      */
     OptionalInt port();
+
+    /**
+     * Additional model options to apply when pulling/loading the model.
+     * These options will be propagated to the chat-model configuration.
+     * For example: {@code quarkus.langchain4j.ollama.devservices.model-options.think=true}
+     */
+    @ConfigDocDefault("{}")
+    Map<String, String> modelOptions();
 }

--- a/model-providers/ollama/deployment/src/main/java/io/quarkiverse/langchain4j/ollama/deployment/devservices/OllamaDevServicesProcessor.java
+++ b/model-providers/ollama/deployment/src/main/java/io/quarkiverse/langchain4j/ollama/deployment/devservices/OllamaDevServicesProcessor.java
@@ -3,6 +3,7 @@ package io.quarkiverse.langchain4j.ollama.deployment.devservices;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.jboss.logging.Logger;
@@ -80,6 +81,10 @@ public class OllamaDevServicesProcessor {
         if (isOllamaClientRunning()) {
             log.infof("Not starting Ollama dev services container, as there is already an Ollama instance running on port %d",
                     OllamaContainer.DEFAULT_OLLAMA_PORT);
+
+            Map<String, String> modelOptions = ollamaDevServicesBuildConfig.modelOptions();
+            ollamaDevServicesBuildItemBuildProducer.produce(
+                    new DevServicesOllamaConfigBuildItem(Map.of(), modelOptions));
             return;
         }
 
@@ -117,7 +122,12 @@ public class OllamaDevServicesProcessor {
 
                 if (devService.isOwner()) {
                     log.info("Dev Services for Ollama started.");
-                    ollamaDevServicesBuildItemBuildProducer.produce(new DevServicesOllamaConfigBuildItem(devServiceConfig));
+                    Map<String, String> modelOptions = ollamaDevServicesBuildConfig.modelOptions();
+                    if (modelOptions != null && !modelOptions.isEmpty()) {
+                        log.infof("Applying model options from Dev Services: %s", modelOptions);
+                    }
+                    ollamaDevServicesBuildItemBuildProducer.produce(
+                            new DevServicesOllamaConfigBuildItem(devServiceConfig, modelOptions));
                 }
 
                 // Configure the watch dog

--- a/model-providers/ollama/deployment/src/test/java/io/quarkiverse/langchain4j/ollama/deployment/OllamaModelOptionsRequestTest.java
+++ b/model-providers/ollama/deployment/src/test/java/io/quarkiverse/langchain4j/ollama/deployment/OllamaModelOptionsRequestTest.java
@@ -1,0 +1,58 @@
+package io.quarkiverse.langchain4j.ollama.deployment;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OllamaModelOptionsRequestTest extends WiremockAware {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.ollama.base-url", WiremockAware.wiremockUrlForConfig())
+            .overrideConfigKey("quarkus.langchain4j.ollama.chat-model.model-name", "qwen3:1.7b")
+            .overrideConfigKey("quarkus.langchain4j.ollama.chat-model.model-options.think", "true")
+            .overrideConfigKey("quarkus.langchain4j.devservices.enabled", "false");
+
+    @Inject
+    ChatModel chatModel;
+
+    @Test
+    void shouldSendThinkOptionInRequest() {
+        wiremock().register(
+                post(urlEqualTo("/api/chat"))
+                        .withRequestBody(matchingJsonPath("$.model", equalTo("qwen3:1.7b")))
+                        .withRequestBody(matchingJsonPath("$.think", equalTo("true")))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("""
+                                        {
+                                          "model": "qwen3:1.7b",
+                                          "created_at": "2024-12-11T15:21:23.422542932Z",
+                                          "message": {
+                                            "role": "assistant",
+                                            "content": "Hello!"
+                                          },
+                                          "done_reason": "stop",
+                                          "done": true
+                                        }
+                                        """)));
+
+        String response = chatModel.chat("Say hello");
+        assertThat(response).isEqualTo("Hello!");
+    }
+}

--- a/model-providers/ollama/deployment/src/test/java/io/quarkiverse/langchain4j/ollama/deployment/OllamaStreamingModelOptionsRequestTest.java
+++ b/model-providers/ollama/deployment/src/test/java/io/quarkiverse/langchain4j/ollama/deployment/OllamaStreamingModelOptionsRequestTest.java
@@ -1,0 +1,77 @@
+package io.quarkiverse.langchain4j.ollama.deployment;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+
+public class OllamaStreamingModelOptionsRequestTest extends WiremockAware {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.ollama.base-url", WiremockAware.wiremockUrlForConfig())
+            .overrideConfigKey("quarkus.langchain4j.ollama.chat-model.model-name", "qwen3:1.7b")
+            .overrideConfigKey("quarkus.langchain4j.ollama.chat-model.model-options.think", "true")
+            .overrideConfigKey("quarkus.langchain4j.ollama.chat-model.seed", "42")
+            .overrideConfigKey("quarkus.langchain4j.devservices.enabled", "false");
+
+    @Singleton
+    @RegisterAiService
+    interface StreamingService {
+        Multi<String> streaming(@dev.langchain4j.service.UserMessage String text);
+    }
+
+    @Inject
+    StreamingService streamingService;
+
+    @Test
+    void shouldSendOptionsInStreamingRequest() {
+        wiremock().register(
+                post(urlEqualTo("/api/chat"))
+                        .withRequestBody(equalToJson("""
+                                {
+                                  "model" : "qwen3:1.7b",
+                                  "messages" : [ {
+                                    "role" : "user",
+                                    "content" : "Say hello"
+                                  } ],
+                                  "options" : {
+                                    "temperature" : 0.8,
+                                    "top_k" : 40,
+                                    "top_p" : 0.9,
+                                    "think" : true,
+                                    "seed" : 42
+                                  },
+                                  "stream" : true
+                                }
+                                """))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/x-ndjson")
+                                .withBody(
+                                        """
+                                                {"model":"qwen3:1.7b","created_at":"2024-12-11T15:21:23.422542932Z","message":{"role":"assistant","content":"Hello"},"done":false}
+                                                {"model":"qwen3:1.7b","created_at":"2024-12-11T15:21:23.522542932Z","message":{"role":"assistant","content":"!"},"done":false}
+                                                {"model":"qwen3:1.7b","created_at":"2024-12-11T15:21:24.109059873Z","message":{"role":"assistant","content":""},"done_reason":"stop","done":true}
+                                                """)));
+
+        List<String> result = streamingService.streaming("Say hello").collect().asList().await().indefinitely();
+        assertThat(result).containsExactly("Hello", "!");
+    }
+}

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/Options.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/Options.java
@@ -1,6 +1,11 @@
 package io.quarkiverse.langchain4j.ollama;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 
 /**
  * request options in completion/embedding API
@@ -9,10 +14,15 @@ import java.util.List;
  *      Doc</a>
  */
 public record Options(Double temperature, Integer topK, Double topP, Double repeatPenalty, Integer seed, Integer numPredict,
-        Integer numCtx, List<String> stop) {
+        Integer numCtx, List<String> stop, Map<String, Object> additionalOptions) {
 
     public static Builder builder() {
         return new Builder();
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalOptions() {
+        return additionalOptions != null ? additionalOptions : Collections.emptyMap();
     }
 
     public static class Builder {
@@ -24,6 +34,7 @@ public record Options(Double temperature, Integer topK, Double topP, Double repe
         private Integer numPredict;
         private Integer numCtx;
         private List<String> stop;
+        private final Map<String, Object> additionalOptions = new HashMap<>();
 
         public Builder temperature(Double temperature) {
             this.temperature = temperature;
@@ -65,8 +76,14 @@ public record Options(Double temperature, Integer topK, Double topP, Double repe
             return this;
         }
 
+        public Builder option(String key, Object value) {
+            this.additionalOptions.put(key, value);
+            return this;
+        }
+
         public Options build() {
-            return new Options(temperature, topK, topP, repeatPenalty, seed, numPredict, numCtx, stop);
+            return new Options(temperature, topK, topP, repeatPenalty, seed, numPredict, numCtx, stop,
+                    additionalOptions.isEmpty() ? null : new HashMap<>(additionalOptions));
         }
     }
 

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/OllamaRecorder.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/OllamaRecorder.java
@@ -91,6 +91,35 @@ public class OllamaRecorder {
                 ollamaChatModelBuilder.supportedCapabilities(Capability.RESPONSE_FORMAT_JSON_SCHEMA);
             }
 
+            ChatModelConfig.ModelOptionsConfig modelOptions = chatModelConfig.modelOptions();
+            if (modelOptions.think().isPresent()) {
+                ollamaChatModelBuilder.think(modelOptions.think().get());
+            }
+            if (modelOptions.returnThinking().isPresent()) {
+                ollamaChatModelBuilder.returnThinking(modelOptions.returnThinking().get());
+            }
+            if (modelOptions.numCtx().isPresent()) {
+                ollamaChatModelBuilder.numCtx(modelOptions.numCtx().getAsInt());
+            }
+            if (modelOptions.repeatLastN().isPresent()) {
+                ollamaChatModelBuilder.repeatLastN(modelOptions.repeatLastN().getAsInt());
+            }
+            if (modelOptions.repeatPenalty().isPresent()) {
+                ollamaChatModelBuilder.repeatPenalty(modelOptions.repeatPenalty().getAsDouble());
+            }
+            if (modelOptions.mirostat().isPresent()) {
+                ollamaChatModelBuilder.mirostat(modelOptions.mirostat().getAsInt());
+            }
+            if (modelOptions.mirostatEta().isPresent()) {
+                ollamaChatModelBuilder.mirostatEta(modelOptions.mirostatEta().getAsDouble());
+            }
+            if (modelOptions.mirostatTau().isPresent()) {
+                ollamaChatModelBuilder.mirostatTau(modelOptions.mirostatTau().getAsDouble());
+            }
+            if (modelOptions.minP().isPresent()) {
+                ollamaChatModelBuilder.minP(modelOptions.minP().getAsDouble());
+            }
+
             return new Function<>() {
                 @Override
                 public ChatModel apply(SyntheticCreationalContext<ChatModel> context) {
@@ -192,6 +221,36 @@ public class OllamaRecorder {
             if (chatModelConfig.seed().isPresent()) {
                 optionsBuilder.seed(chatModelConfig.seed().get());
             }
+
+            ChatModelConfig.ModelOptionsConfig modelOptions = chatModelConfig.modelOptions();
+            if (modelOptions.think().isPresent()) {
+                optionsBuilder.option("think", modelOptions.think().get());
+            }
+            if (modelOptions.returnThinking().isPresent()) {
+                optionsBuilder.option("returnThinking", modelOptions.returnThinking().get());
+            }
+            if (modelOptions.numCtx().isPresent()) {
+                optionsBuilder.option("numCtx", modelOptions.numCtx().getAsInt());
+            }
+            if (modelOptions.repeatLastN().isPresent()) {
+                optionsBuilder.option("repeatLastN", modelOptions.repeatLastN().getAsInt());
+            }
+            if (modelOptions.repeatPenalty().isPresent()) {
+                optionsBuilder.option("repeatPenalty", modelOptions.repeatPenalty().getAsDouble());
+            }
+            if (modelOptions.mirostat().isPresent()) {
+                optionsBuilder.option("mirostat", modelOptions.mirostat().getAsInt());
+            }
+            if (modelOptions.mirostatEta().isPresent()) {
+                optionsBuilder.option("mirostatEta", modelOptions.mirostatEta().getAsDouble());
+            }
+            if (modelOptions.mirostatTau().isPresent()) {
+                optionsBuilder.option("mirostatTau", modelOptions.mirostatTau().getAsDouble());
+            }
+            if (modelOptions.minP().isPresent()) {
+                optionsBuilder.option("minP", modelOptions.minP().getAsDouble());
+            }
+
             var builder = OllamaStreamingChatLanguageModel.builder()
                     .baseUrl(ollamaConfig.baseUrl().orElse(DEFAULT_BASE_URL))
                     .tlsConfigurationName(ollamaConfig.tlsConfigurationName().orElse(null))

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/config/ChatModelConfig.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/config/ChatModelConfig.java
@@ -2,6 +2,7 @@ package io.quarkiverse.langchain4j.ollama.runtime.config;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalDouble;
 import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigDocDefault;
@@ -71,4 +72,62 @@ public interface ChatModelConfig {
      */
     @ConfigDocDefault("false")
     Optional<Boolean> logResponses();
+
+    /**
+     * Additional model options for advanced configuration.
+     */
+    ModelOptionsConfig modelOptions();
+
+    @ConfigGroup
+    interface ModelOptionsConfig {
+
+        /**
+         * Enable thinking mode for models that support it (e.g., Qwen3).
+         * When enabled, the model will output its reasoning process.
+         */
+        Optional<Boolean> think();
+
+        /**
+         * Whether to return thinking/reasoning content in the response.
+         */
+        Optional<Boolean> returnThinking();
+
+        /**
+         * Sets the size of the context window used to generate the next token.
+         */
+        OptionalInt numCtx();
+
+        /**
+         * The last N tokens to penalize. Higher values will penalize more.
+         */
+        OptionalInt repeatLastN();
+
+        /**
+         * The penalty for repeated tokens. Higher values will penalize repetition more.
+         */
+        OptionalDouble repeatPenalty();
+
+        /**
+         * Enable Mirostat sampling for controlling perplexity.
+         * 0 = disabled, 1 = Mirostat, 2 = Mirostat 2.0.
+         */
+        OptionalInt mirostat();
+
+        /**
+         * Controls the learning rate of Mirostat. Lower values result in slower adjustments.
+         */
+        OptionalDouble mirostatEta();
+
+        /**
+         * Controls the target perplexity for Mirostat. Lower values produce more focused outputs.
+         */
+        OptionalDouble mirostatTau();
+
+        /**
+         * Sets the minimum probability relative to the most likely token.
+         * Lower values will result in more diverse outputs.
+         */
+        OptionalDouble minP();
+
+    }
 }


### PR DESCRIPTION
Allow users to pass additional model options (like think=true) to Ollama models via configuration.

### Configuration example:
```
quarkus.langchain4j.ollama.devservices.model-options.think=true
quarkus.langchain4j.ollama.devservices.model-options.num-ctx=4096
```
Or directly at runtime:
```
quarkus.langchain4j.ollama.chat-model.options.think=true
quarkus.langchain4j.ollama.chat-model.options.num-ctx=4096
```
---

Fixes #2255