### PR TITLE
docs: wrap shorthand admonition blocks in ==== delimiters

### DIFF
--- a/docs/modules/ROOT/pages/guide-few-shots.adoc
+++ b/docs/modules/ROOT/pages/guide-few-shots.adoc
@@ -55,7 +55,9 @@ include::{examples-dir}/io/quarkiverse/langchain4j/samples/fewshots/SentimentAiS
 <2> When the method is invoked, Quarkus Langchain4j will replace `\{text}` with the actual text parameter.
 
 [TIP]
+====
 While in this example we added the few-shot example in the user message, they can also be added in the system message.
+====
 
 == Step 3. Invoke the AI Service from an HTTP Endpoint
 

--- a/docs/modules/ROOT/pages/rag-neo4j.adoc
+++ b/docs/modules/ROOT/pages/rag-neo4j.adoc
@@ -125,7 +125,9 @@ RETURN ...
 ----
 
 [NOTE]
+====
 Metadata filtering is fully supported using standard Cypher conditions alongside vector similarity.
+====
 
 == Summary
 

--- a/docs/modules/ROOT/pages/retrievers.adoc
+++ b/docs/modules/ROOT/pages/retrievers.adoc
@@ -21,8 +21,10 @@ image::chatbot-architecture.png[width=1000,align="center"]
 Embeddings denote data representations, typically in a lower-dimensional space (arrays of floats), preserving essential characteristics of the original data. In the realm of language or text, word embeddings represent words as numerical vectors in a continuous space.
 
 [TIP]
+====
 .Why Use Vectors/Embeddings?
 Efficiently comparing documents to user queries during the RAG process, a crucial step in finding relevant documents, relies on computing similarity (or distance) between documents and queries. Vectorizing documents significantly speeds up this process.
+====
 
 == The Ingestion Process
 


### PR DESCRIPTION
## Summary

Three admonitions in the docs set use the bare-attribute shorthand (`[TIP]` / `[NOTE]` on a line followed by a single paragraph, no `====` delimiters). That form renders in Asciidoctor but produces inconsistent output across renderers (Asciidoctor vs. DITA vs. downstream tooling), and makes programmatic content transformations harder.

Wrap each block in the explicit `====` delimited form. No content changes.

## Files

- `docs/modules/ROOT/pages/guide-few-shots.adoc` (`[TIP]`)
- `docs/modules/ROOT/pages/rag-neo4j.adoc` (`[NOTE]`)
- `docs/modules/ROOT/pages/retrievers.adoc` (`[TIP]`)