### PR TITLE
Introduce `ModelBuilderCustomizer` interface for model builder customization

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/BeansProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/BeansProcessor.java
@@ -26,6 +26,7 @@ import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.image.ImageModel;
 import dev.langchain4j.model.moderation.ModerationModel;
 import dev.langchain4j.model.scoring.ScoringModel;
+import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
 import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
 import io.quarkiverse.langchain4j.deployment.config.LangChain4jBuildConfig;
 import io.quarkiverse.langchain4j.deployment.items.AutoCreateEmbeddingModelBuildItem;
@@ -599,6 +600,7 @@ public class BeansProcessor {
     public void unremovableBeans(BuildProducer<UnremovableBeanBuildItem> unremovableProducer) {
         unremovableProducer.produce(UnremovableBeanBuildItem.beanTypes(ObjectMapper.class));
         unremovableProducer.produce(UnremovableBeanBuildItem.beanTypes(ModelAuthProvider.class));
+        unremovableProducer.produce(UnremovableBeanBuildItem.beanTypes(ModelBuilderCustomizer.class));
     }
 
     @BuildStep

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/DotNames.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/DotNames.java
@@ -22,6 +22,7 @@ import org.jboss.jandex.DotName;
 
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
+import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
 import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
 import io.quarkiverse.langchain4j.guardrails.OutputGuardrailAccumulator;
 import io.quarkiverse.langchain4j.response.AiResponseAugmenter;
@@ -86,6 +87,7 @@ public class DotNames {
 
     public static final DotName CHAT_MODEL_LISTENER = DotName.createSimple(ChatModelListener.class);
     public static final DotName MODEL_AUTH_PROVIDER = DotName.createSimple(ModelAuthProvider.class);
+    public static final DotName MODEL_BUILDER_CUSTOMIZER = DotName.createSimple(ModelBuilderCustomizer.class);
     public static final DotName TOOL = DotName.createSimple(Tool.class);
 
     public static final DotName REGISTER_REST_CLIENT = DotName.createSimple(RegisterRestClient.class);

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/ModelBuilderCustomizer.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/ModelBuilderCustomizer.java
@@ -1,0 +1,80 @@
+package io.quarkiverse.langchain4j;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.enterprise.inject.Default;
+import jakarta.enterprise.inject.Instance;
+
+import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
+
+/**
+ * Allows for customizing a model builder.
+ * A common use case is to configure models in ways that have not been anticipated by the available Quarkus configuration.
+ * <p>
+ * Implementations <b>must</b> be CDI beans.
+ * <p>
+ * Customizers without a {@link ModelName} qualifier apply to the default model configuration.
+ * Use {@code @ModelName("x")} to target a specific named configuration.
+ * When a named model has {@code @ModelName}-qualified customizers, those take precedence
+ * and unqualified customizers are not applied for that model.
+ * <p>
+ * Customizers are applied in priority order (higher priority values first).
+ * Override {@link #priority()} to control ordering. The default priority is {@link #DEFAULT_PRIORITY} (0).
+ * <p>
+ * An example could be:
+ *
+ * <pre>
+ * &#64;ApplicationScoped
+ * public class MyCustomizer implements ModelBuilderCustomizer<OpenAiChatModel.OpenAiChatModelBuilder> {
+ *     &#64;Override
+ *     public void customize(OpenAiChatModel.OpenAiChatModelBuilder builder) {
+ *         builder.seed(42);
+ *     }
+ * }
+ * </pre>
+ *
+ * @param <B> the builder type to customize
+ */
+public interface ModelBuilderCustomizer<B> extends Comparable<ModelBuilderCustomizer<?>> {
+
+    int MINIMUM_PRIORITY = Integer.MIN_VALUE;
+    int MAXIMUM_PRIORITY = Integer.MAX_VALUE;
+    int DEFAULT_PRIORITY = 0;
+
+    void customize(B builder);
+
+    /**
+     * Defines the priority that the customizers are applied.
+     * A lower integer value means that the customizer will be applied after a customizer with a higher priority.
+     */
+    default int priority() {
+        return DEFAULT_PRIORITY;
+    }
+
+    @Override
+    default int compareTo(ModelBuilderCustomizer<?> o) {
+        return Integer.compare(o.priority(), priority());
+    }
+
+    static <B> void applyCustomizers(Instance<ModelBuilderCustomizer<B>> allCustomizers, B builder, String configName) {
+        String resolvedName = NamedConfigUtil.isDefault(configName) ? null : configName;
+
+        Instance<ModelBuilderCustomizer<B>> instances;
+        if (NamedConfigUtil.isDefault(configName)) {
+            instances = allCustomizers.select(Default.Literal.INSTANCE);
+        } else {
+            instances = allCustomizers.select(ModelName.Literal.of(resolvedName));
+        }
+
+        List<ModelBuilderCustomizer<B>> customizers = new ArrayList<>();
+        for (ModelBuilderCustomizer<B> instance : instances) {
+            customizers.add(instance);
+        }
+
+        customizers.sort(null);
+        for (ModelBuilderCustomizer<B> customizer : customizers) {
+            customizer.customize(builder);
+        }
+    }
+}

--- a/docs/modules/ROOT/pages/models.adoc
+++ b/docs/modules/ROOT/pages/models.adoc
@@ -206,6 +206,78 @@ flowchart LR
     classDef edge stroke-width:3px,stroke:#DF1862
 ----
 
+== Customizing Model Builders
+
+When Quarkus LangChain4j creates a model instance (chat, streaming, embedding, image, or moderation), it configures a builder using properties from `application.properties` and then calls `build()`.
+Sometimes you need to set builder options that are not exposed as configuration properties — for example, a custom HTTP header, a proxy, or a seed value.
+
+`ModelBuilderCustomizer` is a CDI bean interface that lets you intercept the builder right before `build()` is called, giving you full access to the provider's builder API.
+
+=== Basic Usage
+
+Implement `ModelBuilderCustomizer` parameterized with the builder type of the model you want to customize, and make it a CDI bean:
+
+[source,java]
+----
+@ApplicationScoped
+public class MyCustomizer implements ModelBuilderCustomizer<OpenAiChatModel.OpenAiChatModelBuilder> {
+
+    @Override
+    public void customize(OpenAiChatModel.OpenAiChatModelBuilder builder) {
+        builder.seed(42);
+    }
+}
+----
+
+This customizer applies to the _default_ (unnamed) model configuration.
+
+=== Targeting Named Model Configurations
+
+If you have multiple model configurations (e.g., `quarkus.langchain4j.openai.my-model.chat-model.model-name=...`), you can target a specific one using the `@ModelName` qualifier:
+
+[source,java]
+----
+@ApplicationScoped
+@ModelName("my-model")
+public class MyNamedCustomizer implements ModelBuilderCustomizer<OpenAiChatModel.OpenAiChatModelBuilder> {
+
+    @Override
+    public void customize(OpenAiChatModel.OpenAiChatModelBuilder builder) {
+        builder.seed(99);
+    }
+}
+----
+
+When a named model has `@ModelName`-qualified customizers, those take precedence and unqualified customizers are **not** applied for that model.
+Unqualified customizers still apply to any model that has no `@ModelName`-qualified customizers.
+
+=== Priority
+
+When multiple customizers apply to the same model, you can control the order in which they are applied by overriding the `priority()` method:
+
+[source,java]
+----
+@ApplicationScoped
+public class HighPriorityCustomizer implements ModelBuilderCustomizer<OpenAiChatModel.OpenAiChatModelBuilder> {
+
+    @Override
+    public void customize(OpenAiChatModel.OpenAiChatModelBuilder builder) {
+        builder.seed(42);
+    }
+
+    @Override
+    public int priority() {
+        return 100; // applied before customizers with lower priority
+    }
+}
+----
+
+Higher priority values are applied first.
+The default priority is `0`.
+This follows the same convention as Quarkus's `ObjectMapperCustomizer`.
+
+NOTE: `ModelBuilderCustomizer` works with all model providers that use a builder pattern. Providers that do not use a builder (such as Cohere and GPU-Llama3) are not supported. The type parameter must match the builder type exposed by the provider (e.g., `OpenAiChatModel.OpenAiChatModelBuilder`, `AnthropicChatModel.AnthropicChatModelBuilder`, `BedrockChatModel.Builder`, etc.).
+
 == Related Guides
 
 [.lead]

--- a/model-providers/anthropic/deployment/src/main/java/io/quarkiverse/langchain4j/anthropic/deployment/AnthropicProcessor.java
+++ b/model-providers/anthropic/deployment/src/main/java/io/quarkiverse/langchain4j/anthropic/deployment/AnthropicProcessor.java
@@ -6,12 +6,16 @@ import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.STREAMIN
 import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
 import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 
+import dev.langchain4j.model.anthropic.AnthropicChatModel;
+import dev.langchain4j.model.anthropic.AnthropicStreamingChatModel;
 import io.quarkiverse.langchain4j.ModelName;
 import io.quarkiverse.langchain4j.anthropic.runtime.AnthropicRecorder;
 import io.quarkiverse.langchain4j.deployment.DotNames;
@@ -33,6 +37,13 @@ import io.smallrye.config.Priorities;
 public class AnthropicProcessor {
     private static final String FEATURE = "langchain4j-anthropic";
     private static final String PROVIDER = "anthropic";
+
+    private static final DotName ANTHROPIC_CHAT_MODEL_BUILDER = DotName
+            .createSimple(AnthropicChatModel.AnthropicChatModelBuilder.class);
+    private static final DotName ANTHROPIC_STREAMING_CHAT_MODEL_BUILDER = DotName
+            .createSimple(AnthropicStreamingChatModel.AnthropicStreamingChatModelBuilder.class);
+    private static final AnnotationInstance ANY = AnnotationInstance
+            .builder(DotName.createSimple(Any.class)).build();
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -62,6 +73,10 @@ public class AnthropicProcessor {
                         .scope(ApplicationScoped.class)
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(ANTHROPIC_CHAT_MODEL_BUILDER) }, null) },
+                                null), ANY)
                         .createWith(recorder.chatModel(configName));
 
                 addQualifierIfNecessary(builder, configName);
@@ -74,6 +89,11 @@ public class AnthropicProcessor {
                         .scope(ApplicationScoped.class)
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(ANTHROPIC_STREAMING_CHAT_MODEL_BUILDER) },
+                                        null) },
+                                null), ANY)
                         .createWith(recorder.streamingChatModel(configName));
 
                 addQualifierIfNecessary(streamingBuilder, configName);

--- a/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/AnthropicRecorder.java
+++ b/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/AnthropicRecorder.java
@@ -1,6 +1,5 @@
 package io.quarkiverse.langchain4j.anthropic.runtime;
 
-import static dev.langchain4j.model.chat.request.ResponseFormat.JSON;
 import static io.quarkiverse.langchain4j.runtime.OptionalUtil.firstOrDefault;
 
 import java.time.Duration;
@@ -11,6 +10,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.util.TypeLiteral;
 
@@ -26,6 +26,7 @@ import dev.langchain4j.model.chat.DisabledStreamingChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.chat.request.ResponseFormat;
+import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
 import io.quarkiverse.langchain4j.anthropic.QuarkusAnthropicClient;
 import io.quarkiverse.langchain4j.anthropic.runtime.config.ChatModelConfig;
 import io.quarkiverse.langchain4j.anthropic.runtime.config.LangChain4jAnthropicConfig;
@@ -41,6 +42,10 @@ public class AnthropicRecorder {
     private static final Logger LOG = Logger.getLogger(AnthropicRecorder.class);
 
     private static final TypeLiteral<Instance<ChatModelListener>> CHAT_MODEL_LISTENER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<AnthropicChatModel.AnthropicChatModelBuilder>>> CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<AnthropicStreamingChatModel.AnthropicStreamingChatModelBuilder>>> STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
     };
 
     private static final String DUMMY_KEY = "dummy";
@@ -183,6 +188,9 @@ public class AnthropicRecorder {
                             .collect(Collectors.toList()));
                     QuarkusAnthropicClient.setLogCurlHint(logCurl);
                     QuarkusAnthropicClient.setDisableBetaHint(disableBeta);
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
@@ -325,6 +333,10 @@ public class AnthropicRecorder {
                             .collect(Collectors.toList()));
                     QuarkusAnthropicClient.setLogCurlHint(logCurl);
                     QuarkusAnthropicClient.setDisableBetaHint(disableBeta);
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL,
+                                    Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };

--- a/model-providers/bedrock/deployment/src/main/java/io/quarkiverse/langchain4j/bedrock/deployment/BedrockProcessor.java
+++ b/model-providers/bedrock/deployment/src/main/java/io/quarkiverse/langchain4j/bedrock/deployment/BedrockProcessor.java
@@ -7,12 +7,18 @@ import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.STREAMIN
 import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
 import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 
+import dev.langchain4j.model.bedrock.BedrockChatModel;
+import dev.langchain4j.model.bedrock.BedrockCohereEmbeddingModel;
+import dev.langchain4j.model.bedrock.BedrockStreamingChatModel;
+import dev.langchain4j.model.bedrock.BedrockTitanEmbeddingModel;
 import io.quarkiverse.langchain4j.ModelName;
 import io.quarkiverse.langchain4j.bedrock.runtime.BedrockRecorder;
 import io.quarkiverse.langchain4j.deployment.DotNames;
@@ -39,6 +45,17 @@ public class BedrockProcessor {
 
     private static final String FEATURE = "langchain4j-bedrock";
     private static final String PROVIDER = "bedrock";
+
+    private static final DotName BEDROCK_CHAT_MODEL_BUILDER = DotName.createSimple(BedrockChatModel.Builder.class);
+    private static final DotName BEDROCK_STREAMING_CHAT_MODEL_BUILDER = DotName
+            .createSimple(BedrockStreamingChatModel.Builder.class);
+    private static final DotName BEDROCK_COHERE_EMBEDDING_MODEL_BUILDER = DotName
+            .createSimple(BedrockCohereEmbeddingModel.Builder.class);
+    private static final DotName BEDROCK_TITAN_EMBEDDING_MODEL_BUILDER = DotName
+            .createSimple(BedrockTitanEmbeddingModel.BedrockTitanEmbeddingModelBuilder.class);
+
+    private static final AnnotationInstance ANY = AnnotationInstance.builder(DotName.createSimple(
+            Any.class)).build();
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -82,6 +99,10 @@ public class BedrockProcessor {
                         .addInjectionPoint(ParameterizedType.create(
                                 DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(BEDROCK_CHAT_MODEL_BUILDER) }, null) },
+                                null), ANY)
                         .createWith(chatModel);
 
                 addQualifierIfNecessary(builder, configName);
