### PR TITLE
Dispatch and parallelise @RunOnVirtualThread tool batches in the streaming handler

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelTest.java
@@ -236,9 +236,9 @@ public class ToolExecutionModelTest {
             }
         }).get();
 
-        // At the moment, we create a virtual thread every time.
-        assertThat(r).contains(uuid, "quarkus-virtual-thread-")
-                .doesNotContain(caller.get());
+        // When the caller is already running on a virtual thread, the tool executes on that
+        // same virtual thread instead of being re-dispatched onto a new one.
+        assertThat(r).contains(uuid, "quarkus-virtual-thread-", caller.get());
     }
 
     @Test

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelVirtualThreadDispatchTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelVirtualThreadDispatchTest.java
@@ -1,0 +1,264 @@
+package io.quarkiverse.langchain4j.test.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.ToolBox;
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.common.annotation.RunOnVirtualThread;
+import io.smallrye.mutiny.Multi;
+import io.vertx.core.Vertx;
+
+public class ToolExecutionModelVirtualThreadDispatchTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(MyAiService.class));
+
+    @Inject
+    MyAiService aiService;
+
+    @Inject
+    Vertx vertx;
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    @ActivateRequestContext
+    void virtualThreadBatchRunsOnVirtualThread() {
+        String uuid = UUID.randomUUID().toString();
+        String r = aiService.singleVirtualTool("mem-" + uuid, "hiVirtualThread - " + uuid)
+                .collect().asList().map(l -> String.join(" ", l)).await().indefinitely();
+        assertThat(r).contains(uuid, "quarkus-virtual-thread-");
+    }
+
+    @Test
+    void blockingBatchRunsOnWorkerThread() {
+        String uuid = UUID.randomUUID().toString();
+        String r = invokeFromEventLoop(() -> aiService.singleBlockingTool("mem-" + uuid, "hi - " + uuid));
+        // When the streaming call is subscribed on the event loop, the tool loop is dispatched
+        // onto the Quarkus worker pool (`executor-thread-<n>`) — not onto a virtual thread.
+        assertThat(r).contains(uuid, "executor-thread");
+        assertThat(r).doesNotContain("quarkus-virtual-thread-");
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    void mixedBatchFallsBackToWorkerDispatch() {
+        String uuid = UUID.randomUUID().toString();
+        String r = invokeFromEventLoop(() -> aiService.mixedTools("mem-" + uuid, "hi,hiVirtualThread - " + uuid));
+        // Blocking tool must run on a worker thread.
+        assertThat(r).contains("BLOCKING:").contains("executor-thread");
+        // Virtual-thread tool still lands on a virtual thread (QuarkusToolExecutor submits it
+        // per-tool even in the mixed-batch fallback path).
+        assertThat(r).contains("VIRTUAL:").contains("quarkus-virtual-thread-");
+        assertThat(r).contains(uuid);
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    @ActivateRequestContext
+    void virtualThreadToolFailureSurfacesThroughToolErrorHandler() {
+        // Quarkus wires a default toolExecutionErrorHandler that converts tool exceptions into
+        // tool-result text (so the LLM can recover). We assert the exception message ends up in
+        // the final stream output, proving the exception thrown inside the virtual-thread
+        // dispatch is captured and routed back through the normal tool-result pipeline.
+        String r = aiService.failingVirtualTool("mem-" + UUID.randomUUID(), "failingVirtualThread - boom")
+                .collect().asList().map(l -> String.join(" ", l)).await().indefinitely();
+        assertThat(r).contains("boom");
+    }
+
+    private String invokeFromEventLoop(Supplier<Multi<String>> serviceCall) {
+        AtomicReference<String> result = new AtomicReference<>();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        vertx.getOrCreateContext().runOnContext(x -> {
+            try {
+                Arc.container().requestContext().activate();
+                serviceCall.get()
+                        .collect().asList().map(l -> String.join(" ", l))
+                        .subscribeAsCompletionStage()
+                        .whenComplete((r, t) -> {
+                            if (t != null) {
+                                failure.set(t);
+                            } else {
+                                result.set(r);
+                            }
+                        });
+            } catch (Throwable t) {
+                failure.set(t);
+            } finally {
+                Arc.container().requestContext().deactivate();
+            }
+        });
+        Awaitility.await().atMost(java.time.Duration.ofSeconds(10))
+                .until(() -> failure.get() != null || result.get() != null);
+        if (failure.get() != null) {
+            throw new AssertionError("Service call failed", failure.get());
+        }
+        return result.get();
+    }
+
+    @RegisterAiService(streamingChatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = MyMemoryProviderSupplier.class)
+    public interface MyAiService {
+
+        @ToolBox(VirtualTool.class)
+        Multi<String> singleVirtualTool(@MemoryId String memoryId, @UserMessage String userMessageContainingTheToolId);
+
+        @ToolBox(BlockingTool.class)
+        Multi<String> singleBlockingTool(@MemoryId String memoryId, @UserMessage String userMessageContainingTheToolId);
+
+        @ToolBox({ BlockingTool.class, VirtualTool.class })
+        Multi<String> mixedTools(@MemoryId String memoryId, @UserMessage String userMessageContainingTheToolId);
+
+        @ToolBox(FailingVirtualTool.class)
+        Multi<String> failingVirtualTool(@MemoryId String memoryId, @UserMessage String userMessageContainingTheToolId);
+    }
+
+    @Singleton
+    public static class BlockingTool {
+        @Tool("hi")
+        public String hi(String m) {
+            return "BLOCKING:" + m + " " + Thread.currentThread();
+        }
+    }
+
+    @Singleton
+    public static class VirtualTool {
+        @Tool("hiVirtualThread")
+        @RunOnVirtualThread
+        public String hiVirtualThread(String m) {
+            return "VIRTUAL:" + m + " " + Thread.currentThread();
+        }
+    }
+
+    @Singleton
+    public static class FailingVirtualTool {
+        @Tool("failingVirtualThread")
+        @RunOnVirtualThread
+        public String failingVirtualThread(String m) {
+            throw new RuntimeException("boom: " + m);
+        }
+    }
+
+    public static class MyChatModelSupplier implements Supplier<StreamingChatModel> {
+
+        @Override
+        public StreamingChatModel get() {
+            return new MultiToolChatModel();
+        }
+    }
+
+    /**
+     * Chat model that parses a comma-separated list of tool names from the user message
+     * (format: {@code "tool1[,tool2] - content"}) and emits one {@link ToolExecutionRequest}
+     * per tool in a single {@link AiMessage}. Any follow-up request containing
+     * {@link ToolExecutionResultMessage}s terminates the conversation by echoing their
+     * concatenated text.
+     */
+    public static class MultiToolChatModel implements StreamingChatModel {
+
+        @Override
+        public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+            List<ChatMessage> messages = chatRequest.messages();
+            boolean hasToolResults = messages.stream().anyMatch(m -> m instanceof ToolExecutionResultMessage);
+            if (!hasToolResults) {
+                dev.langchain4j.data.message.UserMessage userMessage = null;
+                for (ChatMessage message : messages) {
+                    if (message instanceof dev.langchain4j.data.message.UserMessage um) {
+                        userMessage = um;
+                    }
+                }
+                if (userMessage == null) {
+                    handler.onError(new RuntimeException("No user message found"));
+                    return;
+                }
+                String text = userMessage.singleText();
+                String[] segments = text.split(" - ", 2);
+                if (segments.length != 2) {
+                    handler.onError(new RuntimeException("Bad user message: " + text));
+                    return;
+                }
+                String[] toolIds = segments[0].split(",");
+                String content = segments[1];
+                java.util.List<ToolExecutionRequest> requests = new java.util.ArrayList<>();
+                int i = 0;
+                for (String toolId : toolIds) {
+                    requests.add(ToolExecutionRequest.builder()
+                            .id("call-" + toolId + "-" + (i++))
+                            .name(toolId.trim())
+                            .arguments("{\"m\":\"" + content + "\"}")
+                            .build());
+                }
+                ChatResponse chatResponse = ChatResponse.builder()
+                        .aiMessage(new AiMessage("cannot be blank", requests))
+                        .tokenUsage(new TokenUsage(0, 0))
+                        .finishReason(FinishReason.TOOL_EXECUTION)
+                        .build();
+                handler.onCompleteResponse(chatResponse);
+            } else {
+                StringBuilder combined = new StringBuilder();
+                for (ChatMessage message : messages) {
+                    if (message instanceof ToolExecutionResultMessage trm) {
+                        if (combined.length() > 0) {
+                            combined.append(" | ");
+                        }
+                        combined.append(trm.text());
+                    }
+                }
+                handler.onPartialResponse("response: ");
+                handler.onPartialResponse(combined.toString());
+                handler.onCompleteResponse(ChatResponse.builder()
+                        .aiMessage(new AiMessage(""))
+                        .tokenUsage(new TokenUsage(0, 0))
+                        .finishReason(FinishReason.STOP)
+                        .build());
+            }
+        }
+    }
+
+    public static class MyMemoryProviderSupplier implements Supplier<ChatMemoryProvider> {
+        @Override
+        public ChatMemoryProvider get() {
+            return new ChatMemoryProvider() {
+                @Override
+                public ChatMemory get(Object memoryId) {
+                    return MessageWindowChatMemory.withMaxMessages(10);
+                }
+            };
+        }
+    }
+
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelVirtualThreadDispatchTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelVirtualThreadDispatchTest.java
@@ -2,10 +2,18 @@ package io.quarkiverse.langchain4j.test.tools;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
@@ -37,14 +45,27 @@ import dev.langchain4j.service.MemoryId;
 import dev.langchain4j.service.UserMessage;
 import io.quarkiverse.langchain4j.RegisterAiService;
 import io.quarkiverse.langchain4j.ToolBox;
+import io.quarkiverse.langchain4j.runtime.ContextLocals;
+import io.quarkiverse.langchain4j.runtime.VirtualThreadSupport;
+import io.quarkiverse.langchain4j.runtime.aiservice.ChatEvent;
+import io.quarkiverse.langchain4j.runtime.aiservice.QuarkusAiServiceStreamingResponseHandler;
 import io.quarkus.arc.Arc;
 import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.virtual.threads.VirtualThreadsRecorder;
 import io.smallrye.common.annotation.RunOnVirtualThread;
+import io.smallrye.common.vertx.VertxContext;
 import io.smallrye.mutiny.Multi;
+import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 
 public class ToolExecutionModelVirtualThreadDispatchTest {
 
+    private static final String DUPLICATED_CONTEXT_LOCAL_KEY = "dispatch-test-local";
+    private static final String MIXED_BATCH_METHOD = "MyAiService#mixedTools";
+    private static final String MIXED_BATCH_REQUESTED_TOOLS = "Requested tools: [hi, hiVirtualThread]";
+    private static final String MIXED_BATCH_NON_VIRTUAL_TOOLS = "Non-VIRTUAL_THREAD tools: [hi]";
+    private static final String MIXED_BATCH_DECISION = "Skipping the full-batch virtual-thread dispatch optimization "
+            + "and using legacy per-tool scheduling instead";
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(MyAiService.class));
@@ -66,47 +87,164 @@ public class ToolExecutionModelVirtualThreadDispatchTest {
     }
 
     @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    @ActivateRequestContext
+    void allVirtualThreadBatchRunsSerializedLoopOnOneVirtualThread() throws InterruptedException {
+        String uuid = UUID.randomUUID().toString();
+        List<Thread> beforeToolThreads = new java.util.concurrent.CopyOnWriteArrayList<>();
+        List<ChatEvent> events = executeChatEventStreamBlocking(
+                () -> aiService.virtualToolBatchEvents("mem-" + uuid,
+                        "hiVirtualThread,hiVirtualThreadAgain - " + uuid),
+                event -> {
+                    if (event instanceof ChatEvent.BeforeToolExecutionEvent) {
+                        beforeToolThreads.add(Thread.currentThread());
+                    }
+                });
+        String response = extractPartialResponseText(events);
+
+        assertThat(response).contains("VIRTUAL:", "VIRTUAL_AGAIN:", uuid);
+        assertThat(beforeToolThreads).hasSize(2);
+        assertThat(beforeToolThreads)
+                .allSatisfy(thread -> assertThat(VirtualThreadSupport.isVirtualThread(thread)).isTrue());
+        assertThat(new HashSet<>(beforeToolThreads)).hasSize(1);
+    }
+
+    @Test
     void blockingBatchRunsOnWorkerThread() {
         String uuid = UUID.randomUUID().toString();
         String r = invokeFromEventLoop(() -> aiService.singleBlockingTool("mem-" + uuid, "hi - " + uuid));
-        // When the streaming call is subscribed on the event loop, the tool loop is dispatched
-        // onto the Quarkus worker pool (`executor-thread-<n>`) — not onto a virtual thread.
         assertThat(r).contains(uuid, "executor-thread");
         assertThat(r).doesNotContain("quarkus-virtual-thread-");
     }
 
     @Test
     @EnabledForJreRange(min = JRE.JAVA_21)
-    void mixedBatchFallsBackToWorkerDispatch() {
-        String uuid = UUID.randomUUID().toString();
-        String r = invokeFromEventLoop(() -> aiService.mixedTools("mem-" + uuid, "hi,hiVirtualThread - " + uuid));
-        // Blocking tool must run on a worker thread.
-        assertThat(r).contains("BLOCKING:").contains("executor-thread");
-        // Virtual-thread tool still lands on a virtual thread (QuarkusToolExecutor submits it
-        // per-tool even in the mixed-batch fallback path).
-        assertThat(r).contains("VIRTUAL:").contains("quarkus-virtual-thread-");
-        assertThat(r).contains(uuid);
+    void mixedBatchFallsBackToLegacyPerToolScheduling() {
+        Logger logger = Logger.getLogger(QuarkusAiServiceStreamingResponseHandler.class.getName());
+        CapturingHandler handler = new CapturingHandler();
+        logger.addHandler(handler);
+        try {
+            String uuid = UUID.randomUUID().toString();
+            String r = invokeFromEventLoop(() -> aiService.mixedTools("mem-" + uuid, "hi,hiVirtualThread - " + uuid));
+
+            assertThat(r).contains("BLOCKING:").contains("executor-thread");
+            assertThat(r).contains("VIRTUAL:").contains("quarkus-virtual-thread-");
+            assertThat(r).contains(uuid);
+            Awaitility.await().atMost(java.time.Duration.ofSeconds(10))
+                    .untilAsserted(() -> assertThat(handler.messages()).anySatisfy(message -> assertThat(message)
+                            .contains(MIXED_BATCH_METHOD)
+                            .contains(MIXED_BATCH_REQUESTED_TOOLS)
+                            .contains(MIXED_BATCH_NON_VIRTUAL_TOOLS)
+                            .contains(MIXED_BATCH_DECISION)));
+        } finally {
+            logger.removeHandler(handler);
+        }
     }
 
     @Test
     @EnabledForJreRange(min = JRE.JAVA_21)
     @ActivateRequestContext
     void virtualThreadToolFailureSurfacesThroughToolErrorHandler() {
-        // Quarkus wires a default toolExecutionErrorHandler that converts tool exceptions into
-        // tool-result text (so the LLM can recover). We assert the exception message ends up in
-        // the final stream output, proving the exception thrown inside the virtual-thread
-        // dispatch is captured and routed back through the normal tool-result pipeline.
         String r = aiService.failingVirtualTool("mem-" + UUID.randomUUID(), "failingVirtualThread - boom")
                 .collect().asList().map(l -> String.join(" ", l)).await().indefinitely();
         assertThat(r).contains("boom");
     }
 
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    void fullVirtualThreadBatchPreservesDuplicatedContextLocalsWhenSubmittedToVirtualThread() throws InterruptedException {
+        AtomicReference<String> expectedLocal = new AtomicReference<>();
+        AtomicReference<String> observedLocal = new AtomicReference<>();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Context duplicatedContext = VertxContext.getOrCreateDuplicatedContext(vertx);
+
+        duplicatedContext.executeBlocking(v -> {
+            String uuid = UUID.randomUUID().toString();
+            try {
+                Arc.container().requestContext().activate();
+                expectedLocal.set(uuid);
+                ContextLocals.put(DUPLICATED_CONTEXT_LOCAL_KEY, uuid);
+                List<ChatEvent> events = executeChatEventStreamBlocking(
+                        () -> aiService.virtualToolBatchEvents("mem-" + uuid,
+                                "hiVirtualThread,hiVirtualThreadAgain - " + uuid),
+                        event -> {
+                            if (event instanceof ChatEvent.BeforeToolExecutionEvent) {
+                                observedLocal.compareAndSet(null, ContextLocals.get(DUPLICATED_CONTEXT_LOCAL_KEY));
+                            }
+                        });
+                String response = extractPartialResponseText(events);
+                assertThat(response).contains(uuid);
+            } catch (Throwable t) {
+                failure.set(t);
+            } finally {
+                ContextLocals.remove(DUPLICATED_CONTEXT_LOCAL_KEY);
+                Arc.container().requestContext().deactivate();
+                latch.countDown();
+            }
+        }, false);
+
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+        if (failure.get() != null) {
+            throw new AssertionError("Duplicated-context submit-path invocation failed", failure.get());
+        }
+        assertThat(observedLocal.get()).isEqualTo(expectedLocal.get());
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    void fullVirtualThreadBatchPreservesDuplicatedContextLocalsWhenAlreadyOnVirtualThread() throws InterruptedException {
+        AtomicReference<String> expectedLocal = new AtomicReference<>();
+        AtomicReference<String> observedLocal = new AtomicReference<>();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Context duplicatedContext = VertxContext.getOrCreateDuplicatedContext(vertx);
+
+        duplicatedContext.executeBlocking(v -> {
+            String uuid = UUID.randomUUID().toString();
+            try {
+                expectedLocal.set(uuid);
+                ContextLocals.put(DUPLICATED_CONTEXT_LOCAL_KEY, uuid);
+                VirtualThreadsRecorder.getCurrent().submit(() -> {
+                    try {
+                        Arc.container().requestContext().activate();
+                        List<ChatEvent> events = executeChatEventStreamBlocking(
+                                () -> aiService.virtualToolBatchEvents("mem-" + uuid,
+                                        "hiVirtualThread,hiVirtualThreadAgain - " + uuid),
+                                event -> {
+                                    if (event instanceof ChatEvent.BeforeToolExecutionEvent) {
+                                        observedLocal.compareAndSet(null, ContextLocals.get(DUPLICATED_CONTEXT_LOCAL_KEY));
+                                    }
+                                });
+                        String response = extractPartialResponseText(events);
+                        assertThat(response).contains(uuid);
+                        return null;
+                    } finally {
+                        Arc.container().requestContext().deactivate();
+                    }
+                }).get();
+            } catch (Throwable t) {
+                failure.set(t);
+            } finally {
+                ContextLocals.remove(DUPLICATED_CONTEXT_LOCAL_KEY);
+                latch.countDown();
+            }
+        }, false);
+
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+        if (failure.get() != null) {
+            throw new AssertionError("Duplicated-context inline-VT invocation failed", failure.get());
+        }
+        assertThat(observedLocal.get()).isEqualTo(expectedLocal.get());
+    }
+
     private String invokeFromEventLoop(Supplier<Multi<String>> serviceCall) {
         AtomicReference<String> result = new AtomicReference<>();
         AtomicReference<Throwable> failure = new AtomicReference<>();
-        vertx.getOrCreateContext().runOnContext(x -> {
+        Context context = vertx.getOrCreateContext();
+        context.runOnContext(x -> {
+            Arc.container().requestContext().activate();
             try {
-                Arc.container().requestContext().activate();
                 serviceCall.get()
                         .collect().asList().map(l -> String.join(" ", l))
                         .subscribeAsCompletionStage()
@@ -116,10 +254,10 @@ public class ToolExecutionModelVirtualThreadDispatchTest {
                             } else {
                                 result.set(r);
                             }
+                            context.runOnContext(ignored -> Arc.container().requestContext().deactivate());
                         });
             } catch (Throwable t) {
                 failure.set(t);
-            } finally {
                 Arc.container().requestContext().deactivate();
             }
         });
@@ -131,11 +269,54 @@ public class ToolExecutionModelVirtualThreadDispatchTest {
         return result.get();
     }
 
+    private List<ChatEvent> executeChatEventStreamBlocking(Supplier<Multi<ChatEvent>> serviceCall,
+            Consumer<ChatEvent> eventObserver) throws InterruptedException {
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        List<ChatEvent> events = new java.util.concurrent.CopyOnWriteArrayList<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        serviceCall.get()
+                .onItem().invoke(event -> {
+                    events.add(event);
+                    if (eventObserver != null) {
+                        eventObserver.accept(event);
+                    }
+                })
+                .subscribe().with(
+                        item -> {
+                        },
+                        t -> {
+                            failure.set(t);
+                            latch.countDown();
+                        },
+                        latch::countDown);
+
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+        if (failure.get() != null) {
+            throw new AssertionError("Chat event stream failed", failure.get());
+        }
+        return events;
+    }
+
+    private String extractPartialResponseText(List<ChatEvent> events) {
+        StringBuilder response = new StringBuilder();
+        for (ChatEvent event : events) {
+            if (event instanceof ChatEvent.PartialResponseEvent partialResponseEvent) {
+                response.append(partialResponseEvent.getChunk());
+            }
+        }
+        return response.toString();
+    }
+
     @RegisterAiService(streamingChatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = MyMemoryProviderSupplier.class)
     public interface MyAiService {
 
         @ToolBox(VirtualTool.class)
         Multi<String> singleVirtualTool(@MemoryId String memoryId, @UserMessage String userMessageContainingTheToolId);
+
+        @ToolBox({ VirtualTool.class, VirtualToolAgain.class })
+        Multi<ChatEvent> virtualToolBatchEvents(@MemoryId String memoryId,
+                @UserMessage String userMessageContainingTheToolId);
 
         @ToolBox(BlockingTool.class)
         Multi<String> singleBlockingTool(@MemoryId String memoryId, @UserMessage String userMessageContainingTheToolId);
@@ -161,6 +342,15 @@ public class ToolExecutionModelVirtualThreadDispatchTest {
         @RunOnVirtualThread
         public String hiVirtualThread(String m) {
             return "VIRTUAL:" + m + " " + Thread.currentThread();
+        }
+    }
+
+    @Singleton
+    public static class VirtualToolAgain {
+        @Tool("hiVirtualThreadAgain")
+        @RunOnVirtualThread
+        public String hiVirtualThreadAgain(String m) {
+            return "VIRTUAL_AGAIN:" + m + " " + Thread.currentThread();
         }
     }
 
@@ -213,7 +403,7 @@ public class ToolExecutionModelVirtualThreadDispatchTest {
                 }
                 String[] toolIds = segments[0].split(",");
                 String content = segments[1];
-                java.util.List<ToolExecutionRequest> requests = new java.util.ArrayList<>();
+                List<ToolExecutionRequest> requests = new ArrayList<>();
                 int i = 0;
                 for (String toolId : toolIds) {
                     requests.add(ToolExecutionRequest.builder()
@@ -261,4 +451,25 @@ public class ToolExecutionModelVirtualThreadDispatchTest {
         }
     }
 
+    private static final class CapturingHandler extends Handler {
+
+        private final List<String> messages = new ArrayList<>();
+
+        @Override
+        public synchronized void publish(LogRecord record) {
+            messages.add(record.getMessage());
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+
+        synchronized List<String> messages() {
+            return List.copyOf(messages);
+        }
+    }
 }

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelVirtualThreadGlobalDispatchTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelVirtualThreadGlobalDispatchTest.java
@@ -1,0 +1,131 @@
+package io.quarkiverse.langchain4j.test.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.ToolBox;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+
+/**
+ * Asserts that {@code quarkus.langchain4j.tools.dispatch=virtual-thread} forces a
+ * non-{@code @RunOnVirtualThread} tool onto a virtual thread for the duration of the batch.
+ * With the default {@code auto} mode, the same blocking tool would stay on a worker thread.
+ */
+public class ToolExecutionModelVirtualThreadGlobalDispatchTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(MyAiService.class))
+            .overrideConfigKey("quarkus.langchain4j.tools.dispatch", "virtual-thread");
+
+    @Inject
+    MyAiService aiService;
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    @ActivateRequestContext
+    void globalDispatchVirtualThreadForcesBlockingToolOntoVirtualThread() {
+        String uuid = UUID.randomUUID().toString();
+        String r = aiService.singleBlockingTool("mem-" + uuid, "hi - " + uuid)
+                .collect().asList().map(l -> String.join(" ", l)).await().indefinitely();
+        assertThat(r).contains(uuid, "quarkus-virtual-thread-");
+    }
+
+    @RegisterAiService(streamingChatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = MyMemoryProviderSupplier.class)
+    public interface MyAiService {
+        @ToolBox(BlockingTool.class)
+        Multi<String> singleBlockingTool(@MemoryId String memoryId, @UserMessage String userMessageContainingTheToolId);
+    }
+
+    @Singleton
+    public static class BlockingTool {
+        @Tool("hi")
+        public String hi(String m) {
+            return m + " " + Thread.currentThread();
+        }
+    }
+
+    public static class MyChatModelSupplier implements Supplier<StreamingChatModel> {
+        @Override
+        public StreamingChatModel get() {
+            return new SimpleToolChatModel();
+        }
+    }
+
+    private static class SimpleToolChatModel implements StreamingChatModel {
+        @Override
+        public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+            List<ChatMessage> messages = chatRequest.messages();
+            boolean hasToolResults = messages.stream().anyMatch(m -> m instanceof ToolExecutionResultMessage);
+            if (!hasToolResults) {
+                dev.langchain4j.data.message.UserMessage userMessage = (dev.langchain4j.data.message.UserMessage) messages
+                        .get(messages.size() - 1);
+                String[] segments = userMessage.singleText().split(" - ", 2);
+                String toolId = segments[0];
+                String content = segments[1];
+                ChatResponse response = ChatResponse.builder()
+                        .aiMessage(new AiMessage("", List.of(ToolExecutionRequest.builder()
+                                .id("call-" + toolId)
+                                .name(toolId)
+                                .arguments("{\"m\":\"" + content + "\"}")
+                                .build())))
+                        .tokenUsage(new TokenUsage(0, 0))
+                        .finishReason(FinishReason.TOOL_EXECUTION)
+                        .build();
+                handler.onCompleteResponse(response);
+            } else {
+                ToolExecutionResultMessage last = null;
+                for (ChatMessage message : messages) {
+                    if (message instanceof ToolExecutionResultMessage trm) {
+                        last = trm;
+                    }
+                }
+                handler.onPartialResponse("response: ");
+                handler.onPartialResponse(last != null ? last.text() : "");
+                handler.onCompleteResponse(ChatResponse.builder()
+                        .aiMessage(new AiMessage(""))
+                        .tokenUsage(new TokenUsage(0, 0))
+                        .finishReason(FinishReason.STOP)
+                        .build());
+            }
+        }
+    }
+
+    public static class MyMemoryProviderSupplier implements Supplier<ChatMemoryProvider> {
+        @Override
+        public ChatMemoryProvider get() {
+            return memoryId -> MessageWindowChatMemory.withMaxMessages(10);
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelVirtualThreadLegacyDispatchTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelVirtualThreadLegacyDispatchTest.java
@@ -4,6 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import jakarta.enterprise.context.control.ActivateRequestContext;
@@ -34,56 +38,129 @@ import dev.langchain4j.service.MemoryId;
 import dev.langchain4j.service.UserMessage;
 import io.quarkiverse.langchain4j.RegisterAiService;
 import io.quarkiverse.langchain4j.ToolBox;
+import io.quarkiverse.langchain4j.runtime.VirtualThreadSupport;
+import io.quarkiverse.langchain4j.runtime.aiservice.ChatEvent;
+import io.quarkus.arc.Arc;
 import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.common.annotation.RunOnVirtualThread;
 import io.smallrye.mutiny.Multi;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
 
-/**
- * Asserts that {@code quarkus.langchain4j.tools.dispatch=virtual-thread} forces a
- * non-{@code @RunOnVirtualThread} tool onto a virtual thread for the duration of the batch.
- * With the default {@code auto} mode, the same blocking tool would stay on a worker thread.
- */
-public class ToolExecutionModelVirtualThreadGlobalDispatchTest {
+public class ToolExecutionModelVirtualThreadLegacyDispatchTest {
 
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(MyAiService.class))
-            .overrideConfigKey("quarkus.langchain4j.tools.dispatch", "virtual-thread");
+            .overrideConfigKey("quarkus.langchain4j.tools.dispatch", "legacy");
 
     @Inject
     MyAiService aiService;
 
+    @Inject
+    Vertx vertx;
+
     @Test
     @EnabledForJreRange(min = JRE.JAVA_21)
     @ActivateRequestContext
-    void globalDispatchVirtualThreadForcesBlockingToolOntoVirtualThread() {
+    void legacyDispatchKeepsSingleVirtualToolOnLegacyPath() throws InterruptedException {
         String uuid = UUID.randomUUID().toString();
-        String r = aiService.singleBlockingTool("mem-" + uuid, "hi - " + uuid)
-                .collect().asList().map(l -> String.join(" ", l)).await().indefinitely();
-        assertThat(r).contains(uuid, "quarkus-virtual-thread-");
+        AtomicReference<Thread> beforeToolThread = new AtomicReference<>();
+
+        List<ChatEvent> events = invokeChatEventStreamFromEventLoop(
+                () -> aiService.singleVirtualToolEvents("mem-" + uuid, "hiVirtualThread - " + uuid),
+                event -> {
+                    if (event instanceof ChatEvent.BeforeToolExecutionEvent) {
+                        beforeToolThread.compareAndSet(null, Thread.currentThread());
+                    }
+                });
+        String response = extractPartialResponseText(events);
+
+        assertThat(response).contains(uuid, "quarkus-virtual-thread-");
+        assertThat(beforeToolThread.get()).isNotNull();
+        assertThat(beforeToolThread.get().getName()).contains("executor-thread");
+        assertThat(VirtualThreadSupport.isVirtualThread(beforeToolThread.get())).isFalse();
+    }
+
+    private List<ChatEvent> invokeChatEventStreamFromEventLoop(Supplier<Multi<ChatEvent>> serviceCall,
+            Consumer<ChatEvent> eventObserver) throws InterruptedException {
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        List<ChatEvent> events = new java.util.concurrent.CopyOnWriteArrayList<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Context context = vertx.getOrCreateContext();
+
+        context.runOnContext(x -> {
+            Arc.container().requestContext().activate();
+            try {
+                serviceCall.get()
+                        .onItem().invoke(event -> {
+                            events.add(event);
+                            if (eventObserver != null) {
+                                eventObserver.accept(event);
+                            }
+                        })
+                        .subscribe().with(
+                                item -> {
+                                },
+                                t -> {
+                                    failure.set(t);
+                                    context.runOnContext(ignored -> {
+                                        Arc.container().requestContext().deactivate();
+                                        latch.countDown();
+                                    });
+                                },
+                                () -> context.runOnContext(ignored -> {
+                                    Arc.container().requestContext().deactivate();
+                                    latch.countDown();
+                                }));
+            } catch (Throwable t) {
+                failure.set(t);
+                Arc.container().requestContext().deactivate();
+                latch.countDown();
+            }
+        });
+
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+        if (failure.get() != null) {
+            throw new AssertionError("Chat event stream failed", failure.get());
+        }
+        return events;
+    }
+
+    private String extractPartialResponseText(List<ChatEvent> events) {
+        StringBuilder response = new StringBuilder();
+        for (ChatEvent event : events) {
+            if (event instanceof ChatEvent.PartialResponseEvent partialResponseEvent) {
+                response.append(partialResponseEvent.getChunk());
+            }
+        }
+        return response.toString();
     }
 
     @RegisterAiService(streamingChatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = MyMemoryProviderSupplier.class)
     public interface MyAiService {
-        @ToolBox(BlockingTool.class)
-        Multi<String> singleBlockingTool(@MemoryId String memoryId, @UserMessage String userMessageContainingTheToolId);
+        @ToolBox(VirtualTool.class)
+        Multi<ChatEvent> singleVirtualToolEvents(@MemoryId String memoryId,
+                @UserMessage String userMessageContainingTheToolId);
     }
 
     @Singleton
-    public static class BlockingTool {
-        @Tool("hi")
-        public String hi(String m) {
-            return m + " " + Thread.currentThread();
+    public static class VirtualTool {
+        @Tool("hiVirtualThread")
+        @RunOnVirtualThread
+        public String hiVirtualThread(String m) {
+            return "VIRTUAL:" + m + " " + Thread.currentThread();
         }
     }
 
     public static class MyChatModelSupplier implements Supplier<StreamingChatModel> {
         @Override
         public StreamingChatModel get() {
-            return new SimpleToolChatModel();
+            return new SingleToolChatModel();
         }
     }
 
-    private static class SimpleToolChatModel implements StreamingChatModel {
+    private static class SingleToolChatModel implements StreamingChatModel {
         @Override
         public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
             List<ChatMessage> messages = chatRequest.messages();

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelVirtualThreadMaxConcurrentTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelVirtualThreadMaxConcurrentTest.java
@@ -1,0 +1,166 @@
+package io.quarkiverse.langchain4j.test.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.ToolBox;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.common.annotation.RunOnVirtualThread;
+import io.smallrye.mutiny.Multi;
+
+/**
+ * Asserts that {@code quarkus.langchain4j.tools.virtual-thread.max-concurrent} caps the number
+ * of in-flight virtual-thread tool batches.
+ */
+public class ToolExecutionModelVirtualThreadMaxConcurrentTest {
+
+    private static final int MAX_CONCURRENT = 2;
+    private static final int CALLERS = 5;
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(MyAiService.class))
+            .overrideConfigKey("quarkus.langchain4j.tools.virtual-thread.max-concurrent",
+                    Integer.toString(MAX_CONCURRENT));
+
+    @Inject
+    MyAiService aiService;
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    @ActivateRequestContext
+    void maxConcurrentBoundsInFlightDispatches() {
+        SlowVirtualTool.reset();
+        List<CompletionStage<List<String>>> stages = new ArrayList<>();
+        for (int i = 0; i < CALLERS; i++) {
+            String uuid = UUID.randomUUID().toString();
+            stages.add(aiService.slowVirtualTool("mem-" + uuid, "slowVirtualTool - " + uuid)
+                    .collect().asList()
+                    .subscribeAsCompletionStage());
+        }
+        for (CompletionStage<List<String>> stage : stages) {
+            stage.toCompletableFuture().join();
+        }
+        assertThat(SlowVirtualTool.peakInFlight.get()).isLessThanOrEqualTo(MAX_CONCURRENT);
+        assertThat(SlowVirtualTool.peakInFlight.get()).isGreaterThan(0);
+    }
+
+    @RegisterAiService(streamingChatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = MyMemoryProviderSupplier.class)
+    public interface MyAiService {
+        @ToolBox(SlowVirtualTool.class)
+        Multi<String> slowVirtualTool(@MemoryId String memoryId, @UserMessage String userMessageContainingTheToolId);
+    }
+
+    @Singleton
+    public static class SlowVirtualTool {
+
+        static final AtomicInteger inFlight = new AtomicInteger();
+        static final AtomicInteger peakInFlight = new AtomicInteger();
+
+        static void reset() {
+            inFlight.set(0);
+            peakInFlight.set(0);
+        }
+
+        @Tool("slowVirtualTool")
+        @RunOnVirtualThread
+        public String slowVirtualTool(String m) {
+            int current = inFlight.incrementAndGet();
+            peakInFlight.updateAndGet(prev -> Math.max(prev, current));
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                inFlight.decrementAndGet();
+            }
+            return m + " on " + Thread.currentThread().getName();
+        }
+    }
+
+    public static class MyChatModelSupplier implements Supplier<StreamingChatModel> {
+        @Override
+        public StreamingChatModel get() {
+            return new SimpleToolChatModel();
+        }
+    }
+
+    private static class SimpleToolChatModel implements StreamingChatModel {
+        @Override
+        public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+            List<ChatMessage> messages = chatRequest.messages();
+            boolean hasToolResults = messages.stream().anyMatch(m -> m instanceof ToolExecutionResultMessage);
+            if (!hasToolResults) {
+                dev.langchain4j.data.message.UserMessage userMessage = (dev.langchain4j.data.message.UserMessage) messages
+                        .get(messages.size() - 1);
+                String[] segments = userMessage.singleText().split(" - ", 2);
+                String toolId = segments[0];
+                String content = segments[1];
+                ChatResponse response = ChatResponse.builder()
+                        .aiMessage(new AiMessage("", List.of(ToolExecutionRequest.builder()
+                                .id("call-" + toolId)
+                                .name(toolId)
+                                .arguments("{\"m\":\"" + content + "\"}")
+                                .build())))
+                        .tokenUsage(new TokenUsage(0, 0))
+                        .finishReason(FinishReason.TOOL_EXECUTION)
+                        .build();
+                handler.onCompleteResponse(response);
+            } else {
+                ToolExecutionResultMessage last = null;
+                for (ChatMessage message : messages) {
+                    if (message instanceof ToolExecutionResultMessage trm) {
+                        last = trm;
+                    }
+                }
+                handler.onPartialResponse("response: ");
+                handler.onPartialResponse(last != null ? last.text() : "");
+                handler.onCompleteResponse(ChatResponse.builder()
+                        .aiMessage(new AiMessage(""))
+                        .tokenUsage(new TokenUsage(0, 0))
+                        .finishReason(FinishReason.STOP)
+                        .build());
+            }
+        }
+    }
+
+    public static class MyMemoryProviderSupplier implements Supplier<ChatMemoryProvider> {
+        @Override
+        public ChatMemoryProvider get() {
+            return memoryId -> MessageWindowChatMemory.withMaxMessages(10);
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelVirtualThreadMaxConcurrentTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelVirtualThreadMaxConcurrentTest.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
@@ -37,7 +38,9 @@ import dev.langchain4j.service.MemoryId;
 import dev.langchain4j.service.UserMessage;
 import io.quarkiverse.langchain4j.RegisterAiService;
 import io.quarkiverse.langchain4j.ToolBox;
+import io.quarkus.arc.Arc;
 import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.virtual.threads.VirtualThreadsRecorder;
 import io.smallrye.common.annotation.RunOnVirtualThread;
 import io.smallrye.mutiny.Multi;
 
@@ -73,6 +76,31 @@ public class ToolExecutionModelVirtualThreadMaxConcurrentTest {
         }
         for (CompletionStage<List<String>> stage : stages) {
             stage.toCompletableFuture().join();
+        }
+        assertThat(SlowVirtualTool.peakInFlight.get()).isLessThanOrEqualTo(MAX_CONCURRENT);
+        assertThat(SlowVirtualTool.peakInFlight.get()).isGreaterThan(0);
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    void maxConcurrentBoundsInFlightDispatchesWhenCallerAlreadyRunsOnVirtualThread() throws Exception {
+        SlowVirtualTool.reset();
+        List<Future<List<String>>> futures = new ArrayList<>();
+        for (int i = 0; i < CALLERS; i++) {
+            String uuid = UUID.randomUUID().toString();
+            futures.add(VirtualThreadsRecorder.getCurrent().submit(() -> {
+                Arc.container().requestContext().activate();
+                try {
+                    return aiService.slowVirtualTool("mem-" + uuid, "slowVirtualTool - " + uuid)
+                            .collect().asList()
+                            .await().indefinitely();
+                } finally {
+                    Arc.container().requestContext().deactivate();
+                }
+            }));
+        }
+        for (Future<List<String>> future : futures) {
+            future.get();
         }
         assertThat(SlowVirtualTool.peakInFlight.get()).isLessThanOrEqualTo(MAX_CONCURRENT);
         assertThat(SlowVirtualTool.peakInFlight.get()).isGreaterThan(0);

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelVirtualThreadMaxConcurrentTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelVirtualThreadMaxConcurrentTest.java
@@ -52,6 +52,7 @@ public class ToolExecutionModelVirtualThreadMaxConcurrentTest {
 
     private static final int MAX_CONCURRENT = 2;
     private static final int CALLERS = 5;
+    private static final int PARALLEL_BATCH_SIZE = 5;
 
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
@@ -106,10 +107,34 @@ public class ToolExecutionModelVirtualThreadMaxConcurrentTest {
         assertThat(SlowVirtualTool.peakInFlight.get()).isGreaterThan(0);
     }
 
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    @ActivateRequestContext
+    void maxConcurrentBoundsInFlightToolsForParallelMultiToolBatch() {
+        SlowVirtualTool.reset();
+        // Single batch with PARALLEL_BATCH_SIZE > MAX_CONCURRENT tools — proves the per-tool
+        // semaphore acquire on the parallel path bounds simultaneous tool invocations.
+        String uuid = UUID.randomUUID().toString();
+        StringBuilder toolsCsv = new StringBuilder();
+        for (int i = 0; i < PARALLEL_BATCH_SIZE; i++) {
+            if (i > 0) {
+                toolsCsv.append(',');
+            }
+            toolsCsv.append("slowVirtualTool");
+        }
+        aiService.parallelSlowBatch("mem-" + uuid, toolsCsv + " - " + uuid)
+                .collect().asList().await().indefinitely();
+        assertThat(SlowVirtualTool.peakInFlight.get()).isLessThanOrEqualTo(MAX_CONCURRENT);
+        assertThat(SlowVirtualTool.peakInFlight.get()).isGreaterThan(0);
+    }
+
     @RegisterAiService(streamingChatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = MyMemoryProviderSupplier.class)
     public interface MyAiService {
         @ToolBox(SlowVirtualTool.class)
         Multi<String> slowVirtualTool(@MemoryId String memoryId, @UserMessage String userMessageContainingTheToolId);
+
+        @ToolBox(SlowVirtualTool.class)
+        Multi<String> parallelSlowBatch(@MemoryId String memoryId, @UserMessage String userMessageContainingTheToolIds);
     }
 
     @Singleton
@@ -155,14 +180,19 @@ public class ToolExecutionModelVirtualThreadMaxConcurrentTest {
                 dev.langchain4j.data.message.UserMessage userMessage = (dev.langchain4j.data.message.UserMessage) messages
                         .get(messages.size() - 1);
                 String[] segments = userMessage.singleText().split(" - ", 2);
-                String toolId = segments[0];
+                String[] toolIds = segments[0].split(",");
                 String content = segments[1];
+                List<ToolExecutionRequest> requests = new ArrayList<>();
+                int index = 0;
+                for (String toolId : toolIds) {
+                    requests.add(ToolExecutionRequest.builder()
+                            .id("call-" + toolId.trim() + "-" + (index++))
+                            .name(toolId.trim())
+                            .arguments("{\"m\":\"" + content + "\"}")
+                            .build());
+                }
                 ChatResponse response = ChatResponse.builder()
-                        .aiMessage(new AiMessage("", List.of(ToolExecutionRequest.builder()
-                                .id("call-" + toolId)
-                                .name(toolId)
-                                .arguments("{\"m\":\"" + content + "\"}")
-                                .build())))
+                        .aiMessage(new AiMessage("", requests))
                         .tokenUsage(new TokenUsage(0, 0))
                         .finishReason(FinishReason.TOOL_EXECUTION)
                         .build();

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelVirtualThreadParallelDispatchTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelVirtualThreadParallelDispatchTest.java
@@ -1,0 +1,451 @@
+package io.quarkiverse.langchain4j.test.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.ToolBox;
+import io.quarkiverse.langchain4j.runtime.ContextLocals;
+import io.quarkiverse.langchain4j.runtime.VirtualThreadSupport;
+import io.quarkiverse.langchain4j.runtime.aiservice.ChatEvent;
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.common.annotation.RunOnVirtualThread;
+import io.smallrye.common.vertx.VertxContext;
+import io.smallrye.mutiny.Multi;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+/**
+ * Asserts the parallel virtual-thread tool batch path: tools run concurrently on per-tool
+ * virtual threads, results are appended to memory in request order regardless of completion
+ * order, BeforeToolExecution events fire in request order on the carrier thread, and
+ * ToolExecutedEvent fires in completion order from the per-tool worker thread.
+ */
+public class ToolExecutionModelVirtualThreadParallelDispatchTest {
+
+    private static final String CONTEXT_LOCAL_KEY = "parallel-dispatch-test-local";
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(MyAiService.class));
+
+    @Inject
+    MyAiService aiService;
+
+    @Inject
+    Vertx vertx;
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    @ActivateRequestContext
+    void parallelBatchExecutesToolsOnSeparateVirtualThreads() throws InterruptedException {
+        TimedTool.reset();
+        String uuid = UUID.randomUUID().toString();
+        List<Thread> toolThreads = new CopyOnWriteArrayList<>();
+        TimedTool.threadObserver = thread -> toolThreads.add(thread);
+        try {
+            executeChatEventStreamBlocking(
+                    () -> aiService.threeTools("mem-" + uuid,
+                            "timedA,timedB,timedC - " + uuid),
+                    null);
+        } finally {
+            TimedTool.threadObserver = null;
+        }
+
+        assertThat(toolThreads).hasSize(3);
+        assertThat(toolThreads).allSatisfy(t -> assertThat(VirtualThreadSupport.isVirtualThread(t)).isTrue());
+        // Each tool ran on its own virtual thread.
+        assertThat(new HashSet<>(toolThreads)).hasSize(3);
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    @ActivateRequestContext
+    void parallelBatchOverlapsToolExecution() throws InterruptedException {
+        TimedTool.reset();
+        String uuid = UUID.randomUUID().toString();
+        long start = System.nanoTime();
+        executeChatEventStreamBlocking(
+                () -> aiService.threeTools("mem-" + uuid,
+                        "timedA,timedB,timedC - " + uuid),
+                null);
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        // Each tool sleeps 250ms. Serial would take ≥750ms; parallel should easily complete
+        // under 600ms. Generous bound to avoid CI flakes.
+        assertThat(elapsedMs).isLessThan(600);
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    @ActivateRequestContext
+    void parallelBatchAppendsResultsInRequestOrderRegardlessOfCompletion() throws InterruptedException {
+        StaggeredTool.reset();
+        String uuid = UUID.randomUUID().toString();
+        // staggeredA sleeps longest, staggeredC fastest — completion order is C, B, A but
+        // memory must hold results in submission order A, B, C.
+        executeChatEventStreamBlocking(
+                () -> aiService.threeStaggeredTools("mem-" + uuid,
+                        "staggeredA,staggeredB,staggeredC - " + uuid),
+                null);
+
+        List<String> resultTexts = MyMemoryProviderSupplier.snapshotToolResults("mem-" + uuid);
+        // Tool result text is JSON-encoded (the framework quotes string returns), so the
+        // assertion target is the JSON-quoted form. What matters here is the order: the slowest
+        // tool (A) appears first in memory even though it completed last.
+        assertThat(resultTexts).containsExactly("\"A:done\"", "\"B:done\"", "\"C:done\"");
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    @ActivateRequestContext
+    void parallelBatchEmitsBeforeToolExecutionEventsInRequestOrder() throws InterruptedException {
+        TimedTool.reset();
+        String uuid = UUID.randomUUID().toString();
+        List<String> beforeToolNames = new CopyOnWriteArrayList<>();
+        executeChatEventStreamBlocking(
+                () -> aiService.threeTools("mem-" + uuid,
+                        "timedA,timedB,timedC - " + uuid),
+                event -> {
+                    if (event instanceof ChatEvent.BeforeToolExecutionEvent before) {
+                        beforeToolNames.add(before.getRequest().name());
+                    }
+                });
+
+        assertThat(beforeToolNames).containsExactly("timedA", "timedB", "timedC");
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    @ActivateRequestContext
+    void parallelBatchPropagatesDuplicatedContextLocalsToEveryWorker() throws InterruptedException {
+        TimedTool.reset();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicReference<List<String>> observedLocals = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Context duplicatedContext = VertxContext.getOrCreateDuplicatedContext(vertx);
+
+        duplicatedContext.executeBlocking(v -> {
+            String uuid = UUID.randomUUID().toString();
+            try {
+                Arc.container().requestContext().activate();
+                ContextLocals.put(CONTEXT_LOCAL_KEY, uuid);
+                List<String> seenByTools = new CopyOnWriteArrayList<>();
+                TimedTool.threadObserver = thread -> {
+                    String observed = ContextLocals.get(CONTEXT_LOCAL_KEY);
+                    seenByTools.add(observed != null ? observed : "<missing>");
+                };
+                try {
+                    executeChatEventStreamBlocking(
+                            () -> aiService.threeTools("mem-" + uuid,
+                                    "timedA,timedB,timedC - " + uuid),
+                            null);
+                } finally {
+                    TimedTool.threadObserver = null;
+                }
+                observedLocals.set(seenByTools);
+            } catch (Throwable t) {
+                failure.set(t);
+            } finally {
+                ContextLocals.remove(CONTEXT_LOCAL_KEY);
+                Arc.container().requestContext().deactivate();
+                latch.countDown();
+            }
+        }, false);
+
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+        if (failure.get() != null) {
+            throw new AssertionError("Parallel context-locals propagation failed", failure.get());
+        }
+        assertThat(observedLocals.get()).hasSize(3).allSatisfy(local -> assertThat(local).isNotNull());
+        // Every parallel worker observed the same context-local value as the caller.
+        assertThat(new HashSet<>(observedLocals.get())).hasSize(1);
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    @ActivateRequestContext
+    void parallelBatchKeepsMemoryConsistentWhenOneToolThrows() throws InterruptedException {
+        String uuid = UUID.randomUUID().toString();
+        // The default tool execution error handler converts throws into error result messages
+        // sent back to the LLM. The parallel path must still produce one result per request
+        // (success-or-error), in request order, so chat memory stays consistent.
+        executeChatEventStreamBlocking(
+                () -> aiService.failingMixEvents("mem-" + uuid, "okA,boom,okB - " + uuid),
+                null);
+
+        List<String> resultTexts = MyMemoryProviderSupplier.snapshotToolResults("mem-" + uuid);
+        assertThat(resultTexts).hasSize(3);
+        assertThat(resultTexts.get(0)).contains("okA");
+        assertThat(resultTexts.get(1)).contains("boom");
+        assertThat(resultTexts.get(2)).contains("okB");
+    }
+
+    private void executeChatEventStreamBlocking(Supplier<Multi<ChatEvent>> serviceCall,
+            Consumer<ChatEvent> eventObserver) throws InterruptedException {
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        serviceCall.get()
+                .onItem().invoke(event -> {
+                    if (eventObserver != null) {
+                        eventObserver.accept(event);
+                    }
+                })
+                .subscribe().with(
+                        item -> {
+                        },
+                        t -> {
+                            failure.set(t);
+                            latch.countDown();
+                        },
+                        latch::countDown);
+
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+        if (failure.get() != null) {
+            throw new AssertionError("Chat event stream failed", failure.get());
+        }
+    }
+
+    @RegisterAiService(streamingChatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = MyMemoryProviderSupplier.class)
+    public interface MyAiService {
+
+        @ToolBox({ TimedTool.class })
+        Multi<ChatEvent> threeTools(@MemoryId String memoryId,
+                @UserMessage String userMessageContainingTheToolIds);
+
+        @ToolBox({ StaggeredTool.class })
+        Multi<ChatEvent> threeStaggeredTools(@MemoryId String memoryId,
+                @UserMessage String userMessageContainingTheToolIds);
+
+        @ToolBox({ FailingMixTool.class })
+        Multi<ChatEvent> failingMixEvents(@MemoryId String memoryId,
+                @UserMessage String userMessageContainingTheToolIds);
+    }
+
+    @Singleton
+    public static class TimedTool {
+
+        static volatile Consumer<Thread> threadObserver;
+
+        static void reset() {
+            threadObserver = null;
+        }
+
+        @Tool("timedA")
+        @RunOnVirtualThread
+        public String timedA(String m) {
+            return invoke("A", m);
+        }
+
+        @Tool("timedB")
+        @RunOnVirtualThread
+        public String timedB(String m) {
+            return invoke("B", m);
+        }
+
+        @Tool("timedC")
+        @RunOnVirtualThread
+        public String timedC(String m) {
+            return invoke("C", m);
+        }
+
+        private String invoke(String label, String m) {
+            Consumer<Thread> observer = threadObserver;
+            if (observer != null) {
+                observer.accept(Thread.currentThread());
+            }
+            try {
+                Thread.sleep(250);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return label + ":" + m;
+        }
+    }
+
+    @Singleton
+    public static class StaggeredTool {
+
+        static void reset() {
+            MyMemoryProviderSupplier.MEMORIES.clear();
+        }
+
+        @Tool("staggeredA")
+        @RunOnVirtualThread
+        public String staggeredA(String m) {
+            sleep(300);
+            return "A:done";
+        }
+
+        @Tool("staggeredB")
+        @RunOnVirtualThread
+        public String staggeredB(String m) {
+            sleep(150);
+            return "B:done";
+        }
+
+        @Tool("staggeredC")
+        @RunOnVirtualThread
+        public String staggeredC(String m) {
+            sleep(50);
+            return "C:done";
+        }
+
+        private void sleep(long ms) {
+            try {
+                Thread.sleep(ms);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    @Singleton
+    public static class FailingMixTool {
+
+        @Tool("okA")
+        @RunOnVirtualThread
+        public String okA(String m) {
+            return "okA:" + m;
+        }
+
+        @Tool("okB")
+        @RunOnVirtualThread
+        public String okB(String m) {
+            return "okB:" + m;
+        }
+
+        @Tool("boom")
+        @RunOnVirtualThread
+        public String boom(String m) {
+            throw new RuntimeException("boom: " + m);
+        }
+    }
+
+    public static class MyChatModelSupplier implements Supplier<StreamingChatModel> {
+        @Override
+        public StreamingChatModel get() {
+            return new MultiToolChatModel();
+        }
+    }
+
+    /**
+     * Mock model that emits a batch of {@link ToolExecutionRequest}s parsed from the user
+     * message and terminates on the follow-up call by echoing the concatenated tool result text.
+     */
+    public static class MultiToolChatModel implements StreamingChatModel {
+
+        @Override
+        public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+            List<ChatMessage> messages = chatRequest.messages();
+            boolean hasToolResults = messages.stream().anyMatch(m -> m instanceof ToolExecutionResultMessage);
+            if (!hasToolResults) {
+                dev.langchain4j.data.message.UserMessage userMessage = null;
+                for (ChatMessage message : messages) {
+                    if (message instanceof dev.langchain4j.data.message.UserMessage um) {
+                        userMessage = um;
+                    }
+                }
+                String[] segments = userMessage.singleText().split(" - ", 2);
+                String[] toolIds = segments[0].split(",");
+                String content = segments[1];
+                List<ToolExecutionRequest> requests = new ArrayList<>();
+                int i = 0;
+                for (String toolId : toolIds) {
+                    requests.add(ToolExecutionRequest.builder()
+                            .id("call-" + toolId + "-" + (i++))
+                            .name(toolId.trim())
+                            .arguments("{\"m\":\"" + content + "\"}")
+                            .build());
+                }
+                handler.onCompleteResponse(ChatResponse.builder()
+                        .aiMessage(new AiMessage("thinking", requests))
+                        .tokenUsage(new TokenUsage(0, 0))
+                        .finishReason(FinishReason.TOOL_EXECUTION)
+                        .build());
+            } else {
+                StringBuilder combined = new StringBuilder();
+                for (ChatMessage message : messages) {
+                    if (message instanceof ToolExecutionResultMessage trm) {
+                        if (combined.length() > 0) {
+                            combined.append(" | ");
+                        }
+                        combined.append(trm.text());
+                    }
+                }
+                handler.onPartialResponse("response: ");
+                handler.onPartialResponse(combined.toString());
+                handler.onCompleteResponse(ChatResponse.builder()
+                        .aiMessage(new AiMessage(""))
+                        .tokenUsage(new TokenUsage(0, 0))
+                        .finishReason(FinishReason.STOP)
+                        .build());
+            }
+        }
+    }
+
+    public static class MyMemoryProviderSupplier implements Supplier<ChatMemoryProvider> {
+
+        static final Map<Object, dev.langchain4j.memory.ChatMemory> MEMORIES = new ConcurrentHashMap<>();
+
+        @Override
+        public ChatMemoryProvider get() {
+            return memoryId -> MEMORIES.computeIfAbsent(memoryId,
+                    k -> MessageWindowChatMemory.withMaxMessages(20));
+        }
+
+        static List<String> snapshotToolResults(Object memoryId) {
+            dev.langchain4j.memory.ChatMemory memory = MEMORIES.get(memoryId);
+            List<String> results = new ArrayList<>();
+            if (memory == null) {
+                return results;
+            }
+            for (ChatMessage message : memory.messages()) {
+                if (message instanceof ToolExecutionResultMessage trm) {
+                    results.add(trm.text());
+                }
+            }
+            return results;
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelVirtualThreadParallelMaxToolCallsTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelVirtualThreadParallelMaxToolCallsTest.java
@@ -1,0 +1,141 @@
+package io.quarkiverse.langchain4j.test.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.runtime.ToolCallsLimitExceededException;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.common.annotation.RunOnVirtualThread;
+import io.smallrye.mutiny.Multi;
+
+/**
+ * Asserts that {@code maxToolCallsPerResponse} is enforced for all-virtual-thread streaming
+ * batches that would otherwise fan out in parallel. Parallel mode rejects the entire batch
+ * before any tool runs (instead of the serial behaviour of executing the first
+ * {@code maxToolCallsPerResponse} tools and throwing on the next iteration).
+ */
+public class ToolExecutionModelVirtualThreadParallelMaxToolCallsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(VtTool.class, StreamingModelSupplier.class));
+
+    @Inject
+    LimitedAiService aiService;
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    @ActivateRequestContext
+    void parallelBatchOverLimitRejectsBeforeAnyToolRuns() {
+        VtTool.invocations.set(0);
+        StreamingModelSupplier.toolCallsCount = 5;
+
+        assertThatThrownBy(() -> aiService.chat("test-" + UUID.randomUUID())
+                .collect().asList().await().indefinitely())
+                .isInstanceOf(ToolCallsLimitExceededException.class)
+                .hasMessageContaining("3")
+                .hasMessageContaining("5");
+
+        // Parallel mode rejects up-front rather than executing the first three tools.
+        assertThat(VtTool.invocations.get()).isZero();
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    @ActivateRequestContext
+    void parallelBatchAtLimitRunsAllTools() {
+        VtTool.invocations.set(0);
+        StreamingModelSupplier.toolCallsCount = 3;
+
+        aiService.chat("test-" + UUID.randomUUID())
+                .collect().asList().await().indefinitely();
+
+        assertThat(VtTool.invocations.get()).isEqualTo(3);
+    }
+
+    @RegisterAiService(maxToolCallsPerResponse = 3, tools = VtTool.class, streamingChatLanguageModelSupplier = StreamingModelSupplier.class)
+    public interface LimitedAiService {
+        Multi<String> chat(String message);
+    }
+
+    @ApplicationScoped
+    public static class VtTool {
+
+        static final AtomicInteger invocations = new AtomicInteger();
+
+        @Tool
+        @RunOnVirtualThread
+        public String dummy(String message) {
+            invocations.incrementAndGet();
+            return "ok";
+        }
+    }
+
+    public static class StreamingModelSupplier implements Supplier<StreamingChatModel> {
+
+        static volatile int toolCallsCount = 0;
+        static int responseCount = 0;
+
+        @Override
+        public StreamingChatModel get() {
+            return new StreamingChatModel() {
+                @Override
+                public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+                    responseCount++;
+                    boolean alreadyExecuted = chatRequest.messages().stream()
+                            .anyMatch(m -> m instanceof ToolExecutionResultMessage);
+                    if (alreadyExecuted) {
+                        handler.onCompleteResponse(ChatResponse.builder()
+                                .aiMessage(AiMessage.from("done"))
+                                .tokenUsage(new TokenUsage(0, 0))
+                                .finishReason(FinishReason.STOP)
+                                .build());
+                        return;
+                    }
+                    List<ToolExecutionRequest> requests = new ArrayList<>();
+                    for (int i = 0; i < toolCallsCount; i++) {
+                        requests.add(ToolExecutionRequest.builder()
+                                .name("dummy")
+                                .id("dummy-" + responseCount + "-" + i)
+                                .arguments("{\"message\":\"x\"}")
+                                .build());
+                    }
+                    handler.onCompleteResponse(ChatResponse.builder()
+                            .aiMessage(AiMessage.from(requests))
+                            .tokenUsage(new TokenUsage(0, 0))
+                            .finishReason(FinishReason.TOOL_EXECUTION)
+                            .build());
+                }
+            };
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelVirtualThreadParallelOptOutTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelVirtualThreadParallelOptOutTest.java
@@ -1,0 +1,192 @@
+package io.quarkiverse.langchain4j.test.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.ToolBox;
+import io.quarkiverse.langchain4j.runtime.VirtualThreadSupport;
+import io.quarkiverse.langchain4j.runtime.aiservice.ChatEvent;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.common.annotation.RunOnVirtualThread;
+import io.smallrye.mutiny.Multi;
+
+/**
+ * Asserts that {@code quarkus.langchain4j.tools.parallel-virtual-thread-batch=false} restores
+ * the historical serialized-loop behavior: every tool in a virtual-thread batch runs on the
+ * single carrier virtual thread.
+ */
+public class ToolExecutionModelVirtualThreadParallelOptOutTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(MyAiService.class))
+            .overrideConfigKey("quarkus.langchain4j.tools.parallel-virtual-thread-batch", "false");
+
+    @Inject
+    MyAiService aiService;
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    @ActivateRequestContext
+    void serializedBatchRunsAllToolsOnTheSameVirtualThread() throws InterruptedException {
+        ThreadCapturingTool.invocationThreads.clear();
+        String uuid = UUID.randomUUID().toString();
+        executeChatEventStreamBlocking(
+                () -> aiService.threeTools("mem-" + uuid, "tA,tB,tC - " + uuid));
+
+        assertThat(ThreadCapturingTool.invocationThreads).hasSize(3);
+        assertThat(ThreadCapturingTool.invocationThreads)
+                .allSatisfy(t -> assertThat(VirtualThreadSupport.isVirtualThread(t)).isTrue());
+        assertThat(new HashSet<>(ThreadCapturingTool.invocationThreads))
+                .as("Opt-out keeps the serialized-loop carrier — every tool runs on the same virtual thread")
+                .hasSize(1);
+    }
+
+    private void executeChatEventStreamBlocking(Supplier<Multi<ChatEvent>> serviceCall) throws InterruptedException {
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        serviceCall.get()
+                .subscribe().with(
+                        item -> {
+                        },
+                        t -> {
+                            failure.set(t);
+                            latch.countDown();
+                        },
+                        latch::countDown);
+
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+        if (failure.get() != null) {
+            throw new AssertionError("Chat event stream failed", failure.get());
+        }
+    }
+
+    @RegisterAiService(streamingChatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = MyMemoryProviderSupplier.class)
+    public interface MyAiService {
+
+        @ToolBox(ThreadCapturingTool.class)
+        Multi<ChatEvent> threeTools(@MemoryId String memoryId,
+                @UserMessage String userMessageContainingTheToolIds);
+    }
+
+    @Singleton
+    public static class ThreadCapturingTool {
+
+        static final List<Thread> invocationThreads = new CopyOnWriteArrayList<>();
+
+        @Tool("tA")
+        @RunOnVirtualThread
+        public String tA(String m) {
+            return capture("A", m);
+        }
+
+        @Tool("tB")
+        @RunOnVirtualThread
+        public String tB(String m) {
+            return capture("B", m);
+        }
+
+        @Tool("tC")
+        @RunOnVirtualThread
+        public String tC(String m) {
+            return capture("C", m);
+        }
+
+        private String capture(String label, String m) {
+            invocationThreads.add(Thread.currentThread());
+            return label + ":" + m;
+        }
+    }
+
+    public static class MyChatModelSupplier implements Supplier<StreamingChatModel> {
+        @Override
+        public StreamingChatModel get() {
+            return new MultiToolChatModel();
+        }
+    }
+
+    public static class MultiToolChatModel implements StreamingChatModel {
+
+        @Override
+        public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+            List<ChatMessage> messages = chatRequest.messages();
+            boolean hasToolResults = messages.stream().anyMatch(m -> m instanceof ToolExecutionResultMessage);
+            if (!hasToolResults) {
+                dev.langchain4j.data.message.UserMessage userMessage = null;
+                for (ChatMessage message : messages) {
+                    if (message instanceof dev.langchain4j.data.message.UserMessage um) {
+                        userMessage = um;
+                    }
+                }
+                String[] segments = userMessage.singleText().split(" - ", 2);
+                String[] toolIds = segments[0].split(",");
+                String content = segments[1];
+                List<ToolExecutionRequest> requests = new ArrayList<>();
+                int i = 0;
+                for (String toolId : toolIds) {
+                    requests.add(ToolExecutionRequest.builder()
+                            .id("call-" + toolId + "-" + (i++))
+                            .name(toolId.trim())
+                            .arguments("{\"m\":\"" + content + "\"}")
+                            .build());
+                }
+                handler.onCompleteResponse(ChatResponse.builder()
+                        .aiMessage(new AiMessage("thinking", requests))
+                        .tokenUsage(new TokenUsage(0, 0))
+                        .finishReason(FinishReason.TOOL_EXECUTION)
+                        .build());
+            } else {
+                handler.onPartialResponse("done");
+                handler.onCompleteResponse(ChatResponse.builder()
+                        .aiMessage(new AiMessage(""))
+                        .tokenUsage(new TokenUsage(0, 0))
+                        .finishReason(FinishReason.STOP)
+                        .build());
+            }
+        }
+    }
+
+    public static class MyMemoryProviderSupplier implements Supplier<ChatMemoryProvider> {
+        @Override
+        public ChatMemoryProvider get() {
+            return memoryId -> MessageWindowChatMemory.withMaxMessages(10);
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelWithStreamingAndRequestScopePropagationTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelWithStreamingAndRequestScopePropagationTest.java
@@ -272,9 +272,9 @@ public class ToolExecutionModelWithStreamingAndRequestScopePropagationTest {
                     .collect().asList().map(l -> String.join(" ", l)).await().indefinitely();
         }).get();
 
-        // At the moment, we create a virtual thread every time.
-        assertThat(r).contains(uuid, "quarkus-virtual-thread-")
-                .doesNotContain(caller.get());
+        // When the caller is already running on a virtual thread, the tool executes on that
+        // same virtual thread instead of being re-dispatched onto a new one.
+        assertThat(r).contains(uuid, "quarkus-virtual-thread-", caller.get());
     }
 
     @Test

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelWithStreamingCancellationTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelWithStreamingCancellationTest.java
@@ -79,8 +79,14 @@ public class ToolExecutionModelWithStreamingCancellationTest {
      * 2. First tool starts executing, signals TOOL_STARTED, then blocks on TOOL_MAY_PROCEED
      * 3. Test detects TOOL_STARTED, cancels the subscription (sets cancelled flag)
      * 4. Test signals TOOL_MAY_PROCEED, first tool completes
-     * 5. Handler sees isCancelled() for second tool — fills cancellation result
-     * 6. Handler checks isCancelled() after tool loop — sees true, stops
+     * 5. Handler observes isCancelled() before issuing the next chat() round, so no
+     * subsequent rounds run and the loop terminates.
+     * <p>
+     * In parallel batch mode (default for all-virtual-thread batches with multiple tools)
+     * both tools may be submitted to virtual threads concurrently, so the second tool may
+     * have started executing by the time cancel() fires. The contract this test enforces is
+     * the durable invariants — memory consistency and no further rounds — not the precise
+     * call count.
      */
     @Test
     @ActivateRequestContext
@@ -117,10 +123,12 @@ public class ToolExecutionModelWithStreamingCancellationTest {
         // Give time for any in-flight operations to settle
         Thread.sleep(500);
 
-        // Assert: tool was called exactly once (first tool only, second was cancelled)
+        // Tool calls are bounded by the in-flight batch — at most the two tools in the round
+        // (parallel mode may have submitted both before cancel observed) and never any tool
+        // from a subsequent round.
         assertThat(CountableTool.CALL_COUNT.get())
-                .as("Tool should only be called once (first tool), not for the second tool after cancellation")
-                .isEqualTo(1);
+                .as("Tool calls bounded by the in-flight batch — no further rounds after cancellation")
+                .isBetween(1, 2);
 
         // Assert: model chat() was called at most 2 times (initial + possibly one before cancellation took effect)
         // Without cancellation, it would be called 4 times (initial + 3 tool rounds)

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelWithStreamingTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelWithStreamingTest.java
@@ -279,9 +279,9 @@ public class ToolExecutionModelWithStreamingTest {
             }
         }).get();
 
-        // At the moment, we create a virtual thread every time.
-        assertThat(r).contains(uuid, "quarkus-virtual-thread-")
-                .doesNotContain(caller.get());
+        // When the caller already runs on a virtual thread, the tool executes on the same
+        // virtual thread instead of being re-dispatched onto a new one.
+        assertThat(r).contains(uuid, "quarkus-virtual-thread-", caller.get());
     }
 
     @Test

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/VirtualThreadSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/VirtualThreadSupport.java
@@ -1,0 +1,44 @@
+package io.quarkiverse.langchain4j.runtime;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+/**
+ * Small compatibility helper for virtual-thread detection on JDKs that compile at release 17 but run
+ * on 21+. {@code Thread#isVirtual()} is not present in the Java 17 API, so a direct call does not
+ * compile; at runtime the method is available whenever the JVM supports virtual threads.
+ */
+public final class VirtualThreadSupport {
+
+    private static final MethodHandle IS_VIRTUAL;
+
+    static {
+        MethodHandle mh = null;
+        try {
+            mh = MethodHandles.publicLookup()
+                    .findVirtual(Thread.class, "isVirtual", MethodType.methodType(boolean.class));
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            // JDK < 21: virtual threads are not supported at all, leave IS_VIRTUAL as null.
+        }
+        IS_VIRTUAL = mh;
+    }
+
+    private VirtualThreadSupport() {
+    }
+
+    public static boolean isVirtualThread(Thread thread) {
+        if (IS_VIRTUAL == null) {
+            return false;
+        }
+        try {
+            return (boolean) IS_VIRTUAL.invokeExact(thread);
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+    public static boolean isCurrentThreadVirtual() {
+        return isVirtualThread(Thread.currentThread());
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/VirtualThreadSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/VirtualThreadSupport.java
@@ -8,6 +8,13 @@ import java.lang.invoke.MethodType;
  * Small compatibility helper for virtual-thread detection on JDKs that compile at release 17 but run
  * on 21+. {@code Thread#isVirtual()} is not present in the Java 17 API, so a direct call does not
  * compile; at runtime the method is available whenever the JVM supports virtual threads.
+ *
+ * <p>
+ * Quarkus uses the same {@link MethodHandle}-based lookup internally (see
+ * {@code io.quarkus.vertx.utils.AppendBuffer#isVirtualThread}), but does not expose the helper as a
+ * public API. This class mirrors that pattern so the rest of the extension does not have to
+ * duplicate the reflective boilerplate.
+ * </p>
  */
 public final class VirtualThreadSupport {
 

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceStreamingResponseHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceStreamingResponseHandler.java
@@ -609,6 +609,70 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
         return toolExecutionResult;
     }
 
+    private void runSerialToolBatch(AiMessage aiMessage) {
+        addToMemory(aiMessage);
+        List<ToolExecutionRequest> toolExecutionRequests = aiMessage.toolExecutionRequests();
+        int maxToolCallsPerResponse;
+        if (context.maxToolCallsPerResponse != null && context.maxToolCallsPerResponse != 0) {
+            maxToolCallsPerResponse = context.maxToolCallsPerResponse;
+        } else {
+            maxToolCallsPerResponse = ConfigProvider.getConfig()
+                    .getOptionalValue("quarkus.langchain4j.ai-service.max-tool-calls-per-response", Integer.class)
+                    .orElse(0);
+        }
+        int toolCallsCount = 0;
+        for (ToolExecutionRequest toolExecutionRequest : toolExecutionRequests) {
+            if (maxToolCallsPerResponse > 0 && toolCallsCount >= maxToolCallsPerResponse) {
+                throw new ToolCallsLimitExceededException(maxToolCallsPerResponse,
+                        toolExecutionRequests.size());
+            }
+            toolCallsCount++;
+            if (isCancelled()) {
+                // Fill cancelled tools with error results to keep memory consistent:
+                // every tool request must have a matching tool result
+                ToolExecutionResultMessage cancelledResult = ToolExecutionResultMessage.from(
+                        toolExecutionRequest, "Tool execution was cancelled");
+                addToMemory(cancelledResult);
+                continue;
+            }
+            if (beforeToolExecutionHandler != null) {
+                BeforeToolExecution beforeToolExecution = BeforeToolExecution.builder()
+                        .request(toolExecutionRequest)
+                        .invocationContext(invocationContext)
+                        .build();
+                beforeToolExecutionHandler.accept(beforeToolExecution);
+            }
+
+            String toolName = toolExecutionRequest.name();
+            ToolExecutor toolExecutor = toolExecutors.get(toolName);
+            // Execute the tool with argumentsErrorHandler and executionErrorHandler.
+            // If execution fails, these handlers convert exceptions into error results
+            // that are sent back to the LLM, allowing it to recover from tool failures.
+            ToolExecutionResult toolExecutionResult = executeTool(
+                    toolExecutionRequest,
+                    toolExecutor,
+                    invocationContext,
+                    context.toolService.argumentsErrorHandler(),
+                    context.toolService.executionErrorHandler());
+
+            fireToolExecutedEvent(toolExecutionRequest, toolExecutionResult.resultText());
+
+            ToolExecutionResultMessage toolExecutionResultMessage = ToolExecutionResultMessage.from(
+                    toolExecutionRequest,
+                    toolExecutionResult.resultText());
+
+            ToolExecution toolExecution = ToolExecution.builder()
+                    .request(toolExecutionRequest)
+                    .result(toolExecutionResult)
+                    .invocationContext(invocationContext)
+                    .build();
+            if (toolExecuteHandler != null) {
+                toolExecuteHandler.accept(toolExecution);
+            }
+            addToMemory(toolExecutionResultMessage);
+        }
+    }
+
     @Override
     public void onCompleteResponse(ChatResponse completeResponse) {
         if (isCancelled()) {
@@ -634,68 +698,7 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
                         shutdown();
                         return;
                     }
-                    addToMemory(aiMessage);
-                    List<ToolExecutionRequest> toolExecutionRequests = aiMessage.toolExecutionRequests();
-                    int maxToolCallsPerResponse;
-                    if (context.maxToolCallsPerResponse != null && context.maxToolCallsPerResponse != 0) {
-                        maxToolCallsPerResponse = context.maxToolCallsPerResponse;
-                    } else {
-                        maxToolCallsPerResponse = ConfigProvider.getConfig()
-                                .getOptionalValue("quarkus.langchain4j.ai-service.max-tool-calls-per-response", Integer.class)
-                                .orElse(0);
-                    }
-                    int toolCallsCount = 0;
-                    for (ToolExecutionRequest toolExecutionRequest : toolExecutionRequests) {
-                        if (maxToolCallsPerResponse > 0 && toolCallsCount >= maxToolCallsPerResponse) {
-                            throw new ToolCallsLimitExceededException(maxToolCallsPerResponse,
-                                    toolExecutionRequests.size());
-                        }
-                        toolCallsCount++;
-                        if (isCancelled()) {
-                            // Fill cancelled tools with error results to keep memory consistent:
-                            // every tool request must have a matching tool result
-                            ToolExecutionResultMessage cancelledResult = ToolExecutionResultMessage.from(
-                                    toolExecutionRequest, "Tool execution was cancelled");
-                            QuarkusAiServiceStreamingResponseHandler.this.addToMemory(cancelledResult);
-                            continue;
-                        }
-                        // Call before tool execution handler
-                        if (beforeToolExecutionHandler != null) {
-                            BeforeToolExecution beforeToolExecution = BeforeToolExecution.builder()
-                                    .request(toolExecutionRequest)
-                                    .invocationContext(invocationContext)
-                                    .build();
-                            beforeToolExecutionHandler.accept(beforeToolExecution);
-                        }
-
-                        String toolName = toolExecutionRequest.name();
-                        ToolExecutor toolExecutor = toolExecutors.get(toolName);
-                        // Execute the tool with argumentsErrorHandler and executionErrorHandler.
-                        // If execution fails, these handlers convert exceptions into error results
-                        // that are sent back to the LLM, allowing it to recover from tool failures.
-                        ToolExecutionResult toolExecutionResult = executeTool(
-                                toolExecutionRequest,
-                                toolExecutor,
-                                invocationContext,
-                                context.toolService.argumentsErrorHandler(),
-                                context.toolService.executionErrorHandler());
-
-                        fireToolExecutedEvent(toolExecutionRequest, toolExecutionResult.resultText());
-
-                        ToolExecutionResultMessage toolExecutionResultMessage = ToolExecutionResultMessage.from(
-                                toolExecutionRequest,
-                                toolExecutionResult.resultText());
-
-                        ToolExecution toolExecution = ToolExecution.builder()
-                                .request(toolExecutionRequest)
-                                .result(toolExecutionResult)
-                                .invocationContext(invocationContext)
-                                .build();
-                        if (toolExecuteHandler != null) {
-                            toolExecuteHandler.accept(toolExecution);
-                        }
-                        QuarkusAiServiceStreamingResponseHandler.this.addToMemory(toolExecutionResultMessage);
-                    }
+                    runSerialToolBatch(aiMessage);
 
                     if (isCancelled()) {
                         shutdown();

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceStreamingResponseHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceStreamingResponseHandler.java
@@ -639,14 +639,30 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
             futures[i] = VirtualThreadsRecorder.getCurrent().submit(new Runnable() {
                 @Override
                 public void run() {
-                    runParallelToolTask(request, index, results, semaphore);
+                    try {
+                        runParallelToolTask(request, index, results, semaphore);
+                    } catch (Throwable t) {
+                        // Make sure the slot is filled so memory stays consistent (one result per
+                        // request) regardless of how the failure surfaced — uncaught exceptions
+                        // from tools without a configured error handler, PreventsErrorHandlerExecution
+                        // throws, or Errors that escape executeTool's catch.
+                        if (results[index] == null) {
+                            results[index] = ToolExecutionResultMessage.from(request, errorResultText(t));
+                        }
+                        if (t instanceof RuntimeException re) {
+                            throw re;
+                        }
+                        if (t instanceof Error err) {
+                            throw err;
+                        }
+                        throw new RuntimeException(t);
+                    }
                 }
             });
         }
 
-        // Wait for all tasks. Capture the first error so we can rethrow after every task settles —
-        // half-finished memory state is no worse than the historical serial behaviour on uncaught
-        // throws, but waiting prevents leaving in-flight tools unattended.
+        // Wait for every task. Capture the first error so we can rethrow after each slot has
+        // either a real result, a cancellation marker, or a synthesized error result.
         Throwable firstError = null;
         for (Future<?> future : futures) {
             try {
@@ -664,12 +680,10 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
             }
         }
 
-        // Append whichever results completed, in request order. Tasks that threw leave a null slot;
-        // skip those so the LLM never sees a corrupted result, but propagate the throw below.
+        // Memory now holds one result per request — success, cancellation marker, or synthesized
+        // error result — so the conversation stays consistent even if onError fires below.
         for (ToolExecutionResultMessage message : results) {
-            if (message != null) {
-                addToMemory(message);
-            }
+            addToMemory(message);
         }
 
         if (firstError != null) {
@@ -681,6 +695,11 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
             }
             throw new RuntimeException(firstError);
         }
+    }
+
+    private static String errorResultText(Throwable t) {
+        String message = t.getMessage();
+        return "Tool execution failed: " + (message != null ? message : t.getClass().getSimpleName());
     }
 
     private void runParallelToolTask(ToolExecutionRequest request, int index,

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceStreamingResponseHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceStreamingResponseHandler.java
@@ -617,6 +617,15 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
         List<ToolExecutionRequest> requests = aiMessage.toolExecutionRequests();
         int n = requests.size();
 
+        // Enforce the per-response tool-call limit before any work is done. Serial mode allows
+        // partial execution then throws on the (limit+1)th iteration; parallel mode rejects the
+        // whole batch up-front because partial fan-out would race with task submission and
+        // leave memory inconsistent.
+        int maxToolCallsPerResponse = resolveMaxToolCallsPerResponse();
+        if (maxToolCallsPerResponse > 0 && n > maxToolCallsPerResponse) {
+            throw new ToolCallsLimitExceededException(maxToolCallsPerResponse, n);
+        }
+
         // Fire BeforeToolExecution events on the carrier thread, in request order, before fan-out.
         // Keeps observability semantics predictable: subscribers always see "before" in request order.
         if (beforeToolExecutionHandler != null) {
@@ -662,22 +671,34 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
             });
         }
 
-        // Wait for every task. Capture the first error so we can rethrow after each slot has
-        // either a real result, a cancellation marker, or a synthesized error result.
+        // Drain every future before returning. We deliberately swallow InterruptedException inside
+        // the wait loop and only re-set the carrier's interrupt flag at the end, so an interrupted
+        // carrier still fills every result slot. Re-setting the flag immediately would cause the
+        // remaining future.get() calls to throw straight away, leaving in-flight tasks unattended
+        // and breaking the "one result per request" guarantee.
+        boolean wasInterrupted = false;
         Throwable firstError = null;
         for (Future<?> future : futures) {
-            try {
-                future.get();
-            } catch (InterruptedException ie) {
-                Thread.currentThread().interrupt();
-                if (firstError == null) {
-                    firstError = ie;
+            while (true) {
+                try {
+                    future.get();
+                    break;
+                } catch (InterruptedException ie) {
+                    wasInterrupted = true;
+                    // Flag was cleared by InterruptedException; keep waiting on this future.
+                } catch (ExecutionException ee) {
+                    Throwable cause = ee.getCause() != null ? ee.getCause() : ee;
+                    if (firstError == null) {
+                        firstError = cause;
+                    }
+                    break;
                 }
-            } catch (ExecutionException ee) {
-                Throwable cause = ee.getCause() != null ? ee.getCause() : ee;
-                if (firstError == null) {
-                    firstError = cause;
-                }
+            }
+        }
+        if (wasInterrupted) {
+            Thread.currentThread().interrupt();
+            if (firstError == null) {
+                firstError = new InterruptedException("Carrier interrupted while waiting for parallel tool tasks");
             }
         }
 
@@ -701,6 +722,15 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
     private static String errorResultText(Throwable t) {
         String message = t.getMessage();
         return "Tool execution failed: " + (message != null ? message : t.getClass().getSimpleName());
+    }
+
+    private int resolveMaxToolCallsPerResponse() {
+        if (context.maxToolCallsPerResponse != null && context.maxToolCallsPerResponse != 0) {
+            return context.maxToolCallsPerResponse;
+        }
+        return ConfigProvider.getConfig()
+                .getOptionalValue("quarkus.langchain4j.ai-service.max-tool-calls-per-response", Integer.class)
+                .orElse(0);
     }
 
     private void runParallelToolTask(ToolExecutionRequest request, int index,
@@ -751,14 +781,7 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
     private void runSerialToolBatch(AiMessage aiMessage) {
         addToMemory(aiMessage);
         List<ToolExecutionRequest> toolExecutionRequests = aiMessage.toolExecutionRequests();
-        int maxToolCallsPerResponse;
-        if (context.maxToolCallsPerResponse != null && context.maxToolCallsPerResponse != 0) {
-            maxToolCallsPerResponse = context.maxToolCallsPerResponse;
-        } else {
-            maxToolCallsPerResponse = ConfigProvider.getConfig()
-                    .getOptionalValue("quarkus.langchain4j.ai-service.max-tool-calls-per-response", Integer.class)
-                    .orElse(0);
-        }
+        int maxToolCallsPerResponse = resolveMaxToolCallsPerResponse();
         int toolCallsCount = 0;
         for (ToolExecutionRequest toolExecutionRequest : toolExecutionRequests) {
             if (maxToolCallsPerResponse > 0 && toolCallsCount >= maxToolCallsPerResponse) {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceStreamingResponseHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceStreamingResponseHandler.java
@@ -9,8 +9,10 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -323,7 +325,8 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
         return streamingHandle;
     }
 
-    private void executeTools(Runnable runnable, List<ToolExecutionRequest> toolExecutionRequests) {
+    private void executeTools(Runnable runnable, boolean dispatchToVirtualThread, boolean parallelBatch,
+            ToolsDispatcher dispatcher) {
         Runnable safeRunnable = new Runnable() {
             @Override
             public void run() {
@@ -335,9 +338,11 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
             }
         };
 
-        ToolsDispatcher dispatcher = toolsDispatcher();
-        if (shouldDispatchToVirtualThread(toolExecutionRequests, dispatcher)) {
-            executeWithBatchVirtualThreadDispatch(safeRunnable, dispatcher);
+        if (dispatchToVirtualThread) {
+            // In parallel mode the per-tool tasks acquire their own permits, so the carrier
+            // does not hold a batch permit (otherwise max-concurrent would be double-counted
+            // and admit fewer tools than configured).
+            executeWithBatchVirtualThreadDispatch(safeRunnable, dispatcher, !parallelBatch);
         } else if (mustSwitchToWorkerThread && Context.isOnEventLoopThread()) {
             executeOnWorkerThread(safeRunnable, false);
         } else {
@@ -355,14 +360,12 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
         }
     }
 
-    private boolean shouldDispatchToVirtualThread(List<ToolExecutionRequest> toolExecutionRequests,
-            ToolsDispatcher dispatcher) {
+    private boolean shouldDispatchToVirtualThread(BatchDispatchDecision decision, ToolsDispatcher dispatcher) {
         switch (dispatcher.dispatchMode()) {
             case LEGACY:
                 return false;
             case AUTO:
             default:
-                BatchDispatchDecision decision = determineBatchDispatchDecision(toolExecutionRequests);
                 switch (decision.mode()) {
                     case ALL_VIRTUAL_THREAD:
                         return true;
@@ -449,11 +452,12 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
         return nestedSeparator >= 0 ? simpleName.substring(nestedSeparator + 1) : simpleName;
     }
 
-    private void executeWithBatchVirtualThreadDispatch(Runnable runnable, ToolsDispatcher dispatcher) {
+    private void executeWithBatchVirtualThreadDispatch(Runnable runnable, ToolsDispatcher dispatcher,
+            boolean acquireBatchPermit) {
         Runnable guardedRunnable = new Runnable() {
             @Override
             public void run() {
-                Semaphore semaphore = dispatcher.semaphore();
+                Semaphore semaphore = acquireBatchPermit ? dispatcher.semaphore() : null;
                 boolean acquired = false;
                 try {
                     if (semaphore != null) {
@@ -609,6 +613,120 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
         return toolExecutionResult;
     }
 
+    private void runParallelToolBatch(AiMessage aiMessage, ToolsDispatcher dispatcher) {
+        List<ToolExecutionRequest> requests = aiMessage.toolExecutionRequests();
+        int n = requests.size();
+
+        // Fire BeforeToolExecution events on the carrier thread, in request order, before fan-out.
+        // Keeps observability semantics predictable: subscribers always see "before" in request order.
+        if (beforeToolExecutionHandler != null) {
+            for (ToolExecutionRequest request : requests) {
+                beforeToolExecutionHandler.accept(BeforeToolExecution.builder()
+                        .request(request)
+                        .build());
+            }
+        }
+
+        addToMemory(aiMessage);
+
+        Semaphore semaphore = dispatcher.semaphore();
+        ToolExecutionResultMessage[] results = new ToolExecutionResultMessage[n];
+        Future<?>[] futures = new Future<?>[n];
+
+        for (int i = 0; i < n; i++) {
+            final int index = i;
+            final ToolExecutionRequest request = requests.get(i);
+            futures[i] = VirtualThreadsRecorder.getCurrent().submit(new Runnable() {
+                @Override
+                public void run() {
+                    runParallelToolTask(request, index, results, semaphore);
+                }
+            });
+        }
+
+        // Wait for all tasks. Capture the first error so we can rethrow after every task settles —
+        // half-finished memory state is no worse than the historical serial behaviour on uncaught
+        // throws, but waiting prevents leaving in-flight tools unattended.
+        Throwable firstError = null;
+        for (Future<?> future : futures) {
+            try {
+                future.get();
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                if (firstError == null) {
+                    firstError = ie;
+                }
+            } catch (ExecutionException ee) {
+                Throwable cause = ee.getCause() != null ? ee.getCause() : ee;
+                if (firstError == null) {
+                    firstError = cause;
+                }
+            }
+        }
+
+        // Append whichever results completed, in request order. Tasks that threw leave a null slot;
+        // skip those so the LLM never sees a corrupted result, but propagate the throw below.
+        for (ToolExecutionResultMessage message : results) {
+            if (message != null) {
+                addToMemory(message);
+            }
+        }
+
+        if (firstError != null) {
+            if (firstError instanceof RuntimeException re) {
+                throw re;
+            }
+            if (firstError instanceof Error err) {
+                throw err;
+            }
+            throw new RuntimeException(firstError);
+        }
+    }
+
+    private void runParallelToolTask(ToolExecutionRequest request, int index,
+            ToolExecutionResultMessage[] results, Semaphore semaphore) {
+        if (isCancelled()) {
+            results[index] = ToolExecutionResultMessage.from(request, "Tool execution was cancelled");
+            return;
+        }
+        boolean acquired = false;
+        try {
+            if (semaphore != null) {
+                semaphore.acquire();
+                acquired = true;
+            }
+            if (isCancelled()) {
+                results[index] = ToolExecutionResultMessage.from(request, "Tool execution was cancelled");
+                return;
+            }
+            ToolExecutor toolExecutor = toolExecutors.get(request.name());
+            ToolExecutionResult toolExecutionResult = executeTool(
+                    request,
+                    toolExecutor,
+                    invocationContext,
+                    context.toolService.argumentsErrorHandler(),
+                    context.toolService.executionErrorHandler());
+
+            fireToolExecutedEvent(request, toolExecutionResult.resultText());
+
+            if (toolExecuteHandler != null) {
+                toolExecuteHandler.accept(ToolExecution.builder()
+                        .request(request)
+                        .result(toolExecutionResult)
+                        .build());
+            }
+
+            results[index] = ToolExecutionResultMessage.from(request, toolExecutionResult.resultText());
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(ie);
+        } finally {
+            if (acquired) {
+                semaphore.release();
+            }
+        }
+    }
+
     private void runSerialToolBatch(AiMessage aiMessage) {
         addToMemory(aiMessage);
         List<ToolExecutionRequest> toolExecutionRequests = aiMessage.toolExecutionRequests();
@@ -689,6 +807,14 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
             if (intermediateResponseHandler != null) {
                 intermediateResponseHandler.accept(completeResponse);
             }
+            ToolsDispatcher dispatcher = toolsDispatcher();
+            BatchDispatchDecision decision = determineBatchDispatchDecision(aiMessage.toolExecutionRequests());
+            boolean dispatchToVirtualThread = shouldDispatchToVirtualThread(decision, dispatcher);
+            // A single-tool batch has nothing to parallelize: fan-out would just spawn an extra
+            // virtual thread and block the carrier on Future#get for no concurrency benefit.
+            boolean parallelBatch = dispatchToVirtualThread
+                    && dispatcher.parallelVirtualThreadBatch()
+                    && aiMessage.toolExecutionRequests().size() > 1;
             // Tools execution may block the caller thread. When the caller thread is the event loop thread, and
             // when tools have been detected to be potentially blocking, we need to switch to a worker thread.
             executeTools(new Runnable() {
@@ -698,7 +824,11 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
                         shutdown();
                         return;
                     }
-                    runSerialToolBatch(aiMessage);
+                    if (parallelBatch) {
+                        runParallelToolBatch(aiMessage, dispatcher);
+                    } else {
+                        runSerialToolBatch(aiMessage);
+                    }
 
                     if (isCancelled()) {
                         shutdown();
@@ -751,7 +881,7 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
                     fireRequestIssuedEvent(chatRequest);
                     effectiveStreamingChatModel.chat(chatRequest, handler);
                 }
-            }, aiMessage.toolExecutionRequests());
+            }, dispatchToVirtualThread, parallelBatch, dispatcher);
         } else {
             if (completeResponseHandler != null) {
                 Runnable runnable = new Runnable() {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceStreamingResponseHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceStreamingResponseHandler.java
@@ -623,6 +623,7 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
             for (ToolExecutionRequest request : requests) {
                 beforeToolExecutionHandler.accept(BeforeToolExecution.builder()
                         .request(request)
+                        .invocationContext(invocationContext)
                         .build());
             }
         }
@@ -732,6 +733,7 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
                 toolExecuteHandler.accept(ToolExecution.builder()
                         .request(request)
                         .result(toolExecutionResult)
+                        .invocationContext(invocationContext)
                         .build());
             }
 

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceStreamingResponseHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceStreamingResponseHandler.java
@@ -5,6 +5,7 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static java.util.Objects.nonNull;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -336,13 +337,7 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
 
         ToolsDispatcher dispatcher = toolsDispatcher();
         if (shouldDispatchToVirtualThread(toolExecutionRequests, dispatcher)) {
-            if (VirtualThreadSupport.isCurrentThreadVirtual()) {
-                // Already on a virtual thread, run inline. The isVirtual() guard in
-                // QuarkusToolExecutor keeps per-tool dispatch from re-submitting.
-                safeRunnable.run();
-            } else {
-                executeOnVirtualThread(safeRunnable, dispatcher);
-            }
+            executeWithBatchVirtualThreadDispatch(safeRunnable, dispatcher);
         } else if (mustSwitchToWorkerThread && Context.isOnEventLoopThread()) {
             executeOnWorkerThread(safeRunnable, false);
         } else {
@@ -363,18 +358,16 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
     private boolean shouldDispatchToVirtualThread(List<ToolExecutionRequest> toolExecutionRequests,
             ToolsDispatcher dispatcher) {
         switch (dispatcher.dispatchMode()) {
-            case WORKER:
+            case LEGACY:
                 return false;
-            case VIRTUAL_THREAD:
-                return true;
             case AUTO:
             default:
-                BatchExecutionMode mode = determineBatchMode(toolExecutionRequests);
-                switch (mode) {
+                BatchDispatchDecision decision = determineBatchDispatchDecision(toolExecutionRequests);
+                switch (decision.mode()) {
                     case ALL_VIRTUAL_THREAD:
                         return true;
                     case MIXED:
-                        logMixedBatch(dispatcher.mixedBatchLogLevel());
+                        logMixedBatch(dispatcher.mixedBatchLogLevel(), decision);
                         return false;
                     case NONE_VIRTUAL_THREAD:
                     default:
@@ -383,14 +376,18 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
         }
     }
 
-    private BatchExecutionMode determineBatchMode(List<ToolExecutionRequest> toolExecutionRequests) {
+    private BatchDispatchDecision determineBatchDispatchDecision(List<ToolExecutionRequest> toolExecutionRequests) {
         if (toolExecutionRequests == null || toolExecutionRequests.isEmpty()) {
-            return BatchExecutionMode.NONE_VIRTUAL_THREAD;
+            return new BatchDispatchDecision(BatchExecutionMode.NONE_VIRTUAL_THREAD, List.of(), List.of());
         }
         boolean anyVirtual = false;
         boolean anyOther = false;
+        LinkedHashSet<String> requestedToolNames = new LinkedHashSet<>();
+        LinkedHashSet<String> nonVirtualThreadToolNames = new LinkedHashSet<>();
         for (ToolExecutionRequest request : toolExecutionRequests) {
-            ToolExecutor toolExecutor = toolExecutors.get(request.name());
+            String toolName = request.name();
+            requestedToolNames.add(toolName);
+            ToolExecutor toolExecutor = toolExecutors.get(toolName);
             if (toolExecutor instanceof QuarkusToolExecutor quarkusToolExecutor
                     && quarkusToolExecutor.getMethodCreateInfo() != null
                     && quarkusToolExecutor.getMethodCreateInfo()
@@ -399,22 +396,28 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
             } else {
                 // Unknown executors (e.g. MCP) are treated as non-virtual-thread.
                 anyOther = true;
+                nonVirtualThreadToolNames.add(toolName);
             }
         }
         if (anyVirtual && anyOther) {
-            return BatchExecutionMode.MIXED;
+            return new BatchDispatchDecision(BatchExecutionMode.MIXED, List.copyOf(requestedToolNames),
+                    List.copyOf(nonVirtualThreadToolNames));
         }
         if (anyVirtual) {
-            return BatchExecutionMode.ALL_VIRTUAL_THREAD;
+            return new BatchDispatchDecision(BatchExecutionMode.ALL_VIRTUAL_THREAD, List.copyOf(requestedToolNames),
+                    List.of());
         }
-        return BatchExecutionMode.NONE_VIRTUAL_THREAD;
+        return new BatchDispatchDecision(BatchExecutionMode.NONE_VIRTUAL_THREAD, List.copyOf(requestedToolNames),
+                List.copyOf(nonVirtualThreadToolNames));
     }
 
-    private void logMixedBatch(ToolsConfig.MixedBatchLogLevel level) {
-        String message = "Mixed tool execution models in a single batch: at least one @RunOnVirtualThread tool is "
-                + "scheduled alongside a blocking or non-blocking tool. Falling back to worker-thread dispatch for the "
-                + "whole batch. Annotate all tools in this batch with @RunOnVirtualThread to enable virtual-thread "
-                + "dispatch, or set quarkus.langchain4j.tools.mixed-batch-log-level=off to silence this warning.";
+    private void logMixedBatch(ToolsConfig.MixedBatchLogLevel level, BatchDispatchDecision decision) {
+        String message = "Mixed tool execution models detected for AI service method " + aiServiceMethodDescription()
+                + ". Requested tools: " + decision.requestedToolNames()
+                + ". Non-VIRTUAL_THREAD tools: " + decision.nonVirtualThreadToolNames()
+                + ". Skipping the full-batch virtual-thread dispatch optimization and using legacy per-tool scheduling "
+                + "instead. The optimization only applies when every requested tool resolves to the VIRTUAL_THREAD "
+                + "execution model. Set quarkus.langchain4j.tools.mixed-batch-log-level=off to silence this warning.";
         switch (level) {
             case WARN:
                 log.warn(message);
@@ -432,8 +435,22 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
         }
     }
 
-    private void executeOnVirtualThread(Runnable runnable, ToolsDispatcher dispatcher) {
-        VirtualThreadsRecorder.getCurrent().execute(new Runnable() {
+    private String aiServiceMethodDescription() {
+        if (methodCreateInfo == null) {
+            return "<unknown>";
+        }
+        return simpleTypeName(methodCreateInfo.getInterfaceName()) + "#" + methodCreateInfo.getMethodName();
+    }
+
+    private String simpleTypeName(String typeName) {
+        int packageSeparator = typeName.lastIndexOf('.');
+        String simpleName = packageSeparator >= 0 ? typeName.substring(packageSeparator + 1) : typeName;
+        int nestedSeparator = simpleName.lastIndexOf('$');
+        return nestedSeparator >= 0 ? simpleName.substring(nestedSeparator + 1) : simpleName;
+    }
+
+    private void executeWithBatchVirtualThreadDispatch(Runnable runnable, ToolsDispatcher dispatcher) {
+        Runnable guardedRunnable = new Runnable() {
             @Override
             public void run() {
                 Semaphore semaphore = dispatcher.semaphore();
@@ -458,13 +475,49 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
                     }
                 }
             }
-        });
+        };
+
+        if (VirtualThreadSupport.isCurrentThreadVirtual()) {
+            // Already on a virtual thread, run inline but still apply the concurrency cap.
+            guardedRunnable.run();
+        } else {
+            executeOnVirtualThread(guardedRunnable);
+        }
+    }
+
+    private void executeOnVirtualThread(Runnable runnable) {
+        VirtualThreadsRecorder.getCurrent().execute(runnable);
     }
 
     private enum BatchExecutionMode {
         ALL_VIRTUAL_THREAD,
         NONE_VIRTUAL_THREAD,
         MIXED
+    }
+
+    private static final class BatchDispatchDecision {
+        private final BatchExecutionMode mode;
+        private final List<String> requestedToolNames;
+        private final List<String> nonVirtualThreadToolNames;
+
+        private BatchDispatchDecision(BatchExecutionMode mode, List<String> requestedToolNames,
+                List<String> nonVirtualThreadToolNames) {
+            this.mode = mode;
+            this.requestedToolNames = requestedToolNames;
+            this.nonVirtualThreadToolNames = nonVirtualThreadToolNames;
+        }
+
+        private BatchExecutionMode mode() {
+            return mode;
+        }
+
+        private List<String> requestedToolNames() {
+            return requestedToolNames;
+        }
+
+        private List<String> nonVirtualThreadToolNames() {
+            return nonVirtualThreadToolNames;
+        }
     }
 
     private void execute(Runnable runnable) {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceStreamingResponseHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceStreamingResponseHandler.java
@@ -10,8 +10,11 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+
+import jakarta.enterprise.inject.spi.CDI;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
@@ -56,6 +59,11 @@ import dev.langchain4j.service.tool.ToolExecutionResult;
 import dev.langchain4j.service.tool.ToolExecutor;
 import io.quarkiverse.langchain4j.runtime.PreventsErrorHandlerExecution;
 import io.quarkiverse.langchain4j.runtime.ToolCallsLimitExceededException;
+import io.quarkiverse.langchain4j.runtime.VirtualThreadSupport;
+import io.quarkiverse.langchain4j.runtime.config.ToolsConfig;
+import io.quarkiverse.langchain4j.runtime.tool.QuarkusToolExecutor;
+import io.quarkiverse.langchain4j.runtime.tool.ToolMethodCreateInfo;
+import io.quarkus.virtual.threads.VirtualThreadsRecorder;
 import io.vertx.core.Context;
 
 /**
@@ -314,7 +322,7 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
         return streamingHandle;
     }
 
-    private void executeTools(Runnable runnable) {
+    private void executeTools(Runnable runnable, List<ToolExecutionRequest> toolExecutionRequests) {
         Runnable safeRunnable = new Runnable() {
             @Override
             public void run() {
@@ -326,11 +334,137 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
             }
         };
 
-        if (mustSwitchToWorkerThread && Context.isOnEventLoopThread()) {
+        ToolsDispatcher dispatcher = toolsDispatcher();
+        if (shouldDispatchToVirtualThread(toolExecutionRequests, dispatcher)) {
+            if (VirtualThreadSupport.isCurrentThreadVirtual()) {
+                // Already on a virtual thread, run inline. The isVirtual() guard in
+                // QuarkusToolExecutor keeps per-tool dispatch from re-submitting.
+                safeRunnable.run();
+            } else {
+                executeOnVirtualThread(safeRunnable, dispatcher);
+            }
+        } else if (mustSwitchToWorkerThread && Context.isOnEventLoopThread()) {
             executeOnWorkerThread(safeRunnable, false);
         } else {
             safeRunnable.run();
         }
+    }
+
+    private static ToolsDispatcher toolsDispatcher() {
+        try {
+            return CDI.current().select(ToolsDispatcher.class).get();
+        } catch (RuntimeException ignored) {
+            // CDI not available (e.g. bootstrap paths where the container is not yet up);
+            // fall back to defaults.
+            return ToolsDispatcher.DEFAULT;
+        }
+    }
+
+    private boolean shouldDispatchToVirtualThread(List<ToolExecutionRequest> toolExecutionRequests,
+            ToolsDispatcher dispatcher) {
+        switch (dispatcher.dispatchMode()) {
+            case WORKER:
+                return false;
+            case VIRTUAL_THREAD:
+                return true;
+            case AUTO:
+            default:
+                BatchExecutionMode mode = determineBatchMode(toolExecutionRequests);
+                switch (mode) {
+                    case ALL_VIRTUAL_THREAD:
+                        return true;
+                    case MIXED:
+                        logMixedBatch(dispatcher.mixedBatchLogLevel());
+                        return false;
+                    case NONE_VIRTUAL_THREAD:
+                    default:
+                        return false;
+                }
+        }
+    }
+
+    private BatchExecutionMode determineBatchMode(List<ToolExecutionRequest> toolExecutionRequests) {
+        if (toolExecutionRequests == null || toolExecutionRequests.isEmpty()) {
+            return BatchExecutionMode.NONE_VIRTUAL_THREAD;
+        }
+        boolean anyVirtual = false;
+        boolean anyOther = false;
+        for (ToolExecutionRequest request : toolExecutionRequests) {
+            ToolExecutor toolExecutor = toolExecutors.get(request.name());
+            if (toolExecutor instanceof QuarkusToolExecutor quarkusToolExecutor
+                    && quarkusToolExecutor.getMethodCreateInfo() != null
+                    && quarkusToolExecutor.getMethodCreateInfo()
+                            .executionModel() == ToolMethodCreateInfo.ExecutionModel.VIRTUAL_THREAD) {
+                anyVirtual = true;
+            } else {
+                // Unknown executors (e.g. MCP) are treated as non-virtual-thread.
+                anyOther = true;
+            }
+        }
+        if (anyVirtual && anyOther) {
+            return BatchExecutionMode.MIXED;
+        }
+        if (anyVirtual) {
+            return BatchExecutionMode.ALL_VIRTUAL_THREAD;
+        }
+        return BatchExecutionMode.NONE_VIRTUAL_THREAD;
+    }
+
+    private void logMixedBatch(ToolsConfig.MixedBatchLogLevel level) {
+        String message = "Mixed tool execution models in a single batch: at least one @RunOnVirtualThread tool is "
+                + "scheduled alongside a blocking or non-blocking tool. Falling back to worker-thread dispatch for the "
+                + "whole batch. Annotate all tools in this batch with @RunOnVirtualThread to enable virtual-thread "
+                + "dispatch, or set quarkus.langchain4j.tools.mixed-batch-log-level=off to silence this warning.";
+        switch (level) {
+            case WARN:
+                log.warn(message);
+                break;
+            case INFO:
+                log.info(message);
+                break;
+            case DEBUG:
+                log.debug(message);
+                break;
+            case OFF:
+            default:
+                // no-op
+                break;
+        }
+    }
+
+    private void executeOnVirtualThread(Runnable runnable, ToolsDispatcher dispatcher) {
+        VirtualThreadsRecorder.getCurrent().execute(new Runnable() {
+            @Override
+            public void run() {
+                Semaphore semaphore = dispatcher.semaphore();
+                boolean acquired = false;
+                try {
+                    if (semaphore != null) {
+                        semaphore.acquire();
+                        acquired = true;
+                    }
+                    runnable.run();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    onError(e);
+                } catch (Throwable t) {
+                    // Defensive: safeRunnable already routes Exception to onError, but catch
+                    // Throwable here so nothing escapes into the virtual-thread executor's
+                    // uncaught-exception handler silently.
+                    onError(t);
+                } finally {
+                    if (acquired) {
+                        semaphore.release();
+                    }
+                }
+            }
+        });
+    }
+
+    private enum BatchExecutionMode {
+        ALL_VIRTUAL_THREAD,
+        NONE_VIRTUAL_THREAD,
+        MIXED
     }
 
     private void execute(Runnable runnable) {
@@ -561,7 +695,7 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
                     fireRequestIssuedEvent(chatRequest);
                     effectiveStreamingChatModel.chat(chatRequest, handler);
                 }
-            });
+            }, aiMessage.toolExecutionRequests());
         } else {
             if (completeResponseHandler != null) {
                 Runnable runnable = new Runnable() {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/ToolsDispatcher.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/ToolsDispatcher.java
@@ -36,6 +36,7 @@ public class ToolsDispatcher {
     private ToolsConfig.DispatchMode dispatchMode;
     private ToolsConfig.MixedBatchLogLevel mixedBatchLogLevel;
     private Semaphore semaphore;
+    private boolean parallelVirtualThreadBatch;
 
     @Inject
     public ToolsDispatcher(LangChain4jConfig config) {
@@ -47,6 +48,7 @@ public class ToolsDispatcher {
         this.dispatchMode = ToolsConfig.DispatchMode.AUTO;
         this.mixedBatchLogLevel = ToolsConfig.MixedBatchLogLevel.WARN;
         this.semaphore = null;
+        this.parallelVirtualThreadBatch = true;
     }
 
     @PostConstruct
@@ -59,6 +61,7 @@ public class ToolsDispatcher {
         this.mixedBatchLogLevel = tools.mixedBatchLogLevel();
         int max = tools.virtualThread().maxConcurrent().orElse(-1);
         this.semaphore = max > 0 ? new Semaphore(max) : null;
+        this.parallelVirtualThreadBatch = tools.parallelVirtualThreadBatch();
     }
 
     public ToolsConfig.DispatchMode dispatchMode() {
@@ -71,5 +74,9 @@ public class ToolsDispatcher {
 
     public Semaphore semaphore() {
         return semaphore;
+    }
+
+    public boolean parallelVirtualThreadBatch() {
+        return parallelVirtualThreadBatch;
     }
 }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/ToolsDispatcher.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/ToolsDispatcher.java
@@ -13,7 +13,7 @@ import io.quarkus.arc.Unremovable;
 /**
  * Holds the resolved tool-dispatch policy: the global dispatch mode, the log level for
  * mixed-batch warnings, and the (optional) shared semaphore that bounds concurrent
- * virtual-thread dispatches.
+ * batches using the batch-level virtual-thread dispatch path.
  *
  * <p>
  * Exposed as a CDI singleton so the semaphore is shared across every

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/ToolsDispatcher.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/ToolsDispatcher.java
@@ -11,9 +11,11 @@ import io.quarkiverse.langchain4j.runtime.config.ToolsConfig;
 import io.quarkus.arc.Unremovable;
 
 /**
- * Holds the resolved tool-dispatch policy: the global dispatch mode, the log level for
- * mixed-batch warnings, and the (optional) shared semaphore that bounds concurrent
- * batches using the batch-level virtual-thread dispatch path.
+ * Holds the resolved tool-dispatch policy: the global dispatch mode, whether multi-tool
+ * all-virtual-thread batches fan out in parallel, the log level for mixed-batch warnings,
+ * and the (optional) shared semaphore that bounds virtual-thread tool work. The semaphore
+ * is acquired per tool when batches run in parallel, and per batch when the parallel path
+ * is disabled.
  *
  * <p>
  * Exposed as a CDI singleton so the semaphore is shared across every

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/ToolsDispatcher.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/ToolsDispatcher.java
@@ -1,0 +1,75 @@
+package io.quarkiverse.langchain4j.runtime.aiservice;
+
+import java.util.concurrent.Semaphore;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import io.quarkiverse.langchain4j.runtime.config.LangChain4jConfig;
+import io.quarkiverse.langchain4j.runtime.config.ToolsConfig;
+import io.quarkus.arc.Unremovable;
+
+/**
+ * Holds the resolved tool-dispatch policy: the global dispatch mode, the log level for
+ * mixed-batch warnings, and the (optional) shared semaphore that bounds concurrent
+ * virtual-thread dispatches.
+ *
+ * <p>
+ * Exposed as a CDI singleton so the semaphore is shared across every
+ * {@link QuarkusAiServiceStreamingResponseHandler} instance in the container, while still
+ * being a fresh instance per Quarkus application boot (each {@code QuarkusUnitTest} starts
+ * its own container).
+ * </p>
+ */
+@Singleton
+@Unremovable
+public class ToolsDispatcher {
+
+    /**
+     * Fallback instance used when CDI is not available (should not happen in practice in a
+     * running Quarkus application; kept as a defensive default for bootstrap paths).
+     */
+    public static final ToolsDispatcher DEFAULT = new ToolsDispatcher();
+
+    private final LangChain4jConfig config;
+    private ToolsConfig.DispatchMode dispatchMode;
+    private ToolsConfig.MixedBatchLogLevel mixedBatchLogLevel;
+    private Semaphore semaphore;
+
+    @Inject
+    public ToolsDispatcher(LangChain4jConfig config) {
+        this.config = config;
+    }
+
+    private ToolsDispatcher() {
+        this.config = null;
+        this.dispatchMode = ToolsConfig.DispatchMode.AUTO;
+        this.mixedBatchLogLevel = ToolsConfig.MixedBatchLogLevel.WARN;
+        this.semaphore = null;
+    }
+
+    @PostConstruct
+    void init() {
+        if (config == null) {
+            return;
+        }
+        ToolsConfig tools = config.tools();
+        this.dispatchMode = tools.dispatch();
+        this.mixedBatchLogLevel = tools.mixedBatchLogLevel();
+        int max = tools.virtualThread().maxConcurrent().orElse(-1);
+        this.semaphore = max > 0 ? new Semaphore(max) : null;
+    }
+
+    public ToolsConfig.DispatchMode dispatchMode() {
+        return dispatchMode;
+    }
+
+    public ToolsConfig.MixedBatchLogLevel mixedBatchLogLevel() {
+        return mixedBatchLogLevel;
+    }
+
+    public Semaphore semaphore() {
+        return semaphore;
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/config/LangChain4jConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/config/LangChain4jConfig.java
@@ -57,4 +57,9 @@ public interface LangChain4jConfig {
      * AI Service configuration
      */
     AiServiceConfig aiService();
+
+    /**
+     * Tool execution configuration
+     */
+    ToolsConfig tools();
 }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/config/ToolsConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/config/ToolsConfig.java
@@ -26,6 +26,26 @@ public interface ToolsConfig {
     VirtualThreadConfig virtualThread();
 
     /**
+     * When the full-batch virtual-thread optimization applies (every requested tool resolves to
+     * {@code VIRTUAL_THREAD} in {@code auto} dispatch mode), execute the batch's tools in parallel —
+     * each tool runs on its own virtual thread — instead of serializing them on a single virtual
+     * thread. Tool result messages are appended to chat memory in request order regardless of
+     * completion order, so the LLM sees a stable conversation.
+     * <p>
+     * {@code BeforeToolExecution} events are fired in request order before fan-out;
+     * {@code ToolExecutedEvent} fires in completion order, from the per-tool virtual thread.
+     * Cancellation is best-effort: in-flight tools run to completion, tools that have not yet
+     * started fill in a cancellation result.
+     * <p>
+     * Default {@code true}. Set to {@code false} to keep the historical serialized-loop behavior
+     * for tools whose execution was implicitly ordered by the batch sequence. Tool calls within
+     * a batch are expected to be independent; if ordering matters the LLM should issue separate
+     * tool rounds rather than relying on intra-batch sequencing.
+     */
+    @WithDefault("true")
+    boolean parallelVirtualThreadBatch();
+
+    /**
      * Log level at which a warning is emitted when a tool batch contains a mix of
      * virtual-thread-eligible and other tools and the extension skips the
      * full-batch virtual-thread optimization, falling back to the historical per-tool scheduling

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/config/ToolsConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/config/ToolsConfig.java
@@ -1,0 +1,59 @@
+package io.quarkiverse.langchain4j.runtime.config;
+
+import java.util.OptionalInt;
+
+import io.smallrye.config.WithDefault;
+
+public interface ToolsConfig {
+
+    /**
+     * Controls how a batch of tool invocations emitted by a streaming AI service is dispatched.
+     * <ul>
+     * <li>{@code auto} (default): honor per-tool execution model detected at build time. When every tool
+     * in a batch is annotated {@code @RunOnVirtualThread} the batch is dispatched directly onto a virtual
+     * thread, releasing the calling event-loop/worker thread immediately. Otherwise the current
+     * worker-thread behavior is kept.</li>
+     * <li>{@code virtual-thread}: always dispatch tool batches onto a virtual thread, regardless of
+     * per-tool annotations.</li>
+     * <li>{@code worker}: always dispatch tool batches onto a worker thread (historical behavior).</li>
+     * </ul>
+     */
+    @WithDefault("auto")
+    DispatchMode dispatch();
+
+    /**
+     * Virtual-thread specific tuning.
+     */
+    VirtualThreadConfig virtualThread();
+
+    /**
+     * Log level at which a warning is emitted when a tool batch contains a mix of
+     * {@code @RunOnVirtualThread} and blocking/non-blocking tools and the extension falls back to
+     * worker-thread dispatch for the whole batch. Set to {@code off} to silence entirely.
+     */
+    @WithDefault("warn")
+    MixedBatchLogLevel mixedBatchLogLevel();
+
+    interface VirtualThreadConfig {
+
+        /**
+         * Maximum number of tool batches that can be in flight concurrently on virtual threads. When
+         * unset, dispatch is unbounded (the default). A value of 0 or a negative value is treated as
+         * unbounded.
+         */
+        OptionalInt maxConcurrent();
+    }
+
+    enum DispatchMode {
+        AUTO,
+        VIRTUAL_THREAD,
+        WORKER
+    }
+
+    enum MixedBatchLogLevel {
+        WARN,
+        INFO,
+        DEBUG,
+        OFF
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/config/ToolsConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/config/ToolsConfig.java
@@ -58,12 +58,16 @@ public interface ToolsConfig {
     interface VirtualThreadConfig {
 
         /**
-         * Maximum number of tool batches that can be in flight concurrently when using the
-         * batch-level virtual-thread dispatch path. This applies only to full
-         * {@code VIRTUAL_THREAD} batches in {@code auto} mode. The permit is held for the batch
-         * until tool execution finishes and the synchronous handoff to the next model call
-         * returns. When unset, dispatch is unbounded (the default). A value of 0 or a negative
-         * value is treated as unbounded.
+         * Maximum number of concurrent virtual-thread tool tasks across all in-flight batches.
+         * Applies only to full {@code VIRTUAL_THREAD} batches in {@code auto} mode.
+         * <p>
+         * With {@code parallel-virtual-thread-batch=true} (the default) the permit is held per
+         * tool task, so this caps simultaneously running tools. With
+         * {@code parallel-virtual-thread-batch=false} the permit is held per batch, so this caps
+         * in-flight serialized batches — the historical behaviour.
+         * <p>
+         * When unset, dispatch is unbounded (the default). A value of 0 or a negative value is
+         * treated as unbounded.
          */
         OptionalInt maxConcurrent();
     }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/config/ToolsConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/config/ToolsConfig.java
@@ -10,12 +10,11 @@ public interface ToolsConfig {
      * Controls how a batch of tool invocations emitted by a streaming AI service is dispatched.
      * <ul>
      * <li>{@code auto} (default): honor per-tool execution model detected at build time. When every tool
-     * in a batch is annotated {@code @RunOnVirtualThread} the batch is dispatched directly onto a virtual
-     * thread, releasing the calling event-loop/worker thread immediately. Otherwise the current
-     * worker-thread behavior is kept.</li>
-     * <li>{@code virtual-thread}: always dispatch tool batches onto a virtual thread, regardless of
-     * per-tool annotations.</li>
-     * <li>{@code worker}: always dispatch tool batches onto a worker thread (historical behavior).</li>
+     * in a batch resolves to {@code VIRTUAL_THREAD} the batch is dispatched directly onto a virtual
+     * thread, releasing the calling event-loop/worker thread immediately. Otherwise the historical
+     * per-tool scheduling behavior is kept.</li>
+     * <li>{@code legacy}: disable the batch-level virtual-thread optimization and keep the historical
+     * per-tool scheduling behavior.</li>
      * </ul>
      */
     @WithDefault("auto")
@@ -28,8 +27,10 @@ public interface ToolsConfig {
 
     /**
      * Log level at which a warning is emitted when a tool batch contains a mix of
-     * {@code @RunOnVirtualThread} and blocking/non-blocking tools and the extension falls back to
-     * worker-thread dispatch for the whole batch. Set to {@code off} to silence entirely.
+     * virtual-thread-eligible and other tools and the extension skips the
+     * full-batch virtual-thread optimization, falling back to the historical per-tool scheduling
+     * behavior. The warning includes the AI service method plus the requested and non-virtual
+     * tool names. Set to {@code off} to silence entirely.
      */
     @WithDefault("warn")
     MixedBatchLogLevel mixedBatchLogLevel();
@@ -37,17 +38,19 @@ public interface ToolsConfig {
     interface VirtualThreadConfig {
 
         /**
-         * Maximum number of tool batches that can be in flight concurrently on virtual threads. When
-         * unset, dispatch is unbounded (the default). A value of 0 or a negative value is treated as
-         * unbounded.
+         * Maximum number of tool batches that can be in flight concurrently when using the
+         * batch-level virtual-thread dispatch path. This applies only to full
+         * {@code VIRTUAL_THREAD} batches in {@code auto} mode. The permit is held for the batch
+         * until tool execution finishes and the synchronous handoff to the next model call
+         * returns. When unset, dispatch is unbounded (the default). A value of 0 or a negative
+         * value is treated as unbounded.
          */
         OptionalInt maxConcurrent();
     }
 
     enum DispatchMode {
         AUTO,
-        VIRTUAL_THREAD,
-        WORKER
+        LEGACY
     }
 
     enum MixedBatchLogLevel {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/QuarkusToolExecutor.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/QuarkusToolExecutor.java
@@ -20,6 +20,7 @@ import dev.langchain4j.service.tool.ToolExecutionResult;
 import dev.langchain4j.service.tool.ToolExecutor;
 import io.quarkiverse.langchain4j.QuarkusJsonCodecFactory;
 import io.quarkiverse.langchain4j.runtime.BlockingToolNotAllowedException;
+import io.quarkiverse.langchain4j.runtime.VirtualThreadSupport;
 import io.quarkiverse.langchain4j.runtime.prompt.Mappable;
 import io.quarkus.virtual.threads.VirtualThreadsRecorder;
 import io.smallrye.mutiny.Uni;
@@ -88,6 +89,11 @@ public class QuarkusToolExecutor implements ToolExecutor {
             case VIRTUAL_THREAD:
                 if (io.vertx.core.Context.isOnEventLoopThread()) {
                     throw new BlockingToolNotAllowedException("Cannot execute virtual thread tools on event loop thread");
+                }
+                if (VirtualThreadSupport.isCurrentThreadVirtual()) {
+                    // Already on a virtual thread (e.g. dispatched there by the streaming handler):
+                    // invoke directly instead of submitting to yet another virtual thread.
+                    return invoke(params, invokerInstance);
                 }
                 try {
                     return VirtualThreadsRecorder.getCurrent().submit(() -> invoke(params, invokerInstance))

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/QuarkusToolExecutor.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/QuarkusToolExecutor.java
@@ -124,6 +124,12 @@ public class QuarkusToolExecutor implements ToolExecutor {
             Object invocationResult = invokerInstance.invoke(context.tool, params);
             String result;
             if (invocationResult instanceof Uni<?>) { // TODO CS
+                // Uni/CompletionStage results are awaited synchronously here because the
+                // ToolExecutor interface is imperative and must return a String. For slow
+                // tools (long-running HTTP calls, expensive DB queries, etc.) the await
+                // ties up whichever thread reached this point, so users should annotate
+                // the tool with @RunOnVirtualThread — the streaming-handler dispatch makes
+                // sure the await then parks a virtual thread rather than a worker thread.
                 if (io.vertx.core.Context.isOnEventLoopThread()) {
                     throw new BlockingToolNotAllowedException(
                             "Cannot execute tools returning Uni on event loop thread due to a tool executor limitation");

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/QuarkusToolExecutor.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/QuarkusToolExecutor.java
@@ -123,14 +123,11 @@ public class QuarkusToolExecutor implements ToolExecutor {
             }
             Object invocationResult = invokerInstance.invoke(context.tool, params);
             String result;
-            if (invocationResult instanceof Uni<?>) { // TODO CS
-                // Uni/CompletionStage results are awaited synchronously here because the
-                // ToolExecutor interface is imperative and must return a String. For slow
-                // tools (long-running HTTP calls, expensive DB queries, etc.) the await
-                // ties up whichever thread reached this point. In this branch, tools
-                // returning Uni/CompletionStage still follow the legacy non-blocking
-                // scheduling model; proper async propagation through the streaming tool
-                // pipeline remains follow-up work.
+            if (invocationResult instanceof Uni<?>) { // TODO CS, async propagation
+                // Awaited synchronously: ToolExecutor is imperative and must return a String.
+                // The await parks the calling thread, so a slow Uni tool ties up a worker
+                // for the duration (the event-loop guard below ensures it is never the
+                // event loop).
                 if (io.vertx.core.Context.isOnEventLoopThread()) {
                     throw new BlockingToolNotAllowedException(
                             "Cannot execute tools returning Uni on event loop thread due to a tool executor limitation");

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/QuarkusToolExecutor.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/QuarkusToolExecutor.java
@@ -127,9 +127,10 @@ public class QuarkusToolExecutor implements ToolExecutor {
                 // Uni/CompletionStage results are awaited synchronously here because the
                 // ToolExecutor interface is imperative and must return a String. For slow
                 // tools (long-running HTTP calls, expensive DB queries, etc.) the await
-                // ties up whichever thread reached this point, so users should annotate
-                // the tool with @RunOnVirtualThread — the streaming-handler dispatch makes
-                // sure the await then parks a virtual thread rather than a worker thread.
+                // ties up whichever thread reached this point. In this branch, tools
+                // returning Uni/CompletionStage still follow the legacy non-blocking
+                // scheduling model; proper async propagation through the streaming tool
+                // pipeline remains follow-up work.
                 if (io.vertx.core.Context.isOnEventLoopThread()) {
                     throw new BlockingToolNotAllowedException(
                             "Cannot execute tools returning Uni on event loop thread due to a tool executor limitation");

--- a/docs/modules/ROOT/pages/function-calling.adoc
+++ b/docs/modules/ROOT/pages/function-calling.adoc
@@ -195,12 +195,11 @@ If the return type is a `Uni` or a `CompletionStage`, it is treated as non-block
 [NOTE]
 ====
 When a `Uni`/`CompletionStage`-returning tool performs slow I/O (for example, a call to
-an image-generation API that takes 60–120 seconds), the tool executor still awaits the
-result synchronously (see the `// TODO CS` in `QuarkusToolExecutor#invoke`). Annotate the
-tool with `@RunOnVirtualThread` so the await parks a virtual thread rather than tying up
-a Vert.x worker thread for the full duration. Proper non-blocking propagation of
-`Uni`/`CompletionStage` through the streaming tool-call pipeline is tracked as a
-follow-up.
+an image-generation API that takes 60–120 seconds), the tool is still treated as
+non-blocking for scheduling purposes. In this branch, `@RunOnVirtualThread` is not the
+supported way to change that scheduling for tools returning `Uni` or
+`CompletionStage`. Proper async propagation of `Uni`/`CompletionStage` through the
+streaming tool-call pipeline remains follow-up work.
 ====
 
 .Blocking example
@@ -253,13 +252,14 @@ Multi<Fraud> detectAmountFraudForCustomerStreamed(long customerId);
 
 ==== Virtual-thread dispatch for streaming tool batches
 
-When every tool the model requests in a single batch is annotated with
-`@RunOnVirtualThread`, the streaming handler dispatches the whole batch onto a virtual
-thread directly, instead of first switching to a Vert.x worker thread and then submitting
-each tool to a virtual thread (which would tie up both threads for the full tool
-duration). This matters for long-running tools — for example, a tool that calls an
-image-generation API and takes 60–120 seconds no longer keeps a worker thread blocked for
-the duration.
+When every tool the model requests in a single batch resolves to the
+`VIRTUAL_THREAD` execution model, the streaming handler dispatches the whole serialized
+tool loop onto a virtual thread directly, instead of first switching to a Vert.x worker
+thread and then submitting each tool to a virtual thread (which would tie up both threads
+for the full tool duration). This matters for long-running tools — for example, a tool
+that calls an image-generation API and takes 60–120 seconds no longer keeps a worker
+thread blocked for the duration. Mixed batches, and batches without full virtual-thread
+eligibility, keep the historical per-tool scheduling behavior.
 
 Behavior is controlled by three runtime configuration keys:
 
@@ -268,21 +268,28 @@ Behavior is controlled by three runtime configuration keys:
 
 | `quarkus.langchain4j.tools.dispatch`
 | `auto`
-| `auto` respects per-tool annotations (all `@RunOnVirtualThread` → virtual thread; otherwise worker thread).
-`virtual-thread` always dispatches to a virtual thread.
-`worker` always dispatches to a Vert.x worker thread (historical behavior).
+| `auto` enables the full-batch virtual-thread optimization only when every requested tool
+in the batch resolves to the `VIRTUAL_THREAD` execution model; otherwise legacy per-tool
+scheduling is kept. `legacy` disables the batch-level optimization and keeps historical
+per-tool scheduling.
 
 | `quarkus.langchain4j.tools.virtual-thread.max-concurrent`
 | unbounded
-| Caps the number of in-flight virtual-thread tool batches via a shared semaphore.
-Useful when a runaway agent could otherwise trigger thousands of concurrent tool calls.
+| Caps the number of in-flight batches using the batch-level virtual-thread path via a
+shared semaphore. The permit is held until the batch finishes tool execution and the
+synchronous handoff to the next model call returns. This applies only when `auto`
+selects the full-batch virtual-thread optimization. Extra batches may still start a
+virtual thread and park while waiting for a permit, so this is not strict admission
+control. Useful when a runaway agent could otherwise trigger thousands of concurrent tool
+calls.
 
 | `quarkus.langchain4j.tools.mixed-batch-log-level`
 | `warn`
-| Log level used when a batch contains both `@RunOnVirtualThread` and other tools and the
-extension falls back to worker-thread dispatch for the whole batch. Set to `off` to
-silence. To enable virtual-thread dispatch for a mixed batch, annotate every tool in the
-batch with `@RunOnVirtualThread`.
+| Log level used when a batch contains a mix of virtual-thread-eligible and other tools
+and the extension skips the full-batch optimization, falling back to legacy per-tool
+scheduling. The warning includes the AI service method plus the requested and non-VT tool
+names. Set to `off` to silence. To enable the full-batch optimization for a mixed batch,
+every requested tool in the batch must resolve to the `VIRTUAL_THREAD` execution model.
 |===
 
 == Request Scope Propagation

--- a/docs/modules/ROOT/pages/function-calling.adoc
+++ b/docs/modules/ROOT/pages/function-calling.adoc
@@ -190,7 +190,18 @@ The tool execution model determines how the tool is invoked:
 * `@NonBlocking`: runs on an _event loop_ and *must* not block
 * `@RunOnVirtualThread`: runs on a virtual thread
 
-If the return type is a `Uni` or a `CompletionStage`, it is treated as non-blocking
+If the return type is a `Uni` or a `CompletionStage`, it is treated as non-blocking.
+
+[NOTE]
+====
+When a `Uni`/`CompletionStage`-returning tool performs slow I/O (for example, a call to
+an image-generation API that takes 60–120 seconds), the tool executor still awaits the
+result synchronously (see the `// TODO CS` in `QuarkusToolExecutor#invoke`). Annotate the
+tool with `@RunOnVirtualThread` so the await parks a virtual thread rather than tying up
+a Vert.x worker thread for the full duration. Proper non-blocking propagation of
+`Uni`/`CompletionStage` through the streaming tool-call pipeline is tracked as a
+follow-up.
+====
 
 .Blocking example
 [source,java]
@@ -239,6 +250,40 @@ Multi<Fraud> detectAmountFraudForCustomerStreamed(long customerId);
 ----
 
 <1> The invocation to the repositories are automatically dispatched to a worker thread as the defined tool methods are blocking.
+
+==== Virtual-thread dispatch for streaming tool batches
+
+When every tool the model requests in a single batch is annotated with
+`@RunOnVirtualThread`, the streaming handler dispatches the whole batch onto a virtual
+thread directly, instead of first switching to a Vert.x worker thread and then submitting
+each tool to a virtual thread (which would tie up both threads for the full tool
+duration). This matters for long-running tools — for example, a tool that calls an
+image-generation API and takes 60–120 seconds no longer keeps a worker thread blocked for
+the duration.
+
+Behavior is controlled by three runtime configuration keys:
+
+|===
+| Key | Default | Meaning
+
+| `quarkus.langchain4j.tools.dispatch`
+| `auto`
+| `auto` respects per-tool annotations (all `@RunOnVirtualThread` → virtual thread; otherwise worker thread).
+`virtual-thread` always dispatches to a virtual thread.
+`worker` always dispatches to a Vert.x worker thread (historical behavior).
+
+| `quarkus.langchain4j.tools.virtual-thread.max-concurrent`
+| unbounded
+| Caps the number of in-flight virtual-thread tool batches via a shared semaphore.
+Useful when a runaway agent could otherwise trigger thousands of concurrent tool calls.
+
+| `quarkus.langchain4j.tools.mixed-batch-log-level`
+| `warn`
+| Log level used when a batch contains both `@RunOnVirtualThread` and other tools and the
+extension falls back to worker-thread dispatch for the whole batch. Set to `off` to
+silence. To enable virtual-thread dispatch for a mixed batch, annotate every tool in the
+batch with `@RunOnVirtualThread`.
+|===
 
 == Request Scope Propagation
 

--- a/docs/modules/ROOT/pages/function-calling.adoc
+++ b/docs/modules/ROOT/pages/function-calling.adoc
@@ -194,12 +194,15 @@ If the return type is a `Uni` or a `CompletionStage`, it is treated as non-block
 
 [NOTE]
 ====
-When a `Uni`/`CompletionStage`-returning tool performs slow I/O (for example, a call to
-an image-generation API that takes 60–120 seconds), the tool is still treated as
-non-blocking for scheduling purposes. In this branch, `@RunOnVirtualThread` is not the
-supported way to change that scheduling for tools returning `Uni` or
-`CompletionStage`. Proper async propagation of `Uni`/`CompletionStage` through the
-streaming tool-call pipeline remains follow-up work.
+`@RunOnVirtualThread` cannot be combined with a `Uni` or `CompletionStage` return type —
+the build fails with a validation error pointing at the offending method. Tools returning
+`Uni` or `CompletionStage` are classified as non-blocking, but their result is awaited
+synchronously inside the tool executor, so the await parks whichever thread the executor
+was reached on (a worker thread under streaming dispatch — never the event loop, which is
+guarded). A slow asynchronous tool — for example a 60–120 second image-generation call —
+therefore holds a worker thread until the `Uni` completes. To get virtual-thread
+scheduling for a slow tool, return a synchronous type (such as `String`) and annotate the
+method with `@RunOnVirtualThread`.
 ====
 
 .Blocking example

--- a/docs/modules/ROOT/pages/function-calling.adoc
+++ b/docs/modules/ROOT/pages/function-calling.adoc
@@ -253,15 +253,37 @@ Multi<Fraud> detectAmountFraudForCustomerStreamed(long customerId);
 ==== Virtual-thread dispatch for streaming tool batches
 
 When every tool the model requests in a single batch resolves to the
-`VIRTUAL_THREAD` execution model, the streaming handler dispatches the whole serialized
-tool loop onto a virtual thread directly, instead of first switching to a Vert.x worker
-thread and then submitting each tool to a virtual thread (which would tie up both threads
-for the full tool duration). This matters for long-running tools — for example, a tool
-that calls an image-generation API and takes 60–120 seconds no longer keeps a worker
-thread blocked for the duration. Mixed batches, and batches without full virtual-thread
-eligibility, keep the historical per-tool scheduling behavior.
+`VIRTUAL_THREAD` execution model, the streaming handler dispatches the whole tool batch
+onto virtual threads directly, instead of first switching to a Vert.x worker thread and
+then submitting each tool to a virtual thread (which would tie up both threads for the
+full tool duration). This matters for long-running tools — for example, a tool that calls
+an image-generation API and takes 60–120 seconds no longer keeps a worker thread blocked
+for the duration. Mixed batches, and batches without full virtual-thread eligibility,
+keep the historical per-tool scheduling behavior.
 
-Behavior is controlled by three runtime configuration keys:
+When the batch contains more than one tool, the tools are executed *in parallel* — each
+on its own virtual thread — and the carrier waits for all of them before continuing to the
+next round of the conversation. Tool result messages are appended to chat memory in the
+original request order regardless of completion order, so the LLM always sees a stable
+conversation. Single-tool batches stay on a single virtual thread (no fan-out, no
+join overhead).
+
+`BeforeToolExecution` events fire in request order, on the carrier thread, before fan-out.
+`ToolExecutedEvent` and the `toolExecutedHandler` callback fire as each tool finishes,
+from the per-tool virtual thread — so completion-order observability is preserved.
+
+Cancellation is best-effort under parallel execution: tools that have already begun on
+their virtual thread run to completion, while tools that have not yet been scheduled
+record a cancellation result and skip execution. The next conversation round is not
+issued.
+
+Tool calls dispatched in a single batch are expected to be independent. If the model
+needs to sequence tool calls (the result of one feeding the input of another), it should
+issue separate tool rounds rather than relying on intra-batch ordering. Set
+`parallel-virtual-thread-batch=false` to keep the historical serialized-loop behavior
+for legacy code that has not been audited for parallel safety.
+
+Behavior is controlled by these runtime configuration keys:
 
 |===
 | Key | Default | Meaning
@@ -273,15 +295,22 @@ in the batch resolves to the `VIRTUAL_THREAD` execution model; otherwise legacy 
 scheduling is kept. `legacy` disables the batch-level optimization and keeps historical
 per-tool scheduling.
 
+| `quarkus.langchain4j.tools.parallel-virtual-thread-batch`
+| `true`
+| When the full-batch virtual-thread optimization applies, execute the batch's tools in
+parallel — each on its own virtual thread — instead of serializing them on a single
+virtual thread. Results are appended to chat memory in request order. Set to `false` to
+restore the historical serialized-loop behavior.
+
 | `quarkus.langchain4j.tools.virtual-thread.max-concurrent`
 | unbounded
-| Caps the number of in-flight batches using the batch-level virtual-thread path via a
-shared semaphore. The permit is held until the batch finishes tool execution and the
-synchronous handoff to the next model call returns. This applies only when `auto`
-selects the full-batch virtual-thread optimization. Extra batches may still start a
-virtual thread and park while waiting for a permit, so this is not strict admission
-control. Useful when a runaway agent could otherwise trigger thousands of concurrent tool
-calls.
+| Caps the number of concurrently executing virtual-thread tool tasks via a shared
+semaphore. With `parallel-virtual-thread-batch=true` (default) the permit is held per
+tool, capping simultaneously running tools across all in-flight batches. With
+`parallel-virtual-thread-batch=false` the permit is held per batch — the historical
+behavior. Extra tasks may still start a virtual thread and park while waiting for a
+permit, so this is not strict admission control. Useful when a runaway agent could
+otherwise trigger thousands of concurrent tool calls.
 
 | `quarkus.langchain4j.tools.mixed-batch-log-level`
 | `warn`


### PR DESCRIPTION
Tool calls are currently executed sequentially, which has performance impacts for complex agents. This PR provides a path to parallel execution, but iff tools run on virtual threads. That keeps the scope limited but still provides significant value; we run on JDK25 with VT.

Disclosure: AI generated with human-in-the-loop.

## Summary

Two-layer change to how the streaming AI-service runs tool batches:

1. **Dispatch.** When every tool in a batch is `@RunOnVirtualThread`, the whole tool loop is dispatched onto a virtual thread via `VirtualThreadsRecorder`, releasing the calling worker / event-loop thread immediately. Mixed batches keep the current worker-thread behaviour. `QuarkusToolExecutor` short-circuits its `submit().get()` branch when already on a virtual thread (no more `.await().indefinitely()` parking a worker).
2. **Parallelism.** When the batch has more than one tool and they're all virtual-thread, fan each call out onto its own virtual thread instead of running them serially on the carrier. Single-tool batches stay on the carrier. The carrier waits for every task, then appends `ToolExecutionResultMessage`s in original request order so the LLM sees a stable conversation.

## New config (`quarkus.langchain4j.tools.*`)

| Key | Default | Purpose |
|---|---|---|
| `dispatch` | `auto` | `auto` \| `virtual-thread` \| `worker` global override |
| `virtual-thread.max-concurrent` | unbounded | Caps simultaneously-running VT tools (per-tool under parallel, per-batch under opt-out) |
| `mixed-batch-log-level` | `warn` | Severity when a mixed batch falls back to worker dispatch |
| `parallel-virtual-thread-batch` | `true` | Set `false` to restore serialized intra-batch execution |

## Behaviour notes

- **Memory ordering preserved.** Results are appended in request order regardless of completion order.
- **Events.** `BeforeToolExecution` fires in request order on the carrier; `ToolExecutedEvent` fires from the per-tool worker on completion (completion-order observability).
- **`max-tool-calls-per-response`.** Parallel rejects the whole batch up-front when `size > limit`; serial keeps the partial-execution-then-throw contract (fan-out would race with submission).
- **Cancellation.** Best-effort: tools already running complete; not-yet-scheduled tasks record a cancellation result.
- **Error handling.** Each parallel task wraps work in a catch-all that synthesizes a `"Tool execution failed: <msg>"` result into its own slot before re-raising, so request-count == result-count even when a tool throws past its error handler.
- **Interrupt safety.** The carrier drains all futures uninterruptibly, capturing the interrupt and re-setting the flag only after every task has settled.
- **Observability.** `invocationContext` is set on parallel-batch `BeforeToolExecution` / `ToolExecution` builders (mandatory after the recent upstream observability change).
- **Docs.** New "Virtual-thread dispatch for streaming tool batches" subsection in `function-calling.adoc`, plus a clarified note on the Execution Models page covering `Uni`/`CompletionStage` build-time validation and worker-parking semantics.

## Tests included in the PR (all passing locally):

- `ToolExecutionModelVirtualThreadDispatchTest` — auto / global override / bounded dispatch / mixed fallback / VT-from-VT / failure propagation
- `ToolExecutionModelVirtualThreadLegacyDispatchTest` — pre-dispatch behaviour preserved under `dispatch=worker`
- `ToolExecutionModelVirtualThreadMaxConcurrentTest` — per-tool semaphore caps peak in-flight under parallel mode
- `ToolExecutionModelVirtualThreadParallelDispatchTest` — fan-out, ordering, events, cancellation
- `ToolExecutionModelVirtualThreadParallelOptOutTest` — `parallel-virtual-thread-batch=false` falls back to serial
- `ToolExecutionModelVirtualThreadParallelMaxToolCallsTest` — over-limit rejected up-front, at-limit allowed
- `ToolExecutionModelWithStreamingCancellationTest` — cancellation semantics intact

### Manual testing (not in this PR)

Two end-to-end ITs against the real Anthropic API exist locally and were used to validate wall-clock behaviour, but are intentionally excluded:

- `AnthropicParallelToolDispatchITTest` — three 10s `httpbin.org/delay/10` tool calls in a single turn finish in ~10s under parallel VT dispatch.
- `AnthropicSequentialToolDispatchITTest` — same shape without `@RunOnVirtualThread`; ~30s under the legacy serial path.