### PR TITLE
Update Gemini Vertex AI embeddings implementation

### DIFF
--- a/model-providers/google/vertex-ai-gemini/deployment/src/test/java/io/quarkiverse/langchain4j/vertexai/gemini/deployment/VertexAiGeminiEmbeddingModelSmokeTest.java
+++ b/model-providers/google/vertex-ai-gemini/deployment/src/test/java/io/quarkiverse/langchain4j/vertexai/gemini/deployment/VertexAiGeminiEmbeddingModelSmokeTest.java
@@ -2,6 +2,7 @@ package io.quarkiverse.langchain4j.vertexai.gemini.deployment;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,6 +36,8 @@ public class VertexAiGeminiEmbeddingModelSmokeTest extends WiremockAware {
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
             .overrideRuntimeConfigKey("quarkus.langchain4j.vertexai.gemini.base-url", WiremockAware.wiremockUrlForConfig())
+            .overrideRuntimeConfigKey("quarkus.langchain4j.vertexai.gemini.location", "test-location")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.vertexai.gemini.project-id", "test-project")
             .overrideRuntimeConfigKey("quarkus.langchain4j.vertexai.gemini.log-requests", "true");
 
     @Inject
@@ -44,44 +47,42 @@ public class VertexAiGeminiEmbeddingModelSmokeTest extends WiremockAware {
     void testBatch() {
         wiremock().register(
                 post(urlEqualTo(
-                        String.format("/v1/projects/dummy/locations/dummy/publishers/google/models/%s:batchEmbedContents",
+                        String.format("/v1/projects/test-project/locations/test-location/publishers/google/models/%s:predict",
                                 EMBED_MODEL_ID)))
                         .withHeader("Authorization", equalTo("Bearer " + API_KEY))
+                        .withRequestBody(equalToJson("""
+                                { "instances": [ { "content": "Hello" } ], "parameters": { "autoTruncate": true } }
+                                        """))
                         .willReturn(aResponse()
                                 .withHeader("Content-Type", "application/json")
                                 .withBody("""
                                          {
-                                           "embeddings": [
+                                           "predictions": [
                                              {
-                                               "values": [
-                                                 -0.010632273,
-                                                 0.019375853,
-                                                 0.020965198,
-                                                 0.0007706437,
-                                                 -0.061464068,
-                                                 -0.007153866,
-                                                 -0.028534686
-                                               ]
-                                             },
-                                             {
-                                               "values": [
-                                                 0.018468002,
-                                                 0.0054281265,
-                                                 -0.017658807,
-                                                 0.013859263,
-                                                 0.05341865,
-                                                 0.026714388,
-                                                 0.0018762478
-                                               ]
+                                               "embeddings": {
+                                                 "values": [
+                                                   -0.010632273,
+                                                   0.019375853,
+                                                   0.020965198,
+                                                   0.0007706437,
+                                                   -0.061464068,
+                                                   -0.007153866,
+                                                   -0.028534686
+                                                 ],
+                                                 "statistics": {
+                                                   "truncated": false,
+                                                   "token_count": 1
+                                                 }
+                                               }
                                              }
                                            ]
                                           }
                                         """)));
 
-        List<TextSegment> textSegments = List.of(TextSegment.from("Hello"), TextSegment.from("Bye"));
+        List<TextSegment> textSegments = List.of(TextSegment.from("Hello")); // Only one for gemini-embedding-001
         Response<List<Embedding>> response = embeddingModel.embedAll(textSegments);
 
-        assertThat(response.content()).hasSize(2);
+        assertThat(response.content()).hasSize(1);
     }
 
     @Test
@@ -90,29 +91,40 @@ public class VertexAiGeminiEmbeddingModelSmokeTest extends WiremockAware {
 
         wiremock().register(
                 post(urlEqualTo(
-                        String.format("/v1/projects/dummy/locations/dummy/publishers/google/models/%s:embedContent",
+                        String.format("/v1/projects/test-project/locations/test-location/publishers/google/models/%s:predict",
                                 EMBED_MODEL_ID)))
                         .withHeader("Authorization", equalTo("Bearer " + API_KEY))
+                        .withRequestBody(equalToJson("""
+                                { "instances": [ { "content": "Hello World" } ], "parameters": { "autoTruncate": true } }
+                                        """))
                         .willReturn(aResponse()
                                 .withHeader("Content-Type", "application/json")
                                 .withBody("""
                                          {
-                                            "embedding": {
-                                              "values": [
-                                                0.013168517,
-                                                -0.00871193,
-                                                -0.046782672,
-                                                0.00069969177,
-                                                -0.009518872,
-                                                -0.008720178,
-                                                0.06010358
-                                                ]
-                                            }
-                                         }
+                                           "predictions": [
+                                             {
+                                               "embeddings": {
+                                                 "values": [
+                                                   0.013168517,
+                                                   -0.00871193,
+                                                   -0.046782672,
+                                                   0.00069969177,
+                                                   -0.009518872,
+                                                   -0.008720178,
+                                                   0.06010358
+                                                 ],
+                                                 "statistics": {
+                                                   "truncated": false,
+                                                   "token_count": 2
+                                                 }
+                                               }
+                                             }
+                                           ]
+                                          }
                                         """)));
 
-        float[] response = embeddingModel.embed("Hello World").content().vector();
-        assertThat(response).hasSize(7);
+        Response<List<Embedding>> response = embeddingModel.embedAll(List.of(TextSegment.from("Hello World")));
+        assertThat(response.content().get(0).vector()).hasSize(7);
     }
 
     @Singleton

--- a/model-providers/google/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/PredictRequest.java
+++ b/model-providers/google/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/PredictRequest.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.langchain4j.vertexai.runtime.gemini;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record PredictRequest(List<Instance> instances, Parameters parameters) {
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Instance(String content, @JsonProperty("task_type") String taskType, String title) {
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Parameters(Boolean autoTruncate, @JsonProperty("outputDimensionality") Integer outputDimensionality) {
+    }
+}

--- a/model-providers/google/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/PredictResponse.java
+++ b/model-providers/google/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/PredictResponse.java
@@ -1,0 +1,22 @@
+package io.quarkiverse.langchain4j.vertexai.runtime.gemini;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record PredictResponse(List<Prediction> predictions) {
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Prediction(Embeddings embeddings) {
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Embeddings(Statistics statistics, List<Float> values) {
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Statistics(boolean truncated, @JsonProperty("token_count") int tokenCount) {
+    }
+}

--- a/model-providers/google/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/VertexAiGeminiEmbeddingModel.java
+++ b/model-providers/google/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/VertexAiGeminiEmbeddingModel.java
@@ -5,26 +5,32 @@ import java.net.Proxy;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import org.jboss.resteasy.reactive.client.api.LoggingScope;
 
-import io.quarkiverse.langchain4j.gemini.common.EmbedContentRequest;
-import io.quarkiverse.langchain4j.gemini.common.EmbedContentRequests;
-import io.quarkiverse.langchain4j.gemini.common.EmbedContentResponse;
-import io.quarkiverse.langchain4j.gemini.common.EmbedContentResponses;
-import io.quarkiverse.langchain4j.gemini.common.GeminiEmbeddingModel;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.Response;
 import io.quarkiverse.langchain4j.gemini.common.ModelAuthProviderFilter;
+import io.quarkiverse.langchain4j.vertexai.runtime.gemini.PredictRequest.Instance;
+import io.quarkiverse.langchain4j.vertexai.runtime.gemini.PredictRequest.Parameters;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 
-public class VertexAiGeminiEmbeddingModel extends GeminiEmbeddingModel {
+public class VertexAiGeminiEmbeddingModel implements EmbeddingModel {
 
     private final VertxAiGeminiRestApi restApi;
     private final VertxAiGeminiRestApi.ApiMetadata apiMetadata;
+    private final String taskType;
+    private final Integer outputDimensionality;
 
     public VertexAiGeminiEmbeddingModel(Builder builder) {
-        super(builder.modelId, builder.dimension, builder.taskType);
+        this.taskType = builder.taskType;
+        this.outputDimensionality = builder.outputDimensionality;
 
         this.apiMetadata = VertxAiGeminiRestApi.ApiMetadata
                 .builder()
@@ -65,20 +71,22 @@ public class VertexAiGeminiEmbeddingModel extends GeminiEmbeddingModel {
     }
 
     @Override
-    protected EmbedContentRequest getEmbedContentRequest(String model, String text) {
-        var withModel = super.getEmbedContentRequest(model, text);
-        return new EmbedContentRequest(null, withModel.content(), withModel.taskType(), withModel.title(),
-                withModel.outputDimensionality());
-    }
+    public Response<List<Embedding>> embedAll(List<TextSegment> textSegments) {
+        List<Embedding> result = new ArrayList<>();
+        for (TextSegment textSegment : textSegments) {
+            PredictRequest.Instance instance = new PredictRequest.Instance(textSegment.text(), taskType, null);
+            PredictRequest.Parameters parameters = new PredictRequest.Parameters(true, outputDimensionality);
+            PredictRequest predictRequest = new PredictRequest(List.of(instance), parameters);
 
-    @Override
-    protected EmbedContentResponse embedContent(EmbedContentRequest embedContentRequest) {
-        return restApi.embedContent(embedContentRequest, apiMetadata);
-    }
-
-    @Override
-    protected EmbedContentResponses batchEmbedContents(EmbedContentRequests embedContentRequests) {
-        return restApi.batchEmbedContents(embedContentRequests, apiMetadata);
+            PredictResponse predictResponse = restApi.predict(predictRequest, apiMetadata);
+            List<Float> floatList = predictResponse.predictions().get(0).embeddings().values();
+            float[] floatArray = new float[floatList.size()];
+            for (int i = 0; i < floatList.size(); i++) {
+                floatArray[i] = floatList.get(i);
+            }
+            result.add(new Embedding(floatArray));
+        }
+        return Response.from(result);
     }
 
     public static Builder builder() {
@@ -92,8 +100,8 @@ public class VertexAiGeminiEmbeddingModel extends GeminiEmbeddingModel {
         private String location;
         private String modelId;
         private String publisher;
-        private Integer dimension;
         private String taskType;
+        private Integer outputDimensionality;
         private Duration timeout = Duration.ofSeconds(10);
         private Boolean logRequests = false;
         private Boolean logResponses = false;
@@ -124,13 +132,13 @@ public class VertexAiGeminiEmbeddingModel extends GeminiEmbeddingModel {
             return this;
         }
 
-        public Builder dimension(Integer dimension) {
-            this.dimension = dimension;
+        public Builder taskType(String taskType) {
+            this.taskType = taskType;
             return this;
         }
 
-        public Builder taskType(String taskType) {
-            this.taskType = taskType;
+        public Builder outputDimensionality(Integer outputDimensionality) {
+            this.outputDimensionality = outputDimensionality;
             return this;
         }
 

--- a/model-providers/google/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/VertexAiGeminiRecorder.java
+++ b/model-providers/google/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/VertexAiGeminiRecorder.java
@@ -52,16 +52,17 @@ public class VertexAiGeminiRecorder {
 
         if (vertexAiConfig.enableIntegration()) {
             var embeddingModelConfig = vertexAiConfig.embeddingModel();
-            Optional<String> baseUrl = vertexAiConfig.baseUrl();
-
             String location = vertexAiConfig.location();
-            if (baseUrl.isEmpty() && DUMMY_KEY.equals(location)) {
+            if (DUMMY_KEY.equals(location)) {
                 throw new ConfigValidationException(createConfigProblems("location", configName));
             }
             String projectId = vertexAiConfig.projectId();
-            if (baseUrl.isEmpty() && DUMMY_KEY.equals(projectId)) {
+            if (DUMMY_KEY.equals(projectId)) {
                 throw new ConfigValidationException(createConfigProblems("project-id", configName));
             }
+            Optional<String> baseUrl = vertexAiConfig.baseUrl()
+                    .or(() -> Optional.of("https://" + location + "-aiplatform.googleapis.com"));
+
             var builder = VertexAiGeminiEmbeddingModel.builder()
                     .baseUrl(baseUrl)
                     .location(location)
@@ -77,13 +78,8 @@ public class VertexAiGeminiRecorder {
                         new InetSocketAddress(host, vertexAiConfig.proxyPort())));
             });
 
-            if (embeddingModelConfig.outputDimension().isPresent()) {
-                builder.dimension(embeddingModelConfig.outputDimension().get());
-            }
-
-            if (embeddingModelConfig.taskType().isPresent()) {
-                builder.taskType(embeddingModelConfig.taskType().get());
-            }
+            builder.outputDimensionality(embeddingModelConfig.outputDimension().orElse(null));
+            builder.taskType(embeddingModelConfig.taskType().orElse(null));
 
             return new Function<>() {
                 @Override

--- a/model-providers/google/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/VertxAiGeminiRestApi.java
+++ b/model-providers/google/vertex-ai-gemini/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/gemini/VertxAiGeminiRestApi.java
@@ -21,10 +21,6 @@ import org.jboss.resteasy.reactive.client.api.ClientLogger;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import io.quarkiverse.langchain4j.gemini.common.EmbedContentRequest;
-import io.quarkiverse.langchain4j.gemini.common.EmbedContentRequests;
-import io.quarkiverse.langchain4j.gemini.common.EmbedContentResponse;
-import io.quarkiverse.langchain4j.gemini.common.EmbedContentResponses;
 import io.quarkiverse.langchain4j.gemini.common.GenerateContentRequest;
 import io.quarkiverse.langchain4j.gemini.common.GenerateContentResponse;
 import io.quarkus.rest.client.reactive.jackson.ClientObjectMapper;
@@ -38,17 +34,13 @@ import io.vertx.core.http.HttpClientResponse;
 @Path("v1/projects/{projectId}/locations/{location}/publishers/{publisher}/models")
 public interface VertxAiGeminiRestApi {
 
+    @Path("{modelId}:predict")
+    @POST
+    PredictResponse predict(PredictRequest request, @BeanParam ApiMetadata apiMetadata);
+
     @Path("{modelId}:generateContent")
     @POST
     GenerateContentResponse generateContent(GenerateContentRequest request, @BeanParam ApiMetadata apiMetadata);
-
-    @Path("{modelId}:batchEmbedContents")
-    @POST
-    EmbedContentResponses batchEmbedContents(EmbedContentRequests embedContentRequest, @BeanParam ApiMetadata apiMetadata);
-
-    @Path("{modelId}:embedContent")
-    @POST
-    EmbedContentResponse embedContent(EmbedContentRequest embedContentRequest, @BeanParam ApiMetadata apiMetadata);
 
     @Path("{modelId}:streamGenerateContent")
     @POST


### PR DESCRIPTION
### The Problem
The previous embedding implementation was incorrectly using the **Google AI Studio (Generative Language API)** request structure. While the models may be shared, the **Vertex AI** endpoint specifically requires the `predict` payload format (where inputs are wrapped in `instances`). This PR fixes the integration specifically for the embedding models.

### Technical Changes
- **Targeted Refactor**: The changes are strictly limited to the **Embedding** logic.
- **Standardized DTOs**: Introduced `PredictRequest` (with nested `Instance`) and `PredictResponse` to match the Vertex AI Predict API specification for embeddings.
- **Payload Mapping**: Updated `VertexAiGeminiEmbeddingModel` to correctly map embedding requests into the `instances` array.
- **Infrastructure**: Updated `VertxAiGeminiRestApi` and `VertexAiGeminiRecorder` to support the new DTOs for the embedding flow.
- **Testing**: Adjusted `VertexAiGeminiEmbeddingModelSmokeTest` to validate the new contract.

----

- Closes: #2376