@@ -96,6 +117,10 @@ public class BedrockProcessor {
                         .addInjectionPoint(ParameterizedType.create(
                                 DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(BEDROCK_STREAMING_CHAT_MODEL_BUILDER) }, null) },
+                                null), ANY)
                         .createWith(streamingChatModel);
                 addQualifierIfNecessary(streamingBuilder, configName);
                 beanProducer.produce(streamingBuilder.done());
@@ -111,7 +136,15 @@ public class BedrockProcessor {
                         .defaultBean()
                         .unremovable()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.embeddingModel(configName));
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(BEDROCK_COHERE_EMBEDDING_MODEL_BUILDER) }, null) },
+                                null), ANY)
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(BEDROCK_TITAN_EMBEDDING_MODEL_BUILDER) }, null) },
+                                null), ANY)
+                        .createWith(recorder.embeddingModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }

--- a/model-providers/bedrock/runtime/src/main/java/io/quarkiverse/langchain4j/bedrock/runtime/BedrockRecorder.java
+++ b/model-providers/bedrock/runtime/src/main/java/io/quarkiverse/langchain4j/bedrock/runtime/BedrockRecorder.java
@@ -8,9 +8,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.util.TypeLiteral;
 
@@ -27,6 +27,7 @@ import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.embedding.DisabledEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
 import io.quarkiverse.langchain4j.bedrock.runtime.config.AwsClientConfig;
 import io.quarkiverse.langchain4j.bedrock.runtime.config.GuardrailConfig;
 import io.quarkiverse.langchain4j.bedrock.runtime.config.LangChain4jBedrockConfig;
@@ -48,6 +49,14 @@ import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 public class BedrockRecorder {
 
     private static final TypeLiteral<Instance<ChatModelListener>> CHAT_MODEL_LISTENER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<BedrockChatModel.Builder>>> CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<BedrockStreamingChatModel.Builder>>> STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<BedrockCohereEmbeddingModel.Builder>>> COHERE_EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<BedrockTitanEmbeddingModel.BedrockTitanEmbeddingModelBuilder>>> TITAN_EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
     };
 
     private final RuntimeValue<LangChain4jConfig> rootRuntimeConfig;
@@ -116,6 +125,9 @@ public class BedrockRecorder {
                 public ChatModel apply(SyntheticCreationalContext<ChatModel> context) {
                     builder.listeners(context.getInjectedReference(CHAT_MODEL_LISTENER_TYPE_LITERAL).stream()
                             .collect(Collectors.toList()));
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
@@ -202,6 +214,9 @@ public class BedrockRecorder {
                 public StreamingChatModel apply(SyntheticCreationalContext<StreamingChatModel> context) {
                     builder.listeners(context.getInjectedReference(CHAT_MODEL_LISTENER_TYPE_LITERAL).stream()
                             .collect(Collectors.toList()));
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
@@ -215,7 +230,7 @@ public class BedrockRecorder {
         }
     }
 
-    public Supplier<EmbeddingModel> embeddingModel(final String configName) {
+    public Function<SyntheticCreationalContext<EmbeddingModel>, EmbeddingModel> embeddingModel(final String configName) {
         LangChain4jBedrockConfig.BedrockConfig config = correspondingBedrockConfig(configName);
 
         if (config.enableIntegration()) {
@@ -230,7 +245,7 @@ public class BedrockRecorder {
 
             var modelId = modelConfig.modelId();
 
-            Supplier<EmbeddingModel> supplier;
+            Function<SyntheticCreationalContext<EmbeddingModel>, EmbeddingModel> function;
             if (modelId.contains("cohere")) {
                 var builder = BedrockCohereEmbeddingModel.builder()
                         .model(modelId)
@@ -244,9 +259,13 @@ public class BedrockRecorder {
                     builder.truncate(modelConfig.cohere().truncate().get());
                 }
 
-                supplier = new Supplier<EmbeddingModel>() {
+                function = new Function<>() {
                     @Override
-                    public EmbeddingModel get() {
+                    public EmbeddingModel apply(SyntheticCreationalContext<EmbeddingModel> context) {
+                        ModelBuilderCustomizer.applyCustomizers(
+                                context.getInjectedReference(COHERE_EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL,
+                                        Any.Literal.INSTANCE),
+                                builder, configName);
                         return builder.build();
                     }
                 };
@@ -263,19 +282,23 @@ public class BedrockRecorder {
                     builder.normalize(modelConfig.titan().normalize().get());
                 }
 
-                supplier = new Supplier<EmbeddingModel>() {
+                function = new Function<>() {
                     @Override
-                    public EmbeddingModel get() {
+                    public EmbeddingModel apply(SyntheticCreationalContext<EmbeddingModel> context) {
+                        ModelBuilderCustomizer.applyCustomizers(
+                                context.getInjectedReference(TITAN_EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL,
+                                        Any.Literal.INSTANCE),
+                                builder, configName);
                         return builder.build();
                     }
                 };
             }
 
-            return supplier;
+            return function;
         } else {
-            return new Supplier<EmbeddingModel>() {
+            return new Function<>() {
                 @Override
-                public EmbeddingModel get() {
+                public EmbeddingModel apply(SyntheticCreationalContext<EmbeddingModel> context) {
                     return new DisabledEmbeddingModel();
                 }
             };

--- a/model-providers/google/gemini/ai-gemini/deployment/src/main/java/io/quarkiverse/langchain4j/ai/gemini/deployment/AiGeminiProcessor.java
+++ b/model-providers/google/gemini/ai-gemini/deployment/src/main/java/io/quarkiverse/langchain4j/ai/gemini/deployment/AiGeminiProcessor.java
@@ -7,12 +7,17 @@ import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.STREAMIN
 import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
 import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 
+import dev.langchain4j.model.googleai.GoogleAiEmbeddingModel;
+import dev.langchain4j.model.googleai.GoogleAiGeminiChatModel;
+import dev.langchain4j.model.googleai.GoogleAiGeminiStreamingChatModel;
 import io.quarkiverse.langchain4j.ModelName;
 import io.quarkiverse.langchain4j.ai.runtime.gemini.AiGeminiRecorder;
 import io.quarkiverse.langchain4j.deployment.DotNames;
@@ -37,6 +42,16 @@ public class AiGeminiProcessor {
 
     private static final String FEATURE = "langchain4j-ai-gemini";
     private static final String PROVIDER = "ai-gemini";
+
+    private static final DotName AI_GEMINI_CHAT_MODEL_BUILDER = DotName
+            .createSimple(GoogleAiGeminiChatModel.GoogleAiGeminiChatModelBuilder.class);
+    private static final DotName AI_GEMINI_STREAMING_CHAT_MODEL_BUILDER = DotName
+            .createSimple(GoogleAiGeminiStreamingChatModel.GoogleAiGeminiStreamingChatModelBuilder.class);
+    private static final DotName AI_GEMINI_EMBEDDING_MODEL_BUILDER = DotName
+            .createSimple(GoogleAiEmbeddingModel.GoogleAiEmbeddingModelBuilder.class);
+
+    private static final AnnotationInstance ANY = AnnotationInstance.builder(DotName.createSimple(
+            Any.class)).build();
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -75,6 +90,10 @@ public class AiGeminiProcessor {
                                 new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.MODEL_AUTH_PROVIDER) }, null))
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(AI_GEMINI_CHAT_MODEL_BUILDER) }, null) },
+                                null), ANY)
                         .createWith(chatModel);
 
                 addQualifierIfNecessary(builder, configName);
@@ -90,6 +109,10 @@ public class AiGeminiProcessor {
                                 new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.MODEL_AUTH_PROVIDER) }, null))
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(AI_GEMINI_STREAMING_CHAT_MODEL_BUILDER) }, null) },
+                                null), ANY)
                         .createWith(streamingChatModel);
 
                 addQualifierIfNecessary(streamingBuilder, configName);
@@ -111,6 +134,10 @@ public class AiGeminiProcessor {
                                 new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.MODEL_AUTH_PROVIDER) }, null))
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(AI_GEMINI_EMBEDDING_MODEL_BUILDER) }, null) },
+                                null), ANY)
                         .createWith(embeddingModel);
 
                 addQualifierIfNecessary(builder, configName);

--- a/model-providers/google/gemini/ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/ai/runtime/gemini/AiGeminiRecorder.java
+++ b/model-providers/google/gemini/ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/ai/runtime/gemini/AiGeminiRecorder.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.util.TypeLiteral;
 
@@ -20,6 +21,7 @@ import dev.langchain4j.model.googleai.GeminiThinkingConfig;
 import dev.langchain4j.model.googleai.GoogleAiEmbeddingModel;
 import dev.langchain4j.model.googleai.GoogleAiGeminiChatModel;
 import dev.langchain4j.model.googleai.GoogleAiGeminiStreamingChatModel;
+import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
 import io.quarkiverse.langchain4j.ai.runtime.gemini.config.ChatModelConfig;
 import io.quarkiverse.langchain4j.ai.runtime.gemini.config.LangChain4jAiGeminiConfig;
 import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
@@ -35,6 +37,12 @@ public class AiGeminiRecorder {
     private static final TypeLiteral<Instance<ChatModelListener>> CHAT_MODEL_LISTENER_TYPE_LITERAL = new TypeLiteral<>() {
     };
     private static final TypeLiteral<Instance<ModelAuthProvider>> MODEL_AUTH_PROVIDER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<GoogleAiGeminiChatModel.GoogleAiGeminiChatModelBuilder>>> CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<GoogleAiGeminiStreamingChatModel.GoogleAiGeminiStreamingChatModelBuilder>>> STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<GoogleAiEmbeddingModel.GoogleAiEmbeddingModelBuilder>>> EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
     };
 
     private final RuntimeValue<LangChain4jAiGeminiConfig> runtimeConfig;
@@ -87,6 +95,9 @@ public class AiGeminiRecorder {
                                 .addClientProvider(new ModelAuthProviderFilter(embeddingModelConfig.modelId()));
                     }
 
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
@@ -152,6 +163,9 @@ public class AiGeminiRecorder {
                         httpClientBuilder.addClientProvider(new ModelAuthProviderFilter(chatModelConfig.modelId()));
                     }
 
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
@@ -231,6 +245,9 @@ public class AiGeminiRecorder {
                         httpClientBuilder.addClientProvider(new ModelAuthProviderFilter(chatModelConfig.modelId()));
                     }
 
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };

--- a/model-providers/google/vertex-ai-gemini/deployment/src/main/java/io/quarkiverse/langchain4j/vertexai/gemini/deployment/VertexAiGeminiProcessor.java
+++ b/model-providers/google/vertex-ai-gemini/deployment/src/main/java/io/quarkiverse/langchain4j/vertexai/gemini/deployment/VertexAiGeminiProcessor.java
@@ -7,9 +7,11 @@ import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.STREAMIN
 import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
 import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 
@@ -20,7 +22,10 @@ import io.quarkiverse.langchain4j.deployment.items.EmbeddingModelProviderCandida
 import io.quarkiverse.langchain4j.deployment.items.SelectedChatModelProviderBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedEmbeddingModelCandidateBuildItem;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
+import io.quarkiverse.langchain4j.vertexai.runtime.gemini.VertexAiGeminiChatLanguageModel;
+import io.quarkiverse.langchain4j.vertexai.runtime.gemini.VertexAiGeminiEmbeddingModel;
 import io.quarkiverse.langchain4j.vertexai.runtime.gemini.VertexAiGeminiRecorder;
+import io.quarkiverse.langchain4j.vertexai.runtime.gemini.VertexAiGeminiStreamingChatLanguageModel;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
@@ -37,6 +42,16 @@ public class VertexAiGeminiProcessor {
 
     private static final String FEATURE = "langchain4j-vertexai-gemini";
     private static final String PROVIDER = "vertexai-gemini";
+
+    private static final DotName VERTEX_AI_GEMINI_CHAT_MODEL_BUILDER = DotName
+            .createSimple(VertexAiGeminiChatLanguageModel.Builder.class);
+    private static final DotName VERTEX_AI_GEMINI_STREAMING_CHAT_MODEL_BUILDER = DotName
+            .createSimple(VertexAiGeminiStreamingChatLanguageModel.Builder.class);
+    private static final DotName VERTEX_AI_GEMINI_EMBEDDING_MODEL_BUILDER = DotName
+            .createSimple(VertexAiGeminiEmbeddingModel.Builder.class);
+
+    private static final AnnotationInstance ANY = AnnotationInstance.builder(DotName.createSimple(
+            Any.class)).build();
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -72,6 +87,10 @@ public class VertexAiGeminiProcessor {
                         .scope(ApplicationScoped.class)
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(VERTEX_AI_GEMINI_CHAT_MODEL_BUILDER) }, null) },
+                                null), ANY)
                         .createWith(chatModel);
 
                 addQualifierIfNecessary(builder, configName);
@@ -87,6 +106,10 @@ public class VertexAiGeminiProcessor {
                                 new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.MODEL_AUTH_PROVIDER) }, null))
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(VERTEX_AI_GEMINI_STREAMING_CHAT_MODEL_BUILDER) }, null) },
+                                null), ANY)
                         .createWith(streamingChatModel);
 
                 addQualifierIfNecessary(streamingBuilder, configName);
@@ -102,7 +125,11 @@ public class VertexAiGeminiProcessor {
                         .defaultBean()
                         .unremovable()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.embeddingModel(configName));
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(VERTEX_AI_GEMINI_EMBEDDING_MODEL_BUILDER) }, null) },
+                                null), ANY)
+                        .createWith(recorder.embeddingModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }

--- a/model-providers/google/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/VertexAiGeminiRecorder.java
+++ b/model-providers/google/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/VertexAiGeminiRecorder.java
@@ -7,9 +7,9 @@ import java.net.Proxy;
 import java.net.Proxy.Type;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.util.TypeLiteral;
 
@@ -20,6 +20,7 @@ import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.embedding.DisabledEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkiverse.langchain4j.vertexai.runtime.gemini.config.LangChain4jVertexAiGeminiConfig;
 import io.quarkus.arc.SyntheticCreationalContext;
