### PR TITLE
docs(streamed-responses): use OpenAI in the Project Setup example

### DIFF
--- a/docs/modules/ROOT/pages/guide-streamed-responses.adoc
+++ b/docs/modules/ROOT/pages/guide-streamed-responses.adoc
@@ -32,10 +32,10 @@ Add the following dependencies in your `pom.xml`:
 
 [source,xml,subs=attributes+]
 ----
-<!-- Or any other model provider that supports streaming, such as OpenAI -->
+<!-- Or any other model provider that supports streaming, such as Ollama -->
 <dependency>
     <groupId>io.quarkiverse.langchain4j</groupId>
-    <artifactId>quarkus-langchain4j-ollama</artifactId>
+    <artifactId>quarkus-langchain4j-openai</artifactId>
     <version>{project-version}</version>
 </dependency>
 <dependency>
@@ -48,11 +48,11 @@ Add the following dependencies in your `pom.xml`:
 </dependency>
 ----
 
-If you are using Ollama, configure your model in `application.properties`:
+Configure your OpenAI API key in `application.properties`:
 
 [source,properties]
 ----
-quarkus.langchain4j.ollama.chat-model.model-name=qwen3:1.7b
+quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 ----
 
 == Streamed Responses in AI Services


### PR DESCRIPTION
The "Using Streamed Responses" guide is provider-agnostic — streaming works with any chat model that supports it. The Project Setup example currently shows Ollama and the comment says "Or any other model provider that supports streaming, such as OpenAI."

Flip the primary example to OpenAI for three reasons:

- OpenAI is the canonical example across most other quarkus-langchain4j guides (openai-chat-model, quickstart-rag, guide-generating-image), so readers arriving here from elsewhere in the docs see a consistent setup pattern.
- OpenAI-only downstream products (such as the Red Hat Build of Quarkus and IBM EBoQ product) currently ship a broken example here, since quarkus-langchain4j-ollama isn't in their supported extensions set. Using OpenAI lets the guide render as a working example in every distribution that packages quarkus-langchain4j-openai.
- The "Or any other model provider..." comment is retained with Ollama as the flipped example, so community users running Ollama locally still have a visible pointer to the alternative.

Content-only change; no behavior or API change.