### PR TITLE
Fix max-retries=0 causing unexpected behavior in OpenAI and Anthropic providers

### DIFF
--- a/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/AnthropicRecorder.java
+++ b/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/AnthropicRecorder.java
@@ -64,6 +64,10 @@ public class AnthropicRecorder {
                 throw new ConfigValidationException(createApiKeyConfigProblem(configName));
             }
 
+            if (chatModelConfig.maxRetries() < 1) {
+                throw new ConfigValidationException(createMaxRetriesConfigProblem(configName));
+            }
+
             var builder = AnthropicChatModel.builder()
                     .baseUrl(anthropicConfig.baseUrl())
                     .apiKey(apiKey)
@@ -347,6 +351,12 @@ public class AnthropicRecorder {
 
     private static ConfigValidationException.Problem[] createApiKeyConfigProblem(String configName) {
         return createConfigProblems("api-key", configName);
+    }
+
+    private static ConfigValidationException.Problem[] createMaxRetriesConfigProblem(String configName) {
+        return new ConfigValidationException.Problem[] { new ConfigValidationException.Problem(
+                "SRCFG00014: The config property quarkus.langchain4j.anthropic%schat-model.max-retries must be greater than zero"
+                        .formatted(NamedConfigUtil.isDefault(configName) ? "." : ("." + configName + "."))) };
     }
 
     private static ConfigValidationException.Problem[] createConfigProblems(String key, String configName) {

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/OpenAiInvalidMaxRetriesTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/OpenAiInvalidMaxRetriesTest.java
@@ -17,8 +17,11 @@ public class OpenAiInvalidMaxRetriesTest {
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
             .overrideConfigKey("quarkus.langchain4j.openai.api-key", "somekey")
             .overrideConfigKey("quarkus.langchain4j.openai.max-retries", "0")
-            .assertException(t -> assertThat(t).rootCause()
-                    .hasMessageContaining("max-retries must be greater than zero"));
+            .assertException(t -> {
+                assertThat(t)
+                        .isInstanceOf(RuntimeException.class)
+                        .hasMessageContaining("max-retries must be greater than zero");
+            });
 
     @Test
     void test() {

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/OpenAiInvalidMaxRetriesTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/OpenAiInvalidMaxRetriesTest.java
@@ -1,0 +1,27 @@
+package io.quarkiverse.langchain4j.openai.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OpenAiInvalidMaxRetriesTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.openai.api-key", "somekey")
+            .overrideConfigKey("quarkus.langchain4j.openai.max-retries", "0")
+            .assertException(t -> assertThat(t).rootCause()
+                    .hasMessageContaining("max-retries must be greater than zero"));
+
+    @Test
+    void test() {
+        fail("Should not be called");
+    }
+}

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/OpenAiInvalidMaxRetriesTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/OpenAiInvalidMaxRetriesTest.java
@@ -3,11 +3,14 @@ package io.quarkiverse.langchain4j.openai.test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import jakarta.inject.Inject;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import dev.langchain4j.model.chat.ChatModel;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class OpenAiInvalidMaxRetriesTest {
@@ -22,6 +25,9 @@ public class OpenAiInvalidMaxRetriesTest {
                         .isInstanceOf(RuntimeException.class)
                         .hasMessageContaining("max-retries must be greater than zero");
             });
+
+    @Inject
+    ChatModel model;
 
     @Test
     void test() {

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
@@ -75,6 +75,9 @@ public class OpenAiRecorder {
             if (DUMMY_KEY.equals(apiKey) && OPENAI_BASE_URL.equals(openAiConfig.baseUrl())) {
                 throw new ConfigValidationException(createApiKeyConfigProblems(configName));
             }
+            if (openAiConfig.maxRetries() < 1) {
+                throw new ConfigValidationException(createMaxRetriesConfigProblems(configName));
+            }
             ChatModelConfig chatModelConfig = openAiConfig.chatModel();
             var builder = (QuarkusOpenAiChatModelBuilderFactory.Builder) OpenAiChatModel.builder();
             builder.logCurl(firstOrDefault(false, openAiConfig.logRequestsCurl()));
@@ -206,6 +209,9 @@ public class OpenAiRecorder {
             if (DUMMY_KEY.equals(apiKey) && OPENAI_BASE_URL.equals(openAiConfig.baseUrl())) {
                 throw new ConfigValidationException(createApiKeyConfigProblems(configName));
             }
+            if (openAiConfig.maxRetries() < 1) {
+                throw new ConfigValidationException(createMaxRetriesConfigProblems(configName));
+            }
             EmbeddingModelConfig embeddingModelConfig = openAiConfig.embeddingModel();
             var builder = (QuarkusOpenAiEmbeddingModelBuilderFactory.Builder) OpenAiEmbeddingModel.builder();
             builder
@@ -254,6 +260,9 @@ public class OpenAiRecorder {
             String apiKey = openAiConfig.apiKey();
             if (DUMMY_KEY.equals(apiKey) && OPENAI_BASE_URL.equals(openAiConfig.baseUrl())) {
                 throw new ConfigValidationException(createApiKeyConfigProblems(configName));
+            }
+            if (openAiConfig.maxRetries() < 1) {
+                throw new ConfigValidationException(createMaxRetriesConfigProblems(configName));
             }
             ModerationModelConfig moderationModelConfig = openAiConfig.moderationModel();
             var builder = (QuarkusOpenAiModerationModelBuilderFactory.Builder) OpenAiModerationModel.builder();
@@ -372,6 +381,12 @@ public class OpenAiRecorder {
 
     private ConfigValidationException.Problem[] createApiKeyConfigProblems(String configName) {
         return createConfigProblems("api-key", configName);
+    }
+
+    private ConfigValidationException.Problem[] createMaxRetriesConfigProblems(String configName) {
+        return new ConfigValidationException.Problem[] { new ConfigValidationException.Problem(String.format(
+                "SRCFG00014: The config property quarkus.langchain4j.openai%smax-retries must be greater than zero",
+                NamedConfigUtil.isDefault(configName) ? "." : ("." + configName + "."))) };
     }
 
     private ConfigValidationException.Problem[] createConfigProblems(String key, String configName) {


### PR DESCRIPTION
## Summary

- Adds startup-time validation in `OpenAiRecorder` that throws `ConfigValidationException` when `max-retries < 1` for chat, embedding, and moderation models
- Adds the same validation in `AnthropicRecorder` for the chat model
- Other providers (`QuarkusOpenAiImageModel`, `AzureOpenAiChatModel`, `AzureOpenAiEmbeddingModel`, `QuarkusCohereScoringModel`) already validate `< 1` at construction time — this change makes OpenAI vanilla and Anthropic consistent
- Adds a `QuarkusUnitTest` that verifies the error message is surfaced at startup when `quarkus.langchain4j.openai.max-retries=0`

Fixes: #482

## Test plan

- [ ] `OpenAiInvalidMaxRetriesTest` verifies that setting `quarkus.langchain4j.openai.max-retries=0` fails at startup with a descriptive error message
- [ ] Existing OpenAI and Anthropic tests continue to pass (default `max-retries=1`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)