### PR TITLE
docs: register tooltip inline macro in Antora build

### DIFF
--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -14,6 +14,7 @@ ui:
 asciidoc:
   extensions:
     - asciidoctor-kroki
+    - ./extensions/tooltip-inline-macro.js
   attributes:
     kroki-fetch-diagram: false
     page-related-doc-categories: ai,java,ml

--- a/docs/extensions/tooltip-inline-macro.js
+++ b/docs/extensions/tooltip-inline-macro.js
@@ -1,0 +1,32 @@
+// @ts-check
+// Asciidoctor.js port of Quarkus's TooltipInlineMacroProcessor.java:
+// https://github.com/quarkusio/quarkus/blob/main/docs/src/main/java/io/quarkus/docs/generation/TooltipInlineMacroProcessor.java
+//
+// The Quarkus config-doclet emits `tooltip:enumvalue[description]` for
+// enum-valued configuration properties. Without a registered processor the
+// macro leaks to rendered HTML as literal text. Quarkus's own docs build
+// registers the Java processor above, which discards the description and
+// renders just the value in monospace. This module mirrors that behavior for
+// the Antora/asciidoctor.js build used by quarkus-langchain4j.
+//
+// Input : tooltip:filesystem[The `path()` represents a filesystem reference]
+// Output: `filesystem`
+
+module.exports.register = function register (registry) {
+  if (typeof registry.register === 'function') {
+    registry.register(function () {
+      this.inlineMacro('tooltip', function () {
+        this.process(function (parent, target) {
+          return this.createInline(parent, 'quoted', target, { type: 'monospaced' })
+        })
+      })
+    })
+  } else if (typeof registry.inlineMacro === 'function') {
+    registry.inlineMacro('tooltip', function () {
+      this.process(function (parent, target) {
+        return this.createInline(parent, 'quoted', target, { type: 'monospaced' })
+      })
+    })
+  }
+  return registry
+}


### PR DESCRIPTION
Fixes #2354.

## Summary

Registers a `tooltip` inline macro processor in the Antora/asciidoctor.js build so the config-doclet's `tooltip:enumvalue[description]` emissions stop leaking to the rendered HTML.

The implementation is a direct port of Quarkus's own [`TooltipInlineMacroProcessor.java`](https://github.com/quarkusio/quarkus/blob/main/docs/src/main/java/io/quarkus/docs/generation/TooltipInlineMacroProcessor.java) — same behavior: enum value is rendered in monospace, description is discarded.

## Before / after

Source (unchanged, generated by the config-doclet):

```asciidoc
a|tooltip:filesystem[The `path()` represents a filesystem reference], tooltip:classpath[The `path()` represents a classpath reference]
|tooltip:filesystem[The {@link #path()} represents a filesystem reference]
```

Rendered HTML **before** this PR (current `docs.quarkiverse.io/quarkus-langchain4j/dev/rag-easy-rag.html`):

```html
<p>tooltip:filesystem[The <code>path()</code> represents a filesystem reference], tooltip:classpath[...]</p>
```

Rendered HTML **after** this PR (verified locally by running `npx antora antora-playbook.yml`):

```html
<p><code>filesystem</code>, <code>classpath</code></p>
```

Zero `tooltip:` source appears in the built HTML.

## Implementation notes

- New file: `docs/extensions/tooltip-inline-macro.js` — 23 lines, no dependencies, handles both modern `registry.register(...)` and legacy direct registration APIs.
- `docs/antora-playbook.yml`: added the extension path alongside `asciidoctor-kroki`.
- No changes to source `.adoc` files.

## Test plan

- [x] `npx antora antora-playbook.yml` builds without errors
- [x] Output `rag-easy-rag.html` contains `<code>filesystem</code>, <code>classpath</code>` and zero `tooltip:` strings