### PR TITLE
Fix openai tlsConfigurationName silently dropped in AdditionalPropertiesHack

### DIFF
--- a/model-providers/openai/openai-common/runtime/src/main/java/io/quarkiverse/langchain4j/openai/common/runtime/AdditionalPropertiesHack.java
+++ b/model-providers/openai/openai-common/runtime/src/main/java/io/quarkiverse/langchain4j/openai/common/runtime/AdditionalPropertiesHack.java
@@ -9,8 +9,7 @@ import java.util.Map;
  * This only works because:
  * <ul>
  * <li>The creation of beans does not happen in parallel</li>
- * <li>The creation of beans happens on the same thread</li>
- * <li>Setting up a model builder always precedes setting up a client builder</li>
+ * <li>Setting up a model builder always precedes setting up a client builder on the same thread</li>
  * </ul>
  */
 public final class AdditionalPropertiesHack {
@@ -18,70 +17,36 @@ public final class AdditionalPropertiesHack {
     private AdditionalPropertiesHack() {
     }
 
-    static final ThreadLocal<Map<String, String>> PROPS = new ThreadLocal<>();
+    static final ThreadLocal<Map<String, String>> PROPS = ThreadLocal.withInitial(HashMap::new);
     static final ThreadLocal<Proxy> PROXY = new ThreadLocal<>();
-    static {
-        reset();
-    }
 
     public static void reset() {
-        PROPS.set(new HashMap<>());
+        PROPS.get().clear();
         PROXY.remove();
     }
 
     public static void setConfigName(String configName) {
-        Map<String, String> map = PROPS.get();
-        if (map == null) {
-            // this should never happen
-            return;
-        }
-        map.put("configName", configName);
+        PROPS.get().put("configName", configName);
     }
 
     public static void setTlsConfigurationName(String tlsConfigurationName) {
-        Map<String, String> map = PROPS.get();
-        if (map == null) {
-            // this should never happen
-            return;
-        }
-        map.put("tlsConfigurationName", tlsConfigurationName);
+        PROPS.get().put("tlsConfigurationName", tlsConfigurationName);
     }
 
     public static String getAndClearConfigName() {
-        Map<String, String> map = PROPS.get();
-        if (map == null) {
-            // this should never happen
-            return null;
-        }
-        return map.remove("configName");
+        return PROPS.get().remove("configName");
     }
 
     public static String getAndClearTlsConfigurationName() {
-        Map<String, String> map = PROPS.get();
-        if (map == null) {
-            // this should never happen
-            return null;
-        }
-        return map.remove("tlsConfigurationName");
+        return PROPS.get().remove("tlsConfigurationName");
     }
 
     public static void setLogCurl(boolean logCurl) {
-        Map<String, String> map = PROPS.get();
-        if (map == null) {
-            // this should never happen
-            return;
-        }
-        map.put("logCurl", Boolean.toString(logCurl));
+        PROPS.get().put("logCurl", Boolean.toString(logCurl));
     }
 
     public static boolean getAndClearLogCurl() {
-        Map<String, String> map = PROPS.get();
-        if (map == null) {
-            // this should never happen
-            return false;
-        }
-        String value = map.remove("logCurl");
-        return Boolean.parseBoolean(value);
+        return Boolean.parseBoolean(PROPS.get().remove("logCurl"));
     }
 
     public static void setProxy(Proxy proxy) {


### PR DESCRIPTION
## Problem

`quarkus.langchain4j.openai.tls-configuration-name` is silently ignored when the OpenAI chat / streaming-chat / embedding / moderation / image model bean is created on a thread other than the one that first loaded `AdditionalPropertiesHack`. The OpenAI client then falls back to `SSLContext.getDefault()`, making a custom named TLS bucket (e.g. `quarkus.tls.vllm.trust-store.pem.certs=...`) completely ineffective and causing `PKIX path building failed` at runtime with no diagnostic.

## Root cause

`AdditionalPropertiesHack` passes Quarkus-specific properties (`tlsConfigurationName`, `configName`, `logCurl`) from the Quarkus model builder to the Quarkus client builder via a `ThreadLocal<Map<String,String>>`. The map is populated by a **static initializer**:

```java
static final ThreadLocal<Map<String, String>> PROPS = new ThreadLocal<>();
static { reset(); }   // only binds a value on the class-loading thread
```

Because `ThreadLocal.set` only touches the current thread, every other thread observes `PROPS.get() == null`. The setters all contain a `// this should never happen` early return in that case:

```java
public static void setTlsConfigurationName(String tlsConfigurationName) {
    Map<String, String> map = PROPS.get();
    if (map == null) {
        // this should never happen
        return;                 // value is silently dropped
    }
    map.put("tlsConfigurationName", tlsConfigurationName);
}
```

In `OpenAiRecorder`, the synthetic-bean creator for `ChatModel` (and the other model kinds) is an anonymous `Function<SyntheticCreationalContext<...>, ...>` that calls `builder.build()` — which calls `AdditionalPropertiesHack.setTlsConfigurationName(...)` — without first calling `reset()` on the current thread. The only call to `reset()` in `OpenAiRecorder` is in `cleanUp(ShutdownContext)`, which runs on the shutdown thread and doesn't help.

Net effect: unless bean creation happens on the exact thread that initialized the class, `tlsConfigurationName` (and `configName`, `logCurl`) never reach `QuarkusOpenAiClient.Builder`, and `TlsConfiguration.from(registry, Optional.ofNullable(null))` returns `Optional.empty()`. Setting `tls-configuration-name` to a nonexistent bucket doesn't even throw `IllegalStateException` from `TlsConfiguration.from`, because the name is never passed.

## Fix

Use `ThreadLocal.withInitial(HashMap::new)` so every thread sees a fresh, non-null map on first access. The `if (map == null)` branches become unreachable and are removed. `reset()` is kept for API compatibility (still called from `OpenAiRecorder.cleanUp`) but now clears the current-thread map rather than rebinding it.

This preserves the existing contract documented on the class:

> - The creation of beans does not happen in parallel
> - Setting up a model builder always precedes setting up a client builder (on the same thread)

…while removing the accidental dependency on *which* thread first loaded the class.

## Reproducer

Minimal app that reproduces the original failure in `quarkus-langchain4j-openai` 1.8.4:

- Use a self-signed CA (e.g. from `mkcert`) for an OpenAI-compatible server.
- Configure:
  ```properties
  quarkus.langchain4j.openai.base-url=https://my-internal-host/v1
  quarkus.langchain4j.openai.tls-configuration-name=vllm
  quarkus.tls.vllm.trust-store.pem.certs=/path/to/rootCA.pem
  ```
- Call the chat model from an AI service.

Before the fix: `PKIX path building failed`; `-Djavax.net.debug=ssl:handshake:trustmanager` shows only the JDK `cacerts` being loaded. Setting `tls-configuration-name=DOES_NOT_EXIST` does **not** throw — confirming the name never reaches `TlsConfiguration.from`.

After the fix: the configured trust store is wired through to Vert.x/Netty and the handshake succeeds. Setting `tls-configuration-name` to a nonexistent bucket now correctly throws `IllegalStateException: Unable to find the TLS configuration for name ...`.

## Scope

Single file, ~10 line net reduction. Same behavior for the existing "happy path" (model builder and client builder on the same thread); previously silently-broken code paths are now correct.