### PR TITLE
Allow to define the model used by an agent through the @ModelName annotation

### DIFF
--- a/agentic/deployment/src/main/java/io/quarkiverse/langchain4j/agentic/deployment/AgenticProcessor.java
+++ b/agentic/deployment/src/main/java/io/quarkiverse/langchain4j/agentic/deployment/AgenticProcessor.java
@@ -93,10 +93,19 @@ public class AgenticProcessor {
                             AgenticLangChain4jDotNames.CHAT_MODEL_SUPPLIER))
                     .findFirst();
 
+            String modelName = extractModelName(methods);
+
+            if (chatModelSupplier.isPresent() && modelName != null) {
+                throw new IllegalConfigurationException(
+                        "Agent interface '" + classInfo.name()
+                                + "' cannot use both @ChatModelSupplier and @ModelName. "
+                                + "Use one or the other to specify the ChatModel.");
+            }
+
             List<MethodInfo> mcpToolBoxMethods = methods.stream()
                     .filter(mi -> mi.hasAnnotation(LangChain4jDotNames.MCP_TOOLBOX)).toList();
             DetectedAiAgentBuildItem item = new DetectedAiAgentBuildItem(classInfo, methods, chatModelSupplier.orElse(null),
-                    mcpToolBoxMethods);
+                    modelName, mcpToolBoxMethods);
             validate(item);
             producer.produce(
                     item);
@@ -412,7 +421,9 @@ public class AgenticProcessor {
 
         Set<String> requestedChatModelNames = new HashSet<>();
         for (DetectedAiAgentBuildItem detectedAiAgentBuildItem : detectedAiAgentBuildItems) {
-            String chatModelName = NamedConfigUtil.DEFAULT_NAME; // TODO: we need to fix this and provide a way to let the user pick the name of the chat model
+            String chatModelName = detectedAiAgentBuildItem.getModelName() != null
+                    ? detectedAiAgentBuildItem.getModelName()
+                    : NamedConfigUtil.DEFAULT_NAME;
             requestedChatModelNames.add(chatModelName);
 
             AiAgentCreateInfo.ChatModelInfo chatModelInfo = detectedAiAgentBuildItem.getChatModelSupplier() != null
@@ -455,6 +466,22 @@ public class AgenticProcessor {
                             AgenticScopeOwner.class.getName(), ChatMemoryAccess.class.getName(),
                             ChatMessagesAccess.class.getName())));
                 });