@@ -33,6 +34,12 @@ public class VertexAiGeminiRecorder {
     private static final String DUMMY_KEY = "dummy";
     private static final TypeLiteral<Instance<ChatModelListener>> CHAT_MODEL_LISTENER_TYPE_LITERAL = new TypeLiteral<>() {
     };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<VertexAiGeminiChatLanguageModel.Builder>>> CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<VertexAiGeminiStreamingChatLanguageModel.Builder>>> STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<VertexAiGeminiEmbeddingModel.Builder>>> EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
 
     private final RuntimeValue<LangChain4jVertexAiGeminiConfig> runtimeConfig;
 
@@ -40,7 +47,7 @@ public class VertexAiGeminiRecorder {
         this.runtimeConfig = runtimeConfig;
     }
 
-    public Supplier<EmbeddingModel> embeddingModel(String configName) {
+    public Function<SyntheticCreationalContext<EmbeddingModel>, EmbeddingModel> embeddingModel(String configName) {
         var vertexAiConfig = correspondingVertexAiConfig(configName);
 
         if (vertexAiConfig.enableIntegration()) {
@@ -78,9 +85,22 @@ public class VertexAiGeminiRecorder {
                 builder.taskType(embeddingModelConfig.taskType().get());
             }
 
-            return builder::build;
+            return new Function<>() {
+                @Override
+                public EmbeddingModel apply(SyntheticCreationalContext<EmbeddingModel> context) {
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
+                    return builder.build();
+                }
+            };
         } else {
-            return DisabledEmbeddingModel::new;
+            return new Function<>() {
+                @Override
+                public EmbeddingModel apply(SyntheticCreationalContext<EmbeddingModel> context) {
+                    return new DisabledEmbeddingModel();
+                }
+            };
         }
     }
 
@@ -134,6 +154,9 @@ public class VertexAiGeminiRecorder {
                 public ChatModel apply(SyntheticCreationalContext<ChatModel> context) {
                     builder.listeners(context.getInjectedReference(CHAT_MODEL_LISTENER_TYPE_LITERAL).stream()
                             .collect(Collectors.toList()));
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
@@ -199,6 +222,9 @@ public class VertexAiGeminiRecorder {
                 public StreamingChatModel apply(SyntheticCreationalContext<StreamingChatModel> context) {
                     builder.listeners(context.getInjectedReference(CHAT_MODEL_LISTENER_TYPE_LITERAL).stream()
                             .collect(Collectors.toList()));
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };

--- a/model-providers/google/vertex-ai/deployment/src/main/java/io/quarkiverse/langchain4j/vertexai/deployment/VertexAiProcessor.java
+++ b/model-providers/google/vertex-ai/deployment/src/main/java/io/quarkiverse/langchain4j/vertexai/deployment/VertexAiProcessor.java
@@ -5,13 +5,20 @@ import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.CHAT_MOD
 import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
 
 import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.Type;
 
 import io.quarkiverse.langchain4j.ModelName;
+import io.quarkiverse.langchain4j.deployment.DotNames;
 import io.quarkiverse.langchain4j.deployment.items.ChatModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedChatModelProviderBuildItem;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
+import io.quarkiverse.langchain4j.vertexai.runtime.VertexAiChatLanguageModel;
 import io.quarkiverse.langchain4j.vertexai.runtime.VertexAiRecorder;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
@@ -29,6 +36,11 @@ public class VertexAiProcessor {
 
     private static final String FEATURE = "langchain4j-vertexai";
     private static final String PROVIDER = "vertexai";
+
+    private static final DotName VERTEX_AI_CHAT_MODEL_BUILDER = DotName
+            .createSimple(VertexAiChatLanguageModel.Builder.class);
+    private static final AnnotationInstance ANY = AnnotationInstance
+            .builder(DotName.createSimple(Any.class)).build();
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -56,7 +68,11 @@ public class VertexAiProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.chatModel(configName));
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(VERTEX_AI_CHAT_MODEL_BUILDER) }, null) },
+                                null), ANY)
+                        .createWith(recorder.chatModel(configName));
 
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());

--- a/model-providers/google/vertex-ai/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/VertexAiRecorder.java
+++ b/model-providers/google/vertex-ai/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/VertexAiRecorder.java
@@ -6,12 +6,18 @@ import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.Proxy.Type;
 import java.util.Optional;
-import java.util.function.Supplier;
+import java.util.function.Function;
+
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.util.TypeLiteral;
 
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.DisabledChatModel;
+import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkiverse.langchain4j.vertexai.runtime.config.LangChain4jVertexAiConfig;
+import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.smallrye.config.ConfigValidationException;
@@ -19,6 +25,8 @@ import io.smallrye.config.ConfigValidationException;
 @Recorder
 public class VertexAiRecorder {
     private static final String DUMMY_KEY = "dummy";
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<VertexAiChatLanguageModel.Builder>>> CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
 
     private final RuntimeValue<LangChain4jVertexAiConfig> runtimeConfig;
 
@@ -26,7 +34,7 @@ public class VertexAiRecorder {
         this.runtimeConfig = runtimeConfig;
     }
 
-    public Supplier<ChatModel> chatModel(String configName) {
+    public Function<SyntheticCreationalContext<ChatModel>, ChatModel> chatModel(String configName) {
         var vertexAiConfig = correspondingVertexAiConfig(configName);
 
         if (vertexAiConfig.enableIntegration()) {
@@ -62,16 +70,19 @@ public class VertexAiRecorder {
 
             // TODO: add the rest of the properties
 
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public ChatModel get() {
+                public ChatModel apply(SyntheticCreationalContext<ChatModel> context) {
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
         } else {
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public ChatModel get() {
+                public ChatModel apply(SyntheticCreationalContext<ChatModel> context) {
                     return new DisabledChatModel();
                 }
             };

--- a/model-providers/hugging-face/deployment/src/main/java/io/quarkiverse/langchain4j/huggingface/deployment/HuggingFaceProcessor.java
+++ b/model-providers/hugging-face/deployment/src/main/java/io/quarkiverse/langchain4j/huggingface/deployment/HuggingFaceProcessor.java
@@ -6,14 +6,22 @@ import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.EMBEDDIN
 import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
 
 import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.Type;
 
 import io.quarkiverse.langchain4j.ModelName;
+import io.quarkiverse.langchain4j.deployment.DotNames;
 import io.quarkiverse.langchain4j.deployment.items.ChatModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.EmbeddingModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedChatModelProviderBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedEmbeddingModelCandidateBuildItem;
+import io.quarkiverse.langchain4j.huggingface.QuarkusHuggingFaceChatModel;
+import io.quarkiverse.langchain4j.huggingface.QuarkusHuggingFaceEmbeddingModel;
 import io.quarkiverse.langchain4j.huggingface.runtime.HuggingFaceRecorder;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
@@ -32,6 +40,14 @@ public class HuggingFaceProcessor {
 
     private static final String FEATURE = "langchain4j-huggingface";
     private static final String PROVIDER = "huggingface";
+
+    private static final DotName HUGGING_FACE_CHAT_MODEL_BUILDER = DotName
+            .createSimple(QuarkusHuggingFaceChatModel.Builder.class);
+    private static final DotName HUGGING_FACE_EMBEDDING_MODEL_BUILDER = DotName
+            .createSimple(QuarkusHuggingFaceEmbeddingModel.Builder.class);
+
+    private static final AnnotationInstance ANY = AnnotationInstance.builder(DotName.createSimple(
+            Any.class)).build();
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -66,7 +82,11 @@ public class HuggingFaceProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.chatModel(configName));
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(HUGGING_FACE_CHAT_MODEL_BUILDER) }, null) },
+                                null), ANY)
+                        .createWith(recorder.chatModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }
@@ -81,7 +101,11 @@ public class HuggingFaceProcessor {
                         .defaultBean()
                         .unremovable()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.embeddingModel(configName));
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(HUGGING_FACE_EMBEDDING_MODEL_BUILDER) }, null) },
+                                null), ANY)
+                        .createWith(recorder.embeddingModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }

--- a/model-providers/hugging-face/runtime/src/main/java/io/quarkiverse/langchain4j/huggingface/runtime/HuggingFaceRecorder.java
+++ b/model-providers/hugging-face/runtime/src/main/java/io/quarkiverse/langchain4j/huggingface/runtime/HuggingFaceRecorder.java
@@ -4,18 +4,24 @@ import static io.quarkiverse.langchain4j.runtime.OptionalUtil.firstOrDefault;
 
 import java.net.URL;
 import java.time.Duration;
-import java.util.function.Supplier;
+import java.util.function.Function;
+
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.util.TypeLiteral;
 
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.DisabledChatModel;
 import dev.langchain4j.model.embedding.DisabledEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
 import io.quarkiverse.langchain4j.huggingface.QuarkusHuggingFaceChatModel;
 import io.quarkiverse.langchain4j.huggingface.QuarkusHuggingFaceEmbeddingModel;
 import io.quarkiverse.langchain4j.huggingface.runtime.config.ChatModelConfig;
 import io.quarkiverse.langchain4j.huggingface.runtime.config.EmbeddingModelConfig;
 import io.quarkiverse.langchain4j.huggingface.runtime.config.LangChain4jHuggingFaceConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
+import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.smallrye.config.ConfigValidationException;
@@ -25,6 +31,10 @@ public class HuggingFaceRecorder {
 
     private static final String DUMMY_KEY = "dummy";
     private static final String HUGGING_FACE_URL_MARKER = "api-inference.huggingface.co";
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<QuarkusHuggingFaceChatModel.Builder>>> CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<QuarkusHuggingFaceEmbeddingModel.Builder>>> EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
 
     private final RuntimeValue<LangChain4jHuggingFaceConfig> runtimeConfig;
 
@@ -32,7 +42,7 @@ public class HuggingFaceRecorder {
         this.runtimeConfig = runtimeConfig;
     }
 
-    public Supplier<ChatModel> chatModel(String configName) {
+    public Function<SyntheticCreationalContext<ChatModel>, ChatModel> chatModel(String configName) {
         LangChain4jHuggingFaceConfig.HuggingFaceConfig huggingFaceConfig = correspondingHuggingFaceConfig(
                 runtimeConfig.getValue(), configName);
 
@@ -66,23 +76,26 @@ public class HuggingFaceRecorder {
                 builder.maxNewTokens(chatModelConfig.maxNewTokens().get());
             }
 
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public ChatModel get() {
+                public ChatModel apply(SyntheticCreationalContext<ChatModel> context) {
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
         } else {
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public ChatModel get() {
+                public ChatModel apply(SyntheticCreationalContext<ChatModel> context) {
                     return new DisabledChatModel();
                 }
             };
         }
     }
 
-    public Supplier<EmbeddingModel> embeddingModel(String configName) {
+    public Function<SyntheticCreationalContext<EmbeddingModel>, EmbeddingModel> embeddingModel(String configName) {
         LangChain4jHuggingFaceConfig.HuggingFaceConfig huggingFaceConfig = correspondingHuggingFaceConfig(
                 runtimeConfig.getValue(), configName);
 
@@ -104,16 +117,19 @@ public class HuggingFaceRecorder {
                 builder.accessToken(apiKey);
             }
 
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public EmbeddingModel get() {
+                public EmbeddingModel apply(SyntheticCreationalContext<EmbeddingModel> context) {
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
         } else {
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public EmbeddingModel get() {
+                public EmbeddingModel apply(SyntheticCreationalContext<EmbeddingModel> context) {
                     return new DisabledEmbeddingModel();
                 }
             };

--- a/model-providers/hugging-face/runtime/src/test/java/io/quarkiverse/langchain4j/huggingface/runtime/DisabledModelsHuggingFaceRecorderTest.java
+++ b/model-providers/hugging-face/runtime/src/test/java/io/quarkiverse/langchain4j/huggingface/runtime/DisabledModelsHuggingFaceRecorderTest.java
@@ -29,14 +29,14 @@ class DisabledModelsHuggingFaceRecorderTest {
 
     @Test
     void disabledChatModel() {
-        assertThat(recorder.chatModel(NamedConfigUtil.DEFAULT_NAME).get())
+        assertThat(recorder.chatModel(NamedConfigUtil.DEFAULT_NAME).apply(null))
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledChatModel.class);
     }
 
     @Test
     void disabledEmbeddingModel() {
-        assertThat(recorder.embeddingModel(NamedConfigUtil.DEFAULT_NAME).get())
+        assertThat(recorder.embeddingModel(NamedConfigUtil.DEFAULT_NAME).apply(null))
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledEmbeddingModel.class);
     }

--- a/model-providers/jlama/deployment/src/main/java/io/quarkiverse/langchain4j/jlama/deployment/JlamaProcessor.java
+++ b/model-providers/jlama/deployment/src/main/java/io/quarkiverse/langchain4j/jlama/deployment/JlamaProcessor.java
@@ -19,9 +19,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
 
 import org.apache.commons.io.file.PathUtils;
 import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,11 +35,15 @@ import com.github.tjake.jlama.safetensors.SafeTensorSupport;
 import com.github.tjake.jlama.util.ProgressReporter;
 
 import io.quarkiverse.langchain4j.ModelName;
+import io.quarkiverse.langchain4j.deployment.DotNames;
 import io.quarkiverse.langchain4j.deployment.items.ChatModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.EmbeddingModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedChatModelProviderBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedEmbeddingModelCandidateBuildItem;
+import io.quarkiverse.langchain4j.jlama.JlamaChatModel;
+import io.quarkiverse.langchain4j.jlama.JlamaEmbeddingModel;
 import io.quarkiverse.langchain4j.jlama.JlamaModelRegistry;
+import io.quarkiverse.langchain4j.jlama.JlamaStreamingChatModel;
 import io.quarkiverse.langchain4j.jlama.runtime.JlamaAiRecorder;
 import io.quarkiverse.langchain4j.jlama.runtime.config.LangChain4jJlamaFixedRuntimeConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
@@ -64,6 +73,16 @@ public class JlamaProcessor {
     private static final String FEATURE = "langchain4j-jlama";
     private static final String PROVIDER = "jlama";
     private static final org.slf4j.Logger log = LoggerFactory.getLogger(JlamaProcessor.class);
+
+    private static final DotName JLAMA_CHAT_MODEL_BUILDER = DotName
+            .createSimple(JlamaChatModel.JlamaChatModelBuilder.class);
+    private static final DotName JLAMA_STREAMING_CHAT_MODEL_BUILDER = DotName
+            .createSimple(JlamaStreamingChatModel.JlamaStreamingChatModelBuilder.class);
+    private static final DotName JLAMA_EMBEDDING_MODEL_BUILDER = DotName
+            .createSimple(JlamaEmbeddingModel.JlamaEmbeddingModelBuilder.class);
+
+    private static final AnnotationInstance ANY = AnnotationInstance.builder(DotName.createSimple(
+            Any.class)).build();
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -99,13 +118,21 @@ public class JlamaProcessor {
                 String configName = selected.getConfigName();
                 var builder = SyntheticBeanBuildItem.configure(CHAT_MODEL).setRuntimeInit().defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.chatModel(configName));
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(JLAMA_CHAT_MODEL_BUILDER) }, null) },
+                                null), ANY)
+                        .createWith(recorder.chatModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
 
                 var streamingBuilder = SyntheticBeanBuildItem.configure(STREAMING_CHAT_MODEL).setRuntimeInit()
                         .defaultBean().scope(ApplicationScoped.class)
-                        .supplier(recorder.streamingChatModel(configName));
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(JLAMA_STREAMING_CHAT_MODEL_BUILDER) }, null) },
+                                null), ANY)
+                        .createWith(recorder.streamingChatModel(configName));
                 addQualifierIfNecessary(streamingBuilder, configName);
                 beanProducer.produce(streamingBuilder.done());
             }
