### PR TITLE
fix(jlama): remove devMode jvmOptions that crash @QuarkusTest bootstrap on Quarkus 3.32+

### DIFF
--- a/model-providers/jlama/deployment/src/test/java/io/quarkiverse/langchain4j/jlama/deployment/JlamaBootstrapSmokeTest.java
+++ b/model-providers/jlama/deployment/src/test/java/io/quarkiverse/langchain4j/jlama/deployment/JlamaBootstrapSmokeTest.java
@@ -1,0 +1,36 @@
+package io.quarkiverse.langchain4j.jlama.deployment;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Regression test for https://github.com/quarkiverse/quarkus-langchain4j/issues/TODO
+ * <p>
+ * The devMode {@code jvmOptions} block in runtime/pom.xml previously included
+ * {@code enable-native-access=ALL-UNNAMED}. On Quarkus 3.32+, the new
+ * {@code ApplicationModelSerializer} resolves {@code ALL-UNNAMED} to a
+ * {@code java.lang.Module} object that {@code Json.appendValue()} cannot
+ * serialize, throwing {@code IllegalStateException: Unsupported value type: [ALL-UNNAMED]}
+ * at {@code @QuarkusTest} bootstrap time.
+ */
+public class JlamaBootstrapSmokeTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.langchain4j.jlama.chat-model.enabled=false\n" +
+                                    "quarkus.langchain4j.jlama.embedding-model.enabled=false\n"),
+                            "application.properties"));
+
+    @Test
+    void bootstrapSucceedsWithJlamaOnClasspath() {
+        // If the devMode jvmOptions block contains enable-native-access=ALL-UNNAMED,
+        // bootstrap throws IllegalStateException before reaching this point.
+    }
+}

--- a/model-providers/jlama/deployment/src/test/java/io/quarkiverse/langchain4j/jlama/deployment/JlamaBootstrapSmokeTest.java
+++ b/model-providers/jlama/deployment/src/test/java/io/quarkiverse/langchain4j/jlama/deployment/JlamaBootstrapSmokeTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusUnitTest;
 
 /**
- * Regression test for https://github.com/quarkiverse/quarkus-langchain4j/issues/TODO
+ * Regression test for https://github.com/quarkiverse/quarkus-langchain4j/issues/2375
  * <p>
  * The devMode {@code jvmOptions} block in runtime/pom.xml previously included
  * {@code enable-native-access=ALL-UNNAMED}. On Quarkus 3.32+, the new

--- a/model-providers/jlama/runtime/pom.xml
+++ b/model-providers/jlama/runtime/pom.xml
@@ -63,11 +63,6 @@
                         <configuration>
                             <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
                             <devMode>
-                                <jvmOptions>
-                                    <add-modules>jdk.incubator.vector</add-modules>
-                                    <enable-preview />
-                                    <enable-native-access>ALL-UNNAMED</enable-native-access>
-                                </jvmOptions>
                                 <lockXxJvmOptions>TieredStopAtLevel</lockXxJvmOptions>
                                 <lockJvmOptions>agentlib:jdwp</lockJvmOptions>
                             </devMode>


### PR DESCRIPTION
Fixes #2375

## Problem

`quarkus-langchain4j-jlama` fails at `@QuarkusTest` bootstrap when used with Quarkus 3.32+:

```
java.lang.IllegalStateException: Unsupported value type: [ALL-UNNAMED]
  at io.quarkus.bootstrap.json.Json.appendValue(Json.java:541)
  at io.quarkus.bootstrap.app.ApplicationModelSerializer.writeJson(...)
```

## Root Cause

`model-providers/jlama/runtime/pom.xml` configures the `quarkus-extension-maven-plugin` with a `<devMode><jvmOptions>` block:

```xml
<devMode>
    <jvmOptions>
        <add-modules>jdk.incubator.vector</add-modules>
        <enable-preview />
        <enable-native-access>ALL-UNNAMED</enable-native-access>
    </jvmOptions>
    ...
</devMode>
```

The plugin bakes these into `META-INF/quarkus-extension.properties` in the runtime JAR:

```
dev-mode.jvm-option.std.enable-native-access=ALL-UNNAMED
dev-mode.jvm-option.std.add-modules=jdk.incubator.vector
```

Quarkus 3.32+ introduced `ApplicationModelSerializer`, which reads extension properties (including dev-mode JVM options) and serializes the full app model to a JSON cache. `Json.appendValue()` resolves `ALL-UNNAMED` to a `java.lang.Module` object and has no case for that type, causing the crash.

## Fix

Remove the `<jvmOptions>` block. These options were dev-mode conveniences for JVM versions where the Vector API was still in incubator (Java < 24) and Panama native access required explicit opt-in. They are not required for the extension to function.

Users who still need these flags on older JVMs can add them explicitly to their project:

```properties
quarkus.jvm-options=--add-modules,jdk.incubator.vector,--enable-native-access,ALL-UNNAMED
```

## Test

Added `JlamaBootstrapSmokeTest` — a `QuarkusUnitTest` that boots the extension with both models disabled (to avoid downloading model weights). If the `<jvmOptions>` block is ever re-added with `enable-native-access=ALL-UNNAMED`, this test will fail with the `IllegalStateException` described above on Quarkus 3.32+.

## Note on Quarkus Core

The underlying serializer bug (`Json.appendValue()` throwing on `Module` objects rather than calling `.toString()`) is a separate issue in Quarkus core and is worth filing there independently — it would protect all extensions that use this JVM option pattern.