### PR TITLE
Add support for named Neo4j embedding stores

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-neo4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-neo4j.adoc
@@ -7,6 +7,27 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-default-store-enabled]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-default-store-enabled[`+++quarkus.langchain4j.neo4j.default-store-enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.neo4j.default-store-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the default (unnamed) Neo4j embedding store should be enabled. Set to `false` when you only want to use named stores.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_NEO4J_DEFAULT_STORE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_NEO4J_DEFAULT_STORE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a| [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-dimension]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-dimension[`+++quarkus.langchain4j.neo4j.dimension+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.neo4j.dimension+++[]
@@ -26,7 +47,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_NEO4J_DIMENSION+++`
 endif::add-copy-button-to-env-var[]
 --
 |int
-|required icon:exclamation-circle[title=Configuration property is required]
+|
 
 a| [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-label]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-label[`+++quarkus.langchain4j.neo4j.label+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -164,6 +185,8 @@ endif::add-copy-button-to-config-props[]
 --
 Name of the database to connect to.
 
+Connecting to a database other than the default `neo4j` requires Neo4j Enterprise Edition. On Community Edition only the default `neo4j` database exists, so this property must be left unchanged (or unset) and named stores must be isolated via `label`, `index-name` and `embedding-property` instead.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_NEO4J_DATABASE_NAME+++[]
@@ -192,6 +215,10 @@ The query to use when retrieving embeddings. This query has to return the follow
  - column of the same name as the 'embedding-property' value
 
 
+
+If not set, a default query is automatically derived from the configured `id-property`, `text-property`, and `embedding-property` values for this store.
+
+
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_NEO4J_RETRIEVAL_QUERY+++[]
 endif::add-copy-button-to-env-var[]
@@ -200,7 +227,234 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_NEO4J_RETRIEVAL_QUERY+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`+++RETURN properties(node) AS metadata, node.${quarkus.langchain4j.neo4j.id-property} AS ${quarkus.langchain4j.neo4j.id-property}, node.${quarkus.langchain4j.neo4j.text-property} AS ${quarkus.langchain4j.neo4j.text-property}, node.${quarkus.langchain4j.neo4j.embedding-property} AS ${quarkus.langchain4j.neo4j.embedding-property}, score+++`
+|
+
+h|[[quarkus-langchain4j-neo4j_section_quarkus-langchain4j-neo4j]] [.section-name.section-level0]##link:#quarkus-langchain4j-neo4j_section_quarkus-langchain4j-neo4j[Named store configurations]##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-enabled]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-enabled[`+++quarkus.langchain4j.neo4j."store-name".enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.neo4j."store-name".enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether this named Neo4j embedding store should be enabled. Set to `false` to skip bean creation for this named store while keeping its configuration.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a| [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-dimension]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-dimension[`+++quarkus.langchain4j.neo4j."store-name".dimension+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.neo4j."store-name".dimension+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Dimension of the embeddings that will be stored in the Neo4j store.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__DIMENSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__DIMENSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-label]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-label[`+++quarkus.langchain4j.neo4j."store-name".label+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.neo4j."store-name".label+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Label for the created nodes.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__LABEL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__LABEL+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++Document+++`
+
+a| [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-embedding-property]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-embedding-property[`+++quarkus.langchain4j.neo4j."store-name".embedding-property+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.neo4j."store-name".embedding-property+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the property to store the embedding vectors.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__EMBEDDING_PROPERTY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__EMBEDDING_PROPERTY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++embedding+++`
+
+a| [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-id-property]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-id-property[`+++quarkus.langchain4j.neo4j."store-name".id-property+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.neo4j."store-name".id-property+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the property to store embedding IDs.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__ID_PROPERTY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__ID_PROPERTY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++id+++`
+
+a| [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-metadata-prefix]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-metadata-prefix[`+++quarkus.langchain4j.neo4j."store-name".metadata-prefix+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.neo4j."store-name".metadata-prefix+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Prefix to be added to the metadata keys. By default, no prefix is used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__METADATA_PREFIX+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__METADATA_PREFIX+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-text-property]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-text-property[`+++quarkus.langchain4j.neo4j."store-name".text-property+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.neo4j."store-name".text-property+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the property to store the embedding text.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__TEXT_PROPERTY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__TEXT_PROPERTY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++text+++`
+
+a| [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-index-name]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-index-name[`+++quarkus.langchain4j.neo4j."store-name".index-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.neo4j."store-name".index-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the index to be created for vector search.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__INDEX_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__INDEX_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++vector+++`
+
+a| [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-database-name]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-database-name[`+++quarkus.langchain4j.neo4j."store-name".database-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.neo4j."store-name".database-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the database to connect to.
+
+Connecting to a database other than the default `neo4j` requires Neo4j Enterprise Edition. On Community Edition only the default `neo4j` database exists, so this property must be left unchanged (or unset) and named stores must be isolated via `label`, `index-name` and `embedding-property` instead.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__DATABASE_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__DATABASE_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++neo4j+++`
+
+a| [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-retrieval-query]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-retrieval-query[`+++quarkus.langchain4j.neo4j."store-name".retrieval-query+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.neo4j."store-name".retrieval-query+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The query to use when retrieving embeddings. This query has to return the following columns:
+
+ - metadata
+ - score
+ - column of the same name as the 'id-property' value
+ - column of the same name as the 'text-property' value
+ - column of the same name as the 'embedding-property' value
+
+
+
+If not set, a default query is automatically derived from the configured `id-property`, `text-property`, and `embedding-property` values for this store.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__RETRIEVAL_QUERY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__RETRIEVAL_QUERY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
 
 |===
 

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-neo4j_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-neo4j_quarkus.langchain4j.adoc
@@ -7,6 +7,27 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-default-store-enabled]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-default-store-enabled[`+++quarkus.langchain4j.neo4j.default-store-enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.neo4j.default-store-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the default (unnamed) Neo4j embedding store should be enabled. Set to `false` when you only want to use named stores.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_NEO4J_DEFAULT_STORE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_NEO4J_DEFAULT_STORE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a| [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-dimension]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-dimension[`+++quarkus.langchain4j.neo4j.dimension+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.neo4j.dimension+++[]
@@ -26,7 +47,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_NEO4J_DIMENSION+++`
 endif::add-copy-button-to-env-var[]
 --
 |int
-|required icon:exclamation-circle[title=Configuration property is required]
+|
 
 a| [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-label]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-label[`+++quarkus.langchain4j.neo4j.label+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -164,6 +185,8 @@ endif::add-copy-button-to-config-props[]
 --
 Name of the database to connect to.
 
+Connecting to a database other than the default `neo4j` requires Neo4j Enterprise Edition. On Community Edition only the default `neo4j` database exists, so this property must be left unchanged (or unset) and named stores must be isolated via `label`, `index-name` and `embedding-property` instead.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_NEO4J_DATABASE_NAME+++[]
@@ -192,6 +215,10 @@ The query to use when retrieving embeddings. This query has to return the follow
  - column of the same name as the 'embedding-property' value
 
 
+
+If not set, a default query is automatically derived from the configured `id-property`, `text-property`, and `embedding-property` values for this store.
+
+
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_NEO4J_RETRIEVAL_QUERY+++[]
 endif::add-copy-button-to-env-var[]
@@ -200,7 +227,234 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_NEO4J_RETRIEVAL_QUERY+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`+++RETURN properties(node) AS metadata, node.${quarkus.langchain4j.neo4j.id-property} AS ${quarkus.langchain4j.neo4j.id-property}, node.${quarkus.langchain4j.neo4j.text-property} AS ${quarkus.langchain4j.neo4j.text-property}, node.${quarkus.langchain4j.neo4j.embedding-property} AS ${quarkus.langchain4j.neo4j.embedding-property}, score+++`
+|
+
+h|[[quarkus-langchain4j-neo4j_section_quarkus-langchain4j-neo4j]] [.section-name.section-level0]##link:#quarkus-langchain4j-neo4j_section_quarkus-langchain4j-neo4j[Named store configurations]##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-enabled]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-enabled[`+++quarkus.langchain4j.neo4j."store-name".enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.neo4j."store-name".enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether this named Neo4j embedding store should be enabled. Set to `false` to skip bean creation for this named store while keeping its configuration.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a| [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-dimension]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-dimension[`+++quarkus.langchain4j.neo4j."store-name".dimension+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.neo4j."store-name".dimension+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Dimension of the embeddings that will be stored in the Neo4j store.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__DIMENSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__DIMENSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-label]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-label[`+++quarkus.langchain4j.neo4j."store-name".label+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.neo4j."store-name".label+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Label for the created nodes.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__LABEL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__LABEL+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++Document+++`
+
+a| [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-embedding-property]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-embedding-property[`+++quarkus.langchain4j.neo4j."store-name".embedding-property+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.neo4j."store-name".embedding-property+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the property to store the embedding vectors.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__EMBEDDING_PROPERTY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__EMBEDDING_PROPERTY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++embedding+++`
+
+a| [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-id-property]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-id-property[`+++quarkus.langchain4j.neo4j."store-name".id-property+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.neo4j."store-name".id-property+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the property to store embedding IDs.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__ID_PROPERTY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__ID_PROPERTY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++id+++`
+
+a| [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-metadata-prefix]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-metadata-prefix[`+++quarkus.langchain4j.neo4j."store-name".metadata-prefix+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.neo4j."store-name".metadata-prefix+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Prefix to be added to the metadata keys. By default, no prefix is used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__METADATA_PREFIX+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__METADATA_PREFIX+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-text-property]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-text-property[`+++quarkus.langchain4j.neo4j."store-name".text-property+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.neo4j."store-name".text-property+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the property to store the embedding text.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__TEXT_PROPERTY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__TEXT_PROPERTY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++text+++`
+
+a| [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-index-name]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-index-name[`+++quarkus.langchain4j.neo4j."store-name".index-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.neo4j."store-name".index-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the index to be created for vector search.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__INDEX_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__INDEX_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++vector+++`
+
+a| [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-database-name]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-database-name[`+++quarkus.langchain4j.neo4j."store-name".database-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.neo4j."store-name".database-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the database to connect to.
+
+Connecting to a database other than the default `neo4j` requires Neo4j Enterprise Edition. On Community Edition only the default `neo4j` database exists, so this property must be left unchanged (or unset) and named stores must be isolated via `label`, `index-name` and `embedding-property` instead.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__DATABASE_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__DATABASE_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++neo4j+++`
+
+a| [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-retrieval-query]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-retrieval-query[`+++quarkus.langchain4j.neo4j."store-name".retrieval-query+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.neo4j."store-name".retrieval-query+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The query to use when retrieving embeddings. This query has to return the following columns:
+
+ - metadata
+ - score
+ - column of the same name as the 'id-property' value
+ - column of the same name as the 'text-property' value
+ - column of the same name as the 'embedding-property' value
+
+
+
+If not set, a default query is automatically derived from the configured `id-property`, `text-property`, and `embedding-property` values for this store.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__RETRIEVAL_QUERY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_NEO4J__STORE_NAME__RETRIEVAL_QUERY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
 
 |===
 

--- a/docs/modules/ROOT/pages/rag-neo4j.adoc
+++ b/docs/modules/ROOT/pages/rag-neo4j.adoc
@@ -76,6 +76,68 @@ Common settings include:
 * `quarkus.langchain4j.neo4j.dimension` – Required; dimension of your embeddings
 * `quarkus.neo4j.uri`, `quarkus.neo4j.authentication.*` – Standard Neo4j driver settings
 
+== Named Stores
+
+You can configure multiple named Neo4j embedding stores, each with its own dimension, label, index name and other per-store settings.
+This is useful when your application needs to manage embeddings for different domains in separate node labels or indexes within the same Neo4j instance.
+
+[NOTE]
+====
+All named stores share the single `org.neo4j.driver.Driver` provided by the `quarkus-neo4j` extension, so they connect to the same Neo4j instance.
+Use a distinct `label`, `index-name` and `embedding-property` per store to keep their data isolated.
+====
+
+[IMPORTANT]
+.Multiple databases require Neo4j Enterprise
+====
+The `database-name` property maps to a Neo4j database, and Neo4j *Community Edition* only ships with the single default `neo4j` database.
+If you set `quarkus.langchain4j.neo4j.<store-name>.database-name` to anything other than `neo4j` against a Community instance, the driver will fail at runtime when the store tries to open a session.
+
+To physically separate named stores into different databases you need *Neo4j Enterprise Edition* with the additional databases pre-created.
+On Community Edition, isolate named stores via distinct `label`, `index-name` and `embedding-property` values within the default `neo4j` database instead.
+====
+
+To configure a named store:
+
+[NOTE]
+====
+The `database-name` property is required for named store discovery at build time.
+On Community Edition, set it to `neo4j` (the default database).
+On Enterprise Edition, set it to the target database name.
+====
+
+[source,properties]
+----
+quarkus.langchain4j.neo4j.products.database-name=neo4j
+quarkus.langchain4j.neo4j.products.dimension=1536
+quarkus.langchain4j.neo4j.products.label=Product
+quarkus.langchain4j.neo4j.products.index-name=product_vector
+----
+
+To inject a named store, use the `@EmbeddingStoreName` qualifier:
+
+[source,java]
+----
+@Inject
+@EmbeddingStoreName("products")
+EmbeddingStore<TextSegment> productsStore;
+----
+
+The default store and named stores can coexist.
+If you only need named stores, disable the default store:
+
+[source,properties]
+----
+quarkus.langchain4j.neo4j.default-store-enabled=false
+----
+
+A specific named store can also be skipped at build time without removing its configuration:
+
+[source,properties]
+----
+quarkus.langchain4j.neo4j.products.enabled=false
+----
+
 == How It Works
 
 Internally, the extension maps each document into a Neo4j node with:

--- a/embedding-stores/neo4j/deployment/src/main/java/io/quarkiverse/langchain4j/neo4j/Neo4jEmbeddingStoreBuildTimeConfig.java
+++ b/embedding-stores/neo4j/deployment/src/main/java/io/quarkiverse/langchain4j/neo4j/Neo4jEmbeddingStoreBuildTimeConfig.java
@@ -1,0 +1,52 @@
+package io.quarkiverse.langchain4j.neo4j;
+
+import static io.quarkus.runtime.annotations.ConfigPhase.BUILD_TIME;
+
+import java.util.Map;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigDocSection;
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithDefaults;
+import io.smallrye.config.WithParentName;
+
+@ConfigRoot(phase = BUILD_TIME)
+@ConfigMapping(prefix = "quarkus.langchain4j.neo4j")
+public interface Neo4jEmbeddingStoreBuildTimeConfig {
+
+    /**
+     * Default store build-time config.
+     */
+    @WithParentName
+    DefaultStoreBuildTimeConfig defaultConfig();
+
+    /**
+     * Named store configurations.
+     */
+    @ConfigDocSection
+    @ConfigDocMapKey("store-name")
+    @WithParentName
+    @WithDefaults
+    Map<String, Neo4jNamedStoreBuildTimeConfig> namedConfig();
+
+    @ConfigGroup
+    interface DefaultStoreBuildTimeConfig {
+
+        /**
+         * Whether the default (unnamed) Neo4j embedding store should be enabled.
+         * Set to {@code false} when you only want to use named stores.
+         */
+        @WithDefault("true")
+        boolean defaultStoreEnabled();
+
+        /**
+         * The name of the Neo4j database the default store connects to.
+         * If not set, the default {@code neo4j} database is used.
+         */
+        Optional<String> databaseName();
+    }
+}

--- a/embedding-stores/neo4j/deployment/src/main/java/io/quarkiverse/langchain4j/neo4j/Neo4jEmbeddingStoreProcessor.java
+++ b/embedding-stores/neo4j/deployment/src/main/java/io/quarkiverse/langchain4j/neo4j/Neo4jEmbeddingStoreProcessor.java
@@ -1,7 +1,10 @@
 package io.quarkiverse.langchain4j.neo4j;
 
+import java.util.Map;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
+import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassType;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.ParameterizedType;
@@ -10,8 +13,10 @@ import org.neo4j.driver.Driver;
 import dev.langchain4j.community.store.embedding.neo4j.Neo4jEmbeddingStore;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
 import io.quarkiverse.langchain4j.deployment.EmbeddingStoreBuildItem;
 import io.quarkiverse.langchain4j.neo4j.runtime.Neo4jEmbeddingStoreRecorder;
+import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -36,21 +41,57 @@ public class Neo4jEmbeddingStoreProcessor {
             BuildProducer<SyntheticBeanBuildItem> beanProducer,
             Neo4jEmbeddingStoreRecorder recorder,
             BuildProducer<UnremovableBeanBuildItem> unremovableProducer,
-            BuildProducer<EmbeddingStoreBuildItem> embeddingStoreProducer) {
+            BuildProducer<EmbeddingStoreBuildItem> embeddingStoreProducer,
+            Neo4jEmbeddingStoreBuildTimeConfig buildTimeConfig) {
         unremovableProducer.produce(UnremovableBeanBuildItem.beanTypes(Driver.class));
-        beanProducer.produce(SyntheticBeanBuildItem
-                .configure(NEO4J_EMBEDDING_STORE)
-                .types(
-                        ClassType.create(EmbeddingStore.class),
-                        ClassType.create(NEO4J_EMBEDDING_STORE),
-                        ParameterizedType.create(EmbeddingStore.class, ClassType.create(TextSegment.class)))
-                .defaultBean()
-                .setRuntimeInit()
-                .unremovable()
-                .scope(ApplicationScoped.class)
-                .addInjectionPoint(ClassType.create(DotName.createSimple(Driver.class)))
-                .createWith(recorder.embeddingStoreFunction())
-                .done());
-        embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
+
+        if (buildTimeConfig.defaultConfig().defaultStoreEnabled()) {
+            beanProducer.produce(SyntheticBeanBuildItem
+                    .configure(NEO4J_EMBEDDING_STORE)
+                    .types(
+                            ClassType.create(EmbeddingStore.class),
+                            ClassType.create(NEO4J_EMBEDDING_STORE),
+                            ParameterizedType.create(EmbeddingStore.class, ClassType.create(TextSegment.class)))
+                    .defaultBean()
+                    .setRuntimeInit()
+                    .unremovable()
+                    .scope(ApplicationScoped.class)
+                    .addInjectionPoint(ClassType.create(DotName.createSimple(Driver.class)))
+                    .createWith(recorder.embeddingStoreFunction(NamedConfigUtil.DEFAULT_NAME))
+                    .done());
+
+            embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
+        }
+
+        Map<String, Neo4jNamedStoreBuildTimeConfig> namedStores = buildTimeConfig.namedConfig();
+        for (Map.Entry<String, Neo4jNamedStoreBuildTimeConfig> entry : namedStores.entrySet()) {
+            String storeName = entry.getKey();
+            Neo4jNamedStoreBuildTimeConfig storeBuildTimeConfig = entry.getValue();
+
+            if (!storeBuildTimeConfig.enabled()) {
+                continue;
+            }
+
+            AnnotationInstance storeNameQualifier = AnnotationInstance.builder(EmbeddingStoreName.class)
+                    .add("value", storeName)
+                    .build();
+
+            beanProducer.produce(SyntheticBeanBuildItem
+                    .configure(NEO4J_EMBEDDING_STORE)
+                    .types(
+                            ClassType.create(EmbeddingStore.class),
+                            ClassType.create(NEO4J_EMBEDDING_STORE),
+                            ParameterizedType.create(EmbeddingStore.class, ClassType.create(TextSegment.class)))
+                    .defaultBean()
+                    .setRuntimeInit()
+                    .unremovable()
+                    .scope(ApplicationScoped.class)
+                    .addQualifier(storeNameQualifier)
+                    .addInjectionPoint(ClassType.create(DotName.createSimple(Driver.class)))
+                    .createWith(recorder.embeddingStoreFunction(storeName))
+                    .done());
+
+            embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
+        }
     }
 }

--- a/embedding-stores/neo4j/deployment/src/main/java/io/quarkiverse/langchain4j/neo4j/Neo4jNamedStoreBuildTimeConfig.java
+++ b/embedding-stores/neo4j/deployment/src/main/java/io/quarkiverse/langchain4j/neo4j/Neo4jNamedStoreBuildTimeConfig.java
@@ -1,0 +1,28 @@
+package io.quarkiverse.langchain4j.neo4j;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+
+@ConfigGroup
+public interface Neo4jNamedStoreBuildTimeConfig {
+
+    /**
+     * Whether this named Neo4j embedding store should be enabled.
+     * Set to {@code false} to skip bean creation for this named store while keeping its configuration.
+     */
+    @WithDefault("true")
+    boolean enabled();
+
+    /**
+     * The name of the Neo4j database this store connects to.
+     * Defaults to the {@code neo4j} database.
+     * <p>
+     * Connecting to a database other than the default {@code neo4j} requires Neo4j Enterprise Edition.
+     * On Community Edition, isolate named stores via distinct {@code label}, {@code index-name}
+     * and {@code embedding-property} values within the default database instead.
+     */
+    @WithDefault("<default>")
+    Optional<String> databaseName();
+}

--- a/embedding-stores/neo4j/deployment/src/test/java/io/quarkiverse/langchain4j/neo4j/Neo4jDefaultAndNamedStoreTest.java
+++ b/embedding-stores/neo4j/deployment/src/test/java/io/quarkiverse/langchain4j/neo4j/Neo4jDefaultAndNamedStoreTest.java
@@ -1,0 +1,49 @@
+package io.quarkiverse.langchain4j.neo4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class Neo4jDefaultAndNamedStoreTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.neo4j.dimension", "384")
+            .overrideConfigKey("quarkus.langchain4j.neo4j.named-store.database-name", "neo4j")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.neo4j.named-store.dimension", "1536")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.neo4j.named-store.label", "Custom")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.neo4j.named-store.index-name", "custom_vector");
+
+    @Inject
+    EmbeddingStore<TextSegment> defaultEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("named-store")
+    EmbeddingStore<TextSegment> namedEmbeddingStore;
+
+    @Test
+    void testDefault() {
+        assertThat(defaultEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void testNamed() {
+        assertThat(namedEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void testNotSame() {
+        assertThat(defaultEmbeddingStore).isNotSameAs(namedEmbeddingStore);
+    }
+}

--- a/embedding-stores/neo4j/deployment/src/test/java/io/quarkiverse/langchain4j/neo4j/Neo4jMultipleNamedStoresTest.java
+++ b/embedding-stores/neo4j/deployment/src/test/java/io/quarkiverse/langchain4j/neo4j/Neo4jMultipleNamedStoresTest.java
@@ -1,0 +1,50 @@
+package io.quarkiverse.langchain4j.neo4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class Neo4jMultipleNamedStoresTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.neo4j.default-store-enabled", "false")
+            .overrideConfigKey("quarkus.langchain4j.neo4j.products.database-name", "neo4j")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.neo4j.products.dimension", "1536")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.neo4j.products.label", "Product")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.neo4j.products.index-name", "product_vector")
+            .overrideConfigKey("quarkus.langchain4j.neo4j.documents.database-name", "neo4j")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.neo4j.documents.dimension", "768")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.neo4j.documents.label", "Document")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.neo4j.documents.index-name", "document_vector");
+
+    @Inject
+    @EmbeddingStoreName("products")
+    EmbeddingStore<TextSegment> productsEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("documents")
+    EmbeddingStore<TextSegment> documentsEmbeddingStore;
+
+    @Test
+    void testBothNamed() {
+        assertThat(productsEmbeddingStore).isNotNull();
+        assertThat(documentsEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void testNotSame() {
+        assertThat(productsEmbeddingStore).isNotSameAs(documentsEmbeddingStore);
+    }
+}

--- a/embedding-stores/neo4j/deployment/src/test/java/io/quarkiverse/langchain4j/neo4j/Neo4jNamedStoreMissingDimensionTest.java
+++ b/embedding-stores/neo4j/deployment/src/test/java/io/quarkiverse/langchain4j/neo4j/Neo4jNamedStoreMissingDimensionTest.java
@@ -1,0 +1,36 @@
+package io.quarkiverse.langchain4j.neo4j;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.config.ConfigValidationException;
+
+public class Neo4jNamedStoreMissingDimensionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.neo4j.default-store-enabled", "false")
+            .overrideConfigKey("quarkus.langchain4j.neo4j.products.database-name", "neo4j")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.neo4j.products.label", "Product");
+
+    @Inject
+    @EmbeddingStoreName("products")
+    EmbeddingStore<TextSegment> productsEmbeddingStore;
+
+    @Test
+    void testMissingDimension() {
+        assertThatThrownBy(() -> productsEmbeddingStore.toString())
+                .hasCauseInstanceOf(ConfigValidationException.class);
+    }
+}

--- a/embedding-stores/neo4j/deployment/src/test/java/io/quarkiverse/langchain4j/neo4j/Neo4jNamedStoreTest.java
+++ b/embedding-stores/neo4j/deployment/src/test/java/io/quarkiverse/langchain4j/neo4j/Neo4jNamedStoreTest.java
@@ -1,0 +1,50 @@
+package io.quarkiverse.langchain4j.neo4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.community.store.embedding.neo4j.Neo4jEmbeddingStore;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class Neo4jNamedStoreTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.neo4j.dimension", "384")
+            .overrideConfigKey("quarkus.langchain4j.neo4j.products.database-name", "neo4j")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.neo4j.products.dimension", "1536")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.neo4j.products.label", "Product")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.neo4j.products.index-name", "product_vector");
+
+    @Inject
+    Neo4jEmbeddingStore defaultEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("products")
+    EmbeddingStore<TextSegment> productsEmbeddingStore;
+
+    @Test
+    void testDefault() {
+        assertThat(defaultEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void testNamed() {
+        assertThat(productsEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void testNotSame() {
+        assertThat((Object) defaultEmbeddingStore).isNotSameAs(productsEmbeddingStore);
+    }
+}

--- a/embedding-stores/neo4j/runtime/src/main/java/io/quarkiverse/langchain4j/neo4j/runtime/Neo4jEmbeddingStoreConfig.java
+++ b/embedding-stores/neo4j/runtime/src/main/java/io/quarkiverse/langchain4j/neo4j/runtime/Neo4jEmbeddingStoreConfig.java
@@ -1,0 +1,32 @@
+package io.quarkiverse.langchain4j.neo4j.runtime;
+
+import static io.quarkus.runtime.annotations.ConfigPhase.RUN_TIME;
+
+import java.util.Map;
+
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigDocSection;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefaults;
+import io.smallrye.config.WithParentName;
+
+@ConfigRoot(phase = RUN_TIME)
+@ConfigMapping(prefix = "quarkus.langchain4j.neo4j")
+public interface Neo4jEmbeddingStoreConfig {
+
+    /**
+     * Default store config.
+     */
+    @WithParentName
+    Neo4jStoreRuntimeConfig defaultConfig();
+
+    /**
+     * Named store configurations.
+     */
+    @ConfigDocSection
+    @ConfigDocMapKey("store-name")
+    @WithParentName
+    @WithDefaults
+    Map<String, Neo4jStoreRuntimeConfig> namedConfig();
+}

--- a/embedding-stores/neo4j/runtime/src/main/java/io/quarkiverse/langchain4j/neo4j/runtime/Neo4jEmbeddingStoreRecorder.java
+++ b/embedding-stores/neo4j/runtime/src/main/java/io/quarkiverse/langchain4j/neo4j/runtime/Neo4jEmbeddingStoreRecorder.java
@@ -8,37 +8,68 @@ import org.neo4j.driver.Driver;
 import org.neo4j.driver.SessionConfig;
 
 import dev.langchain4j.community.store.embedding.neo4j.Neo4jEmbeddingStore;
+import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
+import io.smallrye.config.ConfigValidationException;
 
 @Recorder
 public class Neo4jEmbeddingStoreRecorder {
-    private final RuntimeValue<Neo4jRuntimeConfig> runtimeConfig;
+    private final RuntimeValue<Neo4jEmbeddingStoreConfig> runtimeConfig;
 
-    public Neo4jEmbeddingStoreRecorder(RuntimeValue<Neo4jRuntimeConfig> runtimeConfig) {
+    public Neo4jEmbeddingStoreRecorder(RuntimeValue<Neo4jEmbeddingStoreConfig> runtimeConfig) {
         this.runtimeConfig = runtimeConfig;
     }
 
-    public Function<SyntheticCreationalContext<Neo4jEmbeddingStore>, Neo4jEmbeddingStore> embeddingStoreFunction() {
+    public Function<SyntheticCreationalContext<Neo4jEmbeddingStore>, Neo4jEmbeddingStore> embeddingStoreFunction(
+            String storeName) {
         return new Function<>() {
             @Override
             public Neo4jEmbeddingStore apply(SyntheticCreationalContext<Neo4jEmbeddingStore> context) {
+                Neo4jStoreRuntimeConfig storeConfig = correspondingStoreConfig(storeName);
+
+                if (storeConfig.dimension().isEmpty()) {
+                    throw new ConfigValidationException(createDimensionConfigProblems(storeName));
+                }
+
+                Driver driver = context.getInjectedReference(Driver.class, Default.Literal.INSTANCE);
+
                 var builder = Neo4jEmbeddingStore.builder();
-                Driver driver = context.getInjectedReference(Driver.class, new Default.Literal());
                 builder.driver(driver);
-                builder.dimension(runtimeConfig.getValue().dimension());
-                builder.label(runtimeConfig.getValue().label());
-                builder.embeddingProperty(runtimeConfig.getValue().embeddingProperty());
-                builder.idProperty(runtimeConfig.getValue().idProperty());
-                builder.metadataPrefix(runtimeConfig.getValue().metadataPrefix().orElse(""));
-                builder.textProperty(runtimeConfig.getValue().textProperty());
-                builder.indexName(runtimeConfig.getValue().indexName());
-                builder.databaseName(runtimeConfig.getValue().databaseName());
-                builder.retrievalQuery(runtimeConfig.getValue().retrievalQuery());
-                builder.config(SessionConfig.forDatabase(runtimeConfig.getValue().databaseName()));
+                builder.dimension(storeConfig.dimension().get());
+                builder.label(storeConfig.label());
+                builder.embeddingProperty(storeConfig.embeddingProperty());
+                builder.idProperty(storeConfig.idProperty());
+                builder.metadataPrefix(storeConfig.metadataPrefix().orElse(""));
+                builder.textProperty(storeConfig.textProperty());
+                builder.indexName(storeConfig.indexName());
+                builder.databaseName(storeConfig.databaseName());
+                builder.retrievalQuery(storeConfig.retrievalQuery().orElseGet(() -> defaultRetrievalQuery(storeConfig)));
+                builder.config(SessionConfig.forDatabase(storeConfig.databaseName()));
                 return builder.build();
             }
         };
+    }
+
+    private Neo4jStoreRuntimeConfig correspondingStoreConfig(String storeName) {
+        if (NamedConfigUtil.isDefault(storeName)) {
+            return runtimeConfig.getValue().defaultConfig();
+        }
+        return runtimeConfig.getValue().namedConfig().get(storeName);
+    }
+
+    private static String defaultRetrievalQuery(Neo4jStoreRuntimeConfig storeConfig) {
+        return String.format(
+                "RETURN properties(node) AS metadata, node.%1$s AS %1$s, node.%2$s AS %2$s, node.%3$s AS %3$s, score",
+                storeConfig.idProperty(),
+                storeConfig.textProperty(),
+                storeConfig.embeddingProperty());
+    }
+
+    private ConfigValidationException.Problem[] createDimensionConfigProblems(String storeName) {
+        return new ConfigValidationException.Problem[] { new ConfigValidationException.Problem(String.format(
+                "SRCFG00014: The config property quarkus.langchain4j.neo4j%sdimension is required but it could not be found in any config source",
+                NamedConfigUtil.isDefault(storeName) ? "." : ("." + storeName + "."))) };
     }
 }

--- a/embedding-stores/neo4j/runtime/src/main/java/io/quarkiverse/langchain4j/neo4j/runtime/Neo4jStoreRuntimeConfig.java
+++ b/embedding-stores/neo4j/runtime/src/main/java/io/quarkiverse/langchain4j/neo4j/runtime/Neo4jStoreRuntimeConfig.java
@@ -1,21 +1,17 @@
 package io.quarkiverse.langchain4j.neo4j.runtime;
 
-import static io.quarkus.runtime.annotations.ConfigPhase.RUN_TIME;
-
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigRoot;
-import io.smallrye.config.ConfigMapping;
+import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
-@ConfigRoot(phase = RUN_TIME)
-@ConfigMapping(prefix = "quarkus.langchain4j.neo4j")
-public interface Neo4jRuntimeConfig {
+@ConfigGroup
+public interface Neo4jStoreRuntimeConfig {
 
     /**
      * Dimension of the embeddings that will be stored in the Neo4j store.
      */
-    Integer dimension();
+    Optional<Integer> dimension();
 
     /**
      * Label for the created nodes.
@@ -54,6 +50,11 @@ public interface Neo4jRuntimeConfig {
 
     /**
      * Name of the database to connect to.
+     * <p>
+     * Connecting to a database other than the default {@code neo4j} requires Neo4j Enterprise Edition.
+     * On Community Edition only the default {@code neo4j} database exists, so this property must be left
+     * unchanged (or unset) and named stores must be isolated via {@code label}, {@code index-name} and
+     * {@code embedding-property} instead.
      */
     @WithDefault("neo4j")
     String databaseName();
@@ -67,13 +68,10 @@ public interface Neo4jRuntimeConfig {
      * <li>column of the same name as the 'text-property' value</li>
      * <li>column of the same name as the 'embedding-property' value</li>
      * </ul>
+     * <p>
+     * If not set, a default query is automatically derived from the configured
+     * {@code id-property}, {@code text-property}, and {@code embedding-property} values
+     * for this store.
      */
-    @WithDefault("""
-            RETURN properties(node) AS metadata, \
-            node.${quarkus.langchain4j.neo4j.id-property} AS ${quarkus.langchain4j.neo4j.id-property}, \
-            node.${quarkus.langchain4j.neo4j.text-property} AS ${quarkus.langchain4j.neo4j.text-property}, \
-            node.${quarkus.langchain4j.neo4j.embedding-property} AS ${quarkus.langchain4j.neo4j.embedding-property}, \
-            score""")
-    String retrievalQuery();
-
+    Optional<String> retrievalQuery();
 }

--- a/embedding-stores/pgvector/deployment/src/test/java/io/quarkiverse/langchain4j/pgvector/test/PgVectorDefaultAndNamedStoreTest.java
+++ b/embedding-stores/pgvector/deployment/src/test/java/io/quarkiverse/langchain4j/pgvector/test/PgVectorDefaultAndNamedStoreTest.java
@@ -4,7 +4,6 @@ import jakarta.inject.Inject;
 
 import org.assertj.core.api.Assertions;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -18,17 +17,15 @@ public class PgVectorDefaultAndNamedStoreTest {
 
     @RegisterExtension
     static final QuarkusUnitTest test = new QuarkusUnitTest()
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource(new StringAsset(
-                            "quarkus.datasource.db-kind=postgresql\n" +
-                                    "quarkus.datasource.devservices.image-name=pgvector/pgvector:pg16\n" +
-                                    "quarkus.datasource.named-ds.devservices.image-name=pgvector/pgvector:pg16\n" +
-                                    "quarkus.datasource.named-ds.db-kind=postgresql\n" +
-                                    "quarkus.langchain4j.pgvector.dimension=384\n" +
-                                    "quarkus.langchain4j.pgvector.named-store.datasource=named-ds\n" +
-                                    "quarkus.langchain4j.pgvector.named-store.dimension=1536\n" +
-                                    "quarkus.langchain4j.pgvector.named-store.table=named_embeddings\n"),
-                            "application.properties"));
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.datasource.db-kind", "postgresql")
+            .overrideConfigKey("quarkus.datasource.devservices.image-name", "pgvector/pgvector:pg16")
+            .overrideConfigKey("quarkus.datasource.named-ds.devservices.image-name", "pgvector/pgvector:pg16")
+            .overrideConfigKey("quarkus.datasource.named-ds.db-kind", "postgresql")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.pgvector.dimension", "384")
+            .overrideConfigKey("quarkus.langchain4j.pgvector.named-store.datasource", "named-ds")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.pgvector.named-store.dimension", "1536")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.pgvector.named-store.table", "named_embeddings");
 
     @Inject
     EmbeddingStore<TextSegment> defaultEmbeddingStore;
@@ -38,17 +35,17 @@ public class PgVectorDefaultAndNamedStoreTest {
     EmbeddingStore<TextSegment> namedEmbeddingStore;
 
     @Test
-    void should_injectDefaultStore() {
+    void testDefault() {
         Assertions.assertThat(defaultEmbeddingStore).isNotNull();
     }
 
     @Test
-    void should_injectNamedStore() {
+    void testNamed() {
         Assertions.assertThat(namedEmbeddingStore).isNotNull();
     }
 
     @Test
-    void should_injectDifferentStoreInstances() {
+    void testNotSame() {
         Assertions.assertThat(defaultEmbeddingStore).isNotSameAs(namedEmbeddingStore);
     }
 }

--- a/embedding-stores/pgvector/deployment/src/test/java/io/quarkiverse/langchain4j/pgvector/test/PgVectorMultipleNamedStoresTest.java
+++ b/embedding-stores/pgvector/deployment/src/test/java/io/quarkiverse/langchain4j/pgvector/test/PgVectorMultipleNamedStoresTest.java
@@ -9,7 +9,6 @@ import jakarta.inject.Inject;
 
 import org.assertj.core.api.Assertions;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -17,26 +16,25 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.agroal.DataSource;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class PgVectorMultipleNamedStoresTest {
 
     @RegisterExtension
     static final QuarkusUnitTest test = new QuarkusUnitTest()
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource(new StringAsset(
-                            "quarkus.langchain4j.pgvector.default-store-enabled=false\n" +
-                                    "quarkus.datasource.products-ds.devservices.image-name=pgvector/pgvector:pg16\n" +
-                                    "quarkus.datasource.products-ds.db-kind=postgresql\n" +
-                                    "quarkus.datasource.documents-ds.devservices.image-name=pgvector/pgvector:pg16\n" +
-                                    "quarkus.datasource.documents-ds.db-kind=postgresql\n" +
-                                    "quarkus.langchain4j.pgvector.products.datasource=products-ds\n" +
-                                    "quarkus.langchain4j.pgvector.products.dimension=1536\n" +
-                                    "quarkus.langchain4j.pgvector.products.table=product_embeddings\n" +
-                                    "quarkus.langchain4j.pgvector.documents.datasource=documents-ds\n" +
-                                    "quarkus.langchain4j.pgvector.documents.dimension=768\n" +
-                                    "quarkus.langchain4j.pgvector.documents.table=doc_embeddings\n"),
-                            "application.properties"));
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.pgvector.default-store-enabled", "false")
+            .overrideConfigKey("quarkus.datasource.products-ds.devservices.image-name", "pgvector/pgvector:pg16")
+            .overrideConfigKey("quarkus.datasource.products-ds.db-kind", "postgresql")
+            .overrideConfigKey("quarkus.datasource.documents-ds.devservices.image-name", "pgvector/pgvector:pg16")
+            .overrideConfigKey("quarkus.datasource.documents-ds.db-kind", "postgresql")
+            .overrideConfigKey("quarkus.langchain4j.pgvector.products.datasource", "products-ds")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.pgvector.products.dimension", "1536")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.pgvector.products.table", "product_embeddings")
+            .overrideConfigKey("quarkus.langchain4j.pgvector.documents.datasource", "documents-ds")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.pgvector.documents.dimension", "768")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.pgvector.documents.table", "doc_embeddings");
 
     @Inject
     @EmbeddingStoreName("products")
@@ -46,25 +44,27 @@ public class PgVectorMultipleNamedStoresTest {
     @EmbeddingStoreName("documents")
     EmbeddingStore<TextSegment> documentsEmbeddingStore;
 
-    @io.quarkus.agroal.DataSource("products-ds")
+    @Inject
+    @DataSource("products-ds")
     javax.sql.DataSource productsDs;
 
-    @io.quarkus.agroal.DataSource("documents-ds")
+    @Inject
+    @DataSource("documents-ds")
     javax.sql.DataSource documentsDs;
 
     @Test
-    void should_injectBothNamedStores() {
+    void testBothNamed() {
         Assertions.assertThat(productsEmbeddingStore).isNotNull();
         Assertions.assertThat(documentsEmbeddingStore).isNotNull();
     }
 
     @Test
-    void should_injectDifferentStoreInstances() {
+    void testNotSame() {
         Assertions.assertThat(productsEmbeddingStore).isNotSameAs(documentsEmbeddingStore);
     }
 
     @Test
-    void should_createProductEmbeddingsTable() throws SQLException {
+    void testProductEmbeddingsTable() throws SQLException {
         productsEmbeddingStore.toString();
         try (Connection connection = productsDs.getConnection()) {
             try (Statement statement = connection.createStatement()) {
@@ -78,7 +78,7 @@ public class PgVectorMultipleNamedStoresTest {
     }
 
     @Test
-    void should_createDocEmbeddingsTable() throws SQLException {
+    void testDocEmbeddingsTable() throws SQLException {
         documentsEmbeddingStore.toString();
         try (Connection connection = documentsDs.getConnection()) {
             try (Statement statement = connection.createStatement()) {

--- a/embedding-stores/pgvector/deployment/src/test/java/io/quarkiverse/langchain4j/pgvector/test/PgVectorNamedStoreInvalidDatasourceTest.java
+++ b/embedding-stores/pgvector/deployment/src/test/java/io/quarkiverse/langchain4j/pgvector/test/PgVectorNamedStoreInvalidDatasourceTest.java
@@ -3,7 +3,6 @@ package io.quarkiverse.langchain4j.pgvector.test;
 import jakarta.enterprise.inject.spi.DeploymentException;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -14,15 +13,13 @@ public class PgVectorNamedStoreInvalidDatasourceTest {
 
     @RegisterExtension
     static final QuarkusUnitTest test = new QuarkusUnitTest()
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource(new StringAsset(
-                            "quarkus.langchain4j.pgvector.default-store-enabled=false\n" +
-                                    "quarkus.langchain4j.pgvector.products.datasource=non-existent-ds\n" +
-                                    "quarkus.langchain4j.pgvector.products.dimension=1536\n"),
-                            "application.properties"))
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.pgvector.default-store-enabled", "false")
+            .overrideConfigKey("quarkus.langchain4j.pgvector.products.datasource", "non-existent-ds")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.pgvector.products.dimension", "1536")
             .setExpectedException(DeploymentException.class);
 
     @Test
-    void should_fail_with_invalid_datasource() {
+    void testInvalidDatasource() {
     }
 }

--- a/embedding-stores/pgvector/deployment/src/test/java/io/quarkiverse/langchain4j/pgvector/test/PgVectorNamedStoreMissingDimensionTest.java
+++ b/embedding-stores/pgvector/deployment/src/test/java/io/quarkiverse/langchain4j/pgvector/test/PgVectorNamedStoreMissingDimensionTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import jakarta.inject.Inject;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -20,21 +19,19 @@ public class PgVectorNamedStoreMissingDimensionTest {
 
     @RegisterExtension
     static final QuarkusUnitTest test = new QuarkusUnitTest()
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource(new StringAsset(
-                            "quarkus.datasource.db-kind=postgresql\n" +
-                                    "quarkus.datasource.devservices.image-name=pgvector/pgvector:pg16\n" +
-                                    "quarkus.langchain4j.pgvector.default-store-enabled=false\n" +
-                                    "quarkus.langchain4j.pgvector.products.datasource=<default>\n" +
-                                    "quarkus.langchain4j.pgvector.products.table=product_embeddings\n"),
-                            "application.properties"));
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.datasource.db-kind", "postgresql")
+            .overrideConfigKey("quarkus.datasource.devservices.image-name", "pgvector/pgvector:pg16")
+            .overrideConfigKey("quarkus.langchain4j.pgvector.default-store-enabled", "false")
+            .overrideConfigKey("quarkus.langchain4j.pgvector.products.datasource", "<default>")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.pgvector.products.table", "product_embeddings");
 
     @Inject
     @EmbeddingStoreName("products")
     EmbeddingStore<TextSegment> productsEmbeddingStore;
 
     @Test
-    void should_fail_with_missing_dimension() {
+    void testMissingDimension() {
         assertThatThrownBy(() -> productsEmbeddingStore.toString())
                 .hasCauseInstanceOf(ConfigValidationException.class);
     }

--- a/embedding-stores/pgvector/deployment/src/test/java/io/quarkiverse/langchain4j/pgvector/test/PgVectorNamedStoreTest.java
+++ b/embedding-stores/pgvector/deployment/src/test/java/io/quarkiverse/langchain4j/pgvector/test/PgVectorNamedStoreTest.java
@@ -9,7 +9,6 @@ import jakarta.inject.Inject;
 
 import org.assertj.core.api.Assertions;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -17,23 +16,22 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.agroal.DataSource;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class PgVectorNamedStoreTest {
 
     @RegisterExtension
     static final QuarkusUnitTest test = new QuarkusUnitTest()
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource(new StringAsset(
-                            "quarkus.datasource.db-kind=postgresql\n" +
-                                    "quarkus.datasource.devservices.image-name=pgvector/pgvector:pg16\n" +
-                                    "quarkus.datasource.products-ds.devservices.image-name=pgvector/pgvector:pg16\n" +
-                                    "quarkus.datasource.products-ds.db-kind=postgresql\n" +
-                                    "quarkus.langchain4j.pgvector.dimension=384\n" +
-                                    "quarkus.langchain4j.pgvector.products.datasource=products-ds\n" +
-                                    "quarkus.langchain4j.pgvector.products.dimension=1536\n" +
-                                    "quarkus.langchain4j.pgvector.products.table=product_embeddings\n"),
-                            "application.properties"));
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.datasource.db-kind", "postgresql")
+            .overrideConfigKey("quarkus.datasource.devservices.image-name", "pgvector/pgvector:pg16")
+            .overrideConfigKey("quarkus.datasource.products-ds.devservices.image-name", "pgvector/pgvector:pg16")
+            .overrideConfigKey("quarkus.datasource.products-ds.db-kind", "postgresql")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.pgvector.dimension", "384")
+            .overrideConfigKey("quarkus.langchain4j.pgvector.products.datasource", "products-ds")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.pgvector.products.dimension", "1536")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.pgvector.products.table", "product_embeddings");
 
     @Inject
     EmbeddingStore<TextSegment> defaultEmbeddingStore;
@@ -42,26 +40,27 @@ public class PgVectorNamedStoreTest {
     @EmbeddingStoreName("products")
     EmbeddingStore<TextSegment> productsEmbeddingStore;
 
-    @io.quarkus.agroal.DataSource("products-ds")
+    @Inject
+    @DataSource("products-ds")
     javax.sql.DataSource productsDs;
 
     @Test
-    void should_injectDefaultStore() {
+    void testDefault() {
         Assertions.assertThat(defaultEmbeddingStore).isNotNull();
     }
 
     @Test
-    void should_injectNamedStore() {
+    void testNamed() {
         Assertions.assertThat(productsEmbeddingStore).isNotNull();
     }
 
     @Test
-    void should_injectDifferentStoreInstances() {
+    void testNotSame() {
         Assertions.assertThat(defaultEmbeddingStore).isNotSameAs(productsEmbeddingStore);
     }
 
     @Test
-    void should_createNamedStoreTable() throws SQLException {
+    void testNamedStoreTable() throws SQLException {
         productsEmbeddingStore.toString();
         try (Connection connection = productsDs.getConnection()) {
             try (Statement statement = connection.createStatement()) {


### PR DESCRIPTION
Enables configuring multiple Neo4j embedding stores, each with independent configuration and injectable via `@EmbeddingStoreName`.

Named stores share the CDI-managed `Driver` but isolate via distinct `label`, `index-name`, and `embedding-property` values. The `database-name` property is required at build time for named store discovery. Without it, SmallRye's `@WithDefaults` never populates the `namedConfig()` map because `enabled` (the only other build-time property) has a default of `true` and is never explicitly set. This follows the same pattern as Redis (`client-name`) and pgvector (`datasource`).

## Configuration

Default store (backward compatible):

```properties
quarkus.langchain4j.neo4j.dimension=384
```

Named stores:

```properties
quarkus.langchain4j.neo4j.products.database-name=neo4j
quarkus.langchain4j.neo4j.products.dimension=1536
quarkus.langchain4j.neo4j.products.label=Product
quarkus.langchain4j.neo4j.products.index-name=product_vector
```

Disable default store:

```properties
quarkus.langchain4j.neo4j.default-store-enabled=false
```

## Injection

```java
@Inject
EmbeddingStore<TextSegment> defaultStore;

@Inject
@EmbeddingStoreName("products")
EmbeddingStore<TextSegment> productsStore;
```

- Closes: #2425