@@ -116,7 +143,11 @@ public class JlamaProcessor {
                 String configName = selected.getConfigName();
                 var builder = SyntheticBeanBuildItem.configure(EMBEDDING_MODEL).setRuntimeInit().defaultBean()
                         .unremovable().scope(ApplicationScoped.class)
-                        .supplier(recorder.embeddingModel(configName));
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(JLAMA_EMBEDDING_MODEL_BUILDER) }, null) },
+                                null), ANY)
+                        .createWith(recorder.embeddingModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }

--- a/model-providers/jlama/runtime/src/main/java/io/quarkiverse/langchain4j/jlama/runtime/JlamaAiRecorder.java
+++ b/model-providers/jlama/runtime/src/main/java/io/quarkiverse/langchain4j/jlama/runtime/JlamaAiRecorder.java
@@ -1,6 +1,10 @@
 package io.quarkiverse.langchain4j.jlama.runtime;
 
-import java.util.function.Supplier;
+import java.util.function.Function;
+
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.util.TypeLiteral;
 
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.DisabledChatModel;
@@ -8,6 +12,7 @@ import dev.langchain4j.model.chat.DisabledStreamingChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.embedding.DisabledEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
 import io.quarkiverse.langchain4j.jlama.JlamaChatModel;
 import io.quarkiverse.langchain4j.jlama.JlamaEmbeddingModel;
 import io.quarkiverse.langchain4j.jlama.JlamaStreamingChatModel;
@@ -15,11 +20,19 @@ import io.quarkiverse.langchain4j.jlama.runtime.config.ChatModelConfig;
 import io.quarkiverse.langchain4j.jlama.runtime.config.LangChain4jJlamaConfig;
 import io.quarkiverse.langchain4j.jlama.runtime.config.LangChain4jJlamaFixedRuntimeConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
+import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class JlamaAiRecorder {
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<JlamaChatModel.JlamaChatModelBuilder>>> CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<JlamaStreamingChatModel.JlamaStreamingChatModelBuilder>>> STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<JlamaEmbeddingModel.JlamaEmbeddingModelBuilder>>> EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+
     private final RuntimeValue<LangChain4jJlamaConfig> runtimeConfig;
     private final RuntimeValue<LangChain4jJlamaFixedRuntimeConfig> fixedRuntimeConfig;
 
@@ -29,7 +42,7 @@ public class JlamaAiRecorder {
         this.fixedRuntimeConfig = fixedRuntimeConfig;
     }
 
-    public Supplier<ChatModel> chatModel(String configName) {
+    public Function<SyntheticCreationalContext<ChatModel>, ChatModel> chatModel(String configName) {
         LangChain4jJlamaConfig.JlamaConfig jlamaConfig = correspondingJlamaConfig(configName);
         LangChain4jJlamaFixedRuntimeConfig.JlamaConfig jlamaFixedRuntimeConfig = correspondingJlamaFixedRuntimeConfig(
                 configName);
@@ -48,23 +61,26 @@ public class JlamaAiRecorder {
             chatModelConfig.temperature().ifPresent(temp -> builder.temperature((float) temp));
             chatModelConfig.maxTokens().ifPresent(builder::maxTokens);
 
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public ChatModel get() {
+                public ChatModel apply(SyntheticCreationalContext<ChatModel> context) {
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
         } else {
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public ChatModel get() {
+                public ChatModel apply(SyntheticCreationalContext<ChatModel> context) {
                     return new DisabledChatModel();
                 }
             };
         }
     }
 
-    public Supplier<StreamingChatModel> streamingChatModel(String configName) {
+    public Function<SyntheticCreationalContext<StreamingChatModel>, StreamingChatModel> streamingChatModel(String configName) {
         LangChain4jJlamaConfig.JlamaConfig jlamaConfig = correspondingJlamaConfig(configName);
         LangChain4jJlamaFixedRuntimeConfig.JlamaConfig jlamaFixedRuntimeConfig = correspondingJlamaFixedRuntimeConfig(
                 configName);
@@ -77,23 +93,26 @@ public class JlamaAiRecorder {
 
             chatModelConfig.temperature().ifPresent(temp -> builder.temperature((float) temp));
 
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public StreamingChatModel get() {
+                public StreamingChatModel apply(SyntheticCreationalContext<StreamingChatModel> context) {
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
         } else {
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public StreamingChatModel get() {
+                public StreamingChatModel apply(SyntheticCreationalContext<StreamingChatModel> context) {
                     return new DisabledStreamingChatModel();
                 }
             };
         }
     }
 
-    public Supplier<EmbeddingModel> embeddingModel(String configName) {
+    public Function<SyntheticCreationalContext<EmbeddingModel>, EmbeddingModel> embeddingModel(String configName) {
         LangChain4jJlamaConfig.JlamaConfig jlamaConfig = correspondingJlamaConfig(configName);
         LangChain4jJlamaFixedRuntimeConfig.JlamaConfig jlamaFixedRuntimeConfig = correspondingJlamaFixedRuntimeConfig(
                 configName);
@@ -103,16 +122,19 @@ public class JlamaAiRecorder {
                     .modelName(jlamaFixedRuntimeConfig.embeddingModel().modelName())
                     .modelCachePath(fixedRuntimeConfig.getValue().modelsPath());
 
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public EmbeddingModel get() {
+                public EmbeddingModel apply(SyntheticCreationalContext<EmbeddingModel> context) {
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
         } else {
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public EmbeddingModel get() {
+                public EmbeddingModel apply(SyntheticCreationalContext<EmbeddingModel> context) {
                     return new DisabledEmbeddingModel();
                 }
             };

--- a/model-providers/llama3-java/deployment/src/main/java/io/quarkiverse/langchain4j/llama3/deployment/Llama3Processor.java
+++ b/model-providers/llama3-java/deployment/src/main/java/io/quarkiverse/langchain4j/llama3/deployment/Llama3Processor.java
@@ -16,15 +16,23 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
 
 import org.apache.commons.io.file.PathUtils;
 import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
 
 import io.quarkiverse.langchain4j.ModelName;
+import io.quarkiverse.langchain4j.deployment.DotNames;
 import io.quarkiverse.langchain4j.deployment.items.ChatModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedChatModelProviderBuildItem;
+import io.quarkiverse.langchain4j.llama3.Llama3ChatModel;
 import io.quarkiverse.langchain4j.llama3.Llama3ModelRegistry;
+import io.quarkiverse.langchain4j.llama3.Llama3StreamingChatModel;
 import io.quarkiverse.langchain4j.llama3.ProgressReporter;
 import io.quarkiverse.langchain4j.llama3.runtime.Llama3PreloadRecorder;
 import io.quarkiverse.langchain4j.llama3.runtime.Llama3Recorder;
@@ -62,6 +70,12 @@ public class Llama3Processor {
     private static final String FEATURE = "langchain4j-llama3-java";
     private static final String PROVIDER = "llama3-java";
 
+    private static final DotName LLAMA3_CHAT_MODEL_BUILDER = DotName.createSimple(Llama3ChatModel.Builder.class);
+    private static final DotName LLAMA3_STREAMING_CHAT_MODEL_BUILDER = DotName
+            .createSimple(Llama3StreamingChatModel.Builder.class);
+    private static final AnnotationInstance ANY = AnnotationInstance
+            .builder(DotName.createSimple(Any.class)).build();
+
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FEATURE);
@@ -98,7 +112,11 @@ public class Llama3Processor {
                 String configName = selected.getConfigName();
                 var builder = SyntheticBeanBuildItem.configure(CHAT_MODEL).setRuntimeInit().defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.chatModel(configName));
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(LLAMA3_CHAT_MODEL_BUILDER) }, null) },
+                                null), ANY)
+                        .createWith(recorder.chatModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
 
@@ -107,7 +125,12 @@ public class Llama3Processor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.streamingChatModel(configName));
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(LLAMA3_STREAMING_CHAT_MODEL_BUILDER) },
+                                        null) },
+                                null), ANY)
+                        .createWith(recorder.streamingChatModel(configName));
                 addQualifierIfNecessary(streamingBuilder, configName);
                 beanProducer.produce(streamingBuilder.done());
             }

--- a/model-providers/llama3-java/runtime/src/main/java/io/quarkiverse/langchain4j/llama3/runtime/Llama3Recorder.java
+++ b/model-providers/llama3-java/runtime/src/main/java/io/quarkiverse/langchain4j/llama3/runtime/Llama3Recorder.java
@@ -1,22 +1,33 @@
 package io.quarkiverse.langchain4j.llama3.runtime;
 
-import java.util.function.Supplier;
+import java.util.function.Function;
+
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.util.TypeLiteral;
 
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.DisabledChatModel;
 import dev.langchain4j.model.chat.DisabledStreamingChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
+import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
 import io.quarkiverse.langchain4j.llama3.Llama3ChatModel;
 import io.quarkiverse.langchain4j.llama3.Llama3StreamingChatModel;
 import io.quarkiverse.langchain4j.llama3.runtime.config.ChatModelConfig;
 import io.quarkiverse.langchain4j.llama3.runtime.config.LangChain4jLlama3FixedRuntimeConfig;
 import io.quarkiverse.langchain4j.llama3.runtime.config.LangChain4jLlama3RuntimeConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
+import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class Llama3Recorder {
+
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<Llama3ChatModel.Builder>>> CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<Llama3StreamingChatModel.Builder>>> STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
 
     private final RuntimeValue<LangChain4jLlama3RuntimeConfig> runtimeConfig;
     private final RuntimeValue<LangChain4jLlama3FixedRuntimeConfig> fixedRuntimeConfig;
@@ -27,7 +38,7 @@ public class Llama3Recorder {
         this.fixedRuntimeConfig = fixedRuntimeConfig;
     }
 
-    public Supplier<ChatModel> chatModel(String configName) {
+    public Function<SyntheticCreationalContext<ChatModel>, ChatModel> chatModel(String configName) {
         LangChain4jLlama3RuntimeConfig.Llama3Config llama3Config = correspondingJlamaConfig(configName);
         LangChain4jLlama3FixedRuntimeConfig.Llama3Config llama3FixedRuntimeConfig = correspondingJlamaFixedRuntimeConfig(
                 configName);
@@ -49,23 +60,27 @@ public class Llama3Recorder {
                 builder.maxTokens(chatModelConfig.maxTokens().getAsInt());
             }
 
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public ChatModel get() {
+                public ChatModel apply(SyntheticCreationalContext<ChatModel> context) {
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
         } else {
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public ChatModel get() {
+                public ChatModel apply(SyntheticCreationalContext<ChatModel> context) {
                     return new DisabledChatModel();
                 }
             };
         }
     }
 
-    public Supplier<StreamingChatModel> streamingChatModel(String configName) {
+    public Function<SyntheticCreationalContext<StreamingChatModel>, StreamingChatModel> streamingChatModel(
+            String configName) {
         LangChain4jLlama3RuntimeConfig.Llama3Config llama3Config = correspondingJlamaConfig(configName);
         LangChain4jLlama3FixedRuntimeConfig.Llama3Config llama3FixedRuntimeConfig = correspondingJlamaFixedRuntimeConfig(
                 configName);
@@ -87,16 +102,20 @@ public class Llama3Recorder {
                 builder.maxTokens(chatModelConfig.maxTokens().getAsInt());
             }
 
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public StreamingChatModel get() {
+                public StreamingChatModel apply(SyntheticCreationalContext<StreamingChatModel> context) {
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL,
+                                    Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
         } else {
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public StreamingChatModel get() {
+                public StreamingChatModel apply(SyntheticCreationalContext<StreamingChatModel> context) {
                     return new DisabledStreamingChatModel();
                 }
             };

--- a/model-providers/mistral/deployment/src/main/java/io/quarkiverse/langchain4j/mistralai/deployment/MistralAiProcessor.java
+++ b/model-providers/mistral/deployment/src/main/java/io/quarkiverse/langchain4j/mistralai/deployment/MistralAiProcessor.java
@@ -8,12 +8,22 @@ import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.STREAMIN
 import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
 
 import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.Type;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
+import dev.langchain4j.model.mistralai.MistralAiChatModel;
+import dev.langchain4j.model.mistralai.MistralAiEmbeddingModel;
+import dev.langchain4j.model.mistralai.MistralAiModerationModel;
+import dev.langchain4j.model.mistralai.MistralAiStreamingChatModel;
 import io.quarkiverse.langchain4j.ModelName;
+import io.quarkiverse.langchain4j.deployment.DotNames;
 import io.quarkiverse.langchain4j.deployment.items.ChatModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.EmbeddingModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.ModerationModelProviderCandidateBuildItem;
@@ -40,6 +50,18 @@ public class MistralAiProcessor {
 
     private static final String FEATURE = "langchain4j-mistralai";
     private static final String PROVIDER = "mistralai";
+
+    private static final DotName MISTRAL_CHAT_MODEL_BUILDER = DotName
+            .createSimple(MistralAiChatModel.MistralAiChatModelBuilder.class);
+    private static final DotName MISTRAL_STREAMING_CHAT_MODEL_BUILDER = DotName
+            .createSimple(MistralAiStreamingChatModel.MistralAiStreamingChatModelBuilder.class);
+    private static final DotName MISTRAL_EMBEDDING_MODEL_BUILDER = DotName
+            .createSimple(MistralAiEmbeddingModel.MistralAiEmbeddingModelBuilder.class);
+    private static final DotName MISTRAL_MODERATION_MODEL_BUILDER = DotName
+            .createSimple(MistralAiModerationModel.Builder.class);
+
+    private static final AnnotationInstance ANY = AnnotationInstance.builder(DotName.createSimple(
+            Any.class)).build();
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -91,7 +113,11 @@ public class MistralAiProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.chatModel(configName));
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(MISTRAL_CHAT_MODEL_BUILDER) }, null) },
+                                null), ANY)
+                        .createWith(recorder.chatModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
 
@@ -100,7 +126,11 @@ public class MistralAiProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.streamingChatModel(configName));
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(MISTRAL_STREAMING_CHAT_MODEL_BUILDER) }, null) },
+                                null), ANY)
+                        .createWith(recorder.streamingChatModel(configName));
                 addQualifierIfNecessary(streamingBuilder, configName);
                 beanProducer.produce(streamingBuilder.done());
             }
