### PR TITLE
Add Named Stores section to Redis guide

### DIFF
--- a/docs/modules/ROOT/pages/rag-redis.adoc
+++ b/docs/modules/ROOT/pages/rag-redis.adoc
@@ -122,6 +122,36 @@ quarkus.langchain4j.redis.textual-metadata-fields=language,author
 Textual metadata fields are returned in query results but are not currently usable as filter criteria.
 ====
 
+== Named Stores
+
+You can configure multiple named Redis stores, each backed by a different Redis client.
+This is useful when your application needs to manage embeddings for different domains or tenants in separate Redis instances.
+
+To configure a named store:
+
+[source,properties]
+----
+quarkus.langchain4j.redis.products.dimension=1536
+quarkus.langchain4j.redis.products.client-name=products-redis
+----
+
+To inject a named store, use the `@EmbeddingStoreName` qualifier:
+
+[source,java]
+----
+@Inject
+@EmbeddingStoreName("products")
+EmbeddingStore<TextSegment> productsStore;
+----
+
+The default store and named stores can coexist.
+If you only need named stores, disable the default store:
+
+[source,properties]
+----
+quarkus.langchain4j.redis.default-store-enabled=false
+----
+
 == Summary
 
 To use Redis as a vector store with Quarkus LangChain4j:


### PR DESCRIPTION
## Summary

Supplement to PR #2421. Adds the Named Stores section to `rag-redis.adoc`.

Covers:
- Configuring named stores (`dimension`, `client-name`)
- Injecting with `@EmbeddingStoreName`
- Disabling the default store (`default-store-enabled=false`)

Follows the same structure as the pgvector named stores section in `rag-pgvector-store.adoc`.