### PR TITLE
fix: prevent NPE in programmatic AiServices with single shared chat memory inside request scope

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
@@ -173,7 +173,7 @@ public class AiServiceMethodImplementationSupport {
                 .interfaceName(context.aiServiceClass.getName())
                 .methodName(createInfo.getMethodName())
                 .methodArguments((methodArgs != null) ? Arrays.asList(methodArgs) : List.of())
-                .chatMemoryId(memoryId(createInfo, methodArgs, context.hasChatMemory(), context.defaultMemoryIdProvider))
+                .chatMemoryId(memoryId(createInfo, methodArgs, context))
                 .invocationParameters(findInvocationParams(methodArgs))
                 .managedParameters(LangChain4jManaged.current())
                 .timestampNow()
@@ -1171,14 +1171,14 @@ public class AiServiceMethodImplementationSupport {
     }
 
     private static Object memoryId(AiServiceMethodCreateInfo createInfo, Object[] methodArgs,
-            boolean hasChatMemoryProvider, DefaultMemoryIdProvider defaultMemoryIdProvider) {
+            QuarkusAiServiceContext context) {
         if (createInfo.getMemoryIdParamPosition().isPresent()) {
             return methodArgs[createInfo.getMemoryIdParamPosition().get()];
         }
 
-        if (hasChatMemoryProvider) {
-            if (defaultMemoryIdProvider != null) {
-                Object memoryId = defaultMemoryIdProvider.getMemoryId();
+        if (context.hasChatMemoryProvider()) {
+            if (context.defaultMemoryIdProvider != null) {
+                Object memoryId = context.defaultMemoryIdProvider.getMemoryId();
                 if (memoryId != null) {
                     return memoryId;
                 }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceContext.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceContext.java
@@ -29,6 +29,24 @@ public class QuarkusAiServiceContext extends AiServiceContext {
     public boolean allowContinuousForcedToolCalling;
     public DefaultMemoryIdProvider defaultMemoryIdProvider;
     public ChatMemoryFlushStrategy chatMemoryFlushStrategy = ChatMemoryFlushStrategy.DEFERRED;
+    /**
+     * True when a {@link dev.langchain4j.memory.chat.ChatMemoryProvider} is configured (per-memory-id mode).
+     * False when only a single shared {@link dev.langchain4j.memory.ChatMemory} is configured.
+     * Used to guard DefaultMemoryIdProvider usage: providers must only be consulted when a
+     * ChatMemoryProvider exists — otherwise we risk returning a non-null id from e.g.
+     * RequestScopeStateDefaultMemoryIdProvider when only a single shared memory exists,
+     * causing {@link dev.langchain4j.service.memory.ChatMemoryService#getOrCreateChatMemory}
+     * to receive a null-chatMemoryProvider.
+     */
+    private boolean hasChatMemoryProvider = false;
+
+    public boolean hasChatMemoryProvider() {
+        return hasChatMemoryProvider;
+    }
+
+    public void setHasChatMemoryProvider(boolean hasChatMemoryProvider) {
+        this.hasChatMemoryProvider = hasChatMemoryProvider;
+    }
 
     // needed by Arc
     public QuarkusAiServiceContext() {
@@ -37,6 +55,18 @@ public class QuarkusAiServiceContext extends AiServiceContext {
 
     public QuarkusAiServiceContext(Class<?> aiServiceClass) {
         super(aiServiceClass);
+    }
+
+    @Override
+    public void initChatMemories(ChatMemory chatMemory) {
+        super.initChatMemories(chatMemory);
+        this.hasChatMemoryProvider = false;
+    }
+
+    @Override
+    public void initChatMemories(dev.langchain4j.memory.chat.ChatMemoryProvider chatMemoryProvider) {
+        super.initChatMemories(chatMemoryProvider);
+        this.hasChatMemoryProvider = true;
     }
 
     /**

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/org/acme/examples/aiservices/QuarkusLangchain4jChatMemoryNpeTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/org/acme/examples/aiservices/QuarkusLangchain4jChatMemoryNpeTest.java
@@ -1,0 +1,122 @@
+package io.quarkiverse.langchain4j.test;
+
+import static dev.langchain4j.data.message.ChatMessageType.AI;
+import static dev.langchain4j.data.message.ChatMessageType.USER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import java.io.IOException;
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.store.memory.chat.ChatMemoryStore;
+import dev.langchain4j.store.memory.chat.InMemoryChatMemoryStore;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Regression test for <a href="https://github.com/quarkiverse/quarkus-langchain4j/issues/2381">issue
+ * #2381</a>.
+ * <p>
+ * Verifies that programmatic {@code AiServices.builder()} with a single shared
+ * {@link MessageWindowChatMemory} (no {@link MemoryId} parameter on the method) does NOT throw
+ * NPE when the service is invoked from within an active request scope. Prior to the fix,
+ * {@link io.quarkiverse.langchain4j.runtime.aiservice.AiServiceMethodImplementationSupport#memoryId}
+ * would use the request-scope state object as the memory id (via
+ * {@link io.quarkiverse.langchain4j.runtime.RequestScopeStateDefaultMemoryIdProvider}), and then
+ * call {@code chatMemories.computeIfAbsent(memoryId, chatMemoryProvider::get)} with a null
+ * {@code chatMemoryProvider}, causing an NPE.
+ */
+public class QuarkusLangchain4jChatMemoryNpeTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    static final InMemoryChatMemoryStore STORE = new InMemoryChatMemoryStore();
+
+    @Singleton
+    static class SharedMemoryStoreProducer {
+        @jakarta.enterprise.inject.Produces
+        @Singleton
+        ChatMemoryStore chatMemoryStore() {
+            return STORE;
+        }
+    }
+
+    @Singleton
+    static class SharedMemoryChatMemoryHolder {
+        static final ChatMemory MEMORY = MessageWindowChatMemory.builder()
+                .maxMessages(20)
+                .chatMemoryStore(STORE)
+                .build();
+    }
+
+    @RegisterAiService
+    @Singleton
+    interface SharedMemoryChatBot {
+
+        String chat(@UserMessage String userMessage);
+    }
+
+    @Inject
+    SharedMemoryChatBot sharedMemoryChatBot;
+
+    @Test
+    void should_not_throw_npe_with_single_shared_memory_in_request_scope() throws IOException {
+        // First call — should NOT throw NPE even though we are inside an active request scope
+        setChatCompletionMessageContent("Hi Alice! Nice to meet you.");
+        String response1 = sharedMemoryChatBot.chat("Hello, my name is Alice");
+
+        assertThat(response1).isEqualTo("Hi Alice! Nice to meet you.");
+
+        // Verify the message was stored in the chat memory
+        assertThat(STORE.getMessages(dev.langchain4j.memory.chat.MessageWindowChatMemory.DEFAULT))
+                .hasSize(2)
+                .extracting(ChatMessage::type, LangChain4jUtil::chatMessageToText)
+                .containsExactly(
+                        tuple(USER, "Hello, my name is Alice"),
+                        tuple(AI, "Hi Alice! Nice to meet you."));
+
+        // Second call — verify the bot remembers Alice (shared memory works)
+        resetRequests();
+        setChatCompletionMessageContent("Your name is Alice");
+        String response2 = sharedMemoryChatBot.chat("What is my name?");
+
+        assertThat(response2).isEqualTo("Your name is Alice");
+
+        // Verify that now we have 4 messages (2 more added from second call)
+        List<ChatMessage> messages = STORE
+                .getMessages(dev.langchain4j.memory.chat.MessageWindowChatMemory.DEFAULT);
+        assertThat(messages).hasSize(4);
+        assertThat(messages.get(2).type()).isEqualTo(USER);
+        assertThat(messages.get(3).type()).isEqualTo(AI);
+
+        // Third call — still no NPE
+        resetRequests();
+        setChatCompletionMessageContent("Hello again!");
+        String response3 = sharedMemoryChatBot.chat("Hello again!");
+        assertThat(response3).isEqualTo("Hello again!");
+
+        // Verify message count grew to 6
+        assertThat(STORE.getMessages(dev.langchain4j.memory.chat.MessageWindowChatMemory.DEFAULT))
+                .hasSize(6);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes [quarkiverse/quarkus-langchain4j#2381](https://github.com/quarkiverse/quarkus-langchain4j/issues/2381).

### Root cause

`AiServiceMethodImplementationSupport.memoryId()` was passed `context.hasChatMemory()` (true whenever any chat memory is configured) but used the parameter name `hasChatMemoryProvider`. When a single shared `ChatMemory` was configured (no `ChatMemoryProvider`), `RequestScopeStateDefaultMemoryIdProvider` would return a non-null request-scope state object as the memory id. This id was then passed to `ChatMemoryService.getOrCreateChatMemory(memoryId)`, which called `chatMemories.computeIfAbsent(memoryId, chatMemoryProvider::get)` with a **null** `chatMemoryProvider`, causing an NPE.

### Fix

1. **`QuarkusAiServiceContext`**: Added `hasChatMemoryProvider` boolean field, tracked via overridden `initChatMemories(ChatMemory)` (sets false) and `initChatMemories(ChatMemoryProvider)` (sets true) methods.
2. **`AiServiceMethodImplementationSupport.memoryId()`**: Changed to call `context.hasChatMemoryProvider()` instead of `context.hasChatMemory()`, so `DefaultMemoryIdProvider` instances are only consulted when a `ChatMemoryProvider` is actually configured.

### Regression test

`QuarkusLangchain4jChatMemoryNpeTest`: programmatic `AiServices.builder()` with single shared `MessageWindowChatMemory` (no `@MemoryId`), invoked from within an active request scope via `@QuarkusUnitTest`, verifies no NPE and correct shared memory usage.

### Files changed

| File | Change |
|------|--------|
| `QuarkusAiServiceContext.java` | Added `hasChatMemoryProvider` field + overrides |
| `AiServiceMethodImplementationSupport.java` | `memoryId()` uses `context.hasChatMemoryProvider()` |
| `QuarkusLangchain4jChatMemoryNpeTest.java` | Regression test |

cc @quarkiverse/langchain4j