+    }
+
+    private static String extractModelName(List<MethodInfo> agenticMethods) {
+        for (MethodInfo method : agenticMethods) {
+            if (!method.hasAnnotation(AgenticLangChain4jDotNames.AGENT)) {
+                continue;
+            }
+            AnnotationInstance modelNameAnnotation = method.annotation(LangChain4jDotNames.MODEL_NAME);
+            if (modelNameAnnotation != null) {
+                AnnotationValue value = modelNameAnnotation.value();
+                if (value != null && !value.asString().isEmpty()) {
+                    return value.asString();
+                }
+            }
+        }
+        return null;
     }
 
     private static void collectAgentsWithMethodAnnotations(IndexView index, DotName annotation,

--- a/agentic/deployment/src/main/java/io/quarkiverse/langchain4j/agentic/deployment/DetectedAiAgentBuildItem.java
+++ b/agentic/deployment/src/main/java/io/quarkiverse/langchain4j/agentic/deployment/DetectedAiAgentBuildItem.java
@@ -18,13 +18,15 @@ public final class DetectedAiAgentBuildItem extends MultiBuildItem {
     private final ClassInfo iface;
     private final List<MethodInfo> agenticMethods;
     private final MethodInfo chatModelSupplier;
+    private final String modelName;
     private final List<MethodInfo> mcpToolBoxMethods;
 
     public DetectedAiAgentBuildItem(ClassInfo iface, List<MethodInfo> agenticMethods,
-            MethodInfo chatModelSupplier, List<MethodInfo> mcpToolBoxMethods) {
+            MethodInfo chatModelSupplier, String modelName, List<MethodInfo> mcpToolBoxMethods) {
         this.iface = iface;
         this.agenticMethods = agenticMethods;
         this.chatModelSupplier = chatModelSupplier;
+        this.modelName = modelName;
         this.mcpToolBoxMethods = mcpToolBoxMethods;
     }
 
@@ -38,6 +40,10 @@ public final class DetectedAiAgentBuildItem extends MultiBuildItem {
 
     public MethodInfo getChatModelSupplier() {
         return chatModelSupplier;
+    }
+
+    public String getModelName() {
+        return modelName;
     }
 
     public List<MethodInfo> getMcpToolBoxMethods() {

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/ModelNameAgentTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/ModelNameAgentTest.java
@@ -1,0 +1,107 @@
+package io.quarkiverse.langchain4j.agentic.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import io.quarkiverse.langchain4j.ModelName;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ModelNameAgentTest extends OpenAiBaseTest {
+
+    static final String NAMED_MODEL_RESPONSE = "response-from-named-model";
+    static final String DEFAULT_MODEL_RESPONSE = "response-from-default-model";
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(NamedModelAgent.class, DefaultModelAgent.class, ChatModelProducers.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "default-key")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.mymodel.chat-model.provider", "openai")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.mymodel.api-key", "named-key")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.mymodel.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    public interface NamedModelAgent {
+
+        @UserMessage("Answer the following question: {{question}}")
+        @Agent(value = "An agent using a named model", outputKey = "answer")
+        @ModelName("mymodel")
+        String answer(@V("question") String question);
+    }
+
+    public interface DefaultModelAgent {
+
+        @UserMessage("Answer the following question: {{question}}")
+        @Agent(value = "An agent using the default model", outputKey = "answer")
+        String answer(@V("question") String question);
+    }
+
+    @ApplicationScoped
+    public static class ChatModelProducers {
+
+        @Produces
+        @ApplicationScoped
+        @ModelName("mymodel")
+        ChatModel namedModel() {
+            return new FixedResponseChatModel(NAMED_MODEL_RESPONSE);
+        }
+
+        @Produces
+        @ApplicationScoped
+        ChatModel defaultModel() {
+            return new FixedResponseChatModel(DEFAULT_MODEL_RESPONSE);
+        }
+    }
+
+    public static class FixedResponseChatModel implements ChatModel {
+
+        private final String response;
+
+        FixedResponseChatModel(String response) {
+            this.response = response;
+        }
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            return ChatResponse.builder().aiMessage(new AiMessage(response)).build();
+        }
+    }
+
+    @Inject
+    NamedModelAgent namedModelAgent;
+
+    @Inject
+    DefaultModelAgent defaultModelAgent;
+
+    @Test
+    void agentWithModelNameShouldUseNamedModel() {
+        String result = namedModelAgent.answer("test");
+        assertThat(result).isEqualTo(NAMED_MODEL_RESPONSE);
+    }
+
+    @Test
+    void agentWithDefaultModelShouldUseDefaultModel() {
+        String result = defaultModelAgent.answer("test");
+        assertThat(result).isEqualTo(DEFAULT_MODEL_RESPONSE);
+    }
+}

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/validation/ModelNameWithChatModelSupplierConflictTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/validation/ModelNameWithChatModelSupplierConflictTest.java
@@ -1,0 +1,50 @@
+package io.quarkiverse.langchain4j.agentic.deployment.validation;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.ChatModelSupplier;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.service.IllegalConfigurationException;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import io.quarkiverse.langchain4j.ModelName;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ModelNameWithChatModelSupplierConflictTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class).addClasses(ConflictingAgent.class))
+            .assertException(
+                    throwable -> Assertions.assertThat(throwable).isInstanceOf(IllegalConfigurationException.class)
+                            .hasMessageContaining("@ChatModelSupplier")
+                            .hasMessageContaining("@ModelName"));
+
+    @Test
+    public void test() {
+        fail("should never be called");
+    }
+
+    public interface ConflictingAgent {
+
+        @UserMessage("""
+                Analyze the following request: {{request}}.
+                """)
+        @Agent("An agent with conflicting model configuration")
+        @ModelName("mymodel")
+        String analyze(@V("request") String request);
+
+        @ChatModelSupplier
+        static ChatModel chatModel() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
At the moment it is not possible to define the model used by an agent directly with the `@ModelName` annotation and you have to do something like the following

```
public interface MyAgent {

    @UserMessage("""
            Analyze the following request: {{request}}.
            """)
    @Agent("An agent with conflicting model configuration")
    String analyze(@V("request") String request);

   @ChatModelSupplier
    static ChatModel chatModel() {
        return RemediationModel.model;
    }

    @ApplicationScoped
    class RemediationModel {
        private static ChatModel model;

        @Inject
        void init(@ModelName("remediation") ChatModel remediationModel) {
            model = remediationModel;
        }
    }
}
```

This pull request overcomes this limitation simply allowing to do something like

```
public interface MyAgent {

    @UserMessage("""
            Analyze the following request: {{request}}.
            """)
    @Agent("An agent with conflicting model configuration")
    @ModelName("remediation") 
    String analyze(@V("request") String request);
}
```