### PR TITLE
Add Dev UI to quarkus-langchain4j agentic extension

### DIFF
--- a/agentic/deployment/src/main/java/io/quarkiverse/langchain4j/agentic/deployment/devui/AgentInfo.java
+++ b/agentic/deployment/src/main/java/io/quarkiverse/langchain4j/agentic/deployment/devui/AgentInfo.java
@@ -1,0 +1,66 @@
+package io.quarkiverse.langchain4j.agentic.deployment.devui;
+
+import java.util.List;
+
+public class AgentInfo {
+
+    private final String className;
+    private final String simpleName;
+    private final String agentType;
+    private final String description;
+    private final String outputKey;
+    private final List<String> subAgents;
+    private final List<String> methods;
+    private final List<String> configAnnotations;
+    private final boolean rootAgent;
+
+    public AgentInfo(String className, String simpleName, String agentType, String description,
+            String outputKey, List<String> subAgents, List<String> methods,
+            List<String> configAnnotations, boolean rootAgent) {
+        this.className = className;
+        this.simpleName = simpleName;
+        this.agentType = agentType;
+        this.description = description;
+        this.outputKey = outputKey;
+        this.subAgents = subAgents;
+        this.methods = methods;
+        this.configAnnotations = configAnnotations;
+        this.rootAgent = rootAgent;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public String getSimpleName() {
+        return simpleName;
+    }
+
+    public String getAgentType() {
+        return agentType;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getOutputKey() {
+        return outputKey;
+    }
+
+    public List<String> getSubAgents() {
+        return subAgents;
+    }
+
+    public List<String> getMethods() {
+        return methods;
+    }
+
+    public List<String> getConfigAnnotations() {
+        return configAnnotations;
+    }
+
+    public boolean isRootAgent() {
+        return rootAgent;
+    }
+}

--- a/agentic/deployment/src/main/java/io/quarkiverse/langchain4j/agentic/deployment/devui/AgenticDevUIProcessor.java
+++ b/agentic/deployment/src/main/java/io/quarkiverse/langchain4j/agentic/deployment/devui/AgenticDevUIProcessor.java
@@ -1,0 +1,269 @@
+package io.quarkiverse.langchain4j.agentic.deployment.devui;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.MethodParameterInfo;
+import org.jboss.jandex.Type;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Opcodes;
+
+import dev.langchain4j.agentic.observability.MonitoredAgent;
+import io.quarkiverse.langchain4j.agentic.deployment.AgenticLangChain4jDotNames;
+import io.quarkiverse.langchain4j.agentic.deployment.DetectedAiAgentBuildItem;
+import io.quarkiverse.langchain4j.agentic.runtime.AgenticRecorder;
+import io.quarkiverse.langchain4j.agentic.runtime.devui.AgenticJsonRpcService;
+import io.quarkus.arc.deployment.SyntheticBeansRuntimeInitBuildItem;
+import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
+import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.Consume;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
+import io.quarkus.devui.spi.page.CardPageBuildItem;
+import io.quarkus.devui.spi.page.Page;
+
+public class AgenticDevUIProcessor {
+
+    private static final String INTERNAL_AGENT_PACKAGE_PREFIX = "dev.langchain4j.agentic.";
+
+    private static final List<DotName> CONFIG_ANNOTATIONS = List.of(
+            AgenticLangChain4jDotNames.CHAT_MODEL_SUPPLIER,
+            AgenticLangChain4jDotNames.CHAT_MEMORY_SUPPLIER,
+            AgenticLangChain4jDotNames.CHAT_MEMORY_PROVIDER_SUPPLIER,
+            AgenticLangChain4jDotNames.CONTENT_RETRIEVER_SUPPLIER,
+            AgenticLangChain4jDotNames.RETRIEVAL_AUGMENTER_SUPPLIER,
+            AgenticLangChain4jDotNames.TOOL_SUPPLIER,
+            AgenticLangChain4jDotNames.TOOL_PROVIDER_SUPPLIER,
+            AgenticLangChain4jDotNames.AGENT_LISTENER_SUPPLIER,
+            AgenticLangChain4jDotNames.PARALLEL_EXECUTOR,
+            AgenticLangChain4jDotNames.ACTIVATION_CONDITION,
+            AgenticLangChain4jDotNames.EXIT_CONDITION,
+            AgenticLangChain4jDotNames.ERROR_HANDLER,
+            AgenticLangChain4jDotNames.OUTPUT,
+            AgenticLangChain4jDotNames.HUMAN_IN_THE_LOOP);
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    CardPageBuildItem cardPage(List<DetectedAiAgentBuildItem> agents) {
+        List<DetectedAiAgentBuildItem> userAgents = filterUserAgents(agents);
+        Set<String> allSubAgentClassNames = collectAllSubAgentClassNames(userAgents);
+
+        List<AgentInfo> agentInfos = new ArrayList<>();
+        for (DetectedAiAgentBuildItem agent : userAgents) {
+            agentInfos.add(buildAgentInfo(agent, allSubAgentClassNames));
+        }
+
+        CardPageBuildItem card = new CardPageBuildItem();
+        card.addBuildTimeData("agents", agentInfos);
+
+        card.addPage(Page.webComponentPageBuilder()
+                .title("Agents")
+                .componentLink("qwc-agents.js")
+                .staticLabel(String.valueOf(userAgents.size()))
+                .icon("font-awesome-solid:robot"));
+
+        card.addPage(Page.webComponentPageBuilder()
+                .title("Topology")
+                .componentLink("qwc-agents-topology.js")
+                .icon("font-awesome-solid:diagram-project"));
+
+        card.addPage(Page.webComponentPageBuilder()
+                .title("Executions")
+                .componentLink("qwc-agents-executions.js")
+                .icon("font-awesome-solid:chart-line"));
+
+        card.addPage(Page.webComponentPageBuilder()
+                .title("Testing")
+                .componentLink("qwc-agents-testing.js")
+                .icon("font-awesome-solid:play"));
+
+        return card;
+    }
+
+    @BuildStep
+    void jsonRpcProvider(BuildProducer<JsonRPCProvidersBuildItem> producers) {
+        producers.produce(new JsonRPCProvidersBuildItem(AgenticJsonRpcService.class));
+    }
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    void markAgentBeansUnremovable(List<DetectedAiAgentBuildItem> agents,
+            BuildProducer<UnremovableBeanBuildItem> unremovableProducer) {
+        for (DetectedAiAgentBuildItem agent : filterUserAgents(agents)) {
+            unremovableProducer.produce(UnremovableBeanBuildItem.beanTypes(agent.getIface().name()));
+        }
+    }
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    void addMonitoredAgentInterface(List<DetectedAiAgentBuildItem> agents,
+            BuildProducer<BytecodeTransformerBuildItem> transformers) {
+        List<DetectedAiAgentBuildItem> userAgents = filterUserAgents(agents);
+        Set<String> allSubAgentClassNames = collectAllSubAgentClassNames(userAgents);
+
+        String monitoredAgentInternal = MonitoredAgent.class.getName().replace('.', '/');
+
+        for (DetectedAiAgentBuildItem agent : userAgents) {
+            String className = agent.getIface().name().toString();
+            if (allSubAgentClassNames.contains(className) ||
+                    agent.getIface().interfaceNames().stream()
+                            .anyMatch(dn -> dn.toString().equals(MonitoredAgent.class.getName()))) {
+                continue;
+            }
+
+            transformers.produce(new BytecodeTransformerBuildItem(className,
+                    (name, classVisitor) -> new ClassVisitor(Opcodes.ASM9, classVisitor) {
+                        @Override
+                        public void visit(int version, int access, String name2, String signature,
+                                String superName, String[] interfaces) {
+                            String[] extended = Arrays.copyOf(interfaces, interfaces.length + 1);
+                            extended[interfaces.length] = monitoredAgentInternal;
+                            super.visit(version, access, name2, signature, superName, extended);
+                        }
+                    }));
+        }
+    }
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    @Consume(SyntheticBeansRuntimeInitBuildItem.class)
+    void enableDevModeMonitoring(List<DetectedAiAgentBuildItem> agents,
+            CombinedIndexBuildItem indexBuildItem,
+            AgenticRecorder recorder) {
+        List<DetectedAiAgentBuildItem> userAgents = filterUserAgents(agents);
+        Set<String> allSubAgentClassNames = collectAllSubAgentClassNames(userAgents);
+        Set<String> rootAgentClassNames = userAgents.stream()
+                .map(a -> a.getIface().name().toString())
+                .filter(name -> !allSubAgentClassNames.contains(name))
+                .collect(Collectors.toSet());
+        recorder.enableDevModeMonitoring(rootAgentClassNames);
+        recorder.eagerlyInitRootAgents(rootAgentClassNames);
+    }
+
+    private static List<DetectedAiAgentBuildItem> filterUserAgents(List<DetectedAiAgentBuildItem> agents) {
+        return agents.stream()
+                .filter(a -> !a.getIface().name().toString().startsWith(INTERNAL_AGENT_PACKAGE_PREFIX))
+                .toList();
+    }
+
+    private Set<String> collectAllSubAgentClassNames(List<DetectedAiAgentBuildItem> agents) {
+        Set<String> subAgentClassNames = new HashSet<>();
+        for (DetectedAiAgentBuildItem agent : agents) {
+            for (MethodInfo method : agent.getAgenticMethods()) {
+                for (DotName annotation : AgenticLangChain4jDotNames.AGENT_ANNOTATIONS_WITH_SUB_AGENTS) {
+                    AnnotationInstance instance = method.annotation(annotation);
+                    if (instance == null) {
+                        continue;
+                    }
+                    AnnotationValue subAgentsValue = instance.value("subAgents");
+                    if (subAgentsValue != null) {
+                        for (Type subAgentType : subAgentsValue.asClassArray()) {
+                            subAgentClassNames.add(subAgentType.name().toString());
+                        }
+                    }
+                    AnnotationValue subAgentValue = instance.value("subAgent");
+                    if (subAgentValue != null) {
+                        subAgentClassNames.add(subAgentValue.asClass().name().toString());
+                    }
+                }
+            }
+        }
+        return subAgentClassNames;
+    }
+
+    private AgentInfo buildAgentInfo(DetectedAiAgentBuildItem agent, Set<String> allSubAgentClassNames) {
+        ClassInfo iface = agent.getIface();
+        String className = iface.name().toString();
+        String simpleName = iface.simpleName();
+
+        String agentType = "Agent";
+        String description = "";
+        String outputKey = "";
+        List<String> subAgents = new ArrayList<>();
+
+        for (MethodInfo method : agent.getAgenticMethods()) {
+            for (DotName annotationName : AgenticLangChain4jDotNames.ALL_AGENT_ANNOTATIONS) {
+                AnnotationInstance instance = method.annotation(annotationName);
+                if (instance == null) {
+                    continue;
+                }
+
+                agentType = annotationName.withoutPackagePrefix();
+
+                AnnotationValue descValue = instance.value("description");
+                if (descValue != null) {
+                    description = descValue.asString();
+                }
+                AnnotationValue nameValue = instance.value("name");
+                if (nameValue != null && !nameValue.asString().isEmpty()) {
+                    description = nameValue.asString() + (description.isEmpty() ? "" : " - " + description);
+                }
+
+                AnnotationValue outputKeyValue = instance.value("outputKey");
+                if (outputKeyValue != null) {
+                    outputKey = outputKeyValue.asString();
+                }
+
+                AnnotationValue subAgentsValue = instance.value("subAgents");
+                if (subAgentsValue != null) {
+                    for (Type subType : subAgentsValue.asClassArray()) {
+                        subAgents.add(subType.name().toString());
+                    }
+                }
+                AnnotationValue subAgentValue = instance.value("subAgent");
+                if (subAgentValue != null) {
+                    subAgents.add(subAgentValue.asClass().name().toString());
+                }
+
+                // First matching agent annotation wins (an agent method has exactly one)
+                break;
+            }
+        }
+
+        List<String> methods = agent.getAgenticMethods().stream()
+                .map(this::formatMethodSignature)
+                .toList();
+
+        List<String> configAnnotations = new ArrayList<>();
+        for (DotName configAnnotation : CONFIG_ANNOTATIONS) {
+            if (!iface.annotations(configAnnotation).isEmpty()) {
+                configAnnotations.add("@" + configAnnotation.withoutPackagePrefix());
+            }
+        }
+
+        boolean isRoot = !allSubAgentClassNames.contains(className);
+
+        return new AgentInfo(className, simpleName, agentType, description, outputKey,
+                subAgents, methods, configAnnotations, isRoot);
+    }
+
+    private String formatMethodSignature(MethodInfo method) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(method.returnType().name().withoutPackagePrefix());
+        sb.append(" ").append(method.name()).append("(");
+        List<MethodParameterInfo> params = method.parameters();
+        for (int i = 0; i < params.size(); i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            MethodParameterInfo param = params.get(i);
+            sb.append(param.type().name().withoutPackagePrefix());
+            if (param.name() != null) {
+                sb.append(" ").append(param.name());
+            }
+        }
+        sb.append(")");
+        return sb.toString();
+    }
+}

--- a/agentic/deployment/src/main/resources/dev-ui/qwc-agents-executions.js
+++ b/agentic/deployment/src/main/resources/dev-ui/qwc-agents-executions.js
@@ -1,0 +1,93 @@
+import { LitElement, html, css } from 'lit';
+import { JsonRpc } from 'jsonrpc';
+import '@vaadin/button';
+import '@vaadin/progress-bar';
+
+export class QwcAgentsExecutions extends LitElement {
+
+    static styles = css`
+        :host {
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+        }
+        .toolbar {
+            padding: 10px 15px;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+        .iframe-container {
+            flex: 1;
+            padding: 0 15px 15px 15px;
+        }
+        iframe {
+            width: 100%;
+            height: 100%;
+            border: 1px solid var(--lumo-contrast-20pct);
+            border-radius: 4px;
+            background: var(--lumo-base-color);
+        }
+        .placeholder {
+            padding: 20px;
+            text-align: center;
+            color: var(--lumo-secondary-text-color);
+        }
+    `;
+
+    static properties = {
+        _htmlContent: { state: true },
+        _loading: { state: true },
+        _error: { state: true },
+    };
+
+    jsonRpc = new JsonRpc(this);
+
+    constructor() {
+        super();
+        this._htmlContent = null;
+        this._loading = true;
+        this._error = null;
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this._loadReport();
+    }
+
+    _loadReport() {
+        this._loading = true;
+        this._error = null;
+        this.jsonRpc.getExecutionReportHtml()
+            .then(response => {
+                this._htmlContent = response.result;
+                this._loading = false;
+            })
+            .catch(error => {
+                this._error = String(error);
+                this._loading = false;
+            });
+    }
+
+    render() {
+        return html`
+            <div class="toolbar">
+                <vaadin-button theme="small" @click="${() => this._loadReport()}">
+                    Refresh
+                </vaadin-button>
+                ${this._loading ? html`<span>Loading execution report...</span>` : ''}
+            </div>
+            ${this._loading ? html`
+                <vaadin-progress-bar indeterminate></vaadin-progress-bar>
+            ` : this._error ? html`
+                <div class="placeholder">${this._error}</div>
+            ` : html`
+                <div class="iframe-container">
+                    <iframe .srcdoc="${this._htmlContent}" sandbox="allow-scripts"></iframe>
+                </div>
+            `}
+        `;
+    }
+}
+
+customElements.define('qwc-agents-executions', QwcAgentsExecutions);

--- a/agentic/deployment/src/main/resources/dev-ui/qwc-agents-testing.js
+++ b/agentic/deployment/src/main/resources/dev-ui/qwc-agents-testing.js
@@ -1,0 +1,258 @@
+import { LitElement, html, css } from 'lit';
+import { JsonRpc } from 'jsonrpc';
+import '@vaadin/select';
+import '@vaadin/button';
+import '@vaadin/text-field';
+import '@vaadin/text-area';
+import '@vaadin/progress-bar';
+
+import { agents } from 'build-time-data';
+
+export class QwcAgentsTesting extends LitElement {
+
+    static styles = css`
+        :host {
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+            padding: 15px;
+            gap: 15px;
+            overflow: auto;
+        }
+        .controls {
+            display: flex;
+            gap: 10px;
+            align-items: flex-end;
+            flex-wrap: wrap;
+        }
+        .params-section {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            padding: 10px;
+            background: var(--lumo-contrast-5pct);
+            border-radius: 4px;
+        }
+        .params-section h4 {
+            margin: 0 0 5px 0;
+        }
+        .result-section {
+            flex: 1;
+            min-height: 100px;
+        }
+        .result-success {
+            background: var(--lumo-success-color-10pct);
+            border: 1px solid var(--lumo-success-color);
+            border-radius: 4px;
+            padding: 15px;
+            white-space: pre-wrap;
+            word-break: break-word;
+            font-family: monospace;
+            font-size: 0.9em;
+            overflow: auto;
+        }
+        .result-error {
+            background: var(--lumo-error-color-10pct);
+            border: 1px solid var(--lumo-error-color);
+            border-radius: 4px;
+            padding: 15px;
+            white-space: pre-wrap;
+            word-break: break-word;
+            font-family: monospace;
+            font-size: 0.9em;
+            color: var(--lumo-error-text-color);
+            overflow: auto;
+        }
+        .method-info {
+            font-size: 0.85em;
+            color: var(--lumo-secondary-text-color);
+            margin-top: 4px;
+        }
+        .no-agents {
+            padding: 20px;
+            text-align: center;
+            color: var(--lumo-secondary-text-color);
+        }
+    `;
+
+    static properties = {
+        _agents: { state: true },
+        _selectedAgent: { state: true },
+        _selectedMethod: { state: true },
+        _paramValues: { state: true },
+        _result: { state: true },
+        _invoking: { state: true },
+    };
+
+    jsonRpc = new JsonRpc(this);
+
+    constructor() {
+        super();
+        this._agents = agents || [];
+        this._selectedAgent = null;
+        this._selectedMethod = null;
+        this._paramValues = {};
+        this._result = null;
+        this._invoking = false;
+    }
+
+    _onAgentSelected(e) {
+        const className = e.target.value;
+        this._selectedAgent = this._agents.find(a => a.className === className) || null;
+        this._selectedMethod = null;
+        this._paramValues = {};
+        this._result = null;
+
+        if (this._selectedAgent && this._selectedAgent.methods && this._selectedAgent.methods.length > 0) {
+            this._selectMethod(this._selectedAgent.methods[0]);
+        }
+    }
+
+    _selectMethod(methodSig) {
+        this._selectedMethod = methodSig;
+        this._paramValues = {};
+        this._result = null;
+    }
+
+    _onParamInput(paramName, value) {
+        this._paramValues = { ...this._paramValues, [paramName]: value };
+    }
+
+    _invoke() {
+        if (!this._selectedAgent || !this._selectedMethod) return;
+
+        const methodName = this._extractMethodName(this._selectedMethod);
+        this._invoking = true;
+        this._result = null;
+
+        this.jsonRpc.invokeAgent({
+            agentClassName: this._selectedAgent.className,
+            methodName: methodName,
+            inputJson: JSON.stringify(this._paramValues),
+        })
+        .then(response => {
+            this._result = response.result;
+            this._invoking = false;
+        })
+        .catch(error => {
+            this._result = { success: false, error: String(error) };
+            this._invoking = false;
+        });
+    }
+
+    _extractMethodName(methodSig) {
+        const match = methodSig.match(/\s(\w+)\(/);
+        return match ? match[1] : methodSig;
+    }
+
+    _extractParams(methodSig) {
+        const match = methodSig.match(/\(([^)]*)\)/);
+        if (!match || !match[1].trim()) return [];
+        return match[1].split(',').map(p => {
+            const parts = p.trim().split(/\s+/);
+            return {
+                type: parts[0] || 'String',
+                name: parts[1] || parts[0],
+            };
+        }).filter(p =>
+            p.type !== 'AgenticScope' &&
+            p.type !== 'MemoryId'
+        );
+    }
+
+    render() {
+        if (this._agents.length === 0) {
+            return html`<div class="no-agents">No agents detected.</div>`;
+        }
+
+        const sorted = [...this._agents].sort((a, b) => {
+            if (a.rootAgent !== b.rootAgent) return a.rootAgent ? -1 : 1;
+            return a.simpleName.localeCompare(b.simpleName);
+        });
+        const agentItems = sorted.map(a => ({
+            label: `${a.simpleName} (${a.agentType})${a.rootAgent ? '' : ' [sub-agent]'}`,
+            value: a.className,
+        }));
+
+        return html`
+            <div class="controls">
+                <vaadin-select
+                    label="Agent"
+                    .items="${agentItems}"
+                    @value-changed="${this._onAgentSelected}">
+                </vaadin-select>
+            </div>
+
+            ${this._selectedAgent ? html`
+                ${this._selectedAgent.methods && this._selectedAgent.methods.length > 1 ? html`
+                    <div class="controls">
+                        <vaadin-select
+                            label="Method"
+                            .items="${this._selectedAgent.methods.map(m => ({ label: m, value: m }))}"
+                            .value="${this._selectedMethod}"
+                            @value-changed="${e => this._selectMethod(e.target.value)}">
+                        </vaadin-select>
+                    </div>
+                ` : ''}
+
+                ${this._selectedMethod ? html`
+                    <div class="method-info">
+                        Signature: <code>${this._selectedMethod}</code>
+                    </div>
+
+                    ${this._renderParams()}
+
+                    <div class="controls">
+                        <vaadin-button theme="primary" @click="${this._invoke}"
+                            ?disabled="${this._invoking}">
+                            ${this._invoking ? 'Invoking...' : 'Invoke'}
+                        </vaadin-button>
+                    </div>
+
+                    ${this._invoking ? html`<vaadin-progress-bar indeterminate></vaadin-progress-bar>` : ''}
+
+                    ${this._result ? this._renderResult() : ''}
+                ` : ''}
+            ` : ''}
+        `;
+    }
+
+    _renderParams() {
+        const params = this._extractParams(this._selectedMethod);
+        if (params.length === 0) {
+            return html`<div class="method-info">This method takes no user-provided parameters.</div>`;
+        }
+        return html`
+            <div class="params-section">
+                <h4>Parameters</h4>
+                ${params.map(p => html`
+                    <vaadin-text-field
+                        label="${p.name} (${p.type})"
+                        .value="${this._paramValues[p.name] || ''}"
+                        @input="${e => this._onParamInput(p.name, e.target.value)}">
+                    </vaadin-text-field>
+                `)}
+            </div>
+        `;
+    }
+
+    _renderResult() {
+        if (this._result.success) {
+            return html`
+                <div class="result-section">
+                    <h4>Result</h4>
+                    <div class="result-success">${this._result.result}</div>
+                </div>
+            `;
+        } else {
+            return html`
+                <div class="result-section">
+                    <h4>Error</h4>
+                    <div class="result-error">${this._result.error}</div>
+                </div>
+            `;
+        }
+    }
+}
+
+customElements.define('qwc-agents-testing', QwcAgentsTesting);

--- a/agentic/deployment/src/main/resources/dev-ui/qwc-agents-topology.js
+++ b/agentic/deployment/src/main/resources/dev-ui/qwc-agents-topology.js
@@ -1,0 +1,93 @@
+import { LitElement, html, css } from 'lit';
+import { JsonRpc } from 'jsonrpc';
+import '@vaadin/button';
+import '@vaadin/progress-bar';
+
+export class QwcAgentsTopology extends LitElement {
+
+    static styles = css`
+        :host {
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+        }
+        .toolbar {
+            padding: 10px 15px;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+        .iframe-container {
+            flex: 1;
+            padding: 0 15px 15px 15px;
+        }
+        iframe {
+            width: 100%;
+            height: 100%;
+            border: 1px solid var(--lumo-contrast-20pct);
+            border-radius: 4px;
+            background: var(--lumo-base-color);
+        }
+        .placeholder {
+            padding: 20px;
+            text-align: center;
+            color: var(--lumo-secondary-text-color);
+        }
+    `;
+
+    static properties = {
+        _htmlContent: { state: true },
+        _loading: { state: true },
+        _error: { state: true },
+    };
+
+    jsonRpc = new JsonRpc(this);
+
+    constructor() {
+        super();
+        this._htmlContent = null;
+        this._loading = true;
+        this._error = null;
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this._loadTopology();
+    }
+
+    _loadTopology() {
+        this._loading = true;
+        this._error = null;
+        this.jsonRpc.getTopologyHtml()
+            .then(response => {
+                this._htmlContent = response.result;
+                this._loading = false;
+            })
+            .catch(error => {
+                this._error = String(error);
+                this._loading = false;
+            });
+    }
+
+    render() {
+        return html`
+            <div class="toolbar">
+                <vaadin-button theme="small" @click="${() => this._loadTopology()}">
+                    Refresh
+                </vaadin-button>
+                ${this._loading ? html`<span>Loading topology...</span>` : ''}
+            </div>
+            ${this._loading ? html`
+                <vaadin-progress-bar indeterminate></vaadin-progress-bar>
+            ` : this._error ? html`
+                <div class="placeholder">${this._error}</div>
+            ` : html`
+                <div class="iframe-container">
+                    <iframe .srcdoc="${this._htmlContent}" sandbox="allow-scripts"></iframe>
+                </div>
+            `}
+        `;
+    }
+}
+
+customElements.define('qwc-agents-topology', QwcAgentsTopology);

--- a/agentic/deployment/src/main/resources/dev-ui/qwc-agents.js
+++ b/agentic/deployment/src/main/resources/dev-ui/qwc-agents.js
@@ -1,0 +1,169 @@
+import { LitElement, html, css } from 'lit';
+import '@vaadin/grid';
+import '@vaadin/grid/vaadin-grid-sort-column.js';
+import '@vaadin/text-field';
+import '@vaadin/details';
+import { columnBodyRenderer } from '@vaadin/grid/lit.js';
+
+import { agents } from 'build-time-data';
+
+export class QwcAgents extends LitElement {
+
+    static styles = css`
+        :host {
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+            padding: 15px;
+        }
+        vaadin-grid {
+            flex: 1;
+        }
+        .filter-bar {
+            margin-bottom: 10px;
+        }
+        .badge {
+            display: inline-block;
+            padding: 2px 8px;
+            border-radius: 4px;
+            font-size: 0.8em;
+            font-weight: bold;
+            color: var(--lumo-primary-contrast-color);
+        }
+        .badge-Agent { background-color: var(--lumo-primary-color); }
+        .badge-SequenceAgent { background-color: var(--lumo-success-color); }
+        .badge-ParallelAgent { background-color: var(--lumo-warning-color); }
+        .badge-ParallelMapperAgent { background-color: var(--lumo-warning-color); }
+        .badge-SupervisorAgent { background-color: var(--lumo-primary-color-50pct); }
+        .badge-LoopAgent { background-color: var(--lumo-error-color); }
+        .badge-ConditionalAgent { background-color: var(--lumo-success-color-50pct); }
+        .badge-PlannerAgent { background-color: var(--lumo-contrast-60pct); }
+        .badge-HumanInTheLoop { background-color: var(--lumo-contrast-50pct); }
+        .badge-A2AClientAgent { background-color: var(--lumo-error-color-50pct); }
+        .root-badge {
+            display: inline-block;
+            padding: 1px 5px;
+            border-radius: 3px;
+            font-size: 0.7em;
+            background-color: var(--lumo-success-color);
+            color: var(--lumo-primary-contrast-color);
+            margin-left: 5px;
+        }
+        .detail-section {
+            padding: 10px;
+            font-size: 0.9em;
+        }
+        .detail-section dt { font-weight: bold; margin-top: 8px; }
+        .detail-section dd { margin-left: 15px; margin-bottom: 4px; }
+        .detail-section code {
+            background-color: var(--lumo-contrast-10pct);
+            padding: 1px 4px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+    `;
+
+    static properties = {
+        _agents: { state: true },
+        _filter: { state: true },
+    };
+
+    constructor() {
+        super();
+        this._agents = agents;
+        this._filter = '';
+    }
+
+    render() {
+        if (!this._agents || this._agents.length === 0) {
+            return html`<p>No agents detected.</p>`;
+        }
+
+        const filtered = this._agents.filter(a =>
+            a.simpleName.toLowerCase().includes(this._filter.toLowerCase()) ||
+            a.agentType.toLowerCase().includes(this._filter.toLowerCase()) ||
+            a.description.toLowerCase().includes(this._filter.toLowerCase())
+        );
+
+        return html`
+            <div class="filter-bar">
+                <vaadin-text-field
+                    placeholder="Filter agents..."
+                    clear-button-visible
+                    @input="${e => this._filter = e.target.value}">
+                </vaadin-text-field>
+            </div>
+            <vaadin-grid .items="${filtered}" theme="row-stripes wrap-cell-content">
+                <vaadin-grid-sort-column auto-width path="simpleName" header="Name"
+                    ${columnBodyRenderer(this._nameRenderer, [])}>
+                </vaadin-grid-sort-column>
+                <vaadin-grid-sort-column auto-width path="agentType" header="Type"
+                    ${columnBodyRenderer(this._typeRenderer, [])}>
+                </vaadin-grid-sort-column>
+                <vaadin-grid-column auto-width header="Description"
+                    ${columnBodyRenderer(this._descriptionRenderer, [])}>
+                </vaadin-grid-column>
+                <vaadin-grid-column auto-width header="Output Key" path="outputKey">
+                </vaadin-grid-column>
+                <vaadin-grid-column auto-width header="Sub-Agents"
+                    ${columnBodyRenderer(this._subAgentsRenderer, [])}>
+                </vaadin-grid-column>
+                <vaadin-grid-column auto-width header="Details"
+                    ${columnBodyRenderer(this._detailsRenderer, [])}>
+                </vaadin-grid-column>
+            </vaadin-grid>
+        `;
+    }
+
+    _nameRenderer(agent) {
+        return html`
+            <span>${agent.simpleName}</span>
+            ${agent.rootAgent ? html`<span class="root-badge">root</span>` : ''}
+        `;
+    }
+
+    _typeRenderer(agent) {
+        return html`<span class="badge badge-${agent.agentType}">${agent.agentType}</span>`;
+    }
+
+    _descriptionRenderer(agent) {
+        return html`<span>${agent.description || ''}</span>`;
+    }
+
+    _subAgentsRenderer(agent) {
+        if (!agent.subAgents || agent.subAgents.length === 0) {
+            return html`<span>-</span>`;
+        }
+        return html`
+            <vaadin-vertical-layout>
+                ${agent.subAgents.map(sa => {
+                    const shortName = sa.substring(sa.lastIndexOf('.') + 1);
+                    return html`<code>${shortName}</code>`;
+                })}
+            </vaadin-vertical-layout>
+        `;
+    }
+
+    _detailsRenderer(agent) {
+        return html`
+            <vaadin-details summary="Show">
+                <dl class="detail-section">
+                    <dt>Full class</dt>
+                    <dd><code>${agent.className}</code></dd>
+
+                    ${agent.methods && agent.methods.length > 0 ? html`
+                        <dt>Methods</dt>
+                        ${agent.methods.map(m => html`<dd><code>${m}</code></dd>`)}
+                    ` : ''}
+
+                    ${agent.configAnnotations && agent.configAnnotations.length > 0 ? html`
+                        <dt>Configuration</dt>
+                        ${agent.configAnnotations.map(a => html`<dd><code>${a}</code></dd>`)}
+                    ` : ''}
+                </dl>
+            </vaadin-details>
+        `;
+    }
+}
+
+customElements.define('qwc-agents', QwcAgents);

--- a/agentic/runtime/src/main/java/io/quarkiverse/langchain4j/agentic/runtime/AgenticRecorder.java
+++ b/agentic/runtime/src/main/java/io/quarkiverse/langchain4j/agentic/runtime/AgenticRecorder.java
@@ -11,10 +11,15 @@ import jakarta.enterprise.util.TypeLiteral;
 import org.jboss.logging.Logger;
 
 import dev.langchain4j.agentic.AgenticServices;
+import dev.langchain4j.agentic.observability.AgentMonitor;
+import dev.langchain4j.agentic.observability.MonitoredAgent;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.service.tool.ToolProvider;
 import io.quarkiverse.langchain4j.ModelName;
+import io.quarkiverse.langchain4j.agentic.runtime.devui.DevAgentMonitorHolder;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ClientProxy;
 import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.annotations.RuntimeInit;
@@ -25,10 +30,30 @@ public class AgenticRecorder {
 
     private static final Logger log = Logger.getLogger(AgenticRecorder.class);
     private static Set<String> agentsWithMcpToolBox = Collections.emptySet();
+    private static volatile boolean devModeMonitoringEnabled = false;
+    private static Set<String> rootAgentClassNames = Collections.emptySet();
 
     @StaticInit
     public void setAgentsWithMcpToolBox(Set<String> agentsWithMcpToolBox) {
         AgenticRecorder.agentsWithMcpToolBox = Collections.unmodifiableSet(agentsWithMcpToolBox);
+    }
+
+    @RuntimeInit
+    public void enableDevModeMonitoring(Set<String> rootAgentClassNames) {
+        AgenticRecorder.devModeMonitoringEnabled = true;
+        AgenticRecorder.rootAgentClassNames = Collections.unmodifiableSet(rootAgentClassNames);
+    }
+
+    @RuntimeInit
+    public void eagerlyInitRootAgents(Set<String> rootAgentClassNames) {
+        for (String className : rootAgentClassNames) {
+            try {
+                Class<?> clazz = Class.forName(className, true, Thread.currentThread().getContextClassLoader());
+                ClientProxy.unwrap(Arc.container().select(clazz).get());
+            } catch (Exception e) {
+                log.warn("Failed to eagerly initialize root agent for dev mode topology: " + className, e);
+            }
+        }
     }
 
     @RuntimeInit
@@ -49,8 +74,17 @@ public class AgenticRecorder {
                     throw new IllegalStateException("Unknown type: " + info.chatModelInfo().getClass());
                 }
 
-                return AgenticServices.createAgenticSystem(loadClassSafe(info), chatModel,
+                Object agent = AgenticServices.createAgenticSystem(loadClassSafe(info), chatModel,
                         new QuarkusAgenticContextConsumer(cdiContext, info));
+
+                if (devModeMonitoringEnabled && agent instanceof MonitoredAgent monitoredAgent) {
+                    AgentMonitor monitor = monitoredAgent.agentMonitor();
+                    if (monitor != null) {
+                        DevAgentMonitorHolder.register(monitor);
+                        DevAgentMonitorHolder.registerRootAgent(agent);
+                    }
+                }
+                return agent;
             }
         };
     }

