### PR TITLE
Add named embedding stores support for Milvus

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-milvus.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-milvus.adoc
@@ -7,6 +7,27 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-default-store-enabled]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-default-store-enabled[`+++quarkus.langchain4j.milvus.default-store-enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus.default-store-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the default (unnamed) Milvus embedding store should be enabled. Set to `false` when you only want to use named stores.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS_DEFAULT_STORE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS_DEFAULT_STORE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-devservices-enabled]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-devservices-enabled[`+++quarkus.langchain4j.milvus.devservices.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.milvus.devservices.enabled+++[]
@@ -131,7 +152,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS_HOST+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|required icon:exclamation-circle[title=Configuration property is required]
+|`+++localhost+++`
 
 a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-port]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-port[`+++quarkus.langchain4j.milvus.port+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -152,7 +173,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS_PORT+++`
 endif::add-copy-button-to-env-var[]
 --
 |int
-|required icon:exclamation-circle[title=Configuration property is required]
+|`+++19530+++`
 
 a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-token]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-token[`+++quarkus.langchain4j.milvus.token+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -489,6 +510,410 @@ endif::add-copy-button-to-env-var[]
 --
 a|`strong`, `session`, `bounded`, `eventually`
 |`+++eventually+++`
+
+h|[[quarkus-langchain4j-milvus_section_quarkus-langchain4j-milvus]] [.section-name.section-level0]##link:#quarkus-langchain4j-milvus_section_quarkus-langchain4j-milvus[Named store configurations]##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-host]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-host[`+++quarkus.langchain4j.milvus."store-name".host+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".host+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The host of the Milvus server to use for this named store. If set to `<default>`, the default Milvus server will be used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__HOST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__HOST+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++<default>+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-host]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-host[`+++quarkus.langchain4j.milvus."store-name".host+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".host+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The URL of the Milvus server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__HOST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__HOST+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++localhost+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-port]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-port[`+++quarkus.langchain4j.milvus."store-name".port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The port of the Milvus server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++19530+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-token]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-token[`+++quarkus.langchain4j.milvus."store-name".token+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".token+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The authentication token for the Milvus server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__TOKEN+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__TOKEN+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-username]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-username[`+++quarkus.langchain4j.milvus."store-name".username+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".username+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The username for the Milvus server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__USERNAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__USERNAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-password]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-password[`+++quarkus.langchain4j.milvus."store-name".password+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".password+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The password for the Milvus server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-timeout]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-timeout[`+++quarkus.langchain4j.milvus."store-name".timeout+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".timeout+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The timeout duration for the Milvus client. If not specified, 5 seconds will be used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__TIMEOUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__TIMEOUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-langchain4j-milvus_quarkus-langchain4j[icon:question-circle[title=More information about the Duration format]]
+|
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-db-name]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-db-name[`+++quarkus.langchain4j.milvus."store-name".db-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".db-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the database.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__DB_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__DB_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++default+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-create-collection]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-create-collection[`+++quarkus.langchain4j.milvus."store-name".create-collection+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".create-collection+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Create the collection if it does not exist yet.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__CREATE_COLLECTION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__CREATE_COLLECTION+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-collection-name]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-collection-name[`+++quarkus.langchain4j.milvus."store-name".collection-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".collection-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the collection.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__COLLECTION_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__COLLECTION_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++embeddings+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-dimension]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-dimension[`+++quarkus.langchain4j.milvus."store-name".dimension+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".dimension+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Dimension of the vectors. Only applicable when the collection yet has to be created.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__DIMENSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__DIMENSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-primary-field]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-primary-field[`+++quarkus.langchain4j.milvus."store-name".primary-field+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".primary-field+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the field that contains the ID of the vector.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__PRIMARY_FIELD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__PRIMARY_FIELD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++id+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-text-field]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-text-field[`+++quarkus.langchain4j.milvus."store-name".text-field+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".text-field+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the field that contains the text from which the vector was calculated.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__TEXT_FIELD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__TEXT_FIELD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++text+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-metadata-field]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-metadata-field[`+++quarkus.langchain4j.milvus."store-name".metadata-field+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".metadata-field+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the field that contains JSON metadata associated with the text.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__METADATA_FIELD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__METADATA_FIELD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++metadata+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-vector-field]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-vector-field[`+++quarkus.langchain4j.milvus."store-name".vector-field+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".vector-field+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the field to store the vector in.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__VECTOR_FIELD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__VECTOR_FIELD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++vector+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-description]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-description[`+++quarkus.langchain4j.milvus."store-name".description+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".description+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Description of the collection.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__DESCRIPTION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__DESCRIPTION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-index-type]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-index-type[`+++quarkus.langchain4j.milvus."store-name".index-type+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".index-type+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The index type to use for the collection.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__INDEX_TYPE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__INDEX_TYPE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`none`, `flat`, `ivf-flat`, `ivf-sq8`, `ivf-pq`, `hnsw`, `hnsw-sq`, `hnsw-pq`, `hnsw-prq`, `diskann`, `autoindex`, `scann`, `gpu-ivf-flat`, `gpu-ivf-pq`, `gpu-brute-force`, `gpu-cagra`, `bin-flat`, `bin-ivf-flat`, `trie`, `stl-sort`, `inverted`, `bitmap`, `sparse-inverted-index`, `sparse-wand`
+|`+++flat+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-metric-type]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-metric-type[`+++quarkus.langchain4j.milvus."store-name".metric-type+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".metric-type+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The metric type to use for searching.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__METRIC_TYPE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__METRIC_TYPE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`none`, `l2`, `ip`, `cosine`, `hamming`, `jaccard`
+|`+++cosine+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-consistency-level]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-consistency-level[`+++quarkus.langchain4j.milvus."store-name".consistency-level+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".consistency-level+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The consistency level.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__CONSISTENCY_LEVEL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__CONSISTENCY_LEVEL+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`strong`, `session`, `bounded`, `eventually`
+|`+++eventually+++`
+
 
 |===
 

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-milvus_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-milvus_quarkus.langchain4j.adoc
@@ -7,6 +7,27 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-default-store-enabled]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-default-store-enabled[`+++quarkus.langchain4j.milvus.default-store-enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus.default-store-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the default (unnamed) Milvus embedding store should be enabled. Set to `false` when you only want to use named stores.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS_DEFAULT_STORE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS_DEFAULT_STORE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-devservices-enabled]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-devservices-enabled[`+++quarkus.langchain4j.milvus.devservices.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.milvus.devservices.enabled+++[]
@@ -131,7 +152,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS_HOST+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|required icon:exclamation-circle[title=Configuration property is required]
+|`+++localhost+++`
 
 a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-port]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-port[`+++quarkus.langchain4j.milvus.port+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -152,7 +173,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS_PORT+++`
 endif::add-copy-button-to-env-var[]
 --
 |int
-|required icon:exclamation-circle[title=Configuration property is required]
+|`+++19530+++`
 
 a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-token]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-token[`+++quarkus.langchain4j.milvus.token+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -489,6 +510,410 @@ endif::add-copy-button-to-env-var[]
 --
 a|`strong`, `session`, `bounded`, `eventually`
 |`+++eventually+++`
+
+h|[[quarkus-langchain4j-milvus_section_quarkus-langchain4j-milvus]] [.section-name.section-level0]##link:#quarkus-langchain4j-milvus_section_quarkus-langchain4j-milvus[Named store configurations]##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-host]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-host[`+++quarkus.langchain4j.milvus."store-name".host+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".host+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The host of the Milvus server to use for this named store. If set to `<default>`, the default Milvus server will be used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__HOST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__HOST+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++<default>+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-host]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-host[`+++quarkus.langchain4j.milvus."store-name".host+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".host+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The URL of the Milvus server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__HOST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__HOST+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++localhost+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-port]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-port[`+++quarkus.langchain4j.milvus."store-name".port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The port of the Milvus server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++19530+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-token]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-token[`+++quarkus.langchain4j.milvus."store-name".token+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".token+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The authentication token for the Milvus server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__TOKEN+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__TOKEN+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-username]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-username[`+++quarkus.langchain4j.milvus."store-name".username+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".username+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The username for the Milvus server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__USERNAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__USERNAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-password]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-password[`+++quarkus.langchain4j.milvus."store-name".password+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".password+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The password for the Milvus server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-timeout]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-timeout[`+++quarkus.langchain4j.milvus."store-name".timeout+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".timeout+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The timeout duration for the Milvus client. If not specified, 5 seconds will be used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__TIMEOUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__TIMEOUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-langchain4j-milvus_quarkus-langchain4j[icon:question-circle[title=More information about the Duration format]]
+|
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-db-name]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-db-name[`+++quarkus.langchain4j.milvus."store-name".db-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".db-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the database.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__DB_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__DB_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++default+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-create-collection]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-create-collection[`+++quarkus.langchain4j.milvus."store-name".create-collection+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".create-collection+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Create the collection if it does not exist yet.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__CREATE_COLLECTION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__CREATE_COLLECTION+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-collection-name]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-collection-name[`+++quarkus.langchain4j.milvus."store-name".collection-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".collection-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the collection.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__COLLECTION_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__COLLECTION_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++embeddings+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-dimension]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-dimension[`+++quarkus.langchain4j.milvus."store-name".dimension+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".dimension+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Dimension of the vectors. Only applicable when the collection yet has to be created.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__DIMENSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__DIMENSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-primary-field]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-primary-field[`+++quarkus.langchain4j.milvus."store-name".primary-field+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".primary-field+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the field that contains the ID of the vector.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__PRIMARY_FIELD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__PRIMARY_FIELD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++id+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-text-field]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-text-field[`+++quarkus.langchain4j.milvus."store-name".text-field+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".text-field+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the field that contains the text from which the vector was calculated.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__TEXT_FIELD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__TEXT_FIELD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++text+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-metadata-field]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-metadata-field[`+++quarkus.langchain4j.milvus."store-name".metadata-field+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".metadata-field+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the field that contains JSON metadata associated with the text.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__METADATA_FIELD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__METADATA_FIELD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++metadata+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-vector-field]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-vector-field[`+++quarkus.langchain4j.milvus."store-name".vector-field+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".vector-field+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Name of the field to store the vector in.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__VECTOR_FIELD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__VECTOR_FIELD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++vector+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-description]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-description[`+++quarkus.langchain4j.milvus."store-name".description+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".description+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Description of the collection.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__DESCRIPTION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__DESCRIPTION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-index-type]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-index-type[`+++quarkus.langchain4j.milvus."store-name".index-type+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".index-type+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The index type to use for the collection.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__INDEX_TYPE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__INDEX_TYPE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`none`, `flat`, `ivf-flat`, `ivf-sq8`, `ivf-pq`, `hnsw`, `hnsw-sq`, `hnsw-pq`, `hnsw-prq`, `diskann`, `autoindex`, `scann`, `gpu-ivf-flat`, `gpu-ivf-pq`, `gpu-brute-force`, `gpu-cagra`, `bin-flat`, `bin-ivf-flat`, `trie`, `stl-sort`, `inverted`, `bitmap`, `sparse-inverted-index`, `sparse-wand`
+|`+++flat+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-metric-type]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-metric-type[`+++quarkus.langchain4j.milvus."store-name".metric-type+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".metric-type+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The metric type to use for searching.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__METRIC_TYPE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__METRIC_TYPE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`none`, `l2`, `ip`, `cosine`, `hamming`, `jaccard`
+|`+++cosine+++`
+
+a| [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-consistency-level]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-consistency-level[`+++quarkus.langchain4j.milvus."store-name".consistency-level+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".consistency-level+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The consistency level.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__CONSISTENCY_LEVEL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MILVUS__STORE_NAME__CONSISTENCY_LEVEL+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`strong`, `session`, `bounded`, `eventually`
+|`+++eventually+++`
+
 
 |===
 

--- a/docs/modules/ROOT/pages/rag-milvus-store.adoc
+++ b/docs/modules/ROOT/pages/rag-milvus-store.adoc
@@ -72,6 +72,47 @@ Milvus stores each embedded text segment along with its metadata and vector in a
 
 The extension automatically initializes the collection and schema if it does not already exist. It uses gRPC-based access for high performance and low latency.
 
+== Named Stores
+
+You can configure multiple named Milvus stores, each pointing to a different Milvus instance or collection.
+This is useful when your application needs to manage embeddings for different domains or tenants separately.
+
+To configure a named store:
+
+[source,properties]
+----
+quarkus.langchain4j.milvus.products.host=<default>
+quarkus.langchain4j.milvus.products.dimension=1536
+quarkus.langchain4j.milvus.products.collection-name=product_embeddings
+----
+
+Setting `host` to `<default>` means the named store shares the same Milvus instance as the default store.
+To point to a different Milvus instance, specify its host and port:
+
+[source,properties]
+----
+quarkus.langchain4j.milvus.products.host=another-milvus.internal
+quarkus.langchain4j.milvus.products.port=19530
+quarkus.langchain4j.milvus.products.dimension=1536
+----
+
+To inject a named store, use the `@EmbeddingStoreName` qualifier:
+
+[source,java]
+----
+@Inject
+@EmbeddingStoreName("products")
+MilvusEmbeddingStore productsStore;
+----
+
+The default store and named stores can coexist.
+If you only need named stores, disable the default store:
+
+[source,properties]
+----
+quarkus.langchain4j.milvus.default-store-enabled=false
+----
+
 == Summary
 
 To use Milvus with Quarkus LangChain4j:

--- a/embedding-stores/milvus/deployment/src/main/java/io/quarkiverse/langchain4j/milvus/MilvusBuildConfig.java
+++ b/embedding-stores/milvus/deployment/src/main/java/io/quarkiverse/langchain4j/milvus/MilvusBuildConfig.java
@@ -2,21 +2,52 @@ package io.quarkiverse.langchain4j.milvus;
 
 import static io.quarkus.runtime.annotations.ConfigPhase.BUILD_TIME;
 
+import java.util.Map;
 import java.util.OptionalInt;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithDefaults;
+import io.smallrye.config.WithParentName;
 
 @ConfigRoot(phase = BUILD_TIME)
 @ConfigMapping(prefix = "quarkus.langchain4j.milvus")
 public interface MilvusBuildConfig {
 
     /**
+     * Default store build-time config.
+     */
+    @WithParentName
+    DefaultStoreBuildTimeConfig defaultConfig();
+
+    /**
+     * Named store configurations.
+     */
+    @ConfigDocSection
+    @ConfigDocMapKey("store-name")
+    @WithParentName
+    @WithDefaults
+    Map<String, MilvusNamedStoreBuildTimeConfig> namedConfig();
+
+    /**
      * Configuration for DevServices. DevServices allows Quarkus to automatically start a database in dev and test mode.
      */
     MilvusDevServicesBuildTimeConfig devservices();
+
+    @ConfigGroup
+    interface DefaultStoreBuildTimeConfig {
+
+        /**
+         * Whether the default (unnamed) Milvus embedding store should be enabled.
+         * Set to {@code false} when you only want to use named stores.
+         */
+        @WithDefault("true")
+        boolean defaultStoreEnabled();
+    }
 
     @ConfigGroup
     interface MilvusDevServicesBuildTimeConfig {

--- a/embedding-stores/milvus/deployment/src/main/java/io/quarkiverse/langchain4j/milvus/MilvusNamedStoreBuildTimeConfig.java
+++ b/embedding-stores/milvus/deployment/src/main/java/io/quarkiverse/langchain4j/milvus/MilvusNamedStoreBuildTimeConfig.java
@@ -1,0 +1,17 @@
+package io.quarkiverse.langchain4j.milvus;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+
+@ConfigGroup
+public interface MilvusNamedStoreBuildTimeConfig {
+
+    /**
+     * The host of the Milvus server to use for this named store.
+     * If set to {@code <default>}, the default Milvus server will be used.
+     */
+    @WithDefault("<default>")
+    Optional<String> host();
+}

--- a/embedding-stores/milvus/deployment/src/main/java/io/quarkiverse/langchain4j/milvus/MilvusProcessor.java
+++ b/embedding-stores/milvus/deployment/src/main/java/io/quarkiverse/langchain4j/milvus/MilvusProcessor.java
@@ -1,7 +1,10 @@
 package io.quarkiverse.langchain4j.milvus;
 
+import java.util.Map;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
+import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassType;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.ParameterizedType;
@@ -9,8 +12,10 @@ import org.jboss.jandex.ParameterizedType;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.milvus.MilvusEmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
 import io.quarkiverse.langchain4j.deployment.EmbeddingStoreBuildItem;
 import io.quarkiverse.langchain4j.milvus.runtime.MilvusRecorder;
+import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -33,18 +38,42 @@ public class MilvusProcessor {
     public void createBean(
             BuildProducer<SyntheticBeanBuildItem> beanProducer,
             MilvusRecorder recorder,
-            BuildProducer<EmbeddingStoreBuildItem> embeddingStoreProducer) {
-        beanProducer.produce(SyntheticBeanBuildItem
-                .configure(MILVUS_EMBEDDING_STORE)
-                .types(ClassType.create(EmbeddingStore.class),
-                        ParameterizedType.create(EmbeddingStore.class, ClassType.create(TextSegment.class)))
-                .defaultBean()
-                .setRuntimeInit()
-                .unremovable()
-                .scope(ApplicationScoped.class)
-                .supplier(recorder.milvusStoreSupplier())
-                .done());
-        embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
-    }
+            BuildProducer<EmbeddingStoreBuildItem> embeddingStoreProducer,
+            MilvusBuildConfig buildTimeConfig) {
+        if (buildTimeConfig.defaultConfig().defaultStoreEnabled()) {
+            beanProducer.produce(SyntheticBeanBuildItem
+                    .configure(MILVUS_EMBEDDING_STORE)
+                    .types(ClassType.create(MilvusEmbeddingStore.class),
+                            ClassType.create(EmbeddingStore.class),
+                            ParameterizedType.create(EmbeddingStore.class, ClassType.create(TextSegment.class)))
+                    .defaultBean()
+                    .setRuntimeInit()
+                    .unremovable()
+                    .scope(ApplicationScoped.class)
+                    .createWith(recorder.embeddingStoreFunction(NamedConfigUtil.DEFAULT_NAME))
+                    .done());
+            embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
+        }
 
+        Map<String, MilvusNamedStoreBuildTimeConfig> namedStores = buildTimeConfig.namedConfig();
+        for (Map.Entry<String, MilvusNamedStoreBuildTimeConfig> entry : namedStores.entrySet()) {
+            String storeName = entry.getKey();
+            AnnotationInstance storeNameQualifier = AnnotationInstance.builder(EmbeddingStoreName.class)
+                    .add("value", storeName)
+                    .build();
+            beanProducer.produce(SyntheticBeanBuildItem
+                    .configure(MILVUS_EMBEDDING_STORE)
+                    .types(ClassType.create(MilvusEmbeddingStore.class),
+                            ClassType.create(EmbeddingStore.class),
+                            ParameterizedType.create(EmbeddingStore.class, ClassType.create(TextSegment.class)))
+                    .setRuntimeInit()
+                    .defaultBean()
+                    .unremovable()
+                    .scope(ApplicationScoped.class)
+                    .addQualifier(storeNameQualifier)
+                    .createWith(recorder.embeddingStoreFunction(storeName))
+                    .done());
+            embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
+        }
+    }
 }

--- a/embedding-stores/milvus/deployment/src/test/java/io/quarkiverse/langchain4j/milvus/deployment/MilvusNamedStoreTest.java
+++ b/embedding-stores/milvus/deployment/src/test/java/io/quarkiverse/langchain4j/milvus/deployment/MilvusNamedStoreTest.java
@@ -1,0 +1,48 @@
+package io.quarkiverse.langchain4j.milvus.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.store.embedding.milvus.MilvusEmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MilvusNamedStoreTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.milvus.dimension", "384")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.milvus.consistency-level", "STRONG")
+            .overrideConfigKey("quarkus.langchain4j.milvus.products.host", "<default>")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.milvus.products.dimension", "1536")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.milvus.products.collection-name", "product_embeddings");
+
+    @Inject
+    MilvusEmbeddingStore defaultEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("products")
+    MilvusEmbeddingStore productsEmbeddingStore;
+
+    @Test
+    void testDefault() {
+        assertThat(defaultEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void testNamed() {
+        assertThat(productsEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void testNotSame() {
+        assertThat(defaultEmbeddingStore).isNotSameAs(productsEmbeddingStore);
+    }
+}

--- a/embedding-stores/milvus/runtime/src/main/java/io/quarkiverse/langchain4j/milvus/runtime/MilvusRecorder.java
+++ b/embedding-stores/milvus/runtime/src/main/java/io/quarkiverse/langchain4j/milvus/runtime/MilvusRecorder.java
@@ -1,10 +1,13 @@
 package io.quarkiverse.langchain4j.milvus.runtime;
 
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 import dev.langchain4j.store.embedding.milvus.MilvusEmbeddingStore;
+import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
+import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
+import io.smallrye.config.ConfigValidationException;
 
 @Recorder
 public class MilvusRecorder {
@@ -14,29 +17,50 @@ public class MilvusRecorder {
         this.runtimeConfig = runtimeConfig;
     }
 
-    public Supplier<MilvusEmbeddingStore> milvusStoreSupplier() {
-        return new Supplier<>() {
+    public Function<SyntheticCreationalContext<MilvusEmbeddingStore>, MilvusEmbeddingStore> embeddingStoreFunction(
+            String storeName) {
+        return new Function<>() {
             @Override
-            public MilvusEmbeddingStore get() {
+            public MilvusEmbeddingStore apply(SyntheticCreationalContext<MilvusEmbeddingStore> context) {
+                MilvusStoreRuntimeConfig storeConfig = correspondingStoreConfig(storeName);
+                if (storeConfig.dimension().isEmpty()) {
+                    throw new ConfigValidationException(createDimensionConfigProblems(storeName));
+                }
                 return new MilvusEmbeddingStore.Builder()
-                        .host(runtimeConfig.getValue().host())
-                        .port(runtimeConfig.getValue().port())
-                        .collectionName(runtimeConfig.getValue().collectionName())
-                        .idFieldName(runtimeConfig.getValue().primaryField())
-                        .textFieldName(runtimeConfig.getValue().textField())
-                        .metadataFieldName(runtimeConfig.getValue().metadataField())
-                        .vectorFieldName(runtimeConfig.getValue().vectorField())
-                        .dimension(runtimeConfig.getValue().dimension().orElse(null))
-                        .indexType(runtimeConfig.getValue().indexType())
-                        .metricType(runtimeConfig.getValue().metricType())
-                        .token(runtimeConfig.getValue().token().orElse(null))
-                        .username(runtimeConfig.getValue().username().orElse(null))
-                        .password(runtimeConfig.getValue().password().orElse(null))
-                        .consistencyLevel(runtimeConfig.getValue().consistencyLevel())
+                        .host(storeConfig.host())
+                        .port(storeConfig.port())
+                        .collectionName(storeConfig.collectionName())
+                        .idFieldName(storeConfig.primaryField())
+                        .textFieldName(storeConfig.textField())
+                        .metadataFieldName(storeConfig.metadataField())
+                        .vectorFieldName(storeConfig.vectorField())
+                        .dimension(storeConfig.dimension().get())
+                        .indexType(storeConfig.indexType())
+                        .metricType(storeConfig.metricType())
+                        .token(storeConfig.token().orElse(null))
+                        .username(storeConfig.username().orElse(null))
+                        .password(storeConfig.password().orElse(null))
+                        .consistencyLevel(storeConfig.consistencyLevel())
                         .retrieveEmbeddingsOnSearch(true)
-                        .databaseName(runtimeConfig.getValue().dbName())
+                        .databaseName(storeConfig.dbName())
                         .build();
             }
+        };
+    }
+
+    MilvusStoreRuntimeConfig correspondingStoreConfig(String storeName) {
+        if (NamedConfigUtil.isDefault(storeName)) {
+            return runtimeConfig.getValue().defaultConfig();
+        }
+        return runtimeConfig.getValue().namedConfig().get(storeName);
+    }
+
+    private ConfigValidationException.Problem[] createDimensionConfigProblems(String storeName) {
+        return new ConfigValidationException.Problem[] {
+                new ConfigValidationException.Problem(String.format(
+                        "SRCFG00014: The config property quarkus.langchain4j.milvus%sdimension is required but it could not be found in any config source",
+                        NamedConfigUtil.isDefault(storeName) ? "."
+                                : ("." + storeName + ".")))
         };
     }
 }

--- a/embedding-stores/milvus/runtime/src/main/java/io/quarkiverse/langchain4j/milvus/runtime/MilvusRuntimeConfig.java
+++ b/embedding-stores/milvus/runtime/src/main/java/io/quarkiverse/langchain4j/milvus/runtime/MilvusRuntimeConfig.java
@@ -2,118 +2,31 @@ package io.quarkiverse.langchain4j.milvus.runtime;
 
 import static io.quarkus.runtime.annotations.ConfigPhase.RUN_TIME;
 
-import java.time.Duration;
-import java.util.Optional;
+import java.util.Map;
 
-import io.milvus.common.clientenum.ConsistencyLevelEnum;
-import io.milvus.param.IndexType;
-import io.milvus.param.MetricType;
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
-import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithDefaults;
+import io.smallrye.config.WithParentName;
 
 @ConfigRoot(phase = RUN_TIME)
 @ConfigMapping(prefix = "quarkus.langchain4j.milvus")
 public interface MilvusRuntimeConfig {
 
     /**
-     * The URL of the Milvus server.
+     * Default store config.
      */
-    String host();
+    @WithParentName
+    MilvusStoreRuntimeConfig defaultConfig();
 
     /**
-     * The port of the Milvus server.
+     * Named store configurations.
      */
-    Integer port();
-
-    /**
-     * The authentication token for the Milvus server.
-     */
-    Optional<String> token();
-
-    /**
-     * The username for the Milvus server.
-     */
-    Optional<String> username();
-
-    /**
-     * The password for the Milvus server.
-     */
-    Optional<String> password();
-
-    /**
-     * The timeout duration for the Milvus client. If not specified, 5 seconds will be used.
-     */
-    Optional<Duration> timeout();
-
-    /**
-     * Name of the database.
-     */
-    @WithDefault("default")
-    String dbName();
-
-    /**
-     * Create the collection if it does not exist yet.
-     */
-    @WithDefault("true")
-    boolean createCollection();
-
-    /**
-     * Name of the collection.
-     */
-    @WithDefault("embeddings")
-    String collectionName();
-
-    /**
-     * Dimension of the vectors. Only applicable when the collection yet has to be created.
-     */
-    Optional<Integer> dimension();
-
-    /**
-     * Name of the field that contains the ID of the vector.
-     */
-    @WithDefault("id")
-    String primaryField();
-
-    /**
-     * Name of the field that contains the text from which the vector was calculated.
-     */
-    @WithDefault("text")
-    String textField();
-
-    /**
-     * Name of the field that contains JSON metadata associated with the text.
-     */
-    @WithDefault("metadata")
-    String metadataField();
-
-    /**
-     * Name of the field to store the vector in.
-     */
-    @WithDefault("vector")
-    String vectorField();
-
-    /**
-     * Description of the collection.
-     */
-    Optional<String> description();
-
-    /**
-     * The index type to use for the collection.
-     */
-    @WithDefault("FLAT")
-    IndexType indexType();
-
-    /**
-     * The metric type to use for searching.
-     */
-    @WithDefault("COSINE")
-    MetricType metricType();
-
-    /**
-     * The consistency level.
-     */
-    @WithDefault("EVENTUALLY")
-    ConsistencyLevelEnum consistencyLevel();
-
+    @ConfigDocSection
+    @ConfigDocMapKey("store-name")
+    @WithParentName
+    @WithDefaults
+    Map<String, MilvusStoreRuntimeConfig> namedConfig();
 }

--- a/embedding-stores/milvus/runtime/src/main/java/io/quarkiverse/langchain4j/milvus/runtime/MilvusStoreRuntimeConfig.java
+++ b/embedding-stores/milvus/runtime/src/main/java/io/quarkiverse/langchain4j/milvus/runtime/MilvusStoreRuntimeConfig.java
@@ -1,0 +1,116 @@
+package io.quarkiverse.langchain4j.milvus.runtime;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import io.milvus.common.clientenum.ConsistencyLevelEnum;
+import io.milvus.param.IndexType;
+import io.milvus.param.MetricType;
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+
+@ConfigGroup
+public interface MilvusStoreRuntimeConfig {
+
+    /**
+     * The URL of the Milvus server.
+     */
+    @WithDefault("localhost")
+    String host();
+
+    /**
+     * The port of the Milvus server.
+     */
+    @WithDefault("19530")
+    Integer port();
+
+    /**
+     * The authentication token for the Milvus server.
+     */
+    Optional<String> token();
+
+    /**
+     * The username for the Milvus server.
+     */
+    Optional<String> username();
+
+    /**
+     * The password for the Milvus server.
+     */
+    Optional<String> password();
+
+    /**
+     * The timeout duration for the Milvus client. If not specified, 5 seconds will be used.
+     */
+    Optional<Duration> timeout();
+
+    /**
+     * Name of the database.
+     */
+    @WithDefault("default")
+    String dbName();
+
+    /**
+     * Create the collection if it does not exist yet.
+     */
+    @WithDefault("true")
+    boolean createCollection();
+
+    /**
+     * Name of the collection.
+     */
+    @WithDefault("embeddings")
+    String collectionName();
+
+    /**
+     * Dimension of the vectors. Only applicable when the collection yet has to be created.
+     */
+    Optional<Integer> dimension();
+
+    /**
+     * Name of the field that contains the ID of the vector.
+     */
+    @WithDefault("id")
+    String primaryField();
+
+    /**
+     * Name of the field that contains the text from which the vector was calculated.
+     */
+    @WithDefault("text")
+    String textField();
+
+    /**
+     * Name of the field that contains JSON metadata associated with the text.
+     */
+    @WithDefault("metadata")
+    String metadataField();
+
+    /**
+     * Name of the field to store the vector in.
+     */
+    @WithDefault("vector")
+    String vectorField();
+
+    /**
+     * Description of the collection.
+     */
+    Optional<String> description();
+
+    /**
+     * The index type to use for the collection.
+     */
+    @WithDefault("FLAT")
+    IndexType indexType();
+
+    /**
+     * The metric type to use for searching.
+     */
+    @WithDefault("COSINE")
+    MetricType metricType();
+
+    /**
+     * The consistency level.
+     */
+    @WithDefault("EVENTUALLY")
+    ConsistencyLevelEnum consistencyLevel();
+}


### PR DESCRIPTION
## Describe your changes

Adds support for multiple named Milvus embedding stores, following the same pattern established by the Redis, Neo4j, and pgvector named store implementations.

Named stores allow applications to manage embeddings for different domains or tenants separately, each pointing to a different Milvus instance or collection. The `host` property in the named store build-time config serves as both a trigger for named store creation and a discriminator for which Milvus instance to connect to.

Key changes:
- `MilvusBuildConfig` now supports `default-store-enabled` and named store configurations via `namedConfig` map
- `MilvusNamedStoreBuildTimeConfig` provides the `host` property (defaults to `<default>` to share the default Milvus instance)
- `MilvusStoreRuntimeConfig` extracted as a shared config group for both default and named stores, with `host`/`port` defaults to avoid SmallRye Config `@WithDefaults` collision
- `MilvusRecorder` updated with `embeddingStoreFunction` and `correspondingStoreConfig` for per-store bean creation
- `MilvusProcessor.types()` now includes `MilvusEmbeddingStore.class` for direct `@Inject` usage
- DevServices config kept as inner interface of `MilvusBuildConfig` (no separate config class)
- Documentation updated with "Named Stores" section in `rag-milvus-store.adoc`

## Check List

- [x] My code follows the code style of this project
- [x] My change requires changes to the documentation
- [x] I have updated the documentation accordingly
- [x] All new and existing tests passed