@@ -115,7 +145,11 @@ public class MistralAiProcessor {
                         .defaultBean()
                         .unremovable()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.embeddingModel(configName));
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(MISTRAL_EMBEDDING_MODEL_BUILDER) }, null) },
+                                null), ANY)
+                        .createWith(recorder.embeddingModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }
@@ -129,7 +163,11 @@ public class MistralAiProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.moderationModel(configName));
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(MISTRAL_MODERATION_MODEL_BUILDER) }, null) },
+                                null), ANY)
+                        .createWith(recorder.moderationModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }

--- a/model-providers/mistral/runtime/src/main/java/io/quarkiverse/langchain4j/mistralai/runtime/MistralAiRecorder.java
+++ b/model-providers/mistral/runtime/src/main/java/io/quarkiverse/langchain4j/mistralai/runtime/MistralAiRecorder.java
@@ -5,7 +5,11 @@ import static io.quarkiverse.langchain4j.mistralai.runtime.config.LangChain4jMis
 import static io.quarkiverse.langchain4j.runtime.OptionalUtil.firstOrDefault;
 
 import java.time.Duration;
-import java.util.function.Supplier;
+import java.util.function.Function;
+
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.util.TypeLiteral;
 
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.DisabledChatModel;
@@ -19,25 +23,36 @@ import dev.langchain4j.model.mistralai.MistralAiModerationModel;
 import dev.langchain4j.model.mistralai.MistralAiStreamingChatModel;
 import dev.langchain4j.model.moderation.DisabledModerationModel;
 import dev.langchain4j.model.moderation.ModerationModel;
+import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
 import io.quarkiverse.langchain4j.mistralai.QuarkusMistralAiClient;
 import io.quarkiverse.langchain4j.mistralai.runtime.config.ChatModelConfig;
 import io.quarkiverse.langchain4j.mistralai.runtime.config.EmbeddingModelConfig;
 import io.quarkiverse.langchain4j.mistralai.runtime.config.LangChain4jMistralAiConfig;
 import io.quarkiverse.langchain4j.mistralai.runtime.config.ModerationModelConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
+import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.smallrye.config.ConfigValidationException;
 
 @Recorder
 public class MistralAiRecorder {
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<MistralAiChatModel.MistralAiChatModelBuilder>>> CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<MistralAiStreamingChatModel.MistralAiStreamingChatModelBuilder>>> STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<MistralAiEmbeddingModel.MistralAiEmbeddingModelBuilder>>> EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<MistralAiModerationModel.Builder>>> MODERATION_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+
     private final RuntimeValue<LangChain4jMistralAiConfig> runtimeConfig;
 
     public MistralAiRecorder(RuntimeValue<LangChain4jMistralAiConfig> runtimeConfig) {
         this.runtimeConfig = runtimeConfig;
     }
 
-    public Supplier<ChatModel> chatModel(String configName) {
+    public Function<SyntheticCreationalContext<ChatModel>, ChatModel> chatModel(String configName) {
         LangChain4jMistralAiConfig.MistralAiConfig mistralAiConfig = correspondingMistralAiConfig(configName);
 
         if (mistralAiConfig.enableIntegration()) {
@@ -75,24 +90,27 @@ public class MistralAiRecorder {
 
             var logCurl = firstOrDefault(false, mistralAiConfig.logRequestsCurl());
 
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public ChatModel get() {
+                public ChatModel apply(SyntheticCreationalContext<ChatModel> context) {
                     QuarkusMistralAiClient.setLogCurlHint(logCurl);
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
         } else {
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public ChatModel get() {
+                public ChatModel apply(SyntheticCreationalContext<ChatModel> context) {
                     return new DisabledChatModel();
                 }
             };
         }
     }
 
-    public Supplier<StreamingChatModel> streamingChatModel(String configName) {
+    public Function<SyntheticCreationalContext<StreamingChatModel>, StreamingChatModel> streamingChatModel(String configName) {
         LangChain4jMistralAiConfig.MistralAiConfig mistralAiConfig = correspondingMistralAiConfig(configName);
 
         if (mistralAiConfig.enableIntegration()) {
@@ -130,24 +148,28 @@ public class MistralAiRecorder {
 
             var logCurl = firstOrDefault(false, mistralAiConfig.logRequestsCurl());
 
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public StreamingChatModel get() {
+                public StreamingChatModel apply(SyntheticCreationalContext<StreamingChatModel> context) {
                     QuarkusMistralAiClient.setLogCurlHint(logCurl);
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL,
+                                    Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
         } else {
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public StreamingChatModel get() {
+                public StreamingChatModel apply(SyntheticCreationalContext<StreamingChatModel> context) {
                     return new DisabledStreamingChatModel();
                 }
             };
         }
     }
 
-    public Supplier<EmbeddingModel> embeddingModel(String configName) {
+    public Function<SyntheticCreationalContext<EmbeddingModel>, EmbeddingModel> embeddingModel(String configName) {
         LangChain4jMistralAiConfig.MistralAiConfig mistralAiConfig = correspondingMistralAiConfig(configName);
 
         if (mistralAiConfig.enableIntegration()) {
@@ -167,23 +189,26 @@ public class MistralAiRecorder {
                     .logResponses(firstOrDefault(false, embeddingModelConfig.logResponses(), mistralAiConfig.logResponses()))
                     .timeout(mistralAiConfig.timeout().orElse(Duration.ofSeconds(10)));
 
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public EmbeddingModel get() {
+                public EmbeddingModel apply(SyntheticCreationalContext<EmbeddingModel> context) {
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
         } else {
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public EmbeddingModel get() {
+                public EmbeddingModel apply(SyntheticCreationalContext<EmbeddingModel> context) {
                     return new DisabledEmbeddingModel();
                 }
             };
         }
     }
 
-    public Supplier<ModerationModel> moderationModel(String configName) {
+    public Function<SyntheticCreationalContext<ModerationModel>, ModerationModel> moderationModel(String configName) {
         LangChain4jMistralAiConfig.MistralAiConfig mistralAiConfig = correspondingMistralAiConfig(configName);
 
         if (mistralAiConfig.enableIntegration()) {
@@ -205,17 +230,20 @@ public class MistralAiRecorder {
 
             var logCurl = firstOrDefault(false, mistralAiConfig.logRequestsCurl());
 
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public ModerationModel get() {
+                public ModerationModel apply(SyntheticCreationalContext<ModerationModel> context) {
                     QuarkusMistralAiClient.setLogCurlHint(logCurl);
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(MODERATION_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
         } else {
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public ModerationModel get() {
+                public ModerationModel apply(SyntheticCreationalContext<ModerationModel> context) {
                     return new DisabledModerationModel();
                 }
             };

--- a/model-providers/ollama/deployment/src/main/java/io/quarkiverse/langchain4j/ollama/deployment/OllamaProcessor.java
+++ b/model-providers/ollama/deployment/src/main/java/io/quarkiverse/langchain4j/ollama/deployment/OllamaProcessor.java
@@ -7,13 +7,16 @@ import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.STREAMIN
 import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
 import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 
+import dev.langchain4j.model.ollama.OllamaChatModel;
 import io.quarkiverse.langchain4j.ModelName;
 import io.quarkiverse.langchain4j.deployment.DotNames;
 import io.quarkiverse.langchain4j.deployment.devservice.Langchain4jDevServicesEnabled;
@@ -24,6 +27,8 @@ import io.quarkiverse.langchain4j.deployment.items.EmbeddingModelProviderCandida
 import io.quarkiverse.langchain4j.deployment.items.ImplicitlyUserConfiguredChatProviderBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedChatModelProviderBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedEmbeddingModelCandidateBuildItem;
+import io.quarkiverse.langchain4j.ollama.OllamaEmbeddingModel;
+import io.quarkiverse.langchain4j.ollama.OllamaStreamingChatLanguageModel;
 import io.quarkiverse.langchain4j.ollama.runtime.OllamaRecorder;
 import io.quarkiverse.langchain4j.ollama.runtime.config.LangChain4jOllamaFixedRuntimeConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
@@ -51,6 +56,16 @@ public class OllamaProcessor {
 
     private static final String FEATURE = "langchain4j-ollama";
     private static final String PROVIDER = "ollama";
+
+    private static final DotName OLLAMA_CHAT_MODEL_BUILDER = DotName
+            .createSimple(OllamaChatModel.OllamaChatModelBuilder.class);
+    private static final DotName OLLAMA_STREAMING_CHAT_MODEL_BUILDER = DotName
+            .createSimple(OllamaStreamingChatLanguageModel.Builder.class);
+    private static final DotName OLLAMA_EMBEDDING_MODEL_BUILDER = DotName
+            .createSimple(OllamaEmbeddingModel.Builder.class);
+
+    private static final AnnotationInstance ANY = AnnotationInstance.builder(DotName.createSimple(
+            Any.class)).build();
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -168,6 +183,10 @@ public class OllamaProcessor {
                         .scope(ApplicationScoped.class)
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(OLLAMA_CHAT_MODEL_BUILDER) }, null) },
+                                null), ANY)
                         .createWith(recorder.chatModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
@@ -179,6 +198,10 @@ public class OllamaProcessor {
                         .scope(ApplicationScoped.class)
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(OLLAMA_STREAMING_CHAT_MODEL_BUILDER) }, null) },
+                                null), ANY)
                         .createWith(recorder.streamingChatModel(configName));
                 addQualifierIfNecessary(streamingBuilder, configName);
                 beanProducer.produce(streamingBuilder.done());
@@ -194,7 +217,11 @@ public class OllamaProcessor {
                         .defaultBean()
                         .unremovable()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.embeddingModel(configName));
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(OLLAMA_EMBEDDING_MODEL_BUILDER) }, null) },
+                                null), ANY)
+                        .createWith(recorder.embeddingModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/OllamaRecorder.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/runtime/OllamaRecorder.java
@@ -5,9 +5,9 @@ import static io.quarkiverse.langchain4j.runtime.OptionalUtil.firstOrDefault;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.enterprise.util.TypeLiteral;
@@ -22,6 +22,7 @@ import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.embedding.DisabledEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.ollama.OllamaChatModel;
+import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
 import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
 import io.quarkiverse.langchain4j.jaxrsclient.JaxRsHttpClientBuilder;
 import io.quarkiverse.langchain4j.ollama.OllamaEmbeddingModel;
@@ -54,6 +55,12 @@ public class OllamaRecorder {
     }
 
     private static final TypeLiteral<Instance<ChatModelListener>> CHAT_MODEL_LISTENER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<OllamaChatModel.OllamaChatModelBuilder>>> CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<OllamaStreamingChatLanguageModel.Builder>>> STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<OllamaEmbeddingModel.Builder>>> EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
     };
 
     public Function<SyntheticCreationalContext<ChatModel>, ChatModel> chatModel(String configName) {
@@ -125,6 +132,9 @@ public class OllamaRecorder {
                 public ChatModel apply(SyntheticCreationalContext<ChatModel> context) {
                     ollamaChatModelBuilder.listeners(context.getInjectedReference(CHAT_MODEL_LISTENER_TYPE_LITERAL).stream()
                             .collect(Collectors.toList()));
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            ollamaChatModelBuilder, configName);
 
                     // TODO: we should obtain this from the context
                     Optional<ModelAuthProvider> maybeModelAuthProvider = ModelAuthProvider
@@ -157,7 +167,7 @@ public class OllamaRecorder {
         }
     }
 
-    public Supplier<EmbeddingModel> embeddingModel(String configName) {
+    public Function<SyntheticCreationalContext<EmbeddingModel>, EmbeddingModel> embeddingModel(String configName) {
         LangChain4jOllamaConfig.OllamaConfig ollamaConfig = correspondingOllamaConfig(runtimeConfig.getValue(), configName);
         LangChain4jOllamaFixedRuntimeConfig.OllamaConfig ollamaFixedConfig = correspondingOllamaFixedConfig(fixedRuntimeConfig,
                 configName);
@@ -183,16 +193,19 @@ public class OllamaRecorder {
                     .logResponses(firstOrDefault(false, embeddingModelConfig.logResponses(), ollamaConfig.logResponses()))
                     .configName(NamedConfigUtil.isDefault(configName) ? null : configName);
 
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public EmbeddingModel get() {
+                public EmbeddingModel apply(SyntheticCreationalContext<EmbeddingModel> context) {
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
         } else {
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public EmbeddingModel get() {
+                public EmbeddingModel apply(SyntheticCreationalContext<EmbeddingModel> context) {
                     return new DisabledEmbeddingModel();
                 }
             };
@@ -268,6 +281,9 @@ public class OllamaRecorder {
                         SyntheticCreationalContext<StreamingChatModel> context) {
                     builder.listeners(context.getInjectedReference(CHAT_MODEL_LISTENER_TYPE_LITERAL).stream()
                             .collect(Collectors.toList()));
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };

--- a/model-providers/ollama/runtime/src/test/java/io/quarkiverse/langchain4j/ollama/runtime/DisabledModelsOllamaRecorderTest.java
+++ b/model-providers/ollama/runtime/src/test/java/io/quarkiverse/langchain4j/ollama/runtime/DisabledModelsOllamaRecorderTest.java
@@ -38,7 +38,7 @@ class DisabledModelsOllamaRecorderTest {
 
     @Test
     void disabledEmbeddingModel() {
-        assertThat(recorder.embeddingModel(NamedConfigUtil.DEFAULT_NAME).get())
+        assertThat(recorder.embeddingModel(NamedConfigUtil.DEFAULT_NAME).apply(null))
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledEmbeddingModel.class);
     }

--- a/model-providers/openai/azure-openai/deployment/src/main/java/io/quarkiverse/langchain4j/azure/openai/deployment/AzureOpenAiProcessor.java
+++ b/model-providers/openai/azure-openai/deployment/src/main/java/io/quarkiverse/langchain4j/azure/openai/deployment/AzureOpenAiProcessor.java
@@ -8,13 +8,19 @@ import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.STREAMIN
 import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
 import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 
 import io.quarkiverse.langchain4j.ModelName;
+import io.quarkiverse.langchain4j.azure.openai.AzureOpenAiChatModel;
+import io.quarkiverse.langchain4j.azure.openai.AzureOpenAiEmbeddingModel;
+import io.quarkiverse.langchain4j.azure.openai.AzureOpenAiImageModel;
+import io.quarkiverse.langchain4j.azure.openai.AzureOpenAiStreamingChatModel;
 import io.quarkiverse.langchain4j.azure.openai.runtime.AzureOpenAiRecorder;
 import io.quarkiverse.langchain4j.deployment.DotNames;
 import io.quarkiverse.langchain4j.deployment.items.ChatModelProviderCandidateBuildItem;
@@ -37,6 +43,18 @@ public class AzureOpenAiProcessor {
 
     private static final String FEATURE = "langchain4j-azure-openai";
     private static final String PROVIDER = "azure-openai";
+
+    private static final DotName AZURE_OPENAI_CHAT_MODEL_BUILDER = DotName
+            .createSimple(AzureOpenAiChatModel.Builder.class);
+    private static final DotName AZURE_OPENAI_STREAMING_CHAT_MODEL_BUILDER = DotName
+            .createSimple(AzureOpenAiStreamingChatModel.Builder.class);
+    private static final DotName AZURE_OPENAI_EMBEDDING_MODEL_BUILDER = DotName
+            .createSimple(AzureOpenAiEmbeddingModel.Builder.class);
+    private static final DotName AZURE_OPENAI_IMAGE_MODEL_BUILDER = DotName
+            .createSimple(AzureOpenAiImageModel.Builder.class);
+
+    private static final AnnotationInstance ANY = AnnotationInstance.builder(DotName.createSimple(
+            Any.class)).build();
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -82,6 +100,10 @@ public class AzureOpenAiProcessor {
                                 new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.MODEL_AUTH_PROVIDER) }, null))
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(AZURE_OPENAI_CHAT_MODEL_BUILDER) }, null) },
+                                null), ANY)
                         .createWith(chatModel);
                 addQualifierIfNecessary(chatBuilder, configName);
                 beanProducer.produce(chatBuilder.done());
@@ -96,6 +118,11 @@ public class AzureOpenAiProcessor {
                                 new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.MODEL_AUTH_PROVIDER) }, null))
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(AZURE_OPENAI_STREAMING_CHAT_MODEL_BUILDER) },
+                                        null) },
+                                null), ANY)
                         .createWith(streamingChatModel);
                 addQualifierIfNecessary(streamingBuilder, configName);
                 beanProducer.produce(streamingBuilder.done());
