### PR TITLE
docs: fix MCP Dev UI image width syntax

### DIFF
--- a/docs/modules/ROOT/pages/mcp.adoc
+++ b/docs/modules/ROOT/pages/mcp.adoc
@@ -132,11 +132,11 @@ When running your application in development mode (`mvn quarkus:dev`), Quarkus p
 
 Access the Dev UI by navigating to `http://localhost:8080/q/dev-ui` and clicking on the **MCP clients** card:
 
-image::mcp-dev-ui-card.png[MCP Dev UI Card,400,align="center"]
+image::mcp-dev-ui-card.png[MCP Dev UI Card,width=400,align="center"]
 
 The MCP Dev UI provides a comprehensive interface for interacting with your MCP clients:
 
-image::mcp-dev-ui-tools.png[MCP Dev UI Tools Interface,800,align="center"]
+image::mcp-dev-ui-tools.png[MCP Dev UI Tools Interface,width=800,align="center"]
 
 **Features:**
 


### PR DESCRIPTION
## Summary

The two `image::` macros in `docs/modules/ROOT/pages/mcp.adoc` (Dev UI - Testing MCP Clients section) use a **positional** width argument followed by a named `align=` attribute:

\`\`\`asciidoc
image::mcp-dev-ui-card.png[MCP Dev UI Card,400,align=\"center\"]
image::mcp-dev-ui-tools.png[MCP Dev UI Tools Interface,800,align=\"center\"]
\`\`\`

In downstream publishing pipelines that use Asciidoctor (e.g., the Red Hat Pantheon docs platform), this mixed positional/named form parses incorrectly and the images render as broken — the page shows the alt text (`MCP Dev UI Card`, `MCP Dev UI Tools Interface`) with no image.

## Fix

Convert the width argument to the named `width=` form, which matches the convention used by every other `image::` macro in `docs/modules/ROOT/pages/` (e.g., `rag.adoc`, `function-calling.adoc`, `observability.adoc`):

\`\`\`asciidoc
image::mcp-dev-ui-card.png[MCP Dev UI Card,width=400,align=\"center\"]
image::mcp-dev-ui-tools.png[MCP Dev UI Tools Interface,width=800,align=\"center\"]
\`\`\`

No visual change in upstream Antora-rendered docs; fixes rendering in downstream Asciidoctor pipelines.

## Test plan

- [x] `docs/modules/ROOT/pages/mcp.adoc` renders unchanged in Antora
- [x] Named `width=` is the form used by other image macros in the same directory