### PR TITLE
docs(few-shots): inline-code INPUT/OUTPUT pattern; use [source,bash] for curl

### DIFF
--- a/docs/modules/ROOT/pages/guide-few-shots.adoc
+++ b/docs/modules/ROOT/pages/guide-few-shots.adoc
@@ -51,7 +51,7 @@ Inside the same interface, define a method with `@UserMessage` that inlines your
 include::{examples-dir}/io/quarkiverse/langchain4j/samples/fewshots/SentimentAiService.java[]
 ----
 
-<1>	The multi-line string contains two complete "INPUT: … OUTPUT: …" pairs followed by the placeholder `\{text}` for the new query.
+<1>	The multi-line string contains two complete `INPUT: … OUTPUT: …` pairs followed by the placeholder `\{text}` for the new query.
 <2> When the method is invoked, Quarkus Langchain4j will replace `\{text}` with the actual text parameter.
 
 [TIP]
@@ -69,7 +69,7 @@ include::{examples-dir}/io/quarkiverse/langchain4j/samples/fewshots/SentimentRes
 This `SentimentResource` bean handles HTTP GET requests, delegates to the few-shot prompt method, and returns the classification.
 The endpoint can be tested with a simple HTTP client or browser by accessing:
 
-[source,curl]
+[source,bash]
 ----
 curl http://localhost:8080/sentiment?text=I%20love%20this%20product!
 ----


### PR DESCRIPTION
## Summary

- Wrap the ``INPUT: … OUTPUT: …`` pattern as inline code in `guide-few-shots.adoc` instead of quoting it as prose, so the intent (a literal template for few-shot entries) is clear.
- Switch the curl example block from the unrecognized ``[source,curl]`` to ``[source,bash]``, matching the convention used elsewhere in `docs/modules/ROOT/pages` for shell commands.

No content or behavior changes beyond these two formatting tweaks.