### PR TITLE
Remove <devMode><jvmOptions> block causing Quarkus 3.32+ IllegalStateException (#2375)

### DIFF
--- a/model-providers/jlama/deployment/src/test/java/io/quarkiverse/langchain4j/jlama/deployment/JlamaBootstrapSmokeTest.java
+++ b/model-providers/jlama/deployment/src/test/java/io/quarkiverse/langchain4j/jlama/deployment/JlamaBootstrapSmokeTest.java
@@ -1,0 +1,25 @@
+package io.quarkiverse.langchain4j.jlama.deployment;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class JlamaBootstrapSmokeTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addAsResource(
+                    "application.properties",
+                    "application.properties"))
+            .overrideConfigKey("quarkus.langchain4j.jlama.chat-model.enabled", "false")
+            .overrideConfigKey("quarkus.langchain4j.jlama.embedding-model.enabled", "false");
+
+    @Test
+    void smokeBootstrap() {
+        // Verifies the extension boots cleanly with models disabled (no IllegalStateException from
+        // ApplicationModelSerializer due to the removed <devMode><jvmOptions> block).
+    }
+}

--- a/model-providers/jlama/runtime/pom.xml
+++ b/model-providers/jlama/runtime/pom.xml
@@ -62,15 +62,6 @@
                         </goals>
                         <configuration>
                             <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
-                            <devMode>
-                                <jvmOptions>
-                                    <add-modules>jdk.incubator.vector</add-modules>
-                                    <enable-preview />
-                                    <enable-native-access>ALL-UNNAMED</enable-native-access>
-                                </jvmOptions>
-                                <lockXxJvmOptions>TieredStopAtLevel</lockXxJvmOptions>
-                                <lockJvmOptions>agentlib:jdwp</lockJvmOptions>
-                            </devMode>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
## Summary

The `<devMode><jvmOptions>` block in `model-providers/jlama/runtime/pom.xml` causes Quarkus 3.32+ to throw:

```
IllegalStateException: Unsupported value type: [ALL-UNNAMED]
```

at ApplicationModelSerializer bootstrap.

## Changes

1. **Removed** the `<devMode>` block from `quarkus-extension-maven-plugin` configuration in `model-providers/jlama/runtime/pom.xml`
2. **Added** `JlamaBootstrapSmokeTest` — a QuarkusUnitTest that boots the extension with models disabled, ensuring the fix doesn't regress

## Testing

- `JlamaBootstrapSmokeTest` verifies clean bootstrap with no model initialization

## References

- Fixes [quarkiverse/quarkus-langchain4j#2375](https://github.com/quarkiverse/quarkus-langchain4j/issues/2375)
- Related (not merged): [mdproctor/quarkus-langchain4j#2374](https://github.com/quarkiverse/quarkus-langchain4j/pull/2374)