### PR TITLE
docs: add intro sentences before orphan adjacent code blocks

### DIFF
--- a/docs/modules/ROOT/pages/function-calling.adoc
+++ b/docs/modules/ROOT/pages/function-calling.adoc
@@ -163,6 +163,8 @@ public interface CityExtractorAgent {
 }
 ----
 
+Reference the helper AI service from the main AI service:
+
 [source, java]
 ----
 @RegisterAiService
@@ -272,6 +274,8 @@ public class MyToolProviderSupplier implements Supplier<ToolProvider> {
     }
 }
 ----
+
+Implement the custom `ToolProvider`:
 
 [source, java]
 ----
@@ -430,6 +434,8 @@ public class EmailTools {
     }
 }
 ----
+
+Implement the input guardrail:
 
 [source,java]
 ----


### PR DESCRIPTION
> **🔁 Backport request: `triage/backport-1.7`.** Maintainers — please apply the `triage/backport-1.7` label so this is picked up by the backport workflow. (I tried to self-label and got `does not have the correct permissions to execute AddLabelsToLabelable`.)

## Summary

Three small intro sentences in `function-calling.adoc`, surfaced by an orphan-code-block scan over `docs/modules/ROOT/pages/`. Each pair of adjacent `[source,...]` blocks now has an imperative-voice intro so the reader knows what the second block defines.

- "Calling another AI service": added `Reference the helper AI service from the main AI service:` before the `MainAiService` block.
- "Dynamically Providing Tools": added `Implement the custom \`ToolProvider\`:` before the `MyCustomToolProvider` block (same pattern as PR #2430's `ChatMemoryProviderSupplier` intro).
- "Tool Guardrails / Basic Example": added `Implement the input guardrail:` before the `EmailFormatValidator` block.

Content-only change; no behavior change.

## Files

- `docs/modules/ROOT/pages/function-calling.adoc` (3 lines inserted)
