### PR TITLE
Pass invocation context to tool provider request

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolresolution/InvocationParametersToolProviderTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolresolution/InvocationParametersToolProviderTest.java
@@ -1,0 +1,110 @@
+package io.quarkiverse.langchain4j.test.toolresolution;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.invocation.InvocationParameters;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.tool.ToolExecutor;
+import dev.langchain4j.service.tool.ToolProvider;
+import dev.langchain4j.service.tool.ToolProviderRequest;
+import dev.langchain4j.service.tool.ToolProviderResult;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verify that InvocationParameters are propagated to ToolProvider,
+ * allowing dynamic tool filtering based on parameters passed at invocation time.
+ */
+public class InvocationParametersToolProviderTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestAiSupplier.class,
+                            TestAiModel.class,
+                            RoleBasedToolProvider.class,
+                            RoleBasedToolProviderSupplier.class,
+                            ServiceWithRoleBasedTools.class));
+
+    @ApplicationScoped
+    public static class RoleBasedToolProvider implements ToolProvider {
+
+        @Override
+        public ToolProviderResult provideTools(ToolProviderRequest request) {
+            InvocationParameters params = request.invocationParameters();
+            String role = params.get("role");
+
+            var builder = ToolProviderResult.builder();
+
+            if ("admin".equals(role)) {
+                ToolSpecification writeSpec = ToolSpecification.builder()
+                        .name("write_data")
+                        .description("Writes data")
+                        .build();
+                ToolExecutor writeExecutor = (t, m) -> "WRITE";
+                builder.add(writeSpec, writeExecutor);
+            }
+
+            ToolSpecification readSpec = ToolSpecification.builder()
+                    .name("read_data")
+                    .description("Reads data")
+                    .build();
+            ToolExecutor readExecutor = (t, m) -> "READ";
+            builder.add(readSpec, readExecutor);
+
+            return builder.build();
+        }
+    }
+
+    @ApplicationScoped
+    public static class RoleBasedToolProviderSupplier implements Supplier<ToolProvider> {
+
+        @Inject
+        RoleBasedToolProvider provider;
+
+        @Override
+        public ToolProvider get() {
+            return provider;
+        }
+    }
+
+    @RegisterAiService(toolProviderSupplier = RoleBasedToolProviderSupplier.class, chatLanguageModelSupplier = TestAiSupplier.class)
+    interface ServiceWithRoleBasedTools {
+
+        String chat(@UserMessage String msg, @MemoryId Object id, InvocationParameters params);
+    }
+
+    @Inject
+    ServiceWithRoleBasedTools service;
+
+    @Test
+    @ActivateRequestContext
+    void testAdminGetsWriteTool() {
+        InvocationParameters params = new InvocationParameters();
+        params.put("role", "admin");
+        String answer = service.chat("hello", 1, params);
+        assertEquals("WRITE", answer);
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testUserGetsReadOnlyTool() {
+        InvocationParameters params = new InvocationParameters();
+        params.put("role", "user");
+        String answer = service.chat("hello", 2, params);
+        assertEquals("READ", answer);
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
@@ -261,7 +261,7 @@ public class AiServiceMethodImplementationSupport {
         toolSpecifications = toolSpecifications != null ? new ArrayList<>(toolSpecifications) : new ArrayList<>();
         toolExecutors = toolExecutors != null ? new HashMap<>(toolExecutors) : new HashMap<>();
         for (ToolProvider toolProvider : context.toolService.toolProviders()) {
-            ToolProviderRequest request = new QuarkusToolProviderRequest(memoryId, userMessage,
+            ToolProviderRequest request = new QuarkusToolProviderRequest(invocationContext, userMessage,
                     methodCreateInfo.getMcpClientNames());
             ToolProviderResult result = toolProvider.provideTools(request);
             immediateReturnToolNames = Utils.copy(result.immediateReturnToolNames());

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusToolProviderRequest.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusToolProviderRequest.java
@@ -3,14 +3,18 @@ package io.quarkiverse.langchain4j.runtime.aiservice;
 import java.util.List;
 
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.service.tool.ToolProviderRequest;
 
 public class QuarkusToolProviderRequest extends ToolProviderRequest {
 
     private final List<String> mcpClientNames;
 
-    public QuarkusToolProviderRequest(Object chatMemoryId, UserMessage userMessage, List<String> mcpClientNames) {
-        super(chatMemoryId, userMessage);
+    public QuarkusToolProviderRequest(InvocationContext invocationContext, UserMessage userMessage,
+            List<String> mcpClientNames) {
+        super(ToolProviderRequest.builder()
+                .invocationContext(invocationContext)
+                .userMessage(userMessage));
         this.mcpClientNames = mcpClientNames;
     }
 

--- a/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/MultipleMcpClientsTest.java
+++ b/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/MultipleMcpClientsTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.ChatMemoryProvider;
 import dev.langchain4j.model.chat.ChatModel;
@@ -90,7 +91,10 @@ public class MultipleMcpClientsTest {
 
     @Test
     public void providingSelectedTools() {
-        var request = new QuarkusToolProviderRequest("1", new dev.langchain4j.data.message.UserMessage("hi"),
+        var invocationContext = InvocationContext.builder()
+                .chatMemoryId("1")
+                .build();
+        var request = new QuarkusToolProviderRequest(invocationContext, new dev.langchain4j.data.message.UserMessage("hi"),
                 List.of("client1", "client3"));
         ToolProviderResult toolProviderResult = toolProvider.provideTools(request);
 


### PR DESCRIPTION
Pass invocation context so we can access invocation parameter in the tool provider.

This is useful for dynamic tool access based on user or tenant information

For example

```java
 @Singleton
  public class MyToolProvider implements ToolProvider {

      @Override
      public ToolProviderResult provideTools(ToolProviderRequest request) {
          InvocationParameters params = request.invocationParameters();
          String role = params.get("role");

          var builder = ToolProviderResult.builder();

          // Always provide read-only tools
          builder.add(readToolSpec, readToolExecutor);

          // Only provide write tools for admin users
          if ("admin".equals(role)) {
              builder.add(writeToolSpec, writeToolExecutor);
              builder.add(deleteToolSpec, deleteToolExecutor);
          }

          return builder.build();
      }
  }
```