### PR TITLE
docs(memory): fix orphan sentence introducing ChatMemoryProviderSuppl…

### DIFF
--- a/docs/modules/ROOT/pages/messages-and-memory.adoc
+++ b/docs/modules/ROOT/pages/messages-and-memory.adoc
@@ -178,7 +178,7 @@ public interface MyAssistant {
 }
 ----
 
-with a custom `ChatMemoryProviderSupplier`:
+Implement the custom `ChatMemoryProviderSupplier`:
 
 [source,java]
 ----


### PR DESCRIPTION
> **🔁 Backport target: `1.7` branch.** Red Hat Build of Quarkus 3.33 ships LangChain4j `1.7.4`, so this fix needs to land on the upstream `1.7` maintenance branch in addition to `main` to flow into RHBQ 3.33. Maintainers — please apply the `triage/backport-1.7` label so this is picked up by the backport workflow. (I tried to self-label and got `does not have the correct permissions to execute AddLabelsToLabelable`.)

## Summary

The second code block on the "Custom memory behavior" section of `messages-and-memory.adoc` is introduced by a sentence fragment — `with a custom \`ChatMemoryProviderSupplier\`:` — that has no subject or verb. As rendered today it reads as a dangling prepositional phrase between two `[source,java]` blocks.

This PR replaces it with an imperative-voice intro, `Implement the custom \`ChatMemoryProviderSupplier\`:`, so each of the two code blocks on the page has a complete, grammatical sentence introducing it. The first block is already introduced as "...specify a custom memory implementation in the `@RegisterAiService` annotation with the `chatMemoryProviderSupplier` attribute:"; this fix gives the second block parallel structure.

Content-only change; no behavior change.

## Files

- `docs/modules/ROOT/pages/messages-and-memory.adoc` (1 occurrence)