@@ -115,6 +142,10 @@ public class AzureOpenAiProcessor {
                         .scope(ApplicationScoped.class)
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.MODEL_AUTH_PROVIDER) }, null))
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(AZURE_OPENAI_EMBEDDING_MODEL_BUILDER) }, null) },
+                                null), ANY)
                         .createWith(embeddingModel);
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
@@ -133,6 +164,10 @@ public class AzureOpenAiProcessor {
                         .scope(ApplicationScoped.class)
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.MODEL_AUTH_PROVIDER) }, null))
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(AZURE_OPENAI_IMAGE_MODEL_BUILDER) }, null) },
+                                null), ANY)
                         .createWith(imageModel);
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
@@ -15,6 +15,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.util.TypeLiteral;
 
@@ -27,6 +28,7 @@ import dev.langchain4j.model.embedding.DisabledEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.image.DisabledImageModel;
 import dev.langchain4j.model.image.ImageModel;
+import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
 import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
 import io.quarkiverse.langchain4j.azure.openai.AzureOpenAiChatModel;
 import io.quarkiverse.langchain4j.azure.openai.AzureOpenAiEmbeddingModel;
@@ -54,6 +56,14 @@ public class AzureOpenAiRecorder {
     private static final TypeLiteral<Instance<ChatModelListener>> CHAT_MODEL_LISTENER_TYPE_LITERAL = new TypeLiteral<>() {
     };
     private static final TypeLiteral<Instance<ModelAuthProvider>> MODEL_AUTH_PROVIDER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<AzureOpenAiChatModel.Builder>>> CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<AzureOpenAiStreamingChatModel.Builder>>> STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<AzureOpenAiEmbeddingModel.Builder>>> EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<AzureOpenAiImageModel.Builder>>> IMAGE_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
     };
 
     private final RuntimeValue<LangChain4jAzureOpenAiConfig> runtimeConfig;
@@ -109,6 +119,9 @@ public class AzureOpenAiRecorder {
 
                     builder.listeners(context.getInjectedReference(CHAT_MODEL_LISTENER_TYPE_LITERAL).stream()
                             .collect(Collectors.toList()));
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
@@ -164,6 +177,10 @@ public class AzureOpenAiRecorder {
                             configName);
                     builder.listeners(context.getInjectedReference(CHAT_MODEL_LISTENER_TYPE_LITERAL).stream()
                             .collect(Collectors.toList()));
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL,
+                                    Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
@@ -207,6 +224,9 @@ public class AzureOpenAiRecorder {
                 public EmbeddingModel apply(SyntheticCreationalContext<EmbeddingModel> context) {
                     throwIfApiKeysNotConfigured(apiKey, adToken, isAuthProviderAvailable(context, configName),
                             configName);
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
@@ -271,6 +291,9 @@ public class AzureOpenAiRecorder {
                 public ImageModel apply(SyntheticCreationalContext<ImageModel> context) {
                     throwIfApiKeysNotConfigured(apiKey, adToken, isAuthProviderAvailable(context, configName),
                             configName);
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(IMAGE_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };

--- a/model-providers/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/OpenAiProcessor.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/OpenAiProcessor.java
@@ -9,14 +9,20 @@ import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.STREAMIN
 import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
 import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.model.openai.OpenAiEmbeddingModel;
+import dev.langchain4j.model.openai.OpenAiModerationModel;
+import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
 import dev.langchain4j.model.openai.spi.OpenAiChatModelBuilderFactory;
 import dev.langchain4j.model.openai.spi.OpenAiEmbeddingModelBuilderFactory;
 import dev.langchain4j.model.openai.spi.OpenAiModerationModelBuilderFactory;
@@ -33,6 +39,7 @@ import io.quarkiverse.langchain4j.deployment.items.SelectedImageModelProviderBui
 import io.quarkiverse.langchain4j.deployment.items.SelectedModerationModelProviderBuildItem;
 import io.quarkiverse.langchain4j.openai.QuarkusOpenAiChatModelBuilderFactory;
 import io.quarkiverse.langchain4j.openai.QuarkusOpenAiEmbeddingModelBuilderFactory;
+import io.quarkiverse.langchain4j.openai.QuarkusOpenAiImageModel;
 import io.quarkiverse.langchain4j.openai.QuarkusOpenAiModerationModelBuilderFactory;
 import io.quarkiverse.langchain4j.openai.QuarkusOpenAiStreamingChatModelBuilderFactory;
 import io.quarkiverse.langchain4j.openai.runtime.OpenAiRecorder;
@@ -52,6 +59,20 @@ public class OpenAiProcessor {
     private static final String FEATURE = "langchain4j-openai";
     private static final String PROVIDER = "openai";
     private static final String OPEN_AI_EMBEDDING_DESERIALIZER = "dev.langchain4j.model.openai.internal.embedding.OpenAiEmbeddingDeserializer";
+
+    private static final DotName OPENAI_CHAT_MODEL_BUILDER = DotName
+            .createSimple(OpenAiChatModel.OpenAiChatModelBuilder.class);
+    private static final DotName OPENAI_STREAMING_CHAT_MODEL_BUILDER = DotName
+            .createSimple(OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder.class);
+    private static final DotName OPENAI_EMBEDDING_MODEL_BUILDER = DotName
+            .createSimple(OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder.class);
+    private static final DotName OPENAI_MODERATION_MODEL_BUILDER = DotName
+            .createSimple(OpenAiModerationModel.OpenAiModerationModelBuilder.class);
+    private static final DotName OPENAI_IMAGE_MODEL_BUILDER = DotName
+            .createSimple(QuarkusOpenAiImageModel.Builder.class);
+
+    private static final AnnotationInstance ANY = AnnotationInstance.builder(DotName.createSimple(
+            Any.class)).build();
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -98,6 +119,10 @@ public class OpenAiProcessor {
                         .scope(ApplicationScoped.class)
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(OPENAI_CHAT_MODEL_BUILDER) }, null) },
+                                null), ANY)
                         .createWith(recorder.chatModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
@@ -109,6 +134,10 @@ public class OpenAiProcessor {
                         .scope(ApplicationScoped.class)
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(OPENAI_STREAMING_CHAT_MODEL_BUILDER) }, null) },
+                                null), ANY)
                         .createWith(recorder.streamingChatModel(configName));
                 addQualifierIfNecessary(streamingBuilder, configName);
                 beanProducer.produce(streamingBuilder.done());
