### PR TITLE
When using a ChatModel either directly or through an agent always include all tag keys with sentinel defaults

### DIFF
--- a/agentic/deployment/pom.xml
+++ b/agentic/deployment/pom.xml
@@ -43,6 +43,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-micrometer</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>dev.langchain4j</groupId>
       <artifactId>langchain4j-agentic-a2a</artifactId>
       <scope>test</scope>

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgentMeterRegistryTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgentMeterRegistryTest.java
@@ -1,0 +1,172 @@
+package io.quarkiverse.langchain4j.agentic.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.ChatModelSupplier;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.service.V;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ManagedContext;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.common.vertx.VertxContext;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+/**
+ * Reproducer for <a href="https://github.com/quarkiverse/quarkus-langchain4j/issues/2349">#2349</a>:
+ * MetricsChatModelListener registers gen_ai.client.token.usage with inconsistent tag sets
+ * when both @Agent and @RegisterAiService are used in the same application.
+ */
+public class AgentMeterRegistryTest extends OpenAiBaseTest {
+
+    @BeforeAll
+    static void addSimpleRegistry() {
+        Metrics.globalRegistry.add(new SimpleMeterRegistry());
+    }
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(SimpleAgent.class, SimpleAiService.class, TestChatModelSupplier.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "whatever")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    private static final ChatModel testChatModel = new ChatModel() {
+        @Override
+        public ChatResponse doChat(ChatRequest request) {
+            return ChatResponse.builder()
+                    .aiMessage(new AiMessage("test response"))
+                    .tokenUsage(new TokenUsage(9, 12))
+                    .build();
+        }
+
+        @Override
+        public List<ChatModelListener> listeners() {
+            return Arc.container().select(ChatModelListener.class)
+                    .stream().collect(Collectors.toList());
+        }
+    };
+
+    public interface SimpleAgent {
+
+        @Agent(description = "A simple test agent")
+        String ask(@V("request") String request);
+
+        @ChatModelSupplier
+        static ChatModel chatModel() {
+            return testChatModel;
+        }
+    }
+
+    public static class TestChatModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return testChatModel;
+        }
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = TestChatModelSupplier.class)
+    public interface SimpleAiService {
+
+        String chat(String message);
+    }
+
+    @Inject
+    MeterRegistry registry;
+
+    @Inject
+    SimpleAgent agent;
+
+    @Inject
+    SimpleAiService aiService;
+
+    @Inject
+    Vertx vertx;
+
+    @Test
+    void agentAndAiServiceTokenUsageMetricsHaveConsistentTagKeys() throws Exception {
+        agent.ask("test question");
+
+        assertThat(registry.find("gen_ai.client.token.usage").counters())
+                .as("Agent call should have produced token usage metrics")
+                .isNotEmpty();
+
+        Context dupCtx = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+        CompletableFuture<Void> future = new CompletableFuture<>();
+
+        dupCtx.executeBlocking(() -> {
+            ManagedContext requestContext = Arc.container().requestContext();
+            requestContext.activate();
+            try {
+                aiService.chat("hello");
+            } finally {
+                requestContext.terminate();
+            }
+            return null;
+        }).onComplete(ar -> {
+            if (ar.failed()) {
+                future.completeExceptionally(ar.cause());
+            } else {
+                future.complete(null);
+            }
+        });
+
+        future.get(10, TimeUnit.SECONDS);
+
+        // After both calls, all gen_ai.client.token.usage counters must share the same
+        // tag keys — Prometheus rejects meters with inconsistent tag key sets.
+        // Before the fix for #2349, the agent produced counters WITHOUT ai_service tags
+        // and the AI service produced counters WITH them, causing silent metric loss.
+        var counters = registry.find("gen_ai.client.token.usage").counters();
+        assertThat(counters).hasSizeGreaterThanOrEqualTo(4);
+
+        Set<Set<String>> distinctTagKeySets = counters.stream()
+                .map(c -> c.getId().getTags().stream().map(Tag::getKey).collect(Collectors.toSet()))
+                .collect(Collectors.toSet());
+
+        assertThat(distinctTagKeySets)
+                .as("All gen_ai.client.token.usage counters must have identical tag keys")
+                .hasSize(1);
+
+        assertThat(distinctTagKeySets.iterator().next())
+                .as("Tag keys should include ai_service.class_name and ai_service.method_name")
+                .contains("ai_service.class_name", "ai_service.method_name");
+
+        Counter aiServiceCounter = registry.get("gen_ai.client.token.usage")
+                .tag("gen_ai.token.type", "input")
+                .tag("ai_service.class_name",
+                        "io.quarkiverse.langchain4j.agentic.deployment.AgentMeterRegistryTest$SimpleAiService")
+                .counter();
+        assertThat(aiServiceCounter.count()).isGreaterThan(0);
+    }
+}

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgentMetricsTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgentMetricsTest.java
@@ -1,0 +1,133 @@
+package io.quarkiverse.langchain4j.agentic.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.ChatModelSupplier;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class AgentMetricsTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(SimpleAgent.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "whatever")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    public interface SimpleAgent {
+
+        @UserMessage("Answer the following question: {{request}}")
+        @Agent(description = "A simple agent for testing")
+        String ask(@V("request") String request);
+
+        @ChatModelSupplier
+        static ChatModel chatModel() {
+            return chatModel;
+        }
+    }
+
+    @Inject
+    SimpleAgent agent;
+
+    private static final ChatModel chatModel = new ChatModel() {
+        @Override
+        public ChatResponse doChat(ChatRequest request) {
+            return ChatResponse.builder()
+                    .aiMessage(new AiMessage("test response"))
+                    .tokenUsage(new TokenUsage(9, 12))
+                    .build();
+        }
+
+        @Override
+        public List<ChatModelListener> listeners() {
+            return Arc.container().select(ChatModelListener.class)
+                    .stream().collect(Collectors.toList());
+        }
+    };
+
+    @Test
+    void tokenUsageMetricsFromAgentAndDirectCallHaveConsistentTagKeys() {
+        setChatCompletionMessageContent("test response");
+
+        agent.ask("question via agent");
+        chatModel.chat("question via direct call");
+
+        Collection<Counter> counters = Metrics.globalRegistry.find("gen_ai.client.token.usage").counters();
+        assertThat(counters).isNotEmpty();
+
+        assertAllMetersShareSameTagKeys(counters);
+        assertTagKeysPresentOnAll(counters,
+                "ai_service.class_name", "ai_service.method_name", "error.type",
+                "gen_ai.request.model", "gen_ai.response.model");
+    }
+
+    @Test
+    void durationMetricsFromAgentAndDirectCallHaveConsistentTagKeys() {
+        setChatCompletionMessageContent("test response");
+
+        agent.ask("question via agent");
+        chatModel.chat("question via direct call");
+
+        Collection<Timer> timers = Metrics.globalRegistry.find("gen_ai.client.operation.duration").timers();
+        assertThat(timers).isNotEmpty();
+
+        assertAllMetersShareSameTagKeys(timers);
+        assertTagKeysPresentOnAll(timers,
+                "ai_service.class_name", "ai_service.method_name", "error.type",
+                "gen_ai.request.model", "gen_ai.response.model");
+    }
+
+    private static void assertAllMetersShareSameTagKeys(Collection<? extends Meter> meters) {
+        Set<Set<String>> distinctTagKeySets = meters.stream()
+                .map(meter -> meter.getId().getTags().stream()
+                        .map(Tag::getKey)
+                        .collect(Collectors.toSet()))
+                .collect(Collectors.toSet());
+
+        assertThat(distinctTagKeySets)
+                .as("All meters with the same name must have identical tag keys (Prometheus requirement)")
+                .hasSize(1);
+    }
+
+    private static void assertTagKeysPresentOnAll(Collection<? extends Meter> meters,
+            String... expectedKeys) {
+        for (Meter meter : meters) {
+            Set<String> actualKeys = meter.getId().getTags().stream()
+                    .map(Tag::getKey)
+                    .collect(Collectors.toSet());
+            assertThat(actualKeys)
+                    .as("Meter %s should contain all expected tag keys", meter.getId())
+                    .contains(expectedKeys);
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/listeners/MetricsChatModelListener.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/listeners/MetricsChatModelListener.java
@@ -76,23 +76,31 @@ public class MetricsChatModelListener implements ChatModelListener {
 
         ChatRequest request = responseContext.chatRequest();
         ChatResponse response = responseContext.chatResponse();
-        Tags tags = Tags.empty();
-        if (request.parameters().modelName() != null) {
-            tags = tags.and("gen_ai.request.model", request.parameters().modelName());
-        }
-        if (response.metadata().modelName() != null) {
-            tags = tags.and("gen_ai.response.model", response.metadata().modelName());
-        }
+        String requestModel = request.parameters().modelName() != null
+                ? request.parameters().modelName()
+                : "none";
+        String responseModel = response.metadata().modelName() != null
+                ? response.metadata().modelName()
+                : "none";
+
+        String aiServiceClassName = "none";
+        String aiServiceMethodName = "none";
         if (ContextLocals.duplicatedContextActive()) {
-            String aiServiceClassName = ContextLocals.get(AiServiceConstants.AI_SERVICE_CLASS_NAME);
-            if (aiServiceClassName != null) {
-                tags = tags.and("ai_service.class_name", aiServiceClassName);
+            String cls = ContextLocals.get(AiServiceConstants.AI_SERVICE_CLASS_NAME);
+            if (cls != null) {
+                aiServiceClassName = cls;
             }
-            String aiServiceMethodName = ContextLocals.get(AiServiceConstants.AI_SERVICE_METHODNAME);
-            if (aiServiceMethodName != null) {
-                tags = tags.and("ai_service.method_name", aiServiceMethodName);
+            String mtd = ContextLocals.get(AiServiceConstants.AI_SERVICE_METHODNAME);
+            if (mtd != null) {
+                aiServiceMethodName = mtd;
             }
         }
+
+        Tags tags = Tags.of("gen_ai.request.model", requestModel)
+                .and("gen_ai.response.model", responseModel)
+                .and("ai_service.class_name", aiServiceClassName)
+                .and("ai_service.method_name", aiServiceMethodName)
+                .and("error.type", "none");
 
         recordTokenUsage(responseContext, tags);
         recordDuration(responseContext, endTime, tags);
@@ -109,11 +117,19 @@ public class MetricsChatModelListener implements ChatModelListener {
             return;
         }
 
-        Tags tags = Tags.of("gen_ai.request.model", errorContext.chatRequest().parameters().modelName());
+        String requestModel = errorContext.chatRequest().parameters().modelName() != null
+                ? errorContext.chatRequest().parameters().modelName()
+                : "none";
+        String errorType = errorContext.error() != null
+                ? errorContext.error().getMessage()
+                : "none";
 
-        if (errorContext.error() != null) {
-            tags = tags.and("error.type", errorContext.error().getMessage());
-        }
+        Tags tags = Tags.of("gen_ai.request.model", requestModel)
+                .and("gen_ai.response.model", "none")
+                .and("ai_service.class_name", "none")
+                .and("ai_service.method_name", "none")
+                .and("error.type", errorType);
+
         duration.withTags(tags).record(endTime - startTime, TimeUnit.NANOSECONDS);
     }
 


### PR DESCRIPTION
The problem was that `MetricsChatModelListener` conditionally adds `ai_service.class_name` and `ai_service.method_name` tags to metrics based on whether a Vert.x duplicated context is active. This means that depending on this condition the same metric name could get registered with different tag key sets, while Prometheus requires all meters with the same name to have identical tag keys, and rejects the second registration with `IllegalArgumentException`.

The fix is simply to always include all tag keys with sensible defaults.

- Closes: #2349 