### PR TITLE
Add support for named Chroma embedding stores

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-chroma.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-chroma.adoc
@@ -7,6 +7,27 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-default-store-enabled]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-default-store-enabled[`+++quarkus.langchain4j.chroma.default-store-enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chroma.default-store-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the default (unnamed) Chroma embedding store should be enabled. Set to `false` when you only want to use named stores.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHROMA_DEFAULT_STORE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA_DEFAULT_STORE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-devservices-enabled]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-devservices-enabled[`+++quarkus.langchain4j.chroma.devservices.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.chroma.devservices.enabled+++[]
@@ -162,7 +183,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA_URL+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|required icon:exclamation-circle[title=Configuration property is required]
+|
 
 a| [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-collection-name]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-collection-name[`+++quarkus.langchain4j.chroma.collection-name+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -268,6 +289,158 @@ endif::add-copy-button-to-env-var[]
 --
 a|`v1`, `v2`
 |`+++v2+++`
+
+h|[[quarkus-langchain4j-chroma_section_quarkus-langchain4j-chroma]] [.section-name.section-level0]##link:#quarkus-langchain4j-chroma_section_quarkus-langchain4j-chroma[Named store configurations]##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-collection-name]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-collection-name[`+++quarkus.langchain4j.chroma."store-name".collection-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chroma."store-name".collection-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The collection name for this named store. This property serves as the build-time key that enables named store discovery. If not set, the default collection name will be used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__COLLECTION_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__COLLECTION_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++<default>+++`
+
+a| [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-url]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-url[`+++quarkus.langchain4j.chroma."store-name".url+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chroma."store-name".url+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+URL where the Chroma database is listening for requests
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__URL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__URL+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-collection-name]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-collection-name[`+++quarkus.langchain4j.chroma."store-name".collection-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chroma."store-name".collection-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The collection name.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__COLLECTION_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__COLLECTION_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++default+++`
+
+a| [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-timeout]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-timeout[`+++quarkus.langchain4j.chroma."store-name".timeout+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chroma."store-name".timeout+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The timeout duration for the Chroma client. If not specified, 5 seconds will be used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__TIMEOUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__TIMEOUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-langchain4j-chroma_quarkus-langchain4j[icon:question-circle[title=More information about the Duration format]]
+|
+
+a| [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-log-requests]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-log-requests[`+++quarkus.langchain4j.chroma."store-name".log-requests+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chroma."store-name".log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether requests to Chroma should be logged
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-log-responses]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-log-responses[`+++quarkus.langchain4j.chroma."store-name".log-responses+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chroma."store-name".log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether responses from Chroma should be logged
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-api-version]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-api-version[`+++quarkus.langchain4j.chroma."store-name".api-version+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chroma."store-name".api-version+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The Chroma API version to use. V1 is deprecated (Chroma 0.x) and its support will be removed in the future. Please use Chroma 1.x which uses the V2 API.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__API_VERSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__API_VERSION+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`v1`, `v2`
+|`+++v2+++`
+
 
 |===
 

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-chroma_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-chroma_quarkus.langchain4j.adoc
@@ -7,6 +7,27 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-default-store-enabled]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-default-store-enabled[`+++quarkus.langchain4j.chroma.default-store-enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chroma.default-store-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the default (unnamed) Chroma embedding store should be enabled. Set to `false` when you only want to use named stores.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHROMA_DEFAULT_STORE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA_DEFAULT_STORE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-devservices-enabled]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-devservices-enabled[`+++quarkus.langchain4j.chroma.devservices.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.chroma.devservices.enabled+++[]
@@ -162,7 +183,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA_URL+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|required icon:exclamation-circle[title=Configuration property is required]
+|
 
 a| [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-collection-name]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-collection-name[`+++quarkus.langchain4j.chroma.collection-name+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -268,6 +289,158 @@ endif::add-copy-button-to-env-var[]
 --
 a|`v1`, `v2`
 |`+++v2+++`
+
+h|[[quarkus-langchain4j-chroma_section_quarkus-langchain4j-chroma]] [.section-name.section-level0]##link:#quarkus-langchain4j-chroma_section_quarkus-langchain4j-chroma[Named store configurations]##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-collection-name]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-collection-name[`+++quarkus.langchain4j.chroma."store-name".collection-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chroma."store-name".collection-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The collection name for this named store. This property serves as the build-time key that enables named store discovery. If not set, the default collection name will be used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__COLLECTION_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__COLLECTION_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++<default>+++`
+
+a| [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-url]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-url[`+++quarkus.langchain4j.chroma."store-name".url+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chroma."store-name".url+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+URL where the Chroma database is listening for requests
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__URL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__URL+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-collection-name]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-collection-name[`+++quarkus.langchain4j.chroma."store-name".collection-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chroma."store-name".collection-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The collection name.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__COLLECTION_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__COLLECTION_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++default+++`
+
+a| [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-timeout]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-timeout[`+++quarkus.langchain4j.chroma."store-name".timeout+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chroma."store-name".timeout+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The timeout duration for the Chroma client. If not specified, 5 seconds will be used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__TIMEOUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__TIMEOUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-langchain4j-chroma_quarkus-langchain4j[icon:question-circle[title=More information about the Duration format]]
+|
+
+a| [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-log-requests]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-log-requests[`+++quarkus.langchain4j.chroma."store-name".log-requests+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chroma."store-name".log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether requests to Chroma should be logged
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-log-responses]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-log-responses[`+++quarkus.langchain4j.chroma."store-name".log-responses+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chroma."store-name".log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether responses from Chroma should be logged
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-api-version]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-api-version[`+++quarkus.langchain4j.chroma."store-name".api-version+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chroma."store-name".api-version+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The Chroma API version to use. V1 is deprecated (Chroma 0.x) and its support will be removed in the future. Please use Chroma 1.x which uses the V2 API.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__API_VERSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHROMA__STORE_NAME__API_VERSION+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`v1`, `v2`
+|`+++v2+++`
+
 
 |===
 

--- a/docs/modules/ROOT/pages/rag-chroma-store.adoc
+++ b/docs/modules/ROOT/pages/rag-chroma-store.adoc
@@ -46,6 +46,36 @@ The Chroma extension can be configured using the following options:
 
 include::includes/quarkus-langchain4j-chroma.adoc[leveloffset=+1,opts=optional]
 
+== Named Stores
+
+You can configure multiple named Chroma stores, each using a different collection.
+This is useful when your application needs to manage embeddings for different domains or tenants in separate collections within the same Chroma instance.
+
+To configure a named store:
+
+[source,properties]
+----
+quarkus.langchain4j.chroma.products.collection-name=product_embeddings
+quarkus.langchain4j.chroma.products.url=http://chroma.example.com:8000
+----
+
+To inject a named store, use the `@EmbeddingStoreName` qualifier:
+
+[source,java]
+----
+@Inject
+@EmbeddingStoreName("products")
+EmbeddingStore<TextSegment> productsStore;
+----
+
+The default store and named stores can coexist.
+If you only need named stores, disable the default store:
+
+[source,properties]
+----
+quarkus.langchain4j.chroma.default-store-enabled=false
+----
+
 == Notes
 
 * Chroma supports metadata, but filtering capabilities may depend on the current Chroma version and API behavior.

--- a/embedding-stores/chroma/deployment/src/main/java/io/quarkiverse/langchain4j/chroma/deployment/ChromaDevServicesProcessor.java
+++ b/embedding-stores/chroma/deployment/src/main/java/io/quarkiverse/langchain4j/chroma/deployment/ChromaDevServicesProcessor.java
@@ -2,11 +2,13 @@ package io.quarkiverse.langchain4j.chroma.deployment;
 
 import java.io.Closeable;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import org.jboss.logging.Logger;
@@ -52,11 +54,13 @@ public class ChromaDevServicesProcessor {
     public DevServicesResultBuildItem startChromaDevService(
             DockerStatusBuildItem dockerStatusBuildItem,
             LaunchModeBuildItem launchMode,
-            ChromaBuildConfig chromaBuildConfig,
+            ChromaEmbeddingStoreBuildTimeConfig chromaBuildConfig,
             Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
             List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
             LoggingSetupBuildItem loggingSetupBuildItem,
             DevServicesConfig devServicesConfig) {
+
+        Set<String> namedStoreNames = chromaBuildConfig.namedConfig().keySet();
 
         ChromaDevServiceCfg configuration = getConfiguration(chromaBuildConfig);
 
@@ -75,7 +79,7 @@ public class ChromaDevServicesProcessor {
         try {
             DevServicesResultBuildItem.RunningDevService newDevService = startContainer(dockerStatusBuildItem, configuration,
                     launchMode,
-                    !devServicesSharedNetworkBuildItem.isEmpty(), devServicesConfig.timeout());
+                    !devServicesSharedNetworkBuildItem.isEmpty(), devServicesConfig.timeout(), namedStoreNames);
             if (newDevService != null) {
                 devService = newDevService;
 
@@ -132,7 +136,7 @@ public class ChromaDevServicesProcessor {
 
     private DevServicesResultBuildItem.RunningDevService startContainer(DockerStatusBuildItem dockerStatusBuildItem,
             ChromaDevServiceCfg config, LaunchModeBuildItem launchMode,
-            boolean useSharedNetwork, Optional<Duration> timeout) {
+            boolean useSharedNetwork, Optional<Duration> timeout, Set<String> namedStoreNames) {
         if (!config.devServicesEnabled) {
             // explicitly disabled
             log.debug("Not starting Dev Services for Chroma, as it has been disabled in the config.");
@@ -160,7 +164,8 @@ public class ChromaDevServicesProcessor {
                     container.getContainerId(),
                     container::close,
                     container.getHost(),
-                    container.getPort());
+                    container.getPort(),
+                    namedStoreNames);
         };
 
         return containerLocator
@@ -172,21 +177,24 @@ public class ChromaDevServicesProcessor {
                         containerAddress.getId(),
                         null,
                         containerAddress.getHost(),
-                        containerAddress.getPort()))
+                        containerAddress.getPort(),
+                        namedStoreNames))
                 .orElseGet(defaultChromaSupplier);
     }
 
     private DevServicesResultBuildItem.RunningDevService getRunningDevService(
-            String containerId,
-            Closeable closeable,
-            String host,
-            int port) {
-        Map<String, String> configMap = Map.of("quarkus.langchain4j.chroma.url", "http://" + host + ":" + port);
+            String containerId, Closeable closeable, String host, int port, Set<String> namedStoreNames) {
+        String chromaUrl = "http://" + host + ":" + port;
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put("quarkus.langchain4j.chroma.url", chromaUrl);
+        for (String namedStore : namedStoreNames) {
+            configMap.put("quarkus.langchain4j.chroma." + namedStore + ".url", chromaUrl);
+        }
         return new DevServicesResultBuildItem.RunningDevService(ChromaProcessor.FEATURE,
                 containerId, closeable, configMap);
     }
 
-    private ChromaDevServiceCfg getConfiguration(ChromaBuildConfig cfg) {
+    private ChromaDevServiceCfg getConfiguration(ChromaEmbeddingStoreBuildTimeConfig cfg) {
         return new ChromaDevServiceCfg(cfg.devservices());
     }
 
@@ -200,7 +208,7 @@ public class ChromaDevServicesProcessor {
         private final String serviceName;
         private final Map<String, String> containerEnv;
 
-        public ChromaDevServiceCfg(ChromaBuildConfig.ChromaDevServicesBuildTimeConfig devServicesConfig) {
+        public ChromaDevServiceCfg(ChromaEmbeddingStoreBuildTimeConfig.ChromaDevServicesBuildTimeConfig devServicesConfig) {
             this.devServicesEnabled = devServicesConfig.enabled();
             this.imageName = devServicesConfig.imageName();
             this.fixedExposedPort = devServicesConfig.port();

--- a/embedding-stores/chroma/deployment/src/main/java/io/quarkiverse/langchain4j/chroma/deployment/ChromaEmbeddingStoreBuildTimeConfig.java
+++ b/embedding-stores/chroma/deployment/src/main/java/io/quarkiverse/langchain4j/chroma/deployment/ChromaEmbeddingStoreBuildTimeConfig.java
@@ -5,19 +5,49 @@ import static io.quarkus.runtime.annotations.ConfigPhase.BUILD_TIME;
 import java.util.Map;
 import java.util.OptionalInt;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithDefaults;
+import io.smallrye.config.WithParentName;
 
 @ConfigRoot(phase = BUILD_TIME)
 @ConfigMapping(prefix = "quarkus.langchain4j.chroma")
-public interface ChromaBuildConfig {
+public interface ChromaEmbeddingStoreBuildTimeConfig {
+
+    /**
+     * Default store build-time config.
+     */
+    @WithParentName
+    DefaultStoreBuildTimeConfig defaultConfig();
+
+    /**
+     * Named store configurations.
+     */
+    @ConfigDocSection
+    @ConfigDocMapKey("store-name")
+    @WithParentName
+    @WithDefaults
+    Map<String, ChromaNamedStoreBuildTimeConfig> namedConfig();
 
     /**
      * Configuration for DevServices. DevServices allows Quarkus to automatically start a database in dev and test mode.
      */
     ChromaDevServicesBuildTimeConfig devservices();
+
+    @ConfigGroup
+    interface DefaultStoreBuildTimeConfig {
+
+        /**
+         * Whether the default (unnamed) Chroma embedding store should be enabled.
+         * Set to {@code false} when you only want to use named stores.
+         */
+        @WithDefault("true")
+        boolean defaultStoreEnabled();
+    }
 
     @ConfigGroup
     interface ChromaDevServicesBuildTimeConfig {

--- a/embedding-stores/chroma/deployment/src/main/java/io/quarkiverse/langchain4j/chroma/deployment/ChromaNamedStoreBuildTimeConfig.java
+++ b/embedding-stores/chroma/deployment/src/main/java/io/quarkiverse/langchain4j/chroma/deployment/ChromaNamedStoreBuildTimeConfig.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.langchain4j.chroma.deployment;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+
+@ConfigGroup
+public interface ChromaNamedStoreBuildTimeConfig {
+
+    /**
+     * The collection name for this named store.
+     * This property serves as the build-time key that enables named store discovery.
+     * If not set, the collection name from the runtime configuration will be used.
+     */
+    @WithDefault("<default>")
+    Optional<String> collectionName();
+}

--- a/embedding-stores/chroma/deployment/src/main/java/io/quarkiverse/langchain4j/chroma/deployment/ChromaProcessor.java
+++ b/embedding-stores/chroma/deployment/src/main/java/io/quarkiverse/langchain4j/chroma/deployment/ChromaProcessor.java
@@ -1,7 +1,10 @@
 package io.quarkiverse.langchain4j.chroma.deployment;
 
+import java.util.Map;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
+import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassType;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.ParameterizedType;
@@ -9,8 +12,10 @@ import org.jboss.jandex.ParameterizedType;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.chroma.ChromaEmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
 import io.quarkiverse.langchain4j.chroma.runtime.ChromaRecorder;
 import io.quarkiverse.langchain4j.deployment.EmbeddingStoreBuildItem;
+import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
@@ -39,19 +44,48 @@ class ChromaProcessor {
     public void createBean(
             BuildProducer<SyntheticBeanBuildItem> beanProducer,
             ChromaRecorder recorder,
-            BuildProducer<EmbeddingStoreBuildItem> embeddingStoreProducer) {
-        beanProducer.produce(SyntheticBeanBuildItem
-                .configure(CHROMA_EMBEDDING_STORE)
-                .types(ClassType.create(EmbeddingStore.class),
-                        ClassType.create(ChromaEmbeddingStore.class),
-                        ParameterizedType.create(EmbeddingStore.class, ClassType.create(TextSegment.class)))
-                .defaultBean()
-                .setRuntimeInit()
-                .unremovable()
-                .scope(ApplicationScoped.class)
-                .supplier(recorder.chromaStoreSupplier())
-                .done());
-        embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
+            BuildProducer<EmbeddingStoreBuildItem> embeddingStoreProducer,
+            ChromaEmbeddingStoreBuildTimeConfig buildTimeConfig) {
+
+        if (buildTimeConfig.defaultConfig().defaultStoreEnabled()) {
+            beanProducer.produce(SyntheticBeanBuildItem
+                    .configure(CHROMA_EMBEDDING_STORE)
+                    .types(ClassType.create(EmbeddingStore.class),
+                            ClassType.create(ChromaEmbeddingStore.class),
+                            ParameterizedType.create(EmbeddingStore.class, ClassType.create(TextSegment.class)))
+                    .setRuntimeInit()
+                    .defaultBean()
+                    .unremovable()
+                    .scope(ApplicationScoped.class)
+                    .createWith(recorder.chromaStoreFunction(NamedConfigUtil.DEFAULT_NAME))
+                    .done());
+
+            embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
+        }
+
+        Map<String, ChromaNamedStoreBuildTimeConfig> namedStores = buildTimeConfig.namedConfig();
+        for (Map.Entry<String, ChromaNamedStoreBuildTimeConfig> entry : namedStores.entrySet()) {
+            String storeName = entry.getKey();
+
+            AnnotationInstance storeNameQualifier = AnnotationInstance.builder(EmbeddingStoreName.class)
+                    .add("value", storeName)
+                    .build();
+
+            beanProducer.produce(SyntheticBeanBuildItem
+                    .configure(CHROMA_EMBEDDING_STORE)
+                    .types(ClassType.create(EmbeddingStore.class),
+                            ClassType.create(ChromaEmbeddingStore.class),
+                            ParameterizedType.create(EmbeddingStore.class, ClassType.create(TextSegment.class)))
+                    .setRuntimeInit()
+                    .defaultBean()
+                    .unremovable()
+                    .scope(ApplicationScoped.class)
+                    .addQualifier(storeNameQualifier)
+                    .createWith(recorder.chromaStoreFunction(storeName))
+                    .done());
+
+            embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
+        }
     }
 
     /**

--- a/embedding-stores/chroma/deployment/src/test/java/io/quarkiverse/langchain4j/chroma/deployment/ChromaDefaultAndNamedStoreTest.java
+++ b/embedding-stores/chroma/deployment/src/test/java/io/quarkiverse/langchain4j/chroma/deployment/ChromaDefaultAndNamedStoreTest.java
@@ -1,0 +1,45 @@
+package io.quarkiverse.langchain4j.chroma.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.store.embedding.chroma.ChromaEmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ChromaDefaultAndNamedStoreTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.chroma.products.collection-name", "product_embeddings")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.chroma.products.url", "http://localhost:9000");
+
+    @Inject
+    ChromaEmbeddingStore defaultEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("products")
+    ChromaEmbeddingStore productsEmbeddingStore;
+
+    @Test
+    void testDefault() {
+        assertThat(defaultEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void testNamed() {
+        assertThat(productsEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void testNotSame() {
+        assertThat(defaultEmbeddingStore).isNotSameAs(productsEmbeddingStore);
+    }
+}

--- a/embedding-stores/chroma/deployment/src/test/java/io/quarkiverse/langchain4j/chroma/deployment/ChromaMultipleNamedStoresTest.java
+++ b/embedding-stores/chroma/deployment/src/test/java/io/quarkiverse/langchain4j/chroma/deployment/ChromaMultipleNamedStoresTest.java
@@ -1,0 +1,45 @@
+package io.quarkiverse.langchain4j.chroma.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.store.embedding.chroma.ChromaEmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ChromaMultipleNamedStoresTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.chroma.default-store-enabled", "false")
+            .overrideConfigKey("quarkus.langchain4j.chroma.products.collection-name", "product_embeddings")
+            .overrideConfigKey("quarkus.langchain4j.chroma.documents.collection-name", "doc_embeddings")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.chroma.products.url", "http://localhost:8000")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.chroma.documents.url", "http://localhost:8000");
+
+    @Inject
+    @EmbeddingStoreName("products")
+    ChromaEmbeddingStore productsEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("documents")
+    ChromaEmbeddingStore documentsEmbeddingStore;
+
+    @Test
+    void testBothNamed() {
+        assertThat(productsEmbeddingStore).isNotNull();
+        assertThat(documentsEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void testNotSame() {
+        assertThat(productsEmbeddingStore).isNotSameAs(documentsEmbeddingStore);
+    }
+}

--- a/embedding-stores/chroma/deployment/src/test/java/io/quarkiverse/langchain4j/chroma/deployment/ChromaNamedStoreMissingUrlTest.java
+++ b/embedding-stores/chroma/deployment/src/test/java/io/quarkiverse/langchain4j/chroma/deployment/ChromaNamedStoreMissingUrlTest.java
@@ -1,0 +1,38 @@
+package io.quarkiverse.langchain4j.chroma.deployment;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.store.embedding.chroma.ChromaEmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.config.ConfigValidationException;
+
+public class ChromaNamedStoreMissingUrlTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.langchain4j.chroma.devservices.enabled=false\n" +
+                                    "quarkus.langchain4j.chroma.default-store-enabled=false\n" +
+                                    "quarkus.langchain4j.chroma.products.collection-name=product_embeddings\n"),
+                            "application.properties"));
+
+    @Inject
+    @EmbeddingStoreName("products")
+    ChromaEmbeddingStore productsEmbeddingStore;
+
+    @Test
+    void testMissingUrl() {
+        assertThatThrownBy(() -> productsEmbeddingStore.toString())
+                .hasCauseInstanceOf(ConfigValidationException.class);
+    }
+}

--- a/embedding-stores/chroma/deployment/src/test/java/io/quarkiverse/langchain4j/chroma/deployment/ChromaNamedStoreTest.java
+++ b/embedding-stores/chroma/deployment/src/test/java/io/quarkiverse/langchain4j/chroma/deployment/ChromaNamedStoreTest.java
@@ -1,0 +1,45 @@
+package io.quarkiverse.langchain4j.chroma.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.store.embedding.chroma.ChromaEmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ChromaNamedStoreTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.chroma.products.collection-name", "product_embeddings")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.chroma.products.url", "http://localhost:8000");
+
+    @Inject
+    ChromaEmbeddingStore defaultEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("products")
+    ChromaEmbeddingStore productsEmbeddingStore;
+
+    @Test
+    void testDefault() {
+        assertThat(defaultEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void testNamed() {
+        assertThat(productsEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void testNotSame() {
+        assertThat(defaultEmbeddingStore).isNotSameAs(productsEmbeddingStore);
+    }
+}

--- a/embedding-stores/chroma/runtime/src/main/java/io/quarkiverse/langchain4j/chroma/runtime/ChromaEmbeddingStoreConfig.java
+++ b/embedding-stores/chroma/runtime/src/main/java/io/quarkiverse/langchain4j/chroma/runtime/ChromaEmbeddingStoreConfig.java
@@ -1,0 +1,32 @@
+package io.quarkiverse.langchain4j.chroma.runtime;
+
+import static io.quarkus.runtime.annotations.ConfigPhase.RUN_TIME;
+
+import java.util.Map;
+
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigDocSection;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefaults;
+import io.smallrye.config.WithParentName;
+
+@ConfigRoot(phase = RUN_TIME)
+@ConfigMapping(prefix = "quarkus.langchain4j.chroma")
+public interface ChromaEmbeddingStoreConfig {
+
+    /**
+     * Default store config.
+     */
+    @WithParentName
+    ChromaStoreRuntimeConfig defaultConfig();
+
+    /**
+     * Named store configurations.
+     */
+    @ConfigDocSection
+    @ConfigDocMapKey("store-name")
+    @WithParentName
+    @WithDefaults
+    Map<String, ChromaStoreRuntimeConfig> namedConfig();
+}

--- a/embedding-stores/chroma/runtime/src/main/java/io/quarkiverse/langchain4j/chroma/runtime/ChromaRecorder.java
+++ b/embedding-stores/chroma/runtime/src/main/java/io/quarkiverse/langchain4j/chroma/runtime/ChromaRecorder.java
@@ -1,33 +1,58 @@
 package io.quarkiverse.langchain4j.chroma.runtime;
 
 import java.time.Duration;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 import dev.langchain4j.store.embedding.chroma.ChromaEmbeddingStore;
+import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
+import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
+import io.smallrye.config.ConfigValidationException;
 
 @Recorder
 public class ChromaRecorder {
-    private final RuntimeValue<ChromaConfig> runtimeConfig;
+    private final RuntimeValue<ChromaEmbeddingStoreConfig> runtimeConfig;
 
-    public ChromaRecorder(RuntimeValue<ChromaConfig> runtimeConfig) {
+    public ChromaRecorder(RuntimeValue<ChromaEmbeddingStoreConfig> runtimeConfig) {
         this.runtimeConfig = runtimeConfig;
     }
 
-    public Supplier<ChromaEmbeddingStore> chromaStoreSupplier() {
-        return new Supplier<>() {
+    public Function<SyntheticCreationalContext<ChromaEmbeddingStore>, ChromaEmbeddingStore> chromaStoreFunction(
+            String storeName) {
+        return new Function<>() {
             @Override
-            public ChromaEmbeddingStore get() {
+            public ChromaEmbeddingStore apply(SyntheticCreationalContext<ChromaEmbeddingStore> context) {
+                ChromaStoreRuntimeConfig storeConfig = correspondingStoreConfig(storeName);
+
+                String url = storeConfig.url()
+                        .orElseGet(() -> runtimeConfig.getValue().defaultConfig().url().orElseThrow(
+                                () -> new ConfigValidationException(createUrlConfigProblems(storeName))));
+
                 ChromaEmbeddingStore.Builder builder = ChromaEmbeddingStore.builder();
-                builder.apiVersion(runtimeConfig.getValue().apiVersion());
-                builder.collectionName(runtimeConfig.getValue().collectionName());
-                builder.logRequests(runtimeConfig.getValue().logRequests().orElse(false));
-                builder.logResponses(runtimeConfig.getValue().logResponses().orElse(false));
-                builder.timeout(runtimeConfig.getValue().timeout().orElse(Duration.ofSeconds(5)));
-                builder.baseUrl(runtimeConfig.getValue().url());
+                builder.apiVersion(storeConfig.apiVersion());
+                builder.collectionName(storeConfig.collectionName());
+                builder.logRequests(storeConfig.logRequests().orElse(false));
+                builder.logResponses(storeConfig.logResponses().orElse(false));
+                builder.timeout(storeConfig.timeout().orElse(Duration.ofSeconds(5)));
+                builder.baseUrl(url);
                 return builder.build();
             }
+        };
+    }
+
+    private ChromaStoreRuntimeConfig correspondingStoreConfig(String storeName) {
+        if (NamedConfigUtil.isDefault(storeName)) {
+            return runtimeConfig.getValue().defaultConfig();
+        }
+        return runtimeConfig.getValue().namedConfig().get(storeName);
+    }
+
+    private ConfigValidationException.Problem[] createUrlConfigProblems(String storeName) {
+        return new ConfigValidationException.Problem[] {
+                new ConfigValidationException.Problem(String.format(
+                        "SRCFG00014: The config property quarkus.langchain4j.chroma%surl is required but it could not be found in any config source",
+                        NamedConfigUtil.isDefault(storeName) ? "." : ("." + storeName + ".")))
         };
     }
 }

--- a/embedding-stores/chroma/runtime/src/main/java/io/quarkiverse/langchain4j/chroma/runtime/ChromaStoreRuntimeConfig.java
+++ b/embedding-stores/chroma/runtime/src/main/java/io/quarkiverse/langchain4j/chroma/runtime/ChromaStoreRuntimeConfig.java
@@ -1,24 +1,20 @@
 package io.quarkiverse.langchain4j.chroma.runtime;
 
-import static io.quarkus.runtime.annotations.ConfigPhase.RUN_TIME;
-
 import java.time.Duration;
 import java.util.Optional;
 
 import dev.langchain4j.store.embedding.chroma.ChromaApiVersion;
 import io.quarkus.runtime.annotations.ConfigDocDefault;
-import io.quarkus.runtime.annotations.ConfigRoot;
-import io.smallrye.config.ConfigMapping;
+import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
-@ConfigRoot(phase = RUN_TIME)
-@ConfigMapping(prefix = "quarkus.langchain4j.chroma")
-public interface ChromaConfig {
+@ConfigGroup
+public interface ChromaStoreRuntimeConfig {
 
     /**
      * URL where the Chroma database is listening for requests
      */
-    String url();
+    Optional<String> url();
 
     /**
      * The collection name.
@@ -52,5 +48,4 @@ public interface ChromaConfig {
      */
     @WithDefault("V2")
     ChromaApiVersion apiVersion();
-
 }


### PR DESCRIPTION
Enables configuring multiple Chroma embedding stores, each with independent configuration, following the same named-instance pattern used by model providers (OpenAI, Ollama, Anthropic, etc.) and other embedding store providers (pgvector, Redis, Neo4j).

Chroma has no CDI-managed client, so named stores without an explicit `url` fall back to the default store's `url`. Chroma also manages its own DevServices, so the processor propagates the container URL to each named store automatically.

## Configuration

Default store (backward compatible, no changes required):

```properties
quarkus.langchain4j.chroma.collection-name=default
```

Named stores:

```properties
quarkus.langchain4j.chroma.products.collection-name=product_embeddings
quarkus.langchain4j.chroma.products.url=http://chroma.example.com:8000
```

Disable default store when only named stores are needed:

```properties
quarkus.langchain4j.chroma.default-store-enabled=false
```

## Injection

```java
@Inject
EmbeddingStore<TextSegment> defaultStore;

@Inject
@EmbeddingStoreName("products")
EmbeddingStore<TextSegment> productsStore;
```

- Closes: #2432