@@ -124,7 +153,11 @@ public class OpenAiProcessor {
                         .defaultBean()
                         .unremovable()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.embeddingModel(configName));
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(OPENAI_EMBEDDING_MODEL_BUILDER) }, null) },
+                                null), ANY)
+                        .createWith(recorder.embeddingModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }
@@ -138,7 +171,11 @@ public class OpenAiProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.moderationModel(configName));
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(OPENAI_MODERATION_MODEL_BUILDER) }, null) },
+                                null), ANY)
+                        .createWith(recorder.moderationModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }
@@ -152,7 +189,11 @@ public class OpenAiProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.imageModel(configName));
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(OPENAI_IMAGE_MODEL_BUILDER) }, null) },
+                                null), ANY)
+                        .createWith(recorder.imageModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/ModelBuilderCustomizerMultiModelTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/ModelBuilderCustomizerMultiModelTest.java
@@ -1,0 +1,91 @@
+package io.quarkiverse.langchain4j.openai.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
+import io.quarkiverse.langchain4j.ModelName;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests that customizers are correctly scoped when both default and named models are configured.
+ * <p>
+ * Scenario: A default customizer (no qualifier) and a named customizer ({@code @ModelName("second")})
+ * coexist. The default customizer should only apply to the default model, and the named customizer
+ * should only apply to the named model.
+ */
+public class ModelBuilderCustomizerMultiModelTest extends OpenAiBaseTest {
+
+    @ApplicationScoped
+    public static class DefaultCustomizer implements ModelBuilderCustomizer<OpenAiChatModel.OpenAiChatModelBuilder> {
+        @Override
+        public void customize(OpenAiChatModel.OpenAiChatModelBuilder builder) {
+            builder.customHeaders(java.util.Map.of("X-Default-Customizer", "default-value"));
+        }
+    }
+
+    @ApplicationScoped
+    @ModelName("second")
+    public static class SecondCustomizer implements ModelBuilderCustomizer<OpenAiChatModel.OpenAiChatModelBuilder> {
+        @Override
+        public void customize(OpenAiChatModel.OpenAiChatModelBuilder builder) {
+            builder.customHeaders(java.util.Map.of("X-Second-Customizer", "second-value"));
+        }
+    }
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(DefaultCustomizer.class, SecondCustomizer.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "defaultKey")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.second.api-key", "secondKey")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.second.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    ChatModel defaultModel;
+
+    @Inject
+    @ModelName("second")
+    ChatModel secondModel;
+
+    @BeforeEach
+    void setup() {
+        setChatCompletionMessageContent("hello");
+        resetRequests();
+    }
+
+    @Test
+    void defaultCustomizerAppliedToDefaultModel() {
+        defaultModel.chat("test");
+
+        LoggedRequest request = singleLoggedRequest();
+        assertThat(request.getHeader("X-Default-Customizer")).isEqualTo("default-value");
+        assertThat(request.getHeader("X-Second-Customizer")).isNull();
+    }
+
+    @Test
+    void namedCustomizerAppliedToNamedModel() {
+        secondModel.chat("test");
+
+        LoggedRequest request = singleLoggedRequest();
+        assertThat(request.getHeader("X-Second-Customizer")).isEqualTo("second-value");
+        assertThat(request.getHeader("X-Default-Customizer")).isNull();
+    }
+}

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/ModelBuilderCustomizerNamedTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/ModelBuilderCustomizerNamedTest.java
@@ -1,0 +1,74 @@
+package io.quarkiverse.langchain4j.openai.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
+import io.quarkiverse.langchain4j.ModelName;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ModelBuilderCustomizerNamedTest extends OpenAiBaseTest {
+
+    @ApplicationScoped
+    @ModelName("my-model")
+    public static class NamedCustomizer implements ModelBuilderCustomizer<OpenAiChatModel.OpenAiChatModelBuilder> {
+        @Override
+        public void customize(OpenAiChatModel.OpenAiChatModelBuilder builder) {
+            builder.customHeaders(java.util.Map.of("X-Custom-Named", "named-value"));
+        }
+    }
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(NamedCustomizer.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "defaultKey")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.my-model.api-key", "namedKey")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.my-model.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    ChatModel defaultModel;
+
+    @Inject
+    @ModelName("my-model")
+    ChatModel namedModel;
+
+    @BeforeEach
+    void setup() {
+        setChatCompletionMessageContent("hello");
+        resetRequests();
+    }
+
+    @Test
+    void customizerAppliedToNamedModel() {
+        namedModel.chat("test");
+
+        LoggedRequest request = singleLoggedRequest();
+        assertThat(request.getHeader("X-Custom-Named")).isEqualTo("named-value");
+    }
+
+    @Test
+    void customizerNotAppliedToDefaultModel() {
+        defaultModel.chat("test");
+
+        LoggedRequest request = singleLoggedRequest();
+        assertThat(request.getHeader("X-Custom-Named")).isNull();
+    }
+}

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/ModelBuilderCustomizerPriorityTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/ModelBuilderCustomizerPriorityTest.java
@@ -1,0 +1,73 @@
+package io.quarkiverse.langchain4j.openai.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests that customizer priority ordering works correctly.
+ * A higher-priority customizer runs first; a lower-priority one runs after and can override.
+ */
+public class ModelBuilderCustomizerPriorityTest extends OpenAiBaseTest {
+
+    @ApplicationScoped
+    public static class LowPriorityCustomizer implements ModelBuilderCustomizer<OpenAiChatModel.OpenAiChatModelBuilder> {
+        @Override
+        public void customize(OpenAiChatModel.OpenAiChatModelBuilder builder) {
+            builder.modelName("low-priority-model");
+        }
+
+        @Override
+        public int priority() {
+            return -10;
+        }
+    }
+
+    @ApplicationScoped
+    public static class HighPriorityCustomizer implements ModelBuilderCustomizer<OpenAiChatModel.OpenAiChatModelBuilder> {
+        @Override
+        public void customize(OpenAiChatModel.OpenAiChatModelBuilder builder) {
+            builder.modelName("high-priority-model");
+        }
+
+        @Override
+        public int priority() {
+            return 10;
+        }
+    }
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(LowPriorityCustomizer.class, HighPriorityCustomizer.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    ChatModel chatModel;
+
+    @Test
+    void lowerPriorityCustomizerRunsLastAndWins() throws Exception {
+        setChatCompletionMessageContent("hello");
+        chatModel.chat("test");
+
+        LoggedRequest request = singleLoggedRequest();
+        java.util.Map<String, Object> body = getRequestAsMap(request.getBody());
+        assertThat(body.get("model")).isEqualTo("low-priority-model");
+    }
+}

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/ModelBuilderCustomizerTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/ModelBuilderCustomizerTest.java
@@ -1,0 +1,50 @@
+package io.quarkiverse.langchain4j.openai.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ModelBuilderCustomizerTest extends OpenAiBaseTest {
+
+    @ApplicationScoped
+    public static class MyCustomizer implements ModelBuilderCustomizer<OpenAiChatModel.OpenAiChatModelBuilder> {
+        @Override
+        public void customize(OpenAiChatModel.OpenAiChatModelBuilder builder) {
+            builder.customHeaders(java.util.Map.of("X-Custom-From-Customizer", "customized"));
+        }
+    }
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyCustomizer.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    ChatModel chatModel;
+
+    @Test
+    void customizerIsApplied() {
+        setChatCompletionMessageContent("hello");
+        chatModel.chat("test");
+
+        LoggedRequest loggedRequest = singleLoggedRequest();
+        assertThat(loggedRequest.getHeader("X-Custom-From-Customizer")).isEqualTo("customized");
+    }
+}

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
@@ -13,6 +13,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.util.TypeLiteral;
 
@@ -32,6 +33,7 @@ import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
 import dev.langchain4j.model.openai.OpenAiEmbeddingModel;
 import dev.langchain4j.model.openai.OpenAiModerationModel;
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
+import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
 import io.quarkiverse.langchain4j.openai.QuarkusOpenAiChatModelBuilderFactory;
 import io.quarkiverse.langchain4j.openai.QuarkusOpenAiEmbeddingModelBuilderFactory;
 import io.quarkiverse.langchain4j.openai.QuarkusOpenAiImageModel;
@@ -55,6 +57,16 @@ import io.smallrye.config.ConfigValidationException;
 public class OpenAiRecorder {
 
     private static final TypeLiteral<Instance<ChatModelListener>> CHAT_MODEL_LISTENER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<OpenAiChatModel.OpenAiChatModelBuilder>>> CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder>>> STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder>>> EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<OpenAiModerationModel.OpenAiModerationModelBuilder>>> MODERATION_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<QuarkusOpenAiImageModel.Builder>>> IMAGE_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
     };
 
     private static final String DUMMY_KEY = "dummy";
@@ -122,6 +134,9 @@ public class OpenAiRecorder {
                 public ChatModel apply(SyntheticCreationalContext<ChatModel> context) {
                     builder.listeners(context.getInjectedReference(CHAT_MODEL_LISTENER_TYPE_LITERAL).stream()
                             .collect(Collectors.toList()));
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
@@ -184,6 +199,9 @@ public class OpenAiRecorder {
                         SyntheticCreationalContext<StreamingChatModel> context) {
                     builder.listeners(context.getInjectedReference(CHAT_MODEL_LISTENER_TYPE_LITERAL).stream()
                             .collect(Collectors.toList()));
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
@@ -198,7 +216,7 @@ public class OpenAiRecorder {
         }
     }
 
-    public Supplier<EmbeddingModel> embeddingModel(String configName) {
+    public Function<SyntheticCreationalContext<EmbeddingModel>, EmbeddingModel> embeddingModel(String configName) {
         LangChain4jOpenAiConfig.OpenAiConfig openAiConfig = correspondingOpenAiConfig(runtimeConfig.getValue(), configName);
 
         if (openAiConfig.enableIntegration()) {
@@ -229,25 +247,26 @@ public class OpenAiRecorder {
                         new InetSocketAddress(host, openAiConfig.proxyPort())));
             });
 
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public EmbeddingModel get() {
+                public EmbeddingModel apply(SyntheticCreationalContext<EmbeddingModel> context) {
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
         } else {
-            return new Supplier<>() {
-
+            return new Function<>() {
                 @Override
-                public EmbeddingModel get() {
+                public EmbeddingModel apply(SyntheticCreationalContext<EmbeddingModel> context) {
                     return new DisabledEmbeddingModel();
                 }
-
             };
         }
     }
 
-    public Supplier<ModerationModel> moderationModel(String configName) {
+    public Function<SyntheticCreationalContext<ModerationModel>, ModerationModel> moderationModel(String configName) {
         LangChain4jOpenAiConfig.OpenAiConfig openAiConfig = correspondingOpenAiConfig(runtimeConfig.getValue(), configName);
 
         if (openAiConfig.enableIntegration()) {
@@ -275,25 +294,26 @@ public class OpenAiRecorder {
                         new InetSocketAddress(host, openAiConfig.proxyPort())));
             });
 
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public ModerationModel get() {
+                public ModerationModel apply(SyntheticCreationalContext<ModerationModel> context) {
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(MODERATION_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
         } else {
-            return new Supplier<>() {
-
+            return new Function<>() {
                 @Override
-                public ModerationModel get() {
+                public ModerationModel apply(SyntheticCreationalContext<ModerationModel> context) {
                     return new DisabledModerationModel();
                 }
-
             };
         }
     }
 
-    public Supplier<ImageModel> imageModel(String configName) {
+    public Function<SyntheticCreationalContext<ImageModel>, ImageModel> imageModel(String configName) {
         LangChain4jOpenAiConfig.OpenAiConfig openAiConfig = correspondingOpenAiConfig(runtimeConfig.getValue(), configName);
 
         if (openAiConfig.enableIntegration()) {
@@ -341,17 +361,19 @@ public class OpenAiRecorder {
 
             builder.persistDirectory(persistDirectory);
 
-            return new Supplier<>() {
-
+            return new Function<>() {
                 @Override
-                public ImageModel get() {
+                public ImageModel apply(SyntheticCreationalContext<ImageModel> context) {
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(IMAGE_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
         } else {
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public ImageModel get() {
+                public ImageModel apply(SyntheticCreationalContext<ImageModel> context) {
                     return new DisabledImageModel();
                 }
             };

--- a/model-providers/openai/openai-vanilla/runtime/src/test/java/io/quarkiverse/langchain4j/openai/runtime/DisabledModelsOpenAiRecorderTest.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/test/java/io/quarkiverse/langchain4j/openai/runtime/DisabledModelsOpenAiRecorderTest.java
@@ -46,21 +46,21 @@ class DisabledModelsOpenAiRecorderTest {
 
     @Test
     void disabledEmbeddingModel() {
-        assertThat(recorder.embeddingModel(NamedConfigUtil.DEFAULT_NAME).get())
+        assertThat(recorder.embeddingModel(NamedConfigUtil.DEFAULT_NAME).apply(null))
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledEmbeddingModel.class);
     }
 
     @Test
     void disabledImageModel() {
-        assertThat(recorder.imageModel(NamedConfigUtil.DEFAULT_NAME).get())
+        assertThat(recorder.imageModel(NamedConfigUtil.DEFAULT_NAME).apply(null))
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledImageModel.class);
     }
 
     @Test
     void disabledModerationModel() {
-        assertThat(recorder.moderationModel(NamedConfigUtil.DEFAULT_NAME).get())
+        assertThat(recorder.moderationModel(NamedConfigUtil.DEFAULT_NAME).apply(null))
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledModerationModel.class);
     }

--- a/model-providers/openshift-ai/deployment/src/main/java/io/quarkiverse/langchain4j/openshift/ai/deployment/OpenshiftAiProcessor.java
+++ b/model-providers/openshift-ai/deployment/src/main/java/io/quarkiverse/langchain4j/openshift/ai/deployment/OpenshiftAiProcessor.java
@@ -5,12 +5,19 @@ import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.CHAT_MOD
 import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
 
 import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.ParameterizedType;
+import org.jboss.jandex.Type;
 
 import io.quarkiverse.langchain4j.ModelName;
+import io.quarkiverse.langchain4j.deployment.DotNames;
 import io.quarkiverse.langchain4j.deployment.items.ChatModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedChatModelProviderBuildItem;
+import io.quarkiverse.langchain4j.openshiftai.OpenshiftAiChatModel;
 import io.quarkiverse.langchain4j.openshiftai.runtime.OpenshiftAiRecorder;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
@@ -30,6 +37,11 @@ public class OpenshiftAiProcessor {
     private static final String FEATURE = "langchain4j-openshift-ai";
 
     private static final String PROVIDER = "openshift-ai";
+
+    private static final DotName OPENSHIFT_AI_CHAT_MODEL_BUILDER = DotName
+            .createSimple(OpenshiftAiChatModel.Builder.class);
+    private static final AnnotationInstance ANY = AnnotationInstance
+            .builder(DotName.createSimple(Any.class)).build();
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -59,7 +71,11 @@ public class OpenshiftAiProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.chatModel(configName));
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(OPENSHIFT_AI_CHAT_MODEL_BUILDER) }, null) },
+                                null), ANY)
+                        .createWith(recorder.chatModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }

--- a/model-providers/openshift-ai/runtime/src/main/java/io/quarkiverse/langchain4j/openshiftai/runtime/OpenshiftAiRecorder.java
+++ b/model-providers/openshift-ai/runtime/src/main/java/io/quarkiverse/langchain4j/openshiftai/runtime/OpenshiftAiRecorder.java
@@ -6,20 +6,29 @@ import java.net.URL;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Supplier;
+import java.util.function.Function;
+
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.util.TypeLiteral;
 
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.DisabledChatModel;
+import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
 import io.quarkiverse.langchain4j.openshiftai.OpenshiftAiChatModel;
 import io.quarkiverse.langchain4j.openshiftai.runtime.config.ChatModelConfig;
 import io.quarkiverse.langchain4j.openshiftai.runtime.config.LangChain4jOpenshiftAiConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
+import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.smallrye.config.ConfigValidationException;
 
 @Recorder
 public class OpenshiftAiRecorder {
+
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<OpenshiftAiChatModel.Builder>>> CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
 
     private static final String DUMMY_URL = "https://dummy.ai/api";
     private static final String DUMMY_MODEL_ID = "dummy";
@@ -31,7 +40,7 @@ public class OpenshiftAiRecorder {
         this.runtimeConfig = runtimeConfig;
     }
 
-    public Supplier<ChatModel> chatModel(String configName) {
+    public Function<SyntheticCreationalContext<ChatModel>, ChatModel> chatModel(String configName) {
         LangChain4jOpenshiftAiConfig.OpenshiftAiConfig openshiftAiConfig = correspondingOpenshiftAiConfig(
                 runtimeConfig.getValue(), configName);
 
@@ -61,16 +70,19 @@ public class OpenshiftAiRecorder {
                     .logResponses(firstOrDefault(false, chatModelConfig.logResponses(), openshiftAiConfig.logResponses()))
                     .modelId(modelId);
 
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public ChatModel get() {
+                public ChatModel apply(SyntheticCreationalContext<ChatModel> context) {
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
                     return builder.build();
                 }
             };
         } else {
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public ChatModel get() {
+                public ChatModel apply(SyntheticCreationalContext<ChatModel> context) {
                     return new DisabledChatModel();
                 }
             };

--- a/model-providers/openshift-ai/runtime/src/test/java/io/quarkiverse/langchain4j/openshiftai/runtime/DisabledModelsOpenshiftAiRecorderTest.java
+++ b/model-providers/openshift-ai/runtime/src/test/java/io/quarkiverse/langchain4j/openshiftai/runtime/DisabledModelsOpenshiftAiRecorderTest.java
@@ -28,7 +28,7 @@ class DisabledModelsOpenshiftAiRecorderTest {
 
     @Test
     void disabledChatModel() {
-        assertThat(recorder.chatModel(NamedConfigUtil.DEFAULT_NAME).get())
+        assertThat(recorder.chatModel(NamedConfigUtil.DEFAULT_NAME).apply(null))
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledChatModel.class);
     }

--- a/model-providers/watsonx/deployment/src/main/java/io/quarkiverse/langchain4j/watsonx/deployment/WatsonxProcessor.java
+++ b/model-providers/watsonx/deployment/src/main/java/io/quarkiverse/langchain4j/watsonx/deployment/WatsonxProcessor.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassType;
@@ -57,6 +58,24 @@ public class WatsonxProcessor {
 
     private static final String FEATURE = "langchain4j-watsonx";
     private static final String PROVIDER = "watsonx";
+
+    private static final DotName WATSONX_CHAT_MODEL_BUILDER = DotName
+            .createSimple(dev.langchain4j.model.watsonx.WatsonxChatModel.Builder.class);
+    private static final DotName WATSONX_STREAMING_CHAT_MODEL_BUILDER = DotName
+            .createSimple(dev.langchain4j.model.watsonx.WatsonxStreamingChatModel.Builder.class);
+    private static final DotName WATSONX_EMBEDDING_MODEL_BUILDER = DotName
+            .createSimple(dev.langchain4j.model.watsonx.WatsonxEmbeddingModel.Builder.class);
+    private static final DotName WATSONX_SCORING_MODEL_BUILDER = DotName
+            .createSimple(dev.langchain4j.model.watsonx.WatsonxScoringModel.Builder.class);
+    private static final DotName WATSONX_MODERATION_MODEL_BUILDER = DotName
+            .createSimple(dev.langchain4j.model.watsonx.WatsonxModerationModel.Builder.class);
+    private static final DotName TEXT_EXTRACTION_SERVICE_BUILDER = DotName
+            .createSimple(com.ibm.watsonx.ai.textprocessing.textextraction.TextExtractionService.Builder.class);
+    private static final DotName TEXT_CLASSIFICATION_SERVICE_BUILDER = DotName
+            .createSimple(com.ibm.watsonx.ai.textprocessing.textclassification.TextClassificationService.Builder.class);
+
+    private static final AnnotationInstance ANY = AnnotationInstance.builder(DotName.createSimple(
+            Any.class)).build();
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -234,7 +253,11 @@ public class WatsonxProcessor {
                         .defaultBean()
                         .unremovable()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.textExtraction(configName));
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(TEXT_EXTRACTION_SERVICE_BUILDER) }, null) },
+                                null), ANY)
+                        .createWith(recorder.textExtraction(configName));
                 addQualifierIfNecessary(textExtractionBuilder, configName);
                 beanProducer.produce(textExtractionBuilder.done());
             }
@@ -255,7 +278,11 @@ public class WatsonxProcessor {
                         .defaultBean()
                         .unremovable()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.textClassification(configName));
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(TEXT_CLASSIFICATION_SERVICE_BUILDER) }, null) },
+                                null), ANY)
+                        .createWith(recorder.textClassification(configName));
                 addQualifierIfNecessary(textClassificationBuilder, configName);
                 beanProducer.produce(textClassificationBuilder.done());
             }
@@ -279,6 +306,10 @@ public class WatsonxProcessor {
                     .scope(ApplicationScoped.class)
                     .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                             new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
+                    .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                            new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                    new Type[] { ClassType.create(WATSONX_CHAT_MODEL_BUILDER) }, null) },
+                            null), ANY)
                     .createWith(chatModel);
 
             addQualifierIfNecessary(chatBuilder, configName);
@@ -292,6 +323,10 @@ public class WatsonxProcessor {
                     .scope(ApplicationScoped.class)
                     .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                             new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
+                    .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                            new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                    new Type[] { ClassType.create(WATSONX_STREAMING_CHAT_MODEL_BUILDER) }, null) },
+                            null), ANY)
                     .createWith(streamingChatModel);
 
             addQualifierIfNecessary(streamingBuilder, configName);