--- a/agentic/runtime/src/main/java/io/quarkiverse/langchain4j/agentic/runtime/devui/AgenticJsonRpcService.java
+++ b/agentic/runtime/src/main/java/io/quarkiverse/langchain4j/agentic/runtime/devui/AgenticJsonRpcService.java
@@ -1,0 +1,131 @@
+package io.quarkiverse.langchain4j.agentic.runtime.devui;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.UUID;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+
+import org.jboss.logging.Logger;
+
+import dev.langchain4j.agentic.observability.AgentMonitor;
+import dev.langchain4j.agentic.observability.HtmlReportGenerator;
+import io.quarkus.arc.Arc;
+import io.vertx.core.json.JsonObject;
+
+public class AgenticJsonRpcService {
+
+    private static final Logger log = Logger.getLogger(AgenticJsonRpcService.class);
+
+    public String getTopologyHtml() {
+        List<Object> rootAgents = DevAgentMonitorHolder.rootAgents();
+        if (rootAgents.isEmpty()) {
+            return "<html><body><p>No root agents detected.</p></body></html>";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (Object rootAgent : rootAgents) {
+            try {
+                sb.append(HtmlReportGenerator.generateTopology(rootAgent));
+            } catch (Exception e) {
+                log.warn("Failed to generate topology", e);
+            }
+        }
+        return sb.length() > 0 ? sb.toString()
+                : "<html><body><p>Failed to generate topology.</p></body></html>";
+    }
+
+    public String getExecutionReportHtml() {
+        List<AgentMonitor> monitors = DevAgentMonitorHolder.monitors();
+        if (monitors.isEmpty()) {
+            return "<html><body><p>No execution data available. Invoke an agent first.</p></body></html>";
+        }
+        try {
+            String html = HtmlReportGenerator.generateReport(monitors.get(0));
+            return html.replace("</head>",
+                    "<style>.container > .section:first-child { display: none !important; }</style></head>");
+        } catch (Exception e) {
+            log.warn("Failed to generate execution report", e);
+            return "<html><body><p>Failed to generate execution report.</p></body></html>";
+        }
+    }
+
+    @ActivateRequestContext
+    public JsonObject invokeAgent(String agentClassName, String methodName, String inputJson) {
+        try {
+            Class<?> agentClass = Class.forName(agentClassName, true, Thread.currentThread().getContextClassLoader());
+            Object agent = Arc.container().select(agentClass).get();
+
+            Method targetMethod = null;
+            for (Method m : agentClass.getMethods()) {
+                if (m.getName().equals(methodName)) {
+                    targetMethod = m;
+                    break;
+                }
+            }
+            if (targetMethod == null) {
+                return new JsonObject()
+                        .put("success", false)
+                        .put("error", "Method '" + methodName + "' not found on " + agentClassName);
+            }
+
+            Object[] args = resolveArguments(targetMethod, inputJson);
+            Object result = targetMethod.invoke(agent, args);
+
+            return new JsonObject()
+                    .put("success", true)
+                    .put("result", result != null ? String.valueOf(result) : "null");
+        } catch (Exception e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            return new JsonObject()
+                    .put("success", false)
+                    .put("error", cause.getClass().getSimpleName() + ": " + cause.getMessage());
+        }
+    }
+
+    private Object[] resolveArguments(Method method, String inputJson) {
+        Class<?>[] paramTypes = method.getParameterTypes();
+        if (paramTypes.length == 0) {
+            return new Object[0];
+        }
+
+        JsonObject inputs = (inputJson != null && !inputJson.isBlank()) ? new JsonObject(inputJson) : new JsonObject();
+        java.lang.reflect.Parameter[] params = method.getParameters();
+        Object[] args = new Object[paramTypes.length];
+
+        for (int i = 0; i < paramTypes.length; i++) {
+            Class<?> type = paramTypes[i];
+            String paramName = params[i].getName();
+
+            if (type.getName().equals("dev.langchain4j.agentic.scope.AgenticScope")) {
+                args[i] = null;
+                continue;
+            }
+
+            if (params[i].isAnnotationPresent(dev.langchain4j.service.MemoryId.class)
+                    || paramName.equals("memoryId")) {
+                args[i] = inputs.containsKey(paramName) ? inputs.getString(paramName) : UUID.randomUUID().toString();
+                continue;
+            }
+
+            if (!inputs.containsKey(paramName)) {
+                args[i] = null;
+                continue;
+            }
+
+            if (type == String.class) {
+                args[i] = inputs.getString(paramName);
+            } else if (type == int.class || type == Integer.class) {
+                args[i] = inputs.getInteger(paramName);
+            } else if (type == long.class || type == Long.class) {
+                args[i] = inputs.getLong(paramName);
+            } else if (type == double.class || type == Double.class) {
+                args[i] = inputs.getDouble(paramName);
+            } else if (type == boolean.class || type == Boolean.class) {
+                args[i] = inputs.getBoolean(paramName);
+            } else {
+                args[i] = inputs.getString(paramName);
+            }
+        }
+        return args;
+    }
+}

--- a/agentic/runtime/src/main/java/io/quarkiverse/langchain4j/agentic/runtime/devui/DevAgentMonitorHolder.java
+++ b/agentic/runtime/src/main/java/io/quarkiverse/langchain4j/agentic/runtime/devui/DevAgentMonitorHolder.java
@@ -1,0 +1,35 @@
+package io.quarkiverse.langchain4j.agentic.runtime.devui;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import dev.langchain4j.agentic.observability.AgentMonitor;
+
+public class DevAgentMonitorHolder {
+
+    private static final List<AgentMonitor> MONITORS = new CopyOnWriteArrayList<>();
+    private static final List<Object> ROOT_AGENTS = new CopyOnWriteArrayList<>();
+
+    private DevAgentMonitorHolder() {
+    }
+
+    public static void register(AgentMonitor monitor) {
+        MONITORS.add(monitor);
+    }
+
+    public static void registerRootAgent(Object rootAgent) {
+        ROOT_AGENTS.add(rootAgent);
+    }
+
+    public static List<AgentMonitor> monitors() {
+        return MONITORS;
+    }
+
+    public static List<Object> rootAgents() {
+        return ROOT_AGENTS;
+    }
+
+    public static void reset() {
+        MONITORS.clear();
+    }
+}


### PR DESCRIPTION
This pull request add a Dev UI interface for the langchain4j-agentic extension.

<img width="396" height="344" alt="image" src="https://github.com/user-attachments/assets/ab923c58-8505-4bbb-b430-97d1bc62d96f" />

At the moment it is composed of 4 parts.

1. A static list of all agents in the system with their description.

<img width="1436" height="543" alt="image" src="https://github.com/user-attachments/assets/f8847d76-5665-4e9a-80fe-78b1bece3031" />

2. A view of the topology of the agentic system.

<img width="1442" height="994" alt="image" src="https://github.com/user-attachments/assets/3dec0669-6a08-4d68-b83d-17ccadf84d39" />

3. The tracing of the executions.

<img width="1439" height="539" alt="image" src="https://github.com/user-attachments/assets/00f3655c-3517-4c56-a617-8f0fccba254b" />

4. A console for a quick test of the agentic system ...

<img width="1440" height="1173" alt="image" src="https://github.com/user-attachments/assets/f9c1811d-8e93-4056-957b-33027b15da09" />

... where it is also possible to directly interact with any agent in the system.

<img width="1441" height="1024" alt="image" src="https://github.com/user-attachments/assets/b078610c-3b4a-4f73-8d3b-fdc44e829788" />

