### PR TITLE
fix: SemanticSimilarityStrategy - calculateCosineSimilarity returns double greater 1.0

### DIFF
--- a/testing/evaluation/evaluation-strategies/semantic-similarity/pom.xml
+++ b/testing/evaluation/evaluation-strategies/semantic-similarity/pom.xml
@@ -24,6 +24,21 @@
             <artifactId>quarkus-langchain4j-testing-evaluation-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/testing/evaluation/evaluation-strategies/semantic-similarity/src/main/java/io/quarkiverse/langchain4j/testing/evaluation/similarity/SemanticSimilarityStrategy.java
+++ b/testing/evaluation/evaluation-strategies/semantic-similarity/src/main/java/io/quarkiverse/langchain4j/testing/evaluation/similarity/SemanticSimilarityStrategy.java
@@ -130,6 +130,8 @@ public class SemanticSimilarityStrategy implements EvaluationStrategy<String> {
             throw new IllegalArgumentException("Vector magnitude cannot be zero");
         }
 
-        return dotProduct / (magnitudeA * magnitudeB);
+        double cosineSimilarity = dotProduct / (magnitudeA * magnitudeB);
+        // Floating-point drift can produce tiny out-of-range values (e.g. 1.0000000001).
+        return Math.max(-1.0, Math.min(1.0, cosineSimilarity));
     }
 }

--- a/testing/evaluation/evaluation-strategies/semantic-similarity/src/test/java/io/quarkiverse/langchain4j/testing/evaluation/similarity/SemanticSimilarityStrategyTest.java
+++ b/testing/evaluation/evaluation-strategies/semantic-similarity/src/test/java/io/quarkiverse/langchain4j/testing/evaluation/similarity/SemanticSimilarityStrategyTest.java
@@ -1,0 +1,85 @@
+package io.quarkiverse.langchain4j.testing.evaluation.similarity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.Response;
+import io.quarkiverse.langchain4j.testing.evaluation.EvaluationResult;
+import io.quarkiverse.langchain4j.testing.evaluation.EvaluationSample;
+import io.quarkiverse.langchain4j.testing.evaluation.Parameters;
+
+class SemanticSimilarityStrategyTest {
+
+    @Test
+    void shouldPassWhenSimilarityIsAtLeastThreshold() {
+        EmbeddingModel model = Mockito.mock(EmbeddingModel.class);
+        when(model.embed("expected")).thenReturn(Response.from(Embedding.from(new float[] { 1f, 0f })));
+        when(model.embed("actual")).thenReturn(Response.from(Embedding.from(new float[] { 0.95f, 0.05f })));
+
+        SemanticSimilarityStrategy strategy = new SemanticSimilarityStrategy(model, 0.9);
+        EvaluationSample<String> sample = new EvaluationSample<>("sample-1", Parameters.of("input"), "expected",
+                java.util.List.of());
+
+        EvaluationResult result = strategy.evaluate(sample, "actual");
+
+        assertThat(result.passed()).isTrue();
+        assertThat(result.score()).isGreaterThanOrEqualTo(0.9);
+        assertThat(result.explanation()).isNull();
+        assertThat(result.metadata()).containsEntry("threshold", 0.9);
+        assertThat(result.metadata()).containsKey("similarity");
+    }
+
+    @Test
+    void shouldFailWhenSimilarityIsBelowThreshold() {
+        EmbeddingModel model = Mockito.mock(EmbeddingModel.class);
+        when(model.embed("expected")).thenReturn(Response.from(Embedding.from(new float[] { 1f, 0f })));
+        when(model.embed("actual")).thenReturn(Response.from(Embedding.from(new float[] { 0f, 1f })));
+
+        SemanticSimilarityStrategy strategy = new SemanticSimilarityStrategy(model, 0.9);
+        EvaluationSample<String> sample = new EvaluationSample<>("sample-1", Parameters.of("input"), "expected",
+                java.util.List.of());
+
+        EvaluationResult result = strategy.evaluate(sample, "actual");
+
+        assertThat(result.passed()).isFalse();
+        assertThat(result.score()).isEqualTo(0.0);
+        assertThat(result.explanation())
+                .matches("Similarity 0[\\.,]0000 below threshold 0[\\.,]9000");
+        assertThat(result.metadata()).isEqualTo(Map.of("similarity", 0.0, "threshold", 0.9));
+    }
+
+    @Test
+    void shouldCalculateCosineSimilarityForParallelVectors() {
+        double similarity = SemanticSimilarityStrategy.calculateCosineSimilarity(
+                new float[] { 1f, 2f, 3f },
+                new float[] { 2f, 4f, 6f });
+
+        assertThat(similarity).isEqualTo(1.0);
+    }
+
+    @Test
+    void shouldRejectVectorsWithDifferentLengths() {
+        assertThatThrownBy(() -> SemanticSimilarityStrategy.calculateCosineSimilarity(
+                new float[] { 1f, 2f },
+                new float[] { 1f }))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Vectors must be of the same length");
+    }
+
+    @Test
+    void shouldRejectZeroMagnitudeVectors() {
+        assertThatThrownBy(() -> SemanticSimilarityStrategy.calculateCosineSimilarity(
+                new float[] { 0f, 0f },
+                new float[] { 1f, 2f }))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Vector magnitude cannot be zero");
+    }
+}


### PR DESCRIPTION
I got the following Exception:
```
2026-04-24 09:21:30,746 ERROR [io.quarkiverse.langchain4j.testing.evaluation.Scorer] (pool-12-thread-2) Failed to evaluate sample `german_to_english_question`: java.lang.IllegalArgumentException: Score must be between 0.0 and 1.0, got: 1.0000000026365623
	at io.quarkiverse.langchain4j.testing.evaluation.EvaluationResult.<init>(EvaluationResult.java:30)
EvaluationResult.java:30
	at io.quarkiverse.langchain4j.testing.evaluation.EvaluationResult.passed(EvaluationResult.java:43)
EvaluationResult.java:43
	at io.quarkiverse.langchain4j.testing.evaluation.similarity.SemanticSimilarityStrategy.evaluate(SemanticSimilarityStrategy.java:94)
SemanticSimilarityStrategy.java:94
	at io.quarkiverse.langchain4j.testing.evaluation.similarity.SemanticSimilarityStrategy.evaluate(SemanticSimilarityStrategy.java:14)
SemanticSimilarityStrategy.java:14
	at io.quarkiverse.langchain4j.testing.evaluation.Scorer.lambda$evaluate$0(Scorer.java:47)
Scorer.java:47
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:545)
Executors.java:545
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328)
FutureTask.java:328
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
ThreadPoolExecutor.java:1090
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
ThreadPoolExecutor.java:614
	at java.base/java.lang.Thread.run(Thread.java:1474)

```
Changed calculateCosineSimilarity in SemanticSimilarityStrategy