@@ -307,7 +342,11 @@ public class WatsonxProcessor {
                         .defaultBean()
                         .unremovable()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.embeddingModel(configName));
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(WATSONX_EMBEDDING_MODEL_BUILDER) }, null) },
+                                null), ANY)
+                        .createWith(recorder.embeddingModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }
@@ -322,7 +361,11 @@ public class WatsonxProcessor {
                         .defaultBean()
                         .unremovable()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.scoringModel(configName));
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(WATSONX_SCORING_MODEL_BUILDER) }, null) },
+                                null), ANY)
+                        .createWith(recorder.scoringModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }
@@ -336,7 +379,11 @@ public class WatsonxProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
-                        .supplier(recorder.moderationModel(configName));
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(WATSONX_MODERATION_MODEL_BUILDER) }, null) },
+                                null), ANY)
+                        .createWith(recorder.moderationModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/WatsonxRecorder.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/WatsonxRecorder.java
@@ -7,8 +7,8 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
+import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.util.TypeLiteral;
 
@@ -37,6 +37,7 @@ import dev.langchain4j.model.watsonx.WatsonxEmbeddingModel;
 import dev.langchain4j.model.watsonx.WatsonxModerationModel;
 import dev.langchain4j.model.watsonx.WatsonxScoringModel;
 import dev.langchain4j.model.watsonx.WatsonxStreamingChatModel;
+import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkiverse.langchain4j.watsonx.runtime.client.QuarkusRestClientConfig;
 import io.quarkiverse.langchain4j.watsonx.runtime.config.ChatModelConfig;
@@ -61,6 +62,20 @@ public class WatsonxRecorder {
 
     private static final ConfigValidationException.Problem[] EMPTY_PROBLEMS = new ConfigValidationException.Problem[0];
     private static final TypeLiteral<Instance<ChatModelListener>> CHAT_MODEL_LISTENER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<WatsonxChatModel.Builder>>> CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<WatsonxStreamingChatModel.Builder>>> STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<WatsonxEmbeddingModel.Builder>>> EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<WatsonxScoringModel.Builder>>> SCORING_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<WatsonxModerationModel.Builder>>> MODERATION_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<TextExtractionService.Builder>>> TEXT_EXTRACTION_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<TextClassificationService.Builder>>> TEXT_CLASSIFICATION_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
     };
 
     private final RuntimeValue<LangChain4jWatsonxConfig> runtimeConfig;
@@ -184,10 +199,12 @@ public class WatsonxRecorder {
                                     chatModelConfig.logRequestsCurl(),
                                     specificConfig.logRequestsCurl()));
                     try {
-                        return builder
-                                .authenticator(authenticator)
-                                .listeners(context.getInjectedReference(CHAT_MODEL_LISTENER_TYPE_LITERAL).stream().toList())
-                                .build();
+                        builder.authenticator(authenticator)
+                                .listeners(context.getInjectedReference(CHAT_MODEL_LISTENER_TYPE_LITERAL).stream().toList());
+                        ModelBuilderCustomizer.applyCustomizers(
+                                context.getInjectedReference(CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                                builder, configName);
+                        return builder.build();
                     } finally {
                         QuarkusRestClientConfig.clear();
                     }
@@ -317,10 +334,13 @@ public class WatsonxRecorder {
                                     chatModelConfig.logRequestsCurl(),
                                     specificConfig.logRequestsCurl()));
                     try {
-                        return builder
-                                .authenticator(authenticator)
-                                .listeners(context.getInjectedReference(CHAT_MODEL_LISTENER_TYPE_LITERAL).stream().toList())
-                                .build();
+                        builder.authenticator(authenticator)
+                                .listeners(context.getInjectedReference(CHAT_MODEL_LISTENER_TYPE_LITERAL).stream().toList());
+                        ModelBuilderCustomizer.applyCustomizers(
+                                context.getInjectedReference(STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL,
+                                        Any.Literal.INSTANCE),
+                                builder, configName);
+                        return builder.build();
                     } finally {
                         QuarkusRestClientConfig.clear();
                     }
@@ -336,15 +356,15 @@ public class WatsonxRecorder {
         }
     }
 
-    public Supplier<EmbeddingModel> embeddingModel(String configName) {
+    public Function<SyntheticCreationalContext<EmbeddingModel>, EmbeddingModel> embeddingModel(String configName) {
         WatsonxConfig defaultConfig = runtimeConfig.getValue().defaultConfig();
         WatsonxConfig watsonxConfig = correspondingWatsonxRuntimeConfig(configName);
         EmbeddingModelConfig embeddingModelConfig = watsonxConfig.embeddingModel();
 
         if (!watsonxConfig.enableIntegration()) {
-            return new Supplier<>() {
+            return new Function<>() {
                 @Override
-                public EmbeddingModel get() {
+                public EmbeddingModel apply(SyntheticCreationalContext<EmbeddingModel> context) {
                     return new DisabledEmbeddingModel();
                 }
             };
@@ -390,9 +410,9 @@ public class WatsonxRecorder {
                         defaultConfig.projectId().orElse(null),
                         watsonxConfig.projectId()));
 
-        return new Supplier<>() {
+        return new Function<>() {
             @Override
-            public WatsonxEmbeddingModel get() {
+            public EmbeddingModel apply(SyntheticCreationalContext<EmbeddingModel> context) {
                 var authenticator = getOrCreateTokenGenerator(watsonxConfig.iam().baseUrl().orElse(null), apiKey);
                 QuarkusRestClientConfig.setLogCurl(
                         firstOrDefault(
@@ -400,7 +420,11 @@ public class WatsonxRecorder {
                                 embeddingModelConfig.logRequestsCurl(),
                                 watsonxConfig.logRequestsCurl()));
                 try {
-                    return builder.authenticator(authenticator).build();
+                    builder.authenticator(authenticator);
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
+                    return builder.build();
                 } finally {
                     QuarkusRestClientConfig.clear();
                 }
@@ -409,7 +433,7 @@ public class WatsonxRecorder {
 
     }
 
-    public Supplier<ScoringModel> scoringModel(String configName) {
+    public Function<SyntheticCreationalContext<ScoringModel>, ScoringModel> scoringModel(String configName) {
         WatsonxConfig defaultConfig = runtimeConfig.getValue().defaultConfig();
         WatsonxConfig watsonxConfig = correspondingWatsonxRuntimeConfig(configName);
         ScoringModelConfig rerankModelConfig = watsonxConfig.scoringModel();
@@ -455,9 +479,9 @@ public class WatsonxRecorder {
                         defaultConfig.projectId().orElse(null),
                         watsonxConfig.projectId()));
 
-        return new Supplier<>() {
+        return new Function<>() {
             @Override
-            public WatsonxScoringModel get() {
+            public ScoringModel apply(SyntheticCreationalContext<ScoringModel> context) {
                 var authenticator = getOrCreateTokenGenerator(watsonxConfig.iam().baseUrl().orElse(null), apiKey);
                 QuarkusRestClientConfig.setLogCurl(
                         firstOrDefault(
@@ -465,7 +489,11 @@ public class WatsonxRecorder {
                                 rerankModelConfig.logRequestsCurl(),
                                 watsonxConfig.logRequestsCurl()));
                 try {
-                    return builder.authenticator(authenticator).build();
+                    builder.authenticator(authenticator);
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(SCORING_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
+                    return builder.build();
                 } finally {
                     QuarkusRestClientConfig.clear();
                 }
@@ -473,7 +501,8 @@ public class WatsonxRecorder {
         };
     }
 
-    public Supplier<WatsonxModerationModel> moderationModel(String configName) {
+    public Function<SyntheticCreationalContext<WatsonxModerationModel>, WatsonxModerationModel> moderationModel(
+            String configName) {
         WatsonxConfig defaultConfig = runtimeConfig.getValue().defaultConfig();
         WatsonxConfig watsonxConfig = correspondingWatsonxRuntimeConfig(configName);
         ModerationModelConfig moderationModelConfig = watsonxConfig.moderationModel();
@@ -544,9 +573,9 @@ public class WatsonxRecorder {
                         defaultConfig.projectId().orElse(null),
                         watsonxConfig.projectId()));
 
-        return new Supplier<>() {
+        return new Function<>() {
             @Override
-            public WatsonxModerationModel get() {
+            public WatsonxModerationModel apply(SyntheticCreationalContext<WatsonxModerationModel> context) {
                 var authenticator = getOrCreateTokenGenerator(watsonxConfig.iam().baseUrl().orElse(null), apiKey);
                 QuarkusRestClientConfig.setLogCurl(
                         firstOrDefault(
@@ -554,7 +583,11 @@ public class WatsonxRecorder {
                                 moderationModelConfig.logRequestsCurl(),
                                 watsonxConfig.logRequestsCurl()));
                 try {
-                    return builder.authenticator(authenticator).build();
+                    builder.authenticator(authenticator);
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(MODERATION_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
+                    return builder.build();
                 } finally {
                     QuarkusRestClientConfig.clear();
                 }
@@ -562,7 +595,8 @@ public class WatsonxRecorder {
         };
     }
 
-    public Supplier<TextExtractionService> textExtraction(String configName) {
+    public Function<SyntheticCreationalContext<TextExtractionService>, TextExtractionService> textExtraction(
+            String configName) {
         WatsonxConfig defaultConfig = runtimeConfig.getValue().defaultConfig();
         WatsonxConfig watsonxConfig = correspondingWatsonxRuntimeConfig(configName);
         TextExtractionConfig textExtractionConfig = watsonxConfig.textExtraction().orElse(null);
@@ -605,9 +639,9 @@ public class WatsonxRecorder {
                         defaultConfig.projectId().orElse(null),
                         watsonxConfig.projectId()));
 
-        return new Supplier<>() {
+        return new Function<>() {
             @Override
-            public TextExtractionService get() {
+            public TextExtractionService apply(SyntheticCreationalContext<TextExtractionService> context) {
                 var authenticator = getOrCreateTokenGenerator(watsonxConfig.iam().baseUrl().orElse(null), apiKey);
                 QuarkusRestClientConfig.setLogCurl(
                         firstOrDefault(
@@ -615,7 +649,11 @@ public class WatsonxRecorder {
                                 textExtractionConfig.logRequestsCurl(),
                                 watsonxConfig.logRequestsCurl()));
                 try {
-                    return builder.authenticator(authenticator).build();
+                    builder.authenticator(authenticator);
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(TEXT_EXTRACTION_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
+                    return builder.build();
                 } finally {
                     QuarkusRestClientConfig.clear();
                 }
@@ -623,7 +661,8 @@ public class WatsonxRecorder {
         };
     }
 
-    public Supplier<TextClassificationService> textClassification(String configName) {
+    public Function<SyntheticCreationalContext<TextClassificationService>, TextClassificationService> textClassification(
+            String configName) {
         WatsonxConfig defaultConfig = runtimeConfig.getValue().defaultConfig();
         WatsonxConfig watsonxConfig = correspondingWatsonxRuntimeConfig(configName);
         TextClassificationConfig textClassificationConfig = watsonxConfig.textClassification().orElse(null);
@@ -664,9 +703,9 @@ public class WatsonxRecorder {
                         defaultConfig.projectId().orElse(null),
                         watsonxConfig.projectId()));
 
-        return new Supplier<>() {
+        return new Function<>() {
             @Override
-            public TextClassificationService get() {
+            public TextClassificationService apply(SyntheticCreationalContext<TextClassificationService> context) {
                 var authenticator = getOrCreateTokenGenerator(watsonxConfig.iam().baseUrl().orElse(null), apiKey);
                 QuarkusRestClientConfig.setLogCurl(
                         firstOrDefault(
@@ -674,7 +713,11 @@ public class WatsonxRecorder {
                                 textClassificationConfig.logRequestsCurl(),
                                 watsonxConfig.logRequestsCurl()));
                 try {
-                    return builder.authenticator(authenticator).build();
+                    builder.authenticator(authenticator);
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(TEXT_CLASSIFICATION_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
+                    return builder.build();
                 } finally {
                     QuarkusRestClientConfig.clear();
                 }

--- a/model-providers/watsonx/runtime/src/test/java/io/quarkiverse/langchain4j/watsonx/runtime/DisabledModelsWatsonRecorderTest.java
+++ b/model-providers/watsonx/runtime/src/test/java/io/quarkiverse/langchain4j/watsonx/runtime/DisabledModelsWatsonRecorderTest.java
@@ -42,7 +42,7 @@ class DisabledModelsWatsonRecorderTest {
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledStreamingChatModel.class);
 
-        assertThat(recorder.embeddingModel(NamedConfigUtil.DEFAULT_NAME).get())
+        assertThat(recorder.embeddingModel(NamedConfigUtil.DEFAULT_NAME).apply(null))
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledEmbeddingModel.class);
     }


### PR DESCRIPTION
This was done mainly so users aren't blocked when new properties added by LangChain4j and Quarkus LangChain4j doesn't yet have dedicated configuration options for them