### PR TITLE
Add support for named Qdrant embedding stores

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-chroma.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-chroma.adoc
@@ -302,7 +302,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The collection name for this named store. This property serves as the build-time key that enables named store discovery. If not set, the default collection name will be used.
+The collection name for this named store. This property serves as the build-time key that enables named store discovery. If not set, the collection name from the runtime configuration will be used.
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-chroma_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-chroma_quarkus.langchain4j.adoc
@@ -302,7 +302,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The collection name for this named store. This property serves as the build-time key that enables named store discovery. If not set, the default collection name will be used.
+The collection name for this named store. This property serves as the build-time key that enables named store discovery. If not set, the collection name from the runtime configuration will be used.
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-qdrant.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-qdrant.adoc
@@ -7,6 +7,27 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-default-store-enabled]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-default-store-enabled[`+++quarkus.langchain4j.qdrant.default-store-enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.qdrant.default-store-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the default (unnamed) Qdrant embedding store should be enabled. Set to `false` when you only want to use named stores.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_QDRANT_DEFAULT_STORE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_QDRANT_DEFAULT_STORE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-devservices-enabled]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-devservices-enabled[`+++quarkus.langchain4j.qdrant.devservices.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.qdrant.devservices.enabled+++[]
@@ -173,7 +194,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_QDRANT_HOST+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|required icon:exclamation-circle[title=Configuration property is required]
+|
 
 a| [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-port]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-port[`+++quarkus.langchain4j.qdrant.port+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -278,7 +299,159 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_QDRANT_COLLECTION_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|required icon:exclamation-circle[title=Configuration property is required]
+|`+++default+++`
+
+h|[[quarkus-langchain4j-qdrant_section_quarkus-langchain4j-qdrant]] [.section-name.section-level0]##link:#quarkus-langchain4j-qdrant_section_quarkus-langchain4j-qdrant[Named store configurations]##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-collection-name]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-collection-name[`+++quarkus.langchain4j.qdrant."store-name".collection-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.qdrant."store-name".collection-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The collection name for this named store. This property serves as the build-time key that enables named store discovery. If not set, the collection name from the runtime configuration will be used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__COLLECTION_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__COLLECTION_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++<default>+++`
+
+a| [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-host]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-host[`+++quarkus.langchain4j.qdrant."store-name".host+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.qdrant."store-name".host+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The URL of the Qdrant server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__HOST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__HOST+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-port]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-port[`+++quarkus.langchain4j.qdrant."store-name".port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.qdrant."store-name".port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The gRPC port of the Qdrant server. Defaults to 6334
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++6334+++`
+
+a| [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-api-key]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-api-key[`+++quarkus.langchain4j.qdrant."store-name".api-key+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.qdrant."store-name".api-key+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The Qdrant API key to authenticate with.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__API_KEY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__API_KEY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-use-tls]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-use-tls[`+++quarkus.langchain4j.qdrant."store-name".use-tls+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.qdrant."store-name".use-tls+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to use TLS(HTTPS). Defaults to false.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__USE_TLS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__USE_TLS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-payload-text-key]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-payload-text-key[`+++quarkus.langchain4j.qdrant."store-name".payload-text-key+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.qdrant."store-name".payload-text-key+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The field name of the text segment in the payload. Defaults to "text_segment"
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__PAYLOAD_TEXT_KEY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__PAYLOAD_TEXT_KEY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++text_segment+++`
+
+a| [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-collection-name]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-collection-name[`+++quarkus.langchain4j.qdrant."store-name".collection.name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.qdrant."store-name".collection.name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The name of the collection.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__COLLECTION_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__COLLECTION_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++default+++`
+
 
 |===
 

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-qdrant_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-qdrant_quarkus.langchain4j.adoc
@@ -7,6 +7,27 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-default-store-enabled]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-default-store-enabled[`+++quarkus.langchain4j.qdrant.default-store-enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.qdrant.default-store-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the default (unnamed) Qdrant embedding store should be enabled. Set to `false` when you only want to use named stores.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_QDRANT_DEFAULT_STORE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_QDRANT_DEFAULT_STORE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-devservices-enabled]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-devservices-enabled[`+++quarkus.langchain4j.qdrant.devservices.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.qdrant.devservices.enabled+++[]
@@ -173,7 +194,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_QDRANT_HOST+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|required icon:exclamation-circle[title=Configuration property is required]
+|
 
 a| [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-port]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-port[`+++quarkus.langchain4j.qdrant.port+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -278,7 +299,159 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_QDRANT_COLLECTION_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|required icon:exclamation-circle[title=Configuration property is required]
+|`+++default+++`
+
+h|[[quarkus-langchain4j-qdrant_section_quarkus-langchain4j-qdrant]] [.section-name.section-level0]##link:#quarkus-langchain4j-qdrant_section_quarkus-langchain4j-qdrant[Named store configurations]##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-collection-name]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-collection-name[`+++quarkus.langchain4j.qdrant."store-name".collection-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.qdrant."store-name".collection-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The collection name for this named store. This property serves as the build-time key that enables named store discovery. If not set, the collection name from the runtime configuration will be used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__COLLECTION_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__COLLECTION_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++<default>+++`
+
+a| [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-host]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-host[`+++quarkus.langchain4j.qdrant."store-name".host+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.qdrant."store-name".host+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The URL of the Qdrant server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__HOST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__HOST+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-port]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-port[`+++quarkus.langchain4j.qdrant."store-name".port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.qdrant."store-name".port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The gRPC port of the Qdrant server. Defaults to 6334
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++6334+++`
+
+a| [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-api-key]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-api-key[`+++quarkus.langchain4j.qdrant."store-name".api-key+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.qdrant."store-name".api-key+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The Qdrant API key to authenticate with.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__API_KEY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__API_KEY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-use-tls]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-use-tls[`+++quarkus.langchain4j.qdrant."store-name".use-tls+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.qdrant."store-name".use-tls+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to use TLS(HTTPS). Defaults to false.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__USE_TLS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__USE_TLS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-payload-text-key]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-payload-text-key[`+++quarkus.langchain4j.qdrant."store-name".payload-text-key+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.qdrant."store-name".payload-text-key+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The field name of the text segment in the payload. Defaults to "text_segment"
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__PAYLOAD_TEXT_KEY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__PAYLOAD_TEXT_KEY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++text_segment+++`
+
+a| [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-collection-name]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-collection-name[`+++quarkus.langchain4j.qdrant."store-name".collection.name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.qdrant."store-name".collection.name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The name of the collection.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__COLLECTION_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_QDRANT__STORE_NAME__COLLECTION_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++default+++`
+
 
 |===
 

--- a/docs/modules/ROOT/pages/rag-qdrant-store.adoc
+++ b/docs/modules/ROOT/pages/rag-qdrant-store.adoc
@@ -54,6 +54,36 @@ quarkus.langchain4j.qdrant.collection.vector-params.size=384
 quarkus.langchain4j.qdrant.collection.vector-params.distance=Cosine
 ----
 
+== Named Stores
+
+You can configure multiple named Qdrant stores, each using a different collection.
+This is useful when your application needs to manage embeddings for different domains or tenants in separate collections within the same Qdrant instance.
+
+To configure a named store:
+
+[source,properties]
+----
+quarkus.langchain4j.qdrant.products.collection-name=product_embeddings
+quarkus.langchain4j.qdrant.products.host=qdrant.example.com
+----
+
+To inject a named store, use the `@EmbeddingStoreName` qualifier:
+
+[source,java]
+----
+@Inject
+@EmbeddingStoreName("products")
+EmbeddingStore<TextSegment> productsStore;
+----
+
+The default store and named stores can coexist.
+If you only need named stores, disable the default store:
+
+[source,properties]
+----
+quarkus.langchain4j.qdrant.default-store-enabled=false
+----
+
 == Configuration
 
 You can customize the behavior of the Qdrant extension using the following configuration options:

--- a/embedding-stores/qdrant/deployment/src/main/java/io/quarkiverse/langchain4j/qdrant/QdrantDevServicesProcessor.java
+++ b/embedding-stores/qdrant/deployment/src/main/java/io/quarkiverse/langchain4j/qdrant/QdrantDevServicesProcessor.java
@@ -4,9 +4,11 @@ import java.io.Closeable;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import org.jboss.logging.Logger;
@@ -41,11 +43,13 @@ public class QdrantDevServicesProcessor {
     public List<DevServicesResultBuildItem> startQdrantDevServices(
             DockerStatusBuildItem dockerStatusBuildItem,
             LaunchModeBuildItem launchMode,
-            QdrantBuildConfig qdrantBuildConfig,
+            QdrantEmbeddingStoreBuildTimeConfig qdrantBuildConfig,
             Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
             List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
             LoggingSetupBuildItem loggingSetupBuildItem,
             DevServicesConfig devServicesConfig) {
+
+        Set<String> namedStoreNames = qdrantBuildConfig.namedConfig().keySet();
 
         List<DevServicesResultBuildItem> result = new ArrayList<>();
         QdrantDevServiceCfg configuration = getConfiguration(qdrantBuildConfig);
@@ -81,7 +85,8 @@ public class QdrantDevServicesProcessor {
                     configuration,
                     launchMode,
                     devServicesConfig.timeout(),
-                    !devServicesSharedNetworkBuildItem.isEmpty());
+                    !devServicesSharedNetworkBuildItem.isEmpty(),
+                    namedStoreNames);
 
             if (newDevService != null) {
                 devService = newDevService;
@@ -136,7 +141,8 @@ public class QdrantDevServicesProcessor {
             QdrantDevServiceCfg config,
             LaunchModeBuildItem launchMode,
             Optional<Duration> timeout,
-            boolean useSharedNetwork) {
+            boolean useSharedNetwork,
+            Set<String> namedStoreNames) {
 
         if (!dockerStatusBuildItem.isDockerAvailable()) {
             LOG.warn("Docker isn't working, please configure the Qdrant server location.");
@@ -150,7 +156,6 @@ public class QdrantDevServicesProcessor {
                 useSharedNetwork);
 
         final Supplier<DevServicesResultBuildItem.RunningDevService> defaultQdrantSupplier = () -> {
-
             // Starting Qdrant
             timeout.ifPresent(container::withStartupTimeout);
             container.start();
@@ -175,7 +180,8 @@ public class QdrantDevServicesProcessor {
                     container.getContainerId(),
                     container::close,
                     container.getHost(),
-                    container.getPort());
+                    container.getPort(),
+                    namedStoreNames);
         };
 
         return QdrantDevServices.LOCATOR
@@ -188,7 +194,8 @@ public class QdrantDevServicesProcessor {
                         containerAddress.getId(),
                         null,
                         containerAddress.getHost(),
-                        containerAddress.getPort()))
+                        containerAddress.getPort(),
+                        namedStoreNames))
                 .orElseGet(defaultQdrantSupplier);
     }
 
@@ -197,12 +204,17 @@ public class QdrantDevServicesProcessor {
             String containerId,
             Closeable closeable,
             String host,
-            int port) {
+            int port,
+            Set<String> namedStoreNames) {
 
-        Map<String, String> configMap = Map.of(
-                "quarkus.langchain4j.qdrant.collection.name", serviceName,
-                "quarkus.langchain4j.qdrant.host", host,
-                "quarkus.langchain4j.qdrant.port", String.valueOf(port));
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put("quarkus.langchain4j.qdrant.collection.name", serviceName);
+        configMap.put("quarkus.langchain4j.qdrant.host", host);
+        configMap.put("quarkus.langchain4j.qdrant.port", String.valueOf(port));
+        for (String namedStore : namedStoreNames) {
+            configMap.put("quarkus.langchain4j.qdrant." + namedStore + ".host", host);
+            configMap.put("quarkus.langchain4j.qdrant." + namedStore + ".port", String.valueOf(port));
+        }
 
         return new DevServicesResultBuildItem.RunningDevService(
                 QdrantProcessor.FEATURE,
@@ -211,7 +223,7 @@ public class QdrantDevServicesProcessor {
                 configMap);
     }
 
-    private QdrantDevServiceCfg getConfiguration(QdrantBuildConfig cfg) {
+    private QdrantDevServiceCfg getConfiguration(QdrantEmbeddingStoreBuildTimeConfig cfg) {
         return new QdrantDevServiceCfg(
                 cfg.devservices().enabled(),
                 cfg.devservices().port(),

--- a/embedding-stores/qdrant/deployment/src/main/java/io/quarkiverse/langchain4j/qdrant/QdrantEmbeddingStoreBuildTimeConfig.java
+++ b/embedding-stores/qdrant/deployment/src/main/java/io/quarkiverse/langchain4j/qdrant/QdrantEmbeddingStoreBuildTimeConfig.java
@@ -2,21 +2,53 @@ package io.quarkiverse.langchain4j.qdrant;
 
 import static io.quarkus.runtime.annotations.ConfigPhase.BUILD_TIME;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithDefaults;
+import io.smallrye.config.WithParentName;
 
 @ConfigRoot(phase = BUILD_TIME)
 @ConfigMapping(prefix = "quarkus.langchain4j.qdrant")
-public interface QdrantBuildConfig {
+public interface QdrantEmbeddingStoreBuildTimeConfig {
+
+    /**
+     * Default store build-time config.
+     */
+    @WithParentName
+    DefaultStoreBuildTimeConfig defaultConfig();
+
+    /**
+     * Named store configurations.
+     */
+    @ConfigDocSection
+    @ConfigDocMapKey("store-name")
+    @WithParentName
+    @WithDefaults
+    Map<String, QdrantNamedStoreBuildTimeConfig> namedConfig();
+
     /**
      * Configuration for DevServices. DevServices allows Quarkus to automatically start a database in dev and test mode.
      */
     DevServicesConfig devservices();
+
+    @ConfigGroup
+    interface DefaultStoreBuildTimeConfig {
+
+        /**
+         * Whether the default (unnamed) Qdrant embedding store should be enabled.
+         * Set to {@code false} when you only want to use named stores.
+         */
+        @WithDefault("true")
+        boolean defaultStoreEnabled();
+    }
 
     @ConfigGroup
     interface DevServicesConfig {

--- a/embedding-stores/qdrant/deployment/src/main/java/io/quarkiverse/langchain4j/qdrant/QdrantNamedStoreBuildTimeConfig.java
+++ b/embedding-stores/qdrant/deployment/src/main/java/io/quarkiverse/langchain4j/qdrant/QdrantNamedStoreBuildTimeConfig.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.langchain4j.qdrant;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+
+@ConfigGroup
+public interface QdrantNamedStoreBuildTimeConfig {
+
+    /**
+     * The collection name for this named store.
+     * This property serves as the build-time key that enables named store discovery.
+     * If not set, the collection name from the runtime configuration will be used.
+     */
+    @WithDefault("<default>")
+    Optional<String> collectionName();
+}

--- a/embedding-stores/qdrant/deployment/src/main/java/io/quarkiverse/langchain4j/qdrant/QdrantProcessor.java
+++ b/embedding-stores/qdrant/deployment/src/main/java/io/quarkiverse/langchain4j/qdrant/QdrantProcessor.java
@@ -1,7 +1,10 @@
 package io.quarkiverse.langchain4j.qdrant;
 
+import java.util.Map;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
+import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassType;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.ParameterizedType;
@@ -9,8 +12,10 @@ import org.jboss.jandex.ParameterizedType;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.qdrant.QdrantEmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
 import io.quarkiverse.langchain4j.deployment.EmbeddingStoreBuildItem;
 import io.quarkiverse.langchain4j.qdrant.runtime.QdrantRecorder;
+import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -33,21 +38,47 @@ public class QdrantProcessor {
     public void createBean(
             BuildProducer<SyntheticBeanBuildItem> beanProducer,
             QdrantRecorder recorder,
-            BuildProducer<EmbeddingStoreBuildItem> embeddingStoreProducer) {
+            BuildProducer<EmbeddingStoreBuildItem> embeddingStoreProducer,
+            QdrantEmbeddingStoreBuildTimeConfig buildTimeConfig) {
 
-        beanProducer.produce(SyntheticBeanBuildItem
-                .configure(QDRANT_EMBEDDING_STORE)
-                .types(
-                        ClassType.create(EmbeddingStore.class),
-                        ParameterizedType.create(EmbeddingStore.class, ClassType.create(TextSegment.class)))
-                .defaultBean()
-                .setRuntimeInit()
-                .unremovable()
-                .scope(ApplicationScoped.class)
-                .supplier(recorder.qdrantStoreSupplier())
-                .done());
+        if (buildTimeConfig.defaultConfig().defaultStoreEnabled()) {
+            beanProducer.produce(SyntheticBeanBuildItem
+                    .configure(QDRANT_EMBEDDING_STORE)
+                    .types(
+                            ClassType.create(EmbeddingStore.class),
+                            ParameterizedType.create(EmbeddingStore.class, ClassType.create(TextSegment.class)))
+                    .setRuntimeInit()
+                    .defaultBean()
+                    .unremovable()
+                    .scope(ApplicationScoped.class)
+                    .createWith(recorder.qdrantStoreFunction(NamedConfigUtil.DEFAULT_NAME))
+                    .done());
 
-        embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
+            embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
+        }
+
+        Map<String, QdrantNamedStoreBuildTimeConfig> namedStores = buildTimeConfig.namedConfig();
+        for (Map.Entry<String, QdrantNamedStoreBuildTimeConfig> entry : namedStores.entrySet()) {
+            String storeName = entry.getKey();
+
+            AnnotationInstance storeNameQualifier = AnnotationInstance.builder(EmbeddingStoreName.class)
+                    .add("value", storeName)
+                    .build();
+
+            beanProducer.produce(SyntheticBeanBuildItem
+                    .configure(QDRANT_EMBEDDING_STORE)
+                    .types(
+                            ClassType.create(EmbeddingStore.class),
+                            ParameterizedType.create(EmbeddingStore.class, ClassType.create(TextSegment.class)))
+                    .setRuntimeInit()
+                    .defaultBean()
+                    .unremovable()
+                    .scope(ApplicationScoped.class)
+                    .addQualifier(storeNameQualifier)
+                    .createWith(recorder.qdrantStoreFunction(storeName))
+                    .done());
+
+            embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
+        }
     }
-
 }

--- a/embedding-stores/qdrant/deployment/src/test/java/io/quarkiverse/langchain4j/qdrant/QdrantDefaultAndNamedStoreTest.java
+++ b/embedding-stores/qdrant/deployment/src/test/java/io/quarkiverse/langchain4j/qdrant/QdrantDefaultAndNamedStoreTest.java
@@ -1,0 +1,45 @@
+package io.quarkiverse.langchain4j.qdrant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.store.embedding.qdrant.QdrantEmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class QdrantDefaultAndNamedStoreTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.qdrant.products.collection-name", "product_embeddings")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.qdrant.products.host", "localhost");
+
+    @Inject
+    QdrantEmbeddingStore defaultEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("products")
+    QdrantEmbeddingStore productsEmbeddingStore;
+
+    @Test
+    void testDefault() {
+        assertThat(defaultEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void testNamed() {
+        assertThat(productsEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void testNotSame() {
+        assertThat(defaultEmbeddingStore).isNotSameAs(productsEmbeddingStore);
+    }
+}

--- a/embedding-stores/qdrant/deployment/src/test/java/io/quarkiverse/langchain4j/qdrant/QdrantMultipleNamedStoresTest.java
+++ b/embedding-stores/qdrant/deployment/src/test/java/io/quarkiverse/langchain4j/qdrant/QdrantMultipleNamedStoresTest.java
@@ -1,0 +1,45 @@
+package io.quarkiverse.langchain4j.qdrant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.store.embedding.qdrant.QdrantEmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class QdrantMultipleNamedStoresTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.qdrant.default-store-enabled", "false")
+            .overrideConfigKey("quarkus.langchain4j.qdrant.products.collection-name", "product_embeddings")
+            .overrideConfigKey("quarkus.langchain4j.qdrant.documents.collection-name", "doc_embeddings")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.qdrant.products.host", "localhost")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.qdrant.documents.host", "localhost");
+
+    @Inject
+    @EmbeddingStoreName("products")
+    QdrantEmbeddingStore productsEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("documents")
+    QdrantEmbeddingStore documentsEmbeddingStore;
+
+    @Test
+    void testBothNamed() {
+        assertThat(productsEmbeddingStore).isNotNull();
+        assertThat(documentsEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void testNotSame() {
+        assertThat(productsEmbeddingStore).isNotSameAs(documentsEmbeddingStore);
+    }
+}

--- a/embedding-stores/qdrant/deployment/src/test/java/io/quarkiverse/langchain4j/qdrant/QdrantNamedStoreMissingHostTest.java
+++ b/embedding-stores/qdrant/deployment/src/test/java/io/quarkiverse/langchain4j/qdrant/QdrantNamedStoreMissingHostTest.java
@@ -1,0 +1,35 @@
+package io.quarkiverse.langchain4j.qdrant;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.store.embedding.qdrant.QdrantEmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.config.ConfigValidationException;
+
+public class QdrantNamedStoreMissingHostTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.qdrant.devservices.enabled", "false")
+            .overrideConfigKey("quarkus.langchain4j.qdrant.default-store-enabled", "false")
+            .overrideConfigKey("quarkus.langchain4j.qdrant.products.collection-name", "product_embeddings");
+
+    @Inject
+    @EmbeddingStoreName("products")
+    QdrantEmbeddingStore productsEmbeddingStore;
+
+    @Test
+    void testMissingHost() {
+        assertThatThrownBy(() -> productsEmbeddingStore.toString())
+                .hasCauseInstanceOf(ConfigValidationException.class);
+    }
+}

--- a/embedding-stores/qdrant/deployment/src/test/java/io/quarkiverse/langchain4j/qdrant/QdrantNamedStoreTest.java
+++ b/embedding-stores/qdrant/deployment/src/test/java/io/quarkiverse/langchain4j/qdrant/QdrantNamedStoreTest.java
@@ -1,0 +1,45 @@
+package io.quarkiverse.langchain4j.qdrant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.store.embedding.qdrant.QdrantEmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class QdrantNamedStoreTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.qdrant.products.collection-name", "product_embeddings")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.qdrant.products.host", "localhost");
+
+    @Inject
+    QdrantEmbeddingStore defaultEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("products")
+    QdrantEmbeddingStore productsEmbeddingStore;
+
+    @Test
+    void testDefault() {
+        assertThat(defaultEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void testNamed() {
+        assertThat(productsEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void testNotSame() {
+        assertThat(defaultEmbeddingStore).isNotSameAs(productsEmbeddingStore);
+    }
+}

--- a/embedding-stores/qdrant/runtime/src/main/java/io/quarkiverse/langchain4j/qdrant/runtime/QdrantEmbeddingStoreConfig.java
+++ b/embedding-stores/qdrant/runtime/src/main/java/io/quarkiverse/langchain4j/qdrant/runtime/QdrantEmbeddingStoreConfig.java
@@ -1,0 +1,32 @@
+package io.quarkiverse.langchain4j.qdrant.runtime;
+
+import static io.quarkus.runtime.annotations.ConfigPhase.RUN_TIME;
+
+import java.util.Map;
+
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigDocSection;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefaults;
+import io.smallrye.config.WithParentName;
+
+@ConfigRoot(phase = RUN_TIME)
+@ConfigMapping(prefix = "quarkus.langchain4j.qdrant")
+public interface QdrantEmbeddingStoreConfig {
+
+    /**
+     * Default store config.
+     */
+    @WithParentName
+    QdrantStoreRuntimeConfig defaultConfig();
+
+    /**
+     * Named store configurations.
+     */
+    @ConfigDocSection
+    @ConfigDocMapKey("store-name")
+    @WithParentName
+    @WithDefaults
+    Map<String, QdrantStoreRuntimeConfig> namedConfig();
+}

--- a/embedding-stores/qdrant/runtime/src/main/java/io/quarkiverse/langchain4j/qdrant/runtime/QdrantRecorder.java
+++ b/embedding-stores/qdrant/runtime/src/main/java/io/quarkiverse/langchain4j/qdrant/runtime/QdrantRecorder.java
@@ -1,32 +1,61 @@
 package io.quarkiverse.langchain4j.qdrant.runtime;
 
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 import dev.langchain4j.store.embedding.qdrant.QdrantEmbeddingStore;
+import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
+import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
+import io.smallrye.config.ConfigValidationException;
 
 @Recorder
 public class QdrantRecorder {
-    private final RuntimeValue<QdrantRuntimeConfig> runtimeConfig;
+    private final RuntimeValue<QdrantEmbeddingStoreConfig> runtimeConfig;
 
-    public QdrantRecorder(RuntimeValue<QdrantRuntimeConfig> runtimeConfig) {
+    public QdrantRecorder(RuntimeValue<QdrantEmbeddingStoreConfig> runtimeConfig) {
         this.runtimeConfig = runtimeConfig;
     }
 
-    public Supplier<QdrantEmbeddingStore> qdrantStoreSupplier() {
-        return new Supplier<>() {
+    public Function<SyntheticCreationalContext<QdrantEmbeddingStore>, QdrantEmbeddingStore> qdrantStoreFunction(
+            String storeName) {
+        return new Function<>() {
             @Override
-            public QdrantEmbeddingStore get() {
+            public QdrantEmbeddingStore apply(SyntheticCreationalContext<QdrantEmbeddingStore> context) {
+                QdrantStoreRuntimeConfig storeConfig = correspondingStoreConfig(storeName);
+
+                String host = storeConfig.host()
+                        .orElseGet(() -> runtimeConfig.getValue().defaultConfig().host().orElseThrow(
+                                () -> new ConfigValidationException(createHostConfigProblems(storeName))));
+
                 return new QdrantEmbeddingStore.Builder()
-                        .host(runtimeConfig.getValue().host())
-                        .port(runtimeConfig.getValue().port())
-                        .apiKey(runtimeConfig.getValue().apiKey().orElse(null))
-                        .collectionName(runtimeConfig.getValue().collection().name())
-                        .useTls(runtimeConfig.getValue().useTls())
-                        .payloadTextKey(runtimeConfig.getValue().payloadTextKey())
+                        .host(host)
+                        .port(storeConfig.port())
+                        .apiKey(storeConfig.apiKey().orElse(null))
+                        .collectionName(storeConfig.collection().name())
+                        .useTls(storeConfig.useTls())
+                        .payloadTextKey(storeConfig.payloadTextKey())
                         .build();
             }
+        };
+    }
+
+    private QdrantStoreRuntimeConfig correspondingStoreConfig(String storeName) {
+        if (NamedConfigUtil.isDefault(storeName)) {
+            return runtimeConfig.getValue().defaultConfig();
+        }
+        QdrantStoreRuntimeConfig namedConfig = runtimeConfig.getValue().namedConfig().get(storeName);
+        if (namedConfig != null) {
+            return namedConfig;
+        }
+        return runtimeConfig.getValue().defaultConfig();
+    }
+
+    private ConfigValidationException.Problem[] createHostConfigProblems(String storeName) {
+        return new ConfigValidationException.Problem[] {
+                new ConfigValidationException.Problem(String.format(
+                        "SRCFG00014: The config property quarkus.langchain4j.qdrant%shost is required but it could not be found in any config source",
+                        NamedConfigUtil.isDefault(storeName) ? "." : ("." + storeName + ".")))
         };
     }
 }

--- a/embedding-stores/qdrant/runtime/src/main/java/io/quarkiverse/langchain4j/qdrant/runtime/QdrantStoreRuntimeConfig.java
+++ b/embedding-stores/qdrant/runtime/src/main/java/io/quarkiverse/langchain4j/qdrant/runtime/QdrantStoreRuntimeConfig.java
@@ -1,21 +1,17 @@
 package io.quarkiverse.langchain4j.qdrant.runtime;
 
-import static io.quarkus.runtime.annotations.ConfigPhase.RUN_TIME;
-
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigRoot;
-import io.smallrye.config.ConfigMapping;
+import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
-@ConfigRoot(phase = RUN_TIME)
-@ConfigMapping(prefix = "quarkus.langchain4j.qdrant")
-public interface QdrantRuntimeConfig {
+@ConfigGroup
+public interface QdrantStoreRuntimeConfig {
 
     /**
      * The URL of the Qdrant server.
      */
-    String host();
+    Optional<String> host();
 
     /**
      * The gRPC port of the Qdrant server. Defaults to 6334
@@ -49,6 +45,7 @@ public interface QdrantRuntimeConfig {
         /**
          * The name of the collection.
          */
+        @WithDefault("default")
         String name();
     }
 }


### PR DESCRIPTION
Enables configuring multiple Qdrant embedding stores, each with independent configuration and injectable via `@EmbeddingStoreName`.

## Configuration

Default store (backward compatible, no changes required):

```properties
quarkus.langchain4j.qdrant.host=localhost
quarkus.langchain4j.qdrant.collection.name=default
```

Named stores:

```properties
quarkus.langchain4j.qdrant.products.collection-name=product_embeddings
quarkus.langchain4j.qdrant.products.host=qdrant.example.com
```

Disable default store when only named stores are needed:

```properties
quarkus.langchain4j.qdrant.default-store-enabled=false
```

## Injection

```java
@Inject
EmbeddingStore<TextSegment> defaultStore;

@Inject
@EmbeddingStoreName("products")
EmbeddingStore<TextSegment> productsStore;
```

Also includes a minor docs fix for Chroma's `collection-name` description to clarify the fallback behavior.

- Closes: #2436