### PR TITLE
Add support for named pgvector embedding stores

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/EmbeddingStoreName.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/EmbeddingStoreName.java
@@ -1,0 +1,64 @@
+package io.quarkiverse.langchain4j;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+
+/**
+ * Marker annotation to select a named embedding store.
+ * Configure the {@code value} parameter to select the embedding store instance.
+ * <p>
+ * Currently, only the pgvector extension supports named embedding stores.
+ * Other embedding store providers will need to implement the same capability.
+ * <p>
+ * For example, when configuring pgvector like so:
+ *
+ * <pre>
+ * quarkus.langchain4j.pgvector.products.dimension=1536
+ * quarkus.langchain4j.pgvector.products.datasource=products-ds
+ * </pre>
+ *
+ * Then to inject the proper {@code EmbeddingStore}, you would use {@code EmbeddingStoreName} like so:
+ *
+ * <pre>
+ * &#64;Inject
+ * &#64;EmbeddingStoreName("products")
+ * EmbeddingStore&lt;TextSegment&gt; store;
+ * </pre>
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RUNTIME)
+@Documented
+@Qualifier
+public @interface EmbeddingStoreName {
+    /**
+     * Specify the name of the embedding store.
+     *
+     * @return the value
+     */
+    String value() default "";
+
+    class Literal extends AnnotationLiteral<EmbeddingStoreName> implements EmbeddingStoreName {
+
+        public static Literal of(String value) {
+            return new Literal(value);
+        }
+
+        private final String value;
+
+        public Literal(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String value() {
+            return value;
+        }
+    }
+}

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-pgvector.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-pgvector.adoc
@@ -7,6 +7,27 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-default-store-enabled]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-default-store-enabled[`+++quarkus.langchain4j.pgvector.default-store-enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.pgvector.default-store-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the default (unnamed) PG Vector embedding store should be enabled. Set to `false` when you only want to use named stores.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_PGVECTOR_DEFAULT_STORE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR_DEFAULT_STORE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-datasource]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-datasource[`+++quarkus.langchain4j.pgvector.datasource+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.pgvector.datasource+++[]
@@ -15,7 +36,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The name of the configured Postgres datasource to use for this store. If not set, the default datasource from the Agroal extension will be used.
+The name of the configured Postgres datasource to use for the default store. If not set, the default datasource from the Agroal extension will be used.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -68,7 +89,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR_DIMENSION+++`
 endif::add-copy-button-to-env-var[]
 --
 |int
-|required icon:exclamation-circle[title=Configuration property is required]
+|
 
 a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-use-index]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-use-index[`+++quarkus.langchain4j.pgvector.use-index+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -280,6 +301,285 @@ endif::add-copy-button-to-env-var[]
 --
 |string
 |`+++BTREE+++`
+
+h|[[quarkus-langchain4j-pgvector_section_quarkus-langchain4j-pgvector]] [.section-name.section-level0]##link:#quarkus-langchain4j-pgvector_section_quarkus-langchain4j-pgvector[Named store configurations]##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-datasource]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-datasource[`+++quarkus.langchain4j.pgvector."store-name".datasource+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.pgvector."store-name".datasource+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The name of the configured Postgres datasource to use for this store. If not set, the default datasource from the Agroal extension will be used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__DATASOURCE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__DATASOURCE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++<default>+++`
+
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-table]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-table[`+++quarkus.langchain4j.pgvector."store-name".table+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.pgvector."store-name".table+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The table name for storing embeddings
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__TABLE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__TABLE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++embeddings+++`
+
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-dimension]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-dimension[`+++quarkus.langchain4j.pgvector."store-name".dimension+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.pgvector."store-name".dimension+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The dimension of the embedding vectors. This has to be the same as the dimension of vectors produced by the embedding model that you use. For example, AllMiniLmL6V2QuantizedEmbeddingModel produces vectors of dimension 384. OpenAI's text-embedding-ada-002 produces vectors of dimension 1536.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__DIMENSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__DIMENSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-use-index]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-use-index[`+++quarkus.langchain4j.pgvector."store-name".use-index+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.pgvector."store-name".use-index+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Use index or not
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__USE_INDEX+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__USE_INDEX+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-index-list-size]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-index-list-size[`+++quarkus.langchain4j.pgvector."store-name".index-list-size+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.pgvector."store-name".index-list-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+index size
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__INDEX_LIST_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__INDEX_LIST_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++0+++`
+
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-create-table]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-create-table[`+++quarkus.langchain4j.pgvector."store-name".create-table+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.pgvector."store-name".create-table+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the table should be created if not already existing.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__CREATE_TABLE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__CREATE_TABLE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-drop-table-first]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-drop-table-first[`+++quarkus.langchain4j.pgvector."store-name".drop-table-first+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.pgvector."store-name".drop-table-first+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the table should be dropped prior to being created.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__DROP_TABLE_FIRST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__DROP_TABLE_FIRST+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-register-vector-pg-extension]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-register-vector-pg-extension[`+++quarkus.langchain4j.pgvector."store-name".register-vector-pg-extension+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.pgvector."store-name".register-vector-pg-extension+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the PG extension should be created on Start. By Default, if it's dev or test environment the value is overridden to true
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__REGISTER_VECTOR_PG_EXTENSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__REGISTER_VECTOR_PG_EXTENSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-metadata-storage-mode]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-metadata-storage-mode[`+++quarkus.langchain4j.pgvector."store-name".metadata.storage-mode+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.pgvector."store-name".metadata.storage-mode+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Metadata type:
+
+ - COLUMN_PER_KEY: for static metadata, when you know in advance the list of metadata fields. In this case, you should also override the `quarkus.langchain4j.pgvector.metadata.column-definitions` property to define the right columns.
+ - COMBINED_JSON: For dynamic metadata, when you don't know the list of metadata fields that will be used.
+ - COMBINED_JSONB: Same as JSON, but stored in a binary way. Optimized for query on large dataset. In this case, you should also override the `quarkus.langchain4j.pgvector.metadata.column-definitions` property to change the type of the `metadata` column to COMBINED_JSONB.
+
+
+
+Default value: COMBINED_JSON
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__METADATA_STORAGE_MODE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__METADATA_STORAGE_MODE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`column-per-key`, `combined-json`, `combined-jsonb`
+|`+++combined-json+++`
+
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-metadata-column-definitions]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-metadata-column-definitions[`+++quarkus.langchain4j.pgvector."store-name".metadata.column-definitions+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.pgvector."store-name".metadata.column-definitions+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Metadata Definition: SQL definition of metadata field(s). By default, "metadata JSON NULL" configured. This is only suitable if using the JSON metadata type.
+
+If using JSONB metadata type, this should in most cases be set to `metadata JSONB NULL`.
+
+If using COLUMNS metadata type, this should be a list of columns, one column for each desired metadata field. Example: condominium_id uuid null, user uuid null
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__METADATA_COLUMN_DEFINITIONS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__METADATA_COLUMN_DEFINITIONS+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|`+++metadata JSON NULL+++`
+
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-metadata-indexes]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-metadata-indexes[`+++quarkus.langchain4j.pgvector."store-name".metadata.indexes+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.pgvector."store-name".metadata.indexes+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Metadata Indexes, list of fields to use as index.
+
+For instance:
+
+ - JSON: with JSON metadata, indexes are not allowed, so this property must be empty. To use indexes, switch to JSONB metadata.
+ - JSONB: (metadata->'key'), (metadata->'name'), (metadata->'age')
+ - COLUMNS: key, name, age
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__METADATA_INDEXES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__METADATA_INDEXES+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|
+
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-metadata-index-type]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-metadata-index-type[`+++quarkus.langchain4j.pgvector."store-name".metadata.index-type+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.pgvector."store-name".metadata.index-type+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Index Type:
+
+ - BTREE (default)
+ - GIN
+ - Other link:https://www.postgresql.org/docs/current/indexes-types.html[PostgreSQL index types]
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__METADATA_INDEX_TYPE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__METADATA_INDEX_TYPE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++BTREE+++`
+
 
 |===
 

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-pgvector_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-pgvector_quarkus.langchain4j.adoc
@@ -7,6 +7,27 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-default-store-enabled]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-default-store-enabled[`+++quarkus.langchain4j.pgvector.default-store-enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.pgvector.default-store-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the default (unnamed) PG Vector embedding store should be enabled. Set to `false` when you only want to use named stores.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_PGVECTOR_DEFAULT_STORE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR_DEFAULT_STORE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-datasource]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-datasource[`+++quarkus.langchain4j.pgvector.datasource+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.pgvector.datasource+++[]
@@ -15,7 +36,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The name of the configured Postgres datasource to use for this store. If not set, the default datasource from the Agroal extension will be used.
+The name of the configured Postgres datasource to use for the default store. If not set, the default datasource from the Agroal extension will be used.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -68,7 +89,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR_DIMENSION+++`
 endif::add-copy-button-to-env-var[]
 --
 |int
-|required icon:exclamation-circle[title=Configuration property is required]
+|
 
 a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-use-index]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-use-index[`+++quarkus.langchain4j.pgvector.use-index+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -280,6 +301,285 @@ endif::add-copy-button-to-env-var[]
 --
 |string
 |`+++BTREE+++`
+
+h|[[quarkus-langchain4j-pgvector_section_quarkus-langchain4j-pgvector]] [.section-name.section-level0]##link:#quarkus-langchain4j-pgvector_section_quarkus-langchain4j-pgvector[Named store configurations]##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-datasource]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-datasource[`+++quarkus.langchain4j.pgvector."store-name".datasource+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.pgvector."store-name".datasource+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The name of the configured Postgres datasource to use for this store. If not set, the default datasource from the Agroal extension will be used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__DATASOURCE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__DATASOURCE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++<default>+++`
+
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-table]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-table[`+++quarkus.langchain4j.pgvector."store-name".table+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.pgvector."store-name".table+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The table name for storing embeddings
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__TABLE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__TABLE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++embeddings+++`
+
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-dimension]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-dimension[`+++quarkus.langchain4j.pgvector."store-name".dimension+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.pgvector."store-name".dimension+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The dimension of the embedding vectors. This has to be the same as the dimension of vectors produced by the embedding model that you use. For example, AllMiniLmL6V2QuantizedEmbeddingModel produces vectors of dimension 384. OpenAI's text-embedding-ada-002 produces vectors of dimension 1536.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__DIMENSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__DIMENSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-use-index]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-use-index[`+++quarkus.langchain4j.pgvector."store-name".use-index+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.pgvector."store-name".use-index+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Use index or not
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__USE_INDEX+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__USE_INDEX+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-index-list-size]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-index-list-size[`+++quarkus.langchain4j.pgvector."store-name".index-list-size+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.pgvector."store-name".index-list-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+index size
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__INDEX_LIST_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__INDEX_LIST_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++0+++`
+
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-create-table]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-create-table[`+++quarkus.langchain4j.pgvector."store-name".create-table+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.pgvector."store-name".create-table+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the table should be created if not already existing.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__CREATE_TABLE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__CREATE_TABLE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-drop-table-first]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-drop-table-first[`+++quarkus.langchain4j.pgvector."store-name".drop-table-first+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.pgvector."store-name".drop-table-first+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the table should be dropped prior to being created.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__DROP_TABLE_FIRST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__DROP_TABLE_FIRST+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-register-vector-pg-extension]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-register-vector-pg-extension[`+++quarkus.langchain4j.pgvector."store-name".register-vector-pg-extension+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.pgvector."store-name".register-vector-pg-extension+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the PG extension should be created on Start. By Default, if it's dev or test environment the value is overridden to true
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__REGISTER_VECTOR_PG_EXTENSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__REGISTER_VECTOR_PG_EXTENSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-metadata-storage-mode]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-metadata-storage-mode[`+++quarkus.langchain4j.pgvector."store-name".metadata.storage-mode+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.pgvector."store-name".metadata.storage-mode+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Metadata type:
+
+ - COLUMN_PER_KEY: for static metadata, when you know in advance the list of metadata fields. In this case, you should also override the `quarkus.langchain4j.pgvector.metadata.column-definitions` property to define the right columns.
+ - COMBINED_JSON: For dynamic metadata, when you don't know the list of metadata fields that will be used.
+ - COMBINED_JSONB: Same as JSON, but stored in a binary way. Optimized for query on large dataset. In this case, you should also override the `quarkus.langchain4j.pgvector.metadata.column-definitions` property to change the type of the `metadata` column to COMBINED_JSONB.
+
+
+
+Default value: COMBINED_JSON
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__METADATA_STORAGE_MODE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__METADATA_STORAGE_MODE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`column-per-key`, `combined-json`, `combined-jsonb`
+|`+++combined-json+++`
+
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-metadata-column-definitions]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-metadata-column-definitions[`+++quarkus.langchain4j.pgvector."store-name".metadata.column-definitions+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.pgvector."store-name".metadata.column-definitions+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Metadata Definition: SQL definition of metadata field(s). By default, "metadata JSON NULL" configured. This is only suitable if using the JSON metadata type.
+
+If using JSONB metadata type, this should in most cases be set to `metadata JSONB NULL`.
+
+If using COLUMNS metadata type, this should be a list of columns, one column for each desired metadata field. Example: condominium_id uuid null, user uuid null
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__METADATA_COLUMN_DEFINITIONS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__METADATA_COLUMN_DEFINITIONS+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|`+++metadata JSON NULL+++`
+
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-metadata-indexes]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-metadata-indexes[`+++quarkus.langchain4j.pgvector."store-name".metadata.indexes+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.pgvector."store-name".metadata.indexes+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Metadata Indexes, list of fields to use as index.
+
+For instance:
+
+ - JSON: with JSON metadata, indexes are not allowed, so this property must be empty. To use indexes, switch to JSONB metadata.
+ - JSONB: (metadata->'key'), (metadata->'name'), (metadata->'age')
+ - COLUMNS: key, name, age
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__METADATA_INDEXES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__METADATA_INDEXES+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|
+
+a| [[quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-metadata-index-type]] [.property-path]##link:#quarkus-langchain4j-pgvector_quarkus-langchain4j-pgvector-store-name-metadata-index-type[`+++quarkus.langchain4j.pgvector."store-name".metadata.index-type+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.pgvector."store-name".metadata.index-type+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Index Type:
+
+ - BTREE (default)
+ - GIN
+ - Other link:https://www.postgresql.org/docs/current/indexes-types.html[PostgreSQL index types]
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__METADATA_INDEX_TYPE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_PGVECTOR__STORE_NAME__METADATA_INDEX_TYPE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++BTREE+++`
+
 
 |===
 

--- a/docs/modules/ROOT/pages/rag-pgvector-store.adoc
+++ b/docs/modules/ROOT/pages/rag-pgvector-store.adoc
@@ -55,14 +55,14 @@ If you switch to a different embedding model, ensure the `dimension` value is up
 
 == Embedding Index
 
-Use-index controls whether the engine should create and use an index over the embeddings table. 
+Use-index controls whether the engine should create and use an index over the embeddings table.
 To create an index, you need the index-list-size parameter, which is a fine-tuning parameter.
 This basically creates an IVFFlat index with clusters to extend the effectivness of nearest neighbor search.
 If you set the `use-index=true` you will have to also se the `index-list-size`.
 
 [NOTE]
 ====
-This is something you rarely would need in development. 
+This is something you rarely would need in development.
 ====
 
 [source,properties]
@@ -109,6 +109,37 @@ The PGVector extension maps each ingested document to a row in a PostgreSQL tabl
 During retrieval, a similarity search (e.g., cosine distance) is performed using a `SELECT` query with `ORDER BY embedding +<=>+ :query_vector LIMIT N`.
 
 The extension manages schema creation and indexing automatically unless overridden.
+
+== Named Stores
+
+You can configure multiple named pgvector stores, each backed by a different datasource.
+This is useful when your application needs to manage embeddings for different domains or tenants in separate databases.
+
+To configure a named store:
+
+[source,properties]
+----
+quarkus.langchain4j.pgvector.products.dimension=1536
+quarkus.langchain4j.pgvector.products.datasource=products-ds
+quarkus.langchain4j.pgvector.products.table=product_embeddings
+----
+
+To inject a named store, use the `@EmbeddingStoreName` qualifier:
+
+[source,java]
+----
+@Inject
+@EmbeddingStoreName("products")
+EmbeddingStore<TextSegment> productsStore;
+----
+
+The default store and named stores can coexist.
+If you only need named stores, disable the default store:
+
+[source,properties]
+----
+quarkus.langchain4j.pgvector.default-store-enabled=false
+----
 
 == Summary
 

--- a/embedding-stores/pgvector/deployment/src/main/java/io/quarkiverse/langchain4j/pgvector/deployment/PgVectorEmbeddingStoreBuildTimeConfig.java
+++ b/embedding-stores/pgvector/deployment/src/main/java/io/quarkiverse/langchain4j/pgvector/deployment/PgVectorEmbeddingStoreBuildTimeConfig.java
@@ -2,19 +2,51 @@ package io.quarkiverse.langchain4j.pgvector.deployment;
 
 import static io.quarkus.runtime.annotations.ConfigPhase.BUILD_TIME;
 
+import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigDocSection;
+import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithDefaults;
+import io.smallrye.config.WithParentName;
 
 @ConfigRoot(phase = BUILD_TIME)
 @ConfigMapping(prefix = "quarkus.langchain4j.pgvector")
 public interface PgVectorEmbeddingStoreBuildTimeConfig {
 
     /**
-     * The name of the configured Postgres datasource to use for this store. If not set,
-     * the default datasource from the Agroal extension will be used.
+     * Default store build-time config.
      */
-    Optional<String> datasource();
+    @WithParentName
+    DefaultStoreBuildTimeConfig defaultConfig();
 
+    /**
+     * Named store configurations.
+     */
+    @ConfigDocSection
+    @ConfigDocMapKey("store-name")
+    @WithParentName
+    @WithDefaults
+    Map<String, PgVectorNamedStoreBuildTimeConfig> namedConfig();
+
+    @ConfigGroup
+    interface DefaultStoreBuildTimeConfig {
+
+        /**
+         * Whether the default (unnamed) PG Vector embedding store should be enabled.
+         * Set to {@code false} when you only want to use named stores.
+         */
+        @WithDefault("true")
+        boolean defaultStoreEnabled();
+
+        /**
+         * The name of the configured Postgres datasource to use for the default store. If not set,
+         * the default datasource from the Agroal extension will be used.
+         */
+        Optional<String> datasource();
+    }
 }

--- a/embedding-stores/pgvector/deployment/src/main/java/io/quarkiverse/langchain4j/pgvector/deployment/PgVectorEmbeddingStoreProcessor.java
+++ b/embedding-stores/pgvector/deployment/src/main/java/io/quarkiverse/langchain4j/pgvector/deployment/PgVectorEmbeddingStoreProcessor.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.langchain4j.pgvector.deployment;
 
+import java.util.Map;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
 
@@ -14,10 +16,12 @@ import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import io.agroal.api.AgroalDataSource;
 import io.agroal.api.AgroalPoolInterceptor;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
 import io.quarkiverse.langchain4j.deployment.EmbeddingStoreBuildItem;
 import io.quarkiverse.langchain4j.pgvector.PgVectorAgroalPoolInterceptor;
 import io.quarkiverse.langchain4j.pgvector.PgVectorEmbeddingStore;
 import io.quarkiverse.langchain4j.pgvector.runtime.PgVectorEmbeddingStoreRecorder;
+import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.agroal.DataSource;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -55,34 +59,81 @@ class PgVectorEmbeddingStoreProcessor {
             PgVectorEmbeddingStoreBuildTimeConfig buildTimeConfig,
             BuildProducer<EmbeddingStoreBuildItem> embeddingStoreProducer) {
 
-        AnnotationInstance datasourceQualifier = buildTimeConfig.datasource()
-                .map(dn -> AnnotationInstance.builder(DataSource.class).add("value", dn).build())
-                .orElse(AnnotationInstance.builder(Default.class).build());
+        String defaultDatasourceName = buildTimeConfig.defaultConfig().datasource().orElse(null);
+        AnnotationInstance defaultDatasourceQualifier = resolveDatasourceQualifier(defaultDatasourceName);
 
-        beanProducer.produce(SyntheticBeanBuildItem
-                .configure(PG_VECTOR_EMBEDDING_STORE)
-                .types(ClassType.create(dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore.class),
-                        ClassType.create(EmbeddingStore.class),
-                        ParameterizedType.create(EmbeddingStore.class, ClassType.create(TextSegment.class)))
-                .setRuntimeInit()
-                .defaultBean()
-                .unremovable()
-                .scope(ApplicationScoped.class)
-                .createWith(recorder.embeddingStoreFunction(buildTimeConfig.datasource().orElse(null)))
-                .addInjectionPoint(ClassType.create(DotName.createSimple(AgroalDataSource.class)), datasourceQualifier)
-                .done());
+        if (buildTimeConfig.defaultConfig().defaultStoreEnabled()) {
+            beanProducer.produce(SyntheticBeanBuildItem
+                    .configure(PG_VECTOR_EMBEDDING_STORE)
+                    .types(ClassType.create(dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore.class),
+                            ClassType.create(EmbeddingStore.class),
+                            ParameterizedType.create(EmbeddingStore.class, ClassType.create(TextSegment.class)))
+                    .setRuntimeInit()
+                    .defaultBean()
+                    .unremovable()
+                    .scope(ApplicationScoped.class)
+                    .createWith(recorder.embeddingStoreFunction(defaultDatasourceName, NamedConfigUtil.DEFAULT_NAME))
+                    .addInjectionPoint(ClassType.create(DotName.createSimple(AgroalDataSource.class)),
+                            defaultDatasourceQualifier)
+                    .done());
 
-        beanProducer.produce(SyntheticBeanBuildItem
-                .configure(PG_VECTOR_AGROAL_POOL_INTERCEPTOR)
-                .types(ClassType.create(AGROAL_POOL_INTERCEPTOR))
-                .setRuntimeInit()
-                .unremovable()
-                .scope(ApplicationScoped.class)
-                .supplier(recorder.pgVectorAgroalPoolInterceptor())
-                .qualifiers(datasourceQualifier)
-                .done());
+            beanProducer.produce(SyntheticBeanBuildItem
+                    .configure(PG_VECTOR_AGROAL_POOL_INTERCEPTOR)
+                    .types(ClassType.create(AGROAL_POOL_INTERCEPTOR))
+                    .setRuntimeInit()
+                    .unremovable()
+                    .scope(ApplicationScoped.class)
+                    .supplier(recorder.pgVectorAgroalPoolInterceptor(NamedConfigUtil.DEFAULT_NAME))
+                    .qualifiers(defaultDatasourceQualifier)
+                    .done());
 
-        embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
+            embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
+        }
+
+        Map<String, PgVectorNamedStoreBuildTimeConfig> namedStores = buildTimeConfig.namedConfig();
+        for (Map.Entry<String, PgVectorNamedStoreBuildTimeConfig> entry : namedStores.entrySet()) {
+            String storeName = entry.getKey();
+            PgVectorNamedStoreBuildTimeConfig storeBuildTimeConfig = entry.getValue();
+            String storeDatasourceName = storeBuildTimeConfig.datasource().orElse(null);
+
+            AnnotationInstance storeNameQualifier = AnnotationInstance.builder(EmbeddingStoreName.class).add("value", storeName)
+                    .build();
+            AnnotationInstance storeDatasourceQualifier = resolveDatasourceQualifier(storeDatasourceName);
+
+            beanProducer.produce(SyntheticBeanBuildItem
+                    .configure(PG_VECTOR_EMBEDDING_STORE)
+                    .types(ClassType.create(dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore.class),
+                            ClassType.create(EmbeddingStore.class),
+                            ParameterizedType.create(EmbeddingStore.class, ClassType.create(TextSegment.class)))
+                    .setRuntimeInit()
+                    .defaultBean()
+                    .unremovable()
+                    .scope(ApplicationScoped.class)
+                    .addQualifier(storeNameQualifier)
+                    .createWith(recorder.embeddingStoreFunction(storeDatasourceName, storeName))
+                    .addInjectionPoint(ClassType.create(DotName.createSimple(AgroalDataSource.class)),
+                            storeDatasourceQualifier)
+                    .done());
+
+            beanProducer.produce(SyntheticBeanBuildItem
+                    .configure(PG_VECTOR_AGROAL_POOL_INTERCEPTOR)
+                    .types(ClassType.create(AGROAL_POOL_INTERCEPTOR))
+                    .setRuntimeInit()
+                    .unremovable()
+                    .scope(ApplicationScoped.class)
+                    .supplier(recorder.pgVectorAgroalPoolInterceptor(storeName))
+                    .qualifiers(storeDatasourceQualifier)
+                    .done());
+
+            embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
+        }
+    }
+
+    private AnnotationInstance resolveDatasourceQualifier(String datasourceName) {
+        if (datasourceName != null && !NamedConfigUtil.isDefault(datasourceName)) {
+            return AnnotationInstance.builder(DataSource.class).add("value", datasourceName).build();
+        }
+        return AnnotationInstance.builder(Default.class).build();
     }
 
     @BuildStep

--- a/embedding-stores/pgvector/deployment/src/main/java/io/quarkiverse/langchain4j/pgvector/deployment/PgVectorNamedStoreBuildTimeConfig.java
+++ b/embedding-stores/pgvector/deployment/src/main/java/io/quarkiverse/langchain4j/pgvector/deployment/PgVectorNamedStoreBuildTimeConfig.java
@@ -1,0 +1,17 @@
+package io.quarkiverse.langchain4j.pgvector.deployment;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+
+@ConfigGroup
+public interface PgVectorNamedStoreBuildTimeConfig {
+
+    /**
+     * The name of the configured Postgres datasource to use for this store. If not set,
+     * the default datasource from the Agroal extension will be used.
+     */
+    @WithDefault("<default>")
+    Optional<String> datasource();
+}

--- a/embedding-stores/pgvector/deployment/src/test/java/io/quarkiverse/langchain4j/pgvector/test/PgVectorDefaultAndNamedStoreTest.java
+++ b/embedding-stores/pgvector/deployment/src/test/java/io/quarkiverse/langchain4j/pgvector/test/PgVectorDefaultAndNamedStoreTest.java
@@ -1,0 +1,54 @@
+package io.quarkiverse.langchain4j.pgvector.test;
+
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class PgVectorDefaultAndNamedStoreTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.datasource.db-kind=postgresql\n" +
+                                    "quarkus.datasource.devservices.image-name=pgvector/pgvector:pg16\n" +
+                                    "quarkus.datasource.named-ds.devservices.image-name=pgvector/pgvector:pg16\n" +
+                                    "quarkus.datasource.named-ds.db-kind=postgresql\n" +
+                                    "quarkus.langchain4j.pgvector.dimension=384\n" +
+                                    "quarkus.langchain4j.pgvector.named-store.datasource=named-ds\n" +
+                                    "quarkus.langchain4j.pgvector.named-store.dimension=1536\n" +
+                                    "quarkus.langchain4j.pgvector.named-store.table=named_embeddings\n"),
+                            "application.properties"));
+
+    @Inject
+    EmbeddingStore<TextSegment> defaultEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("named-store")
+    EmbeddingStore<TextSegment> namedEmbeddingStore;
+
+    @Test
+    void should_injectDefaultStore() {
+        Assertions.assertThat(defaultEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void should_injectNamedStore() {
+        Assertions.assertThat(namedEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void should_injectDifferentStoreInstances() {
+        Assertions.assertThat(defaultEmbeddingStore).isNotSameAs(namedEmbeddingStore);
+    }
+}

--- a/embedding-stores/pgvector/deployment/src/test/java/io/quarkiverse/langchain4j/pgvector/test/PgVectorMultipleNamedStoresTest.java
+++ b/embedding-stores/pgvector/deployment/src/test/java/io/quarkiverse/langchain4j/pgvector/test/PgVectorMultipleNamedStoresTest.java
@@ -1,0 +1,93 @@
+package io.quarkiverse.langchain4j.pgvector.test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class PgVectorMultipleNamedStoresTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.langchain4j.pgvector.default-store-enabled=false\n" +
+                                    "quarkus.datasource.products-ds.devservices.image-name=pgvector/pgvector:pg16\n" +
+                                    "quarkus.datasource.products-ds.db-kind=postgresql\n" +
+                                    "quarkus.datasource.documents-ds.devservices.image-name=pgvector/pgvector:pg16\n" +
+                                    "quarkus.datasource.documents-ds.db-kind=postgresql\n" +
+                                    "quarkus.langchain4j.pgvector.products.datasource=products-ds\n" +
+                                    "quarkus.langchain4j.pgvector.products.dimension=1536\n" +
+                                    "quarkus.langchain4j.pgvector.products.table=product_embeddings\n" +
+                                    "quarkus.langchain4j.pgvector.documents.datasource=documents-ds\n" +
+                                    "quarkus.langchain4j.pgvector.documents.dimension=768\n" +
+                                    "quarkus.langchain4j.pgvector.documents.table=doc_embeddings\n"),
+                            "application.properties"));
+
+    @Inject
+    @EmbeddingStoreName("products")
+    EmbeddingStore<TextSegment> productsEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("documents")
+    EmbeddingStore<TextSegment> documentsEmbeddingStore;
+
+    @io.quarkus.agroal.DataSource("products-ds")
+    javax.sql.DataSource productsDs;
+
+    @io.quarkus.agroal.DataSource("documents-ds")
+    javax.sql.DataSource documentsDs;
+
+    @Test
+    void should_injectBothNamedStores() {
+        Assertions.assertThat(productsEmbeddingStore).isNotNull();
+        Assertions.assertThat(documentsEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void should_injectDifferentStoreInstances() {
+        Assertions.assertThat(productsEmbeddingStore).isNotSameAs(documentsEmbeddingStore);
+    }
+
+    @Test
+    void should_createProductEmbeddingsTable() throws SQLException {
+        productsEmbeddingStore.toString();
+        try (Connection connection = productsDs.getConnection()) {
+            try (Statement statement = connection.createStatement()) {
+                try (ResultSet rs = statement.executeQuery(
+                        "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'product_embeddings')")) {
+                    rs.next();
+                    Assertions.assertThat(rs.getBoolean(1)).isTrue();
+                }
+            }
+        }
+    }
+
+    @Test
+    void should_createDocEmbeddingsTable() throws SQLException {
+        documentsEmbeddingStore.toString();
+        try (Connection connection = documentsDs.getConnection()) {
+            try (Statement statement = connection.createStatement()) {
+                try (ResultSet rs = statement.executeQuery(
+                        "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'doc_embeddings')")) {
+                    rs.next();
+                    Assertions.assertThat(rs.getBoolean(1)).isTrue();
+                }
+            }
+        }
+    }
+}

--- a/embedding-stores/pgvector/deployment/src/test/java/io/quarkiverse/langchain4j/pgvector/test/PgVectorNamedStoreInvalidDatasourceTest.java
+++ b/embedding-stores/pgvector/deployment/src/test/java/io/quarkiverse/langchain4j/pgvector/test/PgVectorNamedStoreInvalidDatasourceTest.java
@@ -1,0 +1,28 @@
+package io.quarkiverse.langchain4j.pgvector.test;
+
+import jakarta.enterprise.inject.spi.DeploymentException;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class PgVectorNamedStoreInvalidDatasourceTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.langchain4j.pgvector.default-store-enabled=false\n" +
+                                    "quarkus.langchain4j.pgvector.products.datasource=non-existent-ds\n" +
+                                    "quarkus.langchain4j.pgvector.products.dimension=1536\n"),
+                            "application.properties"))
+            .setExpectedException(DeploymentException.class);
+
+    @Test
+    void should_fail_with_invalid_datasource() {
+    }
+}

--- a/embedding-stores/pgvector/deployment/src/test/java/io/quarkiverse/langchain4j/pgvector/test/PgVectorNamedStoreMissingDimensionTest.java
+++ b/embedding-stores/pgvector/deployment/src/test/java/io/quarkiverse/langchain4j/pgvector/test/PgVectorNamedStoreMissingDimensionTest.java
@@ -1,0 +1,41 @@
+package io.quarkiverse.langchain4j.pgvector.test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.config.ConfigValidationException;
+
+public class PgVectorNamedStoreMissingDimensionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.datasource.db-kind=postgresql\n" +
+                                    "quarkus.datasource.devservices.image-name=pgvector/pgvector:pg16\n" +
+                                    "quarkus.langchain4j.pgvector.default-store-enabled=false\n" +
+                                    "quarkus.langchain4j.pgvector.products.datasource=<default>\n" +
+                                    "quarkus.langchain4j.pgvector.products.table=product_embeddings\n"),
+                            "application.properties"));
+
+    @Inject
+    @EmbeddingStoreName("products")
+    EmbeddingStore<TextSegment> productsEmbeddingStore;
+
+    @Test
+    void should_fail_with_missing_dimension() {
+        assertThatThrownBy(() -> productsEmbeddingStore.toString())
+                .hasCauseInstanceOf(ConfigValidationException.class);
+    }
+}

--- a/embedding-stores/pgvector/deployment/src/test/java/io/quarkiverse/langchain4j/pgvector/test/PgVectorNamedStoreTest.java
+++ b/embedding-stores/pgvector/deployment/src/test/java/io/quarkiverse/langchain4j/pgvector/test/PgVectorNamedStoreTest.java
@@ -1,0 +1,76 @@
+package io.quarkiverse.langchain4j.pgvector.test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class PgVectorNamedStoreTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.datasource.db-kind=postgresql\n" +
+                                    "quarkus.datasource.devservices.image-name=pgvector/pgvector:pg16\n" +
+                                    "quarkus.datasource.products-ds.devservices.image-name=pgvector/pgvector:pg16\n" +
+                                    "quarkus.datasource.products-ds.db-kind=postgresql\n" +
+                                    "quarkus.langchain4j.pgvector.dimension=384\n" +
+                                    "quarkus.langchain4j.pgvector.products.datasource=products-ds\n" +
+                                    "quarkus.langchain4j.pgvector.products.dimension=1536\n" +
+                                    "quarkus.langchain4j.pgvector.products.table=product_embeddings\n"),
+                            "application.properties"));
+
+    @Inject
+    EmbeddingStore<TextSegment> defaultEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("products")
+    EmbeddingStore<TextSegment> productsEmbeddingStore;
+
+    @io.quarkus.agroal.DataSource("products-ds")
+    javax.sql.DataSource productsDs;
+
+    @Test
+    void should_injectDefaultStore() {
+        Assertions.assertThat(defaultEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void should_injectNamedStore() {
+        Assertions.assertThat(productsEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void should_injectDifferentStoreInstances() {
+        Assertions.assertThat(defaultEmbeddingStore).isNotSameAs(productsEmbeddingStore);
+    }
+
+    @Test
+    void should_createNamedStoreTable() throws SQLException {
+        productsEmbeddingStore.toString();
+        try (Connection connection = productsDs.getConnection()) {
+            try (Statement statement = connection.createStatement()) {
+                try (ResultSet rs = statement.executeQuery(
+                        "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'product_embeddings')")) {
+                    rs.next();
+                    Assertions.assertThat(rs.getBoolean(1)).isTrue();
+                }
+            }
+        }
+    }
+}

--- a/embedding-stores/pgvector/runtime/src/main/java/io/quarkiverse/langchain4j/pgvector/PgVectorAgroalPoolInterceptor.java
+++ b/embedding-stores/pgvector/runtime/src/main/java/io/quarkiverse/langchain4j/pgvector/PgVectorAgroalPoolInterceptor.java
@@ -7,7 +7,7 @@ import java.sql.Statement;
 import com.pgvector.PGvector;
 
 import io.agroal.api.AgroalPoolInterceptor;
-import io.quarkiverse.langchain4j.pgvector.runtime.PgVectorEmbeddingStoreConfig;
+import io.quarkiverse.langchain4j.pgvector.runtime.PgVectorStoreRuntimeConfig;
 import io.quarkus.runtime.configuration.ConfigUtils;
 
 /**
@@ -15,9 +15,9 @@ import io.quarkus.runtime.configuration.ConfigUtils;
  */
 public class PgVectorAgroalPoolInterceptor implements AgroalPoolInterceptor {
 
-    PgVectorEmbeddingStoreConfig config;
+    PgVectorStoreRuntimeConfig config;
 
-    public PgVectorAgroalPoolInterceptor(PgVectorEmbeddingStoreConfig config) {
+    public PgVectorAgroalPoolInterceptor(PgVectorStoreRuntimeConfig config) {
         this.config = config;
     }
 

--- a/embedding-stores/pgvector/runtime/src/main/java/io/quarkiverse/langchain4j/pgvector/PgVectorEmbeddingStore.java
+++ b/embedding-stores/pgvector/runtime/src/main/java/io/quarkiverse/langchain4j/pgvector/PgVectorEmbeddingStore.java
@@ -9,7 +9,7 @@ import javax.sql.DataSource;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.pgvector.DefaultMetadataStorageConfig;
-import io.quarkiverse.langchain4j.pgvector.runtime.PgVectorEmbeddingStoreConfig.MetadataConfig;
+import io.quarkiverse.langchain4j.pgvector.runtime.PgVectorStoreRuntimeConfig.MetadataConfig;
 
 /**
  * Quarkus PGVector EmbeddingStore Implementation

--- a/embedding-stores/pgvector/runtime/src/main/java/io/quarkiverse/langchain4j/pgvector/runtime/PgVectorEmbeddingStoreConfig.java
+++ b/embedding-stores/pgvector/runtime/src/main/java/io/quarkiverse/langchain4j/pgvector/runtime/PgVectorEmbeddingStoreConfig.java
@@ -2,126 +2,31 @@ package io.quarkiverse.langchain4j.pgvector.runtime;
 
 import static io.quarkus.runtime.annotations.ConfigPhase.RUN_TIME;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 
-import dev.langchain4j.store.embedding.pgvector.MetadataStorageMode;
-import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
-import io.smallrye.config.WithDefault;
-import io.smallrye.config.WithName;
+import io.smallrye.config.WithDefaults;
+import io.smallrye.config.WithParentName;
 
 @ConfigRoot(phase = RUN_TIME)
 @ConfigMapping(prefix = "quarkus.langchain4j.pgvector")
 public interface PgVectorEmbeddingStoreConfig {
 
     /**
-     * The table name for storing embeddings
+     * Default store config.
      */
-    @WithDefault("embeddings")
-    String table();
+    @WithParentName
+    PgVectorStoreRuntimeConfig defaultConfig();
 
     /**
-     * The dimension of the embedding vectors. This has to be the same as the dimension of vectors produced by
-     * the embedding model that you use. For example, AllMiniLmL6V2QuantizedEmbeddingModel produces vectors of dimension 384.
-     * OpenAI's text-embedding-ada-002 produces vectors of dimension 1536.
+     * Named store configurations.
      */
-    Integer dimension();
-
-    /**
-     * Use index or not
-     */
-    @WithDefault("false")
-    Boolean useIndex();
-
-    /**
-     *
-     * index size
-     */
-    @WithDefault("0")
-    Integer indexListSize();
-
-    /**
-     * Whether the table should be created if not already existing.
-     */
-    @WithDefault("true")
-    Boolean createTable();
-
-    /**
-     * Whether the table should be dropped prior to being created.
-     */
-    @WithDefault("false")
-    Boolean dropTableFirst();
-
-    /**
-     * Whether the PG extension should be created on Start.
-     * By Default, if it's dev or test environment the value is overridden to true
-     */
-    @WithDefault("false")
-    @WithName("register-vector-pg-extension")
-    Boolean registerVectorPGExtension();
-
-    /**
-     * Metadata configuration.
-     */
-    MetadataConfig metadata();
-
-    @ConfigGroup
-    interface MetadataConfig {
-        // Could not extends dev.langchain4j.store.embedding.pgvector.MetadataConfig {
-        // because of asciidoctor generating twice the same properties and build fail.
-        /**
-         * Metadata type:
-         * <ul>
-         * <li>COLUMN_PER_KEY: for static metadata, when you know in advance the list of metadata fields. In this case,
-         * you should also override the `quarkus.langchain4j.pgvector.metadata.column-definitions` property to define the right
-         * columns.
-         * <li>COMBINED_JSON: For dynamic metadata, when you don't know the list of metadata fields that will be used.
-         * <li>COMBINED_JSONB: Same as JSON, but stored in a binary way. Optimized for query on large dataset. In this case,
-         * you should also override the `quarkus.langchain4j.pgvector.metadata.column-definitions` property to change the
-         * type of the `metadata` column to COMBINED_JSONB.
-         * </ul>
-         * <p>
-         * Default value: COMBINED_JSON
-         */
-        @WithDefault("COMBINED_JSON")
-        MetadataStorageMode storageMode();
-
-        /**
-         * Metadata Definition: SQL definition of metadata field(s).
-         * By default, "metadata JSON NULL" configured. This is only suitable if using the JSON metadata type.
-         * <p>
-         * If using JSONB metadata type, this should in most cases be set to `metadata JSONB NULL`.
-         * <p>
-         * If using COLUMNS metadata type, this should be a list of columns, one column for each desired metadata field.
-         * Example: condominium_id uuid null, user uuid null
-         */
-        @WithDefault("metadata JSON NULL")
-        List<String> columnDefinitions();
-
-        /**
-         * Metadata Indexes, list of fields to use as index.
-         * <p>
-         * For instance:
-         * <ul>
-         * <li>JSON: with JSON metadata, indexes are not allowed, so this property must be empty. To use indexes, switch to
-         * JSONB metadata.
-         * <li>JSONB: (metadata->'key'), (metadata->'name'), (metadata->'age')
-         * <li>COLUMNS: key, name, age
-         * </ul>
-         */
-        Optional<List<String>> indexes();
-
-        /**
-         * Index Type:
-         * <ul>
-         * <li>BTREE (default)
-         * <li>GIN
-         * <li>Other <a href="https://www.postgresql.org/docs/current/indexes-types.html">PostgreSQL index types</a>
-         * </ul>
-         */
-        @WithDefault("BTREE")
-        String indexType();
-    }
+    @ConfigDocSection
+    @ConfigDocMapKey("store-name")
+    @WithParentName
+    @WithDefaults
+    Map<String, PgVectorStoreRuntimeConfig> namedConfig();
 }

--- a/embedding-stores/pgvector/runtime/src/main/java/io/quarkiverse/langchain4j/pgvector/runtime/PgVectorEmbeddingStoreRecorder.java
+++ b/embedding-stores/pgvector/runtime/src/main/java/io/quarkiverse/langchain4j/pgvector/runtime/PgVectorEmbeddingStoreRecorder.java
@@ -8,10 +8,12 @@ import jakarta.enterprise.inject.Default;
 import io.agroal.api.AgroalDataSource;
 import io.quarkiverse.langchain4j.pgvector.PgVectorAgroalPoolInterceptor;
 import io.quarkiverse.langchain4j.pgvector.PgVectorEmbeddingStore;
+import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.agroal.DataSource.DataSourceLiteral;
 import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
+import io.smallrye.config.ConfigValidationException;
 
 @Recorder
 public class PgVectorEmbeddingStoreRecorder {
@@ -22,12 +24,12 @@ public class PgVectorEmbeddingStoreRecorder {
     }
 
     public Function<SyntheticCreationalContext<PgVectorEmbeddingStore>, PgVectorEmbeddingStore> embeddingStoreFunction(
-            String datasourceName) {
+            String datasourceName, String storeName) {
         return new Function<>() {
             @Override
             public PgVectorEmbeddingStore apply(SyntheticCreationalContext<PgVectorEmbeddingStore> context) {
                 AgroalDataSource dataSource;
-                if (datasourceName != null) {
+                if (datasourceName != null && !NamedConfigUtil.isDefault(datasourceName)) {
                     dataSource = context.getInjectedReference(AgroalDataSource.class, new DataSourceLiteral(datasourceName));
                 } else {
                     dataSource = context.getInjectedReference(AgroalDataSource.class, Default.Literal.INSTANCE);
@@ -35,23 +37,45 @@ public class PgVectorEmbeddingStoreRecorder {
 
                 dataSource.flush(AgroalDataSource.FlushMode.GRACEFUL);
 
+                PgVectorStoreRuntimeConfig storeConfig = correspondingStoreConfig(storeName);
+
+                if (storeConfig.dimension().isEmpty()) {
+                    throw new ConfigValidationException(createDimensionConfigProblems(storeName));
+                }
+
                 return new PgVectorEmbeddingStore(dataSource,
-                        runtimeConfig.getValue().table(),
-                        runtimeConfig.getValue().dimension(),
-                        runtimeConfig.getValue().useIndex(),
-                        runtimeConfig.getValue().indexListSize(),
-                        runtimeConfig.getValue().createTable(),
-                        runtimeConfig.getValue().dropTableFirst(),
-                        runtimeConfig.getValue().metadata());
+                        storeConfig.table(),
+                        storeConfig.dimension().get(),
+                        storeConfig.useIndex(),
+                        storeConfig.indexListSize(),
+                        storeConfig.createTable(),
+                        storeConfig.dropTableFirst(),
+                        storeConfig.metadata());
             }
         };
     }
 
-    public Supplier<PgVectorAgroalPoolInterceptor> pgVectorAgroalPoolInterceptor() {
+    private PgVectorStoreRuntimeConfig correspondingStoreConfig(String storeName) {
+        PgVectorStoreRuntimeConfig storeConfig;
+        if (NamedConfigUtil.isDefault(storeName)) {
+            storeConfig = runtimeConfig.getValue().defaultConfig();
+        } else {
+            storeConfig = runtimeConfig.getValue().namedConfig().get(storeName);
+        }
+        return storeConfig;
+    }
+
+    private ConfigValidationException.Problem[] createDimensionConfigProblems(String storeName) {
+        return new ConfigValidationException.Problem[] { new ConfigValidationException.Problem(String.format(
+                "SRCFG00014: The config property quarkus.langchain4j.pgvector%sdimension is required but it could not be found in any config source",
+                NamedConfigUtil.isDefault(storeName) ? "." : ("." + storeName + "."))) };
+    }
+
+    public Supplier<PgVectorAgroalPoolInterceptor> pgVectorAgroalPoolInterceptor(String storeName) {
         return new Supplier<>() {
             @Override
             public PgVectorAgroalPoolInterceptor get() {
-                return new PgVectorAgroalPoolInterceptor(runtimeConfig.getValue());
+                return new PgVectorAgroalPoolInterceptor(correspondingStoreConfig(storeName));
             }
         };
     }

--- a/embedding-stores/pgvector/runtime/src/main/java/io/quarkiverse/langchain4j/pgvector/runtime/PgVectorStoreRuntimeConfig.java
+++ b/embedding-stores/pgvector/runtime/src/main/java/io/quarkiverse/langchain4j/pgvector/runtime/PgVectorStoreRuntimeConfig.java
@@ -1,0 +1,122 @@
+package io.quarkiverse.langchain4j.pgvector.runtime;
+
+import java.util.List;
+import java.util.Optional;
+
+import dev.langchain4j.store.embedding.pgvector.MetadataStorageMode;
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
+
+@ConfigGroup
+public interface PgVectorStoreRuntimeConfig {
+
+    /**
+     * The table name for storing embeddings
+     */
+    @WithDefault("embeddings")
+    String table();
+
+    /**
+     * The dimension of the embedding vectors. This has to be the same as the dimension of vectors produced by
+     * the embedding model that you use. For example, AllMiniLmL6V2QuantizedEmbeddingModel produces vectors of dimension 384.
+     * OpenAI's text-embedding-ada-002 produces vectors of dimension 1536.
+     */
+    Optional<Integer> dimension();
+
+    /**
+     * Use index or not
+     */
+    @WithDefault("false")
+    Boolean useIndex();
+
+    /**
+     * index size
+     */
+    @WithDefault("0")
+    Integer indexListSize();
+
+    /**
+     * Whether the table should be created if not already existing.
+     */
+    @WithDefault("true")
+    Boolean createTable();
+
+    /**
+     * Whether the table should be dropped prior to being created.
+     */
+    @WithDefault("false")
+    Boolean dropTableFirst();
+
+    /**
+     * Whether the PG extension should be created on Start.
+     * By Default, if it's dev or test environment the value is overridden to true
+     */
+    @WithDefault("false")
+    @WithName("register-vector-pg-extension")
+    Boolean registerVectorPGExtension();
+
+    /**
+     * Metadata configuration.
+     */
+    MetadataConfig metadata();
+
+    @ConfigGroup
+    interface MetadataConfig {
+        // Could not extends dev.langchain4j.store.embedding.pgvector.MetadataConfig {
+        // because of asciidoctor generating twice the same properties and build fail.
+
+        /**
+         * Metadata type:
+         * <ul>
+         * <li>COLUMN_PER_KEY: for static metadata, when you know in advance the list of metadata fields. In this case,
+         * you should also override the `quarkus.langchain4j.pgvector.metadata.column-definitions` property to define the right
+         * columns.
+         * <li>COMBINED_JSON: For dynamic metadata, when you don't know the list of metadata fields that will be used.
+         * <li>COMBINED_JSONB: Same as JSON, but stored in a binary way. Optimized for query on large dataset. In this case,
+         * you should also override the `quarkus.langchain4j.pgvector.metadata.column-definitions` property to change the
+         * type of the `metadata` column to COMBINED_JSONB.
+         * </ul>
+         * <p>
+         * Default value: COMBINED_JSON
+         */
+        @WithDefault("COMBINED_JSON")
+        MetadataStorageMode storageMode();
+
+        /**
+         * Metadata Definition: SQL definition of metadata field(s).
+         * By default, "metadata JSON NULL" configured. This is only suitable if using the JSON metadata type.
+         * <p>
+         * If using JSONB metadata type, this should in most cases be set to `metadata JSONB NULL`.
+         * <p>
+         * If using COLUMNS metadata type, this should be a list of columns, one column for each desired metadata field.
+         * Example: condominium_id uuid null, user uuid null
+         */
+        @WithDefault("metadata JSON NULL")
+        List<String> columnDefinitions();
+
+        /**
+         * Metadata Indexes, list of fields to use as index.
+         * <p>
+         * For instance:
+         * <ul>
+         * <li>JSON: with JSON metadata, indexes are not allowed, so this property must be empty. To use indexes, switch to
+         * JSONB metadata.
+         * <li>JSONB: (metadata->'key'), (metadata->'name'), (metadata->'age')
+         * <li>COLUMNS: key, name, age
+         * </ul>
+         */
+        Optional<List<String>> indexes();
+
+        /**
+         * Index Type:
+         * <ul>
+         * <li>BTREE (default)
+         * <li>GIN
+         * <li>Other <a href="https://www.postgresql.org/docs/current/indexes-types.html">PostgreSQL index types</a>
+         * </ul>
+         */
+        @WithDefault("BTREE")
+        String indexType();
+    }
+}


### PR DESCRIPTION
Enables configuring multiple pgvector embedding stores, each backed by a different datasource, following the same named-instance pattern used by model providers (OpenAI, Ollama, Anthropic, etc.).

## Configuration

Default store (backward compatible, no changes required):

```properties
quarkus.langchain4j.pgvector.dimension=384
quarkus.langchain4j.pgvector.table=embeddings
```

Named stores:

```properties
quarkus.langchain4j.pgvector.products.datasource=products-ds
quarkus.langchain4j.pgvector.products.dimension=1536
quarkus.langchain4j.pgvector.products.table=product_embeddings
```

Disable default store when only named stores are needed:

```properties
quarkus.langchain4j.pgvector.default-store-enabled=false
```

## Injection

```java
@Inject
EmbeddingStore<TextSegment> defaultStore;

@Inject
@EmbeddingStoreName("products")
EmbeddingStore<TextSegment> productsStore;
```

Named stores use `@EmbeddingStoreName` rather than `@ModelName` — embedding stores are not models, and a store name is not a model name. This avoids semantic confusion and keeps the qualifier applicable to non-JDBC stores in the future.

### Note on `quarkus-all-config.adoc`

The auto-generated `quarkus-all-config.adoc` aggregator file is **not** included in this PR. A clean `mvn install` from the project root regenerates it with ~12,000 line diffs that include changes from multiple unrelated modules (bedrock, jlama, llama3-java, etc.), not just pgvector. This is a known artifact of the docs generation process (see #2371). Including it would pollute the diff with changes outside the scope of this PR. The two pgvector-specific adoc files (`quarkus-langchain4j-pgvector.adoc` and `quarkus-langchain4j-pgvector_quarkus.langchain4j.adoc`) are included and reflect the new named-store configuration properties.

The branch has been rebased onto the latest `origin/main` to incorporate recent upstream changes.

Closes #2041