### PR TITLE
Add named embedding stores support for Weaviate

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-weaviate.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-weaviate.adoc
@@ -7,6 +7,27 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-default-store-enabled]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-default-store-enabled[`+++quarkus.langchain4j.weaviate.default-store-enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate.default-store-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the default (unnamed) Weaviate embedding store should be enabled. Set to `false` when you only want to use named stores.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE_DEFAULT_STORE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE_DEFAULT_STORE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-devservices-enabled]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-devservices-enabled[`+++quarkus.langchain4j.weaviate.devservices.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.weaviate.devservices.enabled+++[]
@@ -38,7 +59,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The container image name to use, for container based DevServices providers. If you want to use Redis Stack modules (bloom, graph, search...), use: `redis/redis-stack:latest`.
+The container image name to use, for container based DevServices providers.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -82,7 +103,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-Indicates if the Redis server managed by Quarkus Dev Services is shared. When shared, Quarkus looks for running containers using label-based service discovery. If a matching container is found, it is used, and so a second one is not started. Otherwise, Dev Services for Redis starts a new container.
+Indicates if the Weaviate server managed by Quarkus Dev Services is shared. When shared, Quarkus looks for running containers using label-based service discovery. If a matching container is found, it is used, and so a second one is not started. Otherwise, Dev Services for Weaviate starts a new container.
 
 The discovery uses the `quarkus-dev-service-weaviate` label. The value is configured using the `service-name` property.
 
@@ -107,7 +128,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The value of the `quarkus-dev-service-weaviate` label attached to the started container. This property is used when `shared` is set to `true`. In this case, before starting a container, Dev Services for Redis looks for a container with the `quarkus-dev-service-weaviate` label set to the configured value. If found, it will use this container instead of starting a new one. Otherwise, it starts a new container with the `quarkus-dev-service-weaviate` label set to the specified value.
+The value of the `quarkus-dev-service-weaviate` label attached to the started container. This property is used when `shared` is set to `true`. In this case, before starting a container, Dev Services for Weaviate looks for a container with the `quarkus-dev-service-weaviate` label set to the configured value. If found, it will use this container instead of starting a new one. Otherwise, it starts a new container with the `quarkus-dev-service-weaviate` label set to the specified value.
 
 This property is used when you need multiple shared Weaviate servers.
 
@@ -214,7 +235,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The gRPC port of the Weaviate server. Defaults to 8080
+The port of the Weaviate server. Defaults to 8080
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -319,7 +340,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The name of the field that contains the text of a `TextSegment`. Default is "text"
+The name of the field that contains the text of a `dev.langchain4j.data.segment.TextSegment`. Default is "text"
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -403,7 +424,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The name of the field where `Metadata` entries are stored
+The name of the field where `dev.langchain4j.data.segment.Metadata` entries are stored
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -415,6 +436,305 @@ endif::add-copy-button-to-env-var[]
 --
 |string
 |`+++_metadata+++`
+
+h|[[quarkus-langchain4j-weaviate_section_quarkus-langchain4j-weaviate]] [.section-name.section-level0]##link:#quarkus-langchain4j-weaviate_section_quarkus-langchain4j-weaviate[Named store configurations]##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-object-class]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-object-class[`+++quarkus.langchain4j.weaviate."store-name".object-class+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".object-class+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The object class used as the build-time discovery key for this named store. Each named store is identified by its object class within the same Weaviate server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__OBJECT_CLASS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__OBJECT_CLASS+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++<default>+++`
+
+a| [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-api-key]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-api-key[`+++quarkus.langchain4j.weaviate."store-name".api-key+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".api-key+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The Weaviate API key to authenticate with.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__API_KEY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__API_KEY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-scheme]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-scheme[`+++quarkus.langchain4j.weaviate."store-name".scheme+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".scheme+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The scheme, e.g. "https" of cluster URL. Find it under Details of your Weaviate cluster.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__SCHEME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__SCHEME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++http+++`
+
+a| [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-host]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-host[`+++quarkus.langchain4j.weaviate."store-name".host+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".host+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The URL of the Weaviate server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__HOST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__HOST+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++localhost+++`
+
+a| [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-port]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-port[`+++quarkus.langchain4j.weaviate."store-name".port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The port of the Weaviate server. Defaults to 8080
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++8080+++`
+
+a| [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-grpc-port]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-grpc-port[`+++quarkus.langchain4j.weaviate."store-name".grpc.port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".grpc.port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The gRPC port of the Weaviate server. Defaults to 50051
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__GRPC_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__GRPC_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++50051+++`
+
+a| [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-grpc-secure]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-grpc-secure[`+++quarkus.langchain4j.weaviate."store-name".grpc.secure+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".grpc.secure+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The gRPC connection is secured.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__GRPC_SECURE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__GRPC_SECURE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-grpc-use-for-inserts]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-grpc-use-for-inserts[`+++quarkus.langchain4j.weaviate."store-name".grpc.use-for-inserts+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".grpc.use-for-inserts+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Use gRPC instead of http for batch inserts only. Will still be used for search.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__GRPC_USE_FOR_INSERTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__GRPC_USE_FOR_INSERTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-object-class]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-object-class[`+++quarkus.langchain4j.weaviate."store-name".object-class+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".object-class+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The object class you want to store, e.g. "MyGreatClass". Must start from an uppercase letter.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__OBJECT_CLASS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__OBJECT_CLASS+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++Default+++`
+
+a| [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-text-field-name]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-text-field-name[`+++quarkus.langchain4j.weaviate."store-name".text-field-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".text-field-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The name of the field that contains the text of a `dev.langchain4j.data.segment.TextSegment`. Default is "text"
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__TEXT_FIELD_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__TEXT_FIELD_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++text+++`
+
+a| [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-avoid-dups]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-avoid-dups[`+++quarkus.langchain4j.weaviate."store-name".avoid-dups+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".avoid-dups+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+If true (default), then `WeaviateEmbeddingStore` will generate a hashed ID based on provided text segment, which avoids duplicated entries in DB. If false, then random ID will be generated.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__AVOID_DUPS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__AVOID_DUPS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-consistency-level]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-consistency-level[`+++quarkus.langchain4j.weaviate."store-name".consistency-level+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".consistency-level+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Consistency level: ONE, QUORUM (default) or ALL.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__CONSISTENCY_LEVEL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__CONSISTENCY_LEVEL+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`one`, `quorum`, `all`
+|`+++quorum+++`
+
+a| [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-metadata-keys]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-metadata-keys[`+++quarkus.langchain4j.weaviate."store-name".metadata.keys+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".metadata.keys+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Metadata keys that should be persisted. The default in Weaviate ++[]++, however it is required to specify at least one for the EmbeddingStore to work. Thus, we use "tags" as default
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__METADATA_KEYS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__METADATA_KEYS+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|`+++tags+++`
+
+a| [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-metadata-field-name]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-metadata-field-name[`+++quarkus.langchain4j.weaviate."store-name".metadata.field-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".metadata.field-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The name of the field where `dev.langchain4j.data.segment.Metadata` entries are stored
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__METADATA_FIELD_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__METADATA_FIELD_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++_metadata+++`
+
 
 |===
 

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-weaviate_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-weaviate_quarkus.langchain4j.adoc
@@ -7,6 +7,27 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-default-store-enabled]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-default-store-enabled[`+++quarkus.langchain4j.weaviate.default-store-enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate.default-store-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the default (unnamed) Weaviate embedding store should be enabled. Set to `false` when you only want to use named stores.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE_DEFAULT_STORE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE_DEFAULT_STORE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-devservices-enabled]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-devservices-enabled[`+++quarkus.langchain4j.weaviate.devservices.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.weaviate.devservices.enabled+++[]
@@ -38,7 +59,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The container image name to use, for container based DevServices providers. If you want to use Redis Stack modules (bloom, graph, search...), use: `redis/redis-stack:latest`.
+The container image name to use, for container based DevServices providers.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -82,7 +103,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-Indicates if the Redis server managed by Quarkus Dev Services is shared. When shared, Quarkus looks for running containers using label-based service discovery. If a matching container is found, it is used, and so a second one is not started. Otherwise, Dev Services for Redis starts a new container.
+Indicates if the Weaviate server managed by Quarkus Dev Services is shared. When shared, Quarkus looks for running containers using label-based service discovery. If a matching container is found, it is used, and so a second one is not started. Otherwise, Dev Services for Weaviate starts a new container.
 
 The discovery uses the `quarkus-dev-service-weaviate` label. The value is configured using the `service-name` property.
 
@@ -107,7 +128,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The value of the `quarkus-dev-service-weaviate` label attached to the started container. This property is used when `shared` is set to `true`. In this case, before starting a container, Dev Services for Redis looks for a container with the `quarkus-dev-service-weaviate` label set to the configured value. If found, it will use this container instead of starting a new one. Otherwise, it starts a new container with the `quarkus-dev-service-weaviate` label set to the specified value.
+The value of the `quarkus-dev-service-weaviate` label attached to the started container. This property is used when `shared` is set to `true`. In this case, before starting a container, Dev Services for Weaviate looks for a container with the `quarkus-dev-service-weaviate` label set to the configured value. If found, it will use this container instead of starting a new one. Otherwise, it starts a new container with the `quarkus-dev-service-weaviate` label set to the specified value.
 
 This property is used when you need multiple shared Weaviate servers.
 
@@ -214,7 +235,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The gRPC port of the Weaviate server. Defaults to 8080
+The port of the Weaviate server. Defaults to 8080
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -319,7 +340,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The name of the field that contains the text of a `TextSegment`. Default is "text"
+The name of the field that contains the text of a `dev.langchain4j.data.segment.TextSegment`. Default is "text"
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -403,7 +424,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The name of the field where `Metadata` entries are stored
+The name of the field where `dev.langchain4j.data.segment.Metadata` entries are stored
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -415,6 +436,305 @@ endif::add-copy-button-to-env-var[]
 --
 |string
 |`+++_metadata+++`
+
+h|[[quarkus-langchain4j-weaviate_section_quarkus-langchain4j-weaviate]] [.section-name.section-level0]##link:#quarkus-langchain4j-weaviate_section_quarkus-langchain4j-weaviate[Named store configurations]##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-object-class]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-object-class[`+++quarkus.langchain4j.weaviate."store-name".object-class+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".object-class+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The object class used as the build-time discovery key for this named store. Each named store is identified by its object class within the same Weaviate server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__OBJECT_CLASS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__OBJECT_CLASS+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++<default>+++`
+
+a| [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-api-key]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-api-key[`+++quarkus.langchain4j.weaviate."store-name".api-key+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".api-key+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The Weaviate API key to authenticate with.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__API_KEY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__API_KEY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-scheme]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-scheme[`+++quarkus.langchain4j.weaviate."store-name".scheme+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".scheme+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The scheme, e.g. "https" of cluster URL. Find it under Details of your Weaviate cluster.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__SCHEME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__SCHEME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++http+++`
+
+a| [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-host]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-host[`+++quarkus.langchain4j.weaviate."store-name".host+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".host+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The URL of the Weaviate server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__HOST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__HOST+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++localhost+++`
+
+a| [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-port]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-port[`+++quarkus.langchain4j.weaviate."store-name".port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The port of the Weaviate server. Defaults to 8080
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++8080+++`
+
+a| [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-grpc-port]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-grpc-port[`+++quarkus.langchain4j.weaviate."store-name".grpc.port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".grpc.port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The gRPC port of the Weaviate server. Defaults to 50051
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__GRPC_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__GRPC_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++50051+++`
+
+a| [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-grpc-secure]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-grpc-secure[`+++quarkus.langchain4j.weaviate."store-name".grpc.secure+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".grpc.secure+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The gRPC connection is secured.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__GRPC_SECURE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__GRPC_SECURE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-grpc-use-for-inserts]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-grpc-use-for-inserts[`+++quarkus.langchain4j.weaviate."store-name".grpc.use-for-inserts+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".grpc.use-for-inserts+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Use gRPC instead of http for batch inserts only. Will still be used for search.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__GRPC_USE_FOR_INSERTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__GRPC_USE_FOR_INSERTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-object-class]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-object-class[`+++quarkus.langchain4j.weaviate."store-name".object-class+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".object-class+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The object class you want to store, e.g. "MyGreatClass". Must start from an uppercase letter.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__OBJECT_CLASS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__OBJECT_CLASS+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++Default+++`
+
+a| [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-text-field-name]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-text-field-name[`+++quarkus.langchain4j.weaviate."store-name".text-field-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".text-field-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The name of the field that contains the text of a `dev.langchain4j.data.segment.TextSegment`. Default is "text"
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__TEXT_FIELD_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__TEXT_FIELD_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++text+++`
+
+a| [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-avoid-dups]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-avoid-dups[`+++quarkus.langchain4j.weaviate."store-name".avoid-dups+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".avoid-dups+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+If true (default), then `WeaviateEmbeddingStore` will generate a hashed ID based on provided text segment, which avoids duplicated entries in DB. If false, then random ID will be generated.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__AVOID_DUPS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__AVOID_DUPS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-consistency-level]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-consistency-level[`+++quarkus.langchain4j.weaviate."store-name".consistency-level+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".consistency-level+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Consistency level: ONE, QUORUM (default) or ALL.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__CONSISTENCY_LEVEL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__CONSISTENCY_LEVEL+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`one`, `quorum`, `all`
+|`+++quorum+++`
+
+a| [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-metadata-keys]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-metadata-keys[`+++quarkus.langchain4j.weaviate."store-name".metadata.keys+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".metadata.keys+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Metadata keys that should be persisted. The default in Weaviate ++[]++, however it is required to specify at least one for the EmbeddingStore to work. Thus, we use "tags" as default
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__METADATA_KEYS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__METADATA_KEYS+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|`+++tags+++`
+
+a| [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-metadata-field-name]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-metadata-field-name[`+++quarkus.langchain4j.weaviate."store-name".metadata.field-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".metadata.field-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The name of the field where `dev.langchain4j.data.segment.Metadata` entries are stored
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__METADATA_FIELD_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WEAVIATE__STORE_NAME__METADATA_FIELD_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++_metadata+++`
+
 
 |===
 

--- a/docs/modules/ROOT/pages/rag-weaviate.adoc
+++ b/docs/modules/ROOT/pages/rag-weaviate.adoc
@@ -52,6 +52,50 @@ You can customize the behavior of the extension using the following configuratio
 
 include::includes/quarkus-langchain4j-weaviate.adoc[leveloffset=+1,opts=optional]
 
+== Named Stores
+
+You can configure multiple named Weaviate stores, each pointing to a different Weaviate instance or using a different object class.
+This is useful when your application needs to manage embeddings for different domains or tenants separately.
+
+To configure a named store:
+
+[source,properties]
+----
+quarkus.langchain4j.weaviate.products.object-class=ProductClass
+quarkus.langchain4j.weaviate.products.metadata.keys=tags
+----
+
+To point to a different Weaviate instance, specify its scheme, host, and port:
+
+[source,properties]
+----
+quarkus.langchain4j.weaviate.products.scheme=https
+quarkus.langchain4j.weaviate.products.host=weaviate.example.com
+quarkus.langchain4j.weaviate.products.port=8080
+quarkus.langchain4j.weaviate.products.object-class=ProductClass
+----
+
+To inject a named store, use the `@EmbeddingStoreName` qualifier:
+
+[source,java]
+----
+@Inject
+@EmbeddingStoreName("products")
+WeaviateEmbeddingStore productsStore;
+
+@Inject
+@EmbeddingStoreName("products")
+WeaviateClient productsClient;
+----
+
+The default store and named stores can coexist.
+If you only need named stores, disable the default store:
+
+[source,properties]
+----
+quarkus.langchain4j.weaviate.default-store-enabled=false
+----
+
 == How It Works
 
 * Ingested content is stored as `objects` in a Weaviate class with associated vector embeddings.

--- a/embedding-stores/weaviate/deployment/src/main/java/io/quarkiverse/langchain4j/weaviate/deployment/WeaviateDevServicesProcessor.java
+++ b/embedding-stores/weaviate/deployment/src/main/java/io/quarkiverse/langchain4j/weaviate/deployment/WeaviateDevServicesProcessor.java
@@ -2,11 +2,13 @@ package io.quarkiverse.langchain4j.weaviate.deployment;
 
 import java.io.Closeable;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import org.jboss.logging.Logger;
@@ -51,11 +53,13 @@ public class WeaviateDevServicesProcessor {
     public DevServicesResultBuildItem startWeaviateDevService(
             DockerStatusBuildItem dockerStatusBuildItem,
             LaunchModeBuildItem launchMode,
-            WeaviateBuildConfig weaviateBuildConfig,
+            WeaviateEmbeddingStoreBuildTimeConfig weaviateBuildConfig,
             Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
             List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
             LoggingSetupBuildItem loggingSetupBuildItem,
             DevServicesConfig devServicesConfig) {
+
+        Set<String> namedStoreNames = weaviateBuildConfig.namedConfig().keySet();
 
         WeaviateDevServiceCfg configuration = getConfiguration(weaviateBuildConfig);
 
@@ -74,7 +78,7 @@ public class WeaviateDevServicesProcessor {
         try {
             DevServicesResultBuildItem.RunningDevService newDevService = startContainer(dockerStatusBuildItem, configuration,
                     launchMode,
-                    !devServicesSharedNetworkBuildItem.isEmpty(), devServicesConfig.timeout());
+                    !devServicesSharedNetworkBuildItem.isEmpty(), devServicesConfig.timeout(), namedStoreNames);
             if (newDevService != null) {
                 devService = newDevService;
 
@@ -131,7 +135,7 @@ public class WeaviateDevServicesProcessor {
 
     private DevServicesResultBuildItem.RunningDevService startContainer(DockerStatusBuildItem dockerStatusBuildItem,
             WeaviateDevServiceCfg config, LaunchModeBuildItem launchMode,
-            boolean useSharedNetwork, Optional<Duration> timeout) {
+            boolean useSharedNetwork, Optional<Duration> timeout, Set<String> namedStoreNames) {
         if (!config.devServicesEnabled) {
             // explicitly disabled
             log.debug("Not starting Dev Services for Weaviate, as it has been disabled in the config.");
@@ -158,7 +162,8 @@ public class WeaviateDevServicesProcessor {
                     container.getContainerId(),
                     container::close,
                     container.getHost(),
-                    container.getMappedPort(8080));
+                    container.getMappedPort(8080),
+                    namedStoreNames);
         };
 
         return containerLocator
@@ -170,7 +175,8 @@ public class WeaviateDevServicesProcessor {
                         containerAddress.getId(),
                         null,
                         containerAddress.getHost(),
-                        containerAddress.getPort()))
+                        containerAddress.getPort(),
+                        namedStoreNames))
                 .orElseGet(defaultWeaviateSupplier);
     }
 
@@ -178,18 +184,24 @@ public class WeaviateDevServicesProcessor {
             String containerId,
             Closeable closeable,
             String host,
-            int port) {
+            int port,
+            Set<String> namedStoreNames) {
 
-        Map<String, String> configMap = Map.of(
-                "quarkus.langchain4j.weaviate.scheme", "http",
-                "quarkus.langchain4j.weaviate.host", host,
-                "quarkus.langchain4j.weaviate.port", String.valueOf(port));
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put("quarkus.langchain4j.weaviate.scheme", "http");
+        configMap.put("quarkus.langchain4j.weaviate.host", host);
+        configMap.put("quarkus.langchain4j.weaviate.port", String.valueOf(port));
+        for (String namedStore : namedStoreNames) {
+            configMap.put("quarkus.langchain4j.weaviate." + namedStore + ".scheme", "http");
+            configMap.put("quarkus.langchain4j.weaviate." + namedStore + ".host", host);
+            configMap.put("quarkus.langchain4j.weaviate." + namedStore + ".port", String.valueOf(port));
+        }
 
         return new DevServicesResultBuildItem.RunningDevService(WeaviateProcessor.FEATURE,
                 containerId, closeable, configMap);
     }
 
-    private WeaviateDevServiceCfg getConfiguration(WeaviateBuildConfig cfg) {
+    private WeaviateDevServiceCfg getConfiguration(WeaviateEmbeddingStoreBuildTimeConfig cfg) {
         return new WeaviateDevServiceCfg(cfg.devservices());
     }
 
@@ -203,7 +215,8 @@ public class WeaviateDevServicesProcessor {
         private final String serviceName;
         private final Map<String, String> containerEnv;
 
-        public WeaviateDevServiceCfg(WeaviateBuildConfig.WeaviateDevServicesBuildTimeConfig devServicesConfig) {
+        public WeaviateDevServiceCfg(
+                WeaviateEmbeddingStoreBuildTimeConfig.WeaviateDevServicesBuildTimeConfig devServicesConfig) {
             this.devServicesEnabled = devServicesConfig.enabled();
             this.imageName = devServicesConfig.imageName();
             this.fixedExposedPort = devServicesConfig.port();

--- a/embedding-stores/weaviate/deployment/src/main/java/io/quarkiverse/langchain4j/weaviate/deployment/WeaviateEmbeddingStoreBuildTimeConfig.java
+++ b/embedding-stores/weaviate/deployment/src/main/java/io/quarkiverse/langchain4j/weaviate/deployment/WeaviateEmbeddingStoreBuildTimeConfig.java
@@ -5,19 +5,49 @@ import static io.quarkus.runtime.annotations.ConfigPhase.BUILD_TIME;
 import java.util.Map;
 import java.util.OptionalInt;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithDefaults;
+import io.smallrye.config.WithParentName;
 
 @ConfigRoot(phase = BUILD_TIME)
 @ConfigMapping(prefix = "quarkus.langchain4j.weaviate")
-public interface WeaviateBuildConfig {
+public interface WeaviateEmbeddingStoreBuildTimeConfig {
+
+    /**
+     * Default store build-time config.
+     */
+    @WithParentName
+    DefaultStoreBuildTimeConfig defaultConfig();
+
+    /**
+     * Named store configurations.
+     */
+    @ConfigDocSection
+    @ConfigDocMapKey("store-name")
+    @WithParentName
+    @WithDefaults
+    Map<String, WeaviateNamedStoreBuildTimeConfig> namedConfig();
 
     /**
      * Configuration for DevServices. DevServices allows Quarkus to automatically start a database in dev and test mode.
      */
     WeaviateDevServicesBuildTimeConfig devservices();
+
+    @ConfigGroup
+    interface DefaultStoreBuildTimeConfig {
+
+        /**
+         * Whether the default (unnamed) Weaviate embedding store should be enabled.
+         * Set to {@code false} when you only want to use named stores.
+         */
+        @WithDefault("true")
+        boolean defaultStoreEnabled();
+    }
 
     @ConfigGroup
     interface WeaviateDevServicesBuildTimeConfig {
@@ -34,8 +64,6 @@ public interface WeaviateBuildConfig {
 
         /**
          * The container image name to use, for container based DevServices providers.
-         * If you want to use Redis Stack modules (bloom, graph, search...), use:
-         * {@code redis/redis-stack:latest}.
          */
         @WithDefault("cr.weaviate.io/semitechnologies/weaviate:1.25.5")
         String imageName();
@@ -48,10 +76,10 @@ public interface WeaviateBuildConfig {
         OptionalInt port();
 
         /**
-         * Indicates if the Redis server managed by Quarkus Dev Services is shared.
+         * Indicates if the Weaviate server managed by Quarkus Dev Services is shared.
          * When shared, Quarkus looks for running containers using label-based service discovery.
          * If a matching container is found, it is used, and so a second one is not started.
-         * Otherwise, Dev Services for Redis starts a new container.
+         * Otherwise, Dev Services for Weaviate starts a new container.
          * <p>
          * The discovery uses the {@code quarkus-dev-service-weaviate} label.
          * The value is configured using the {@code service-name} property.
@@ -64,7 +92,7 @@ public interface WeaviateBuildConfig {
         /**
          * The value of the {@code quarkus-dev-service-weaviate} label attached to the started container.
          * This property is used when {@code shared} is set to {@code true}.
-         * In this case, before starting a container, Dev Services for Redis looks for a container with the
+         * In this case, before starting a container, Dev Services for Weaviate looks for a container with the
          * {@code quarkus-dev-service-weaviate} label
          * set to the configured value. If found, it will use this container instead of starting a new one. Otherwise, it
          * starts a new container with the {@code quarkus-dev-service-weaviate} label set to the specified value.

--- a/embedding-stores/weaviate/deployment/src/main/java/io/quarkiverse/langchain4j/weaviate/deployment/WeaviateNamedStoreBuildTimeConfig.java
+++ b/embedding-stores/weaviate/deployment/src/main/java/io/quarkiverse/langchain4j/weaviate/deployment/WeaviateNamedStoreBuildTimeConfig.java
@@ -1,0 +1,17 @@
+package io.quarkiverse.langchain4j.weaviate.deployment;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+
+@ConfigGroup
+public interface WeaviateNamedStoreBuildTimeConfig {
+
+    /**
+     * The object class used as the build-time discovery key for this named store.
+     * Each named store is identified by its object class within the same Weaviate server.
+     */
+    @WithDefault("<default>")
+    Optional<String> objectClass();
+}

--- a/embedding-stores/weaviate/deployment/src/main/java/io/quarkiverse/langchain4j/weaviate/deployment/WeaviateProcessor.java
+++ b/embedding-stores/weaviate/deployment/src/main/java/io/quarkiverse/langchain4j/weaviate/deployment/WeaviateProcessor.java
@@ -1,7 +1,10 @@
 package io.quarkiverse.langchain4j.weaviate.deployment;
 
+import java.util.Map;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
+import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassType;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.ParameterizedType;
@@ -9,7 +12,9 @@ import org.jboss.jandex.ParameterizedType;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.weaviate.WeaviateEmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
 import io.quarkiverse.langchain4j.deployment.EmbeddingStoreBuildItem;
+import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkiverse.langchain4j.weaviate.runtime.WeaviateRecorder;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -36,28 +41,68 @@ class WeaviateProcessor {
     public void createBeans(
             BuildProducer<SyntheticBeanBuildItem> beanProducer,
             WeaviateRecorder recorder,
-            BuildProducer<EmbeddingStoreBuildItem> embeddingStoreProducer) {
-        beanProducer.produce(SyntheticBeanBuildItem
-                .configure(WEAVIATE_EMBEDDING_STORE)
-                .types(ClassType.create(EmbeddingStore.class),
-                        ParameterizedType.create(EmbeddingStore.class, ClassType.create(TextSegment.class)))
-                .defaultBean()
-                .setRuntimeInit()
-                .unremovable()
-                .scope(ApplicationScoped.class)
-                .supplier(recorder.weaviateStoreSupplier())
-                .done());
+            BuildProducer<EmbeddingStoreBuildItem> embeddingStoreProducer,
+            WeaviateEmbeddingStoreBuildTimeConfig buildTimeConfig) {
 
-        beanProducer.produce(SyntheticBeanBuildItem
-                .configure(WEAVIATE_CLIENT)
-                .types(ClassType.create(WeaviateClient.class))
-                .defaultBean()
-                .setRuntimeInit()
-                .unremovable()
-                .scope(ApplicationScoped.class)
-                .supplier(recorder.weaviateClientSupplier())
-                .done());
+        if (buildTimeConfig.defaultConfig().defaultStoreEnabled()) {
+            beanProducer.produce(SyntheticBeanBuildItem
+                    .configure(WEAVIATE_EMBEDDING_STORE)
+                    .types(ClassType.create(WeaviateEmbeddingStore.class),
+                            ClassType.create(EmbeddingStore.class),
+                            ParameterizedType.create(EmbeddingStore.class, ClassType.create(TextSegment.class)))
+                    .defaultBean()
+                    .setRuntimeInit()
+                    .unremovable()
+                    .scope(ApplicationScoped.class)
+                    .supplier(recorder.weaviateStoreSupplier(NamedConfigUtil.DEFAULT_NAME))
+                    .done());
 
-        embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
+            beanProducer.produce(SyntheticBeanBuildItem
+                    .configure(WEAVIATE_CLIENT)
+                    .types(ClassType.create(WeaviateClient.class))
+                    .defaultBean()
+                    .setRuntimeInit()
+                    .unremovable()
+                    .scope(ApplicationScoped.class)
+                    .supplier(recorder.weaviateClientSupplier(NamedConfigUtil.DEFAULT_NAME))
+                    .done());
+
+            embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
+        }
+
+        Map<String, WeaviateNamedStoreBuildTimeConfig> namedStores = buildTimeConfig.namedConfig();
+        for (Map.Entry<String, WeaviateNamedStoreBuildTimeConfig> entry : namedStores.entrySet()) {
+            String storeName = entry.getKey();
+
+            AnnotationInstance storeNameQualifier = AnnotationInstance.builder(EmbeddingStoreName.class)
+                    .add("value", storeName)
+                    .build();
+
+            beanProducer.produce(SyntheticBeanBuildItem
+                    .configure(WEAVIATE_EMBEDDING_STORE)
+                    .types(ClassType.create(WeaviateEmbeddingStore.class),
+                            ClassType.create(EmbeddingStore.class),
+                            ParameterizedType.create(EmbeddingStore.class, ClassType.create(TextSegment.class)))
+                    .setRuntimeInit()
+                    .defaultBean()
+                    .unremovable()
+                    .scope(ApplicationScoped.class)
+                    .addQualifier(storeNameQualifier)
+                    .supplier(recorder.weaviateStoreSupplier(storeName))
+                    .done());
+
+            beanProducer.produce(SyntheticBeanBuildItem
+                    .configure(WEAVIATE_CLIENT)
+                    .types(ClassType.create(WeaviateClient.class))
+                    .setRuntimeInit()
+                    .defaultBean()
+                    .unremovable()
+                    .scope(ApplicationScoped.class)
+                    .addQualifier(storeNameQualifier)
+                    .supplier(recorder.weaviateClientSupplier(storeName))
+                    .done());
+
+            embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
+        }
     }
 }

--- a/embedding-stores/weaviate/deployment/src/test/java/io/quarkiverse/langchain4j/weaviate/deployment/WeaviateDefaultAndNamedStoreTest.java
+++ b/embedding-stores/weaviate/deployment/src/test/java/io/quarkiverse/langchain4j/weaviate/deployment/WeaviateDefaultAndNamedStoreTest.java
@@ -1,0 +1,56 @@
+package io.quarkiverse.langchain4j.weaviate.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.store.embedding.weaviate.WeaviateEmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+import io.weaviate.client.WeaviateClient;
+
+public class WeaviateDefaultAndNamedStoreTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.weaviate.products.object-class", "ProductClass")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.weaviate.products.metadata.keys", "tags");
+
+    @Inject
+    WeaviateEmbeddingStore defaultEmbeddingStore;
+
+    @Inject
+    WeaviateClient defaultClient;
+
+    @Inject
+    @EmbeddingStoreName("products")
+    WeaviateEmbeddingStore productsEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("products")
+    WeaviateClient productsClient;
+
+    @Test
+    void testDefault() {
+        assertThat(defaultEmbeddingStore).isNotNull();
+        assertThat(defaultClient).isNotNull();
+    }
+
+    @Test
+    void testNamed() {
+        assertThat(productsEmbeddingStore).isNotNull();
+        assertThat(productsClient).isNotNull();
+    }
+
+    @Test
+    void testNotSame() {
+        assertThat(defaultEmbeddingStore).isNotSameAs(productsEmbeddingStore);
+        assertThat(defaultClient).isNotSameAs(productsClient);
+    }
+}

--- a/embedding-stores/weaviate/deployment/src/test/java/io/quarkiverse/langchain4j/weaviate/deployment/WeaviateMultipleNamedStoresTest.java
+++ b/embedding-stores/weaviate/deployment/src/test/java/io/quarkiverse/langchain4j/weaviate/deployment/WeaviateMultipleNamedStoresTest.java
@@ -1,0 +1,57 @@
+package io.quarkiverse.langchain4j.weaviate.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.store.embedding.weaviate.WeaviateEmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+import io.weaviate.client.WeaviateClient;
+
+public class WeaviateMultipleNamedStoresTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.weaviate.default-store-enabled", "false")
+            .overrideConfigKey("quarkus.langchain4j.weaviate.products.object-class", "ProductClass")
+            .overrideConfigKey("quarkus.langchain4j.weaviate.documents.object-class", "DocumentClass")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.weaviate.products.metadata.keys", "tags")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.weaviate.documents.metadata.keys", "tags");
+
+    @Inject
+    @EmbeddingStoreName("products")
+    WeaviateEmbeddingStore productsEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("products")
+    WeaviateClient productsClient;
+
+    @Inject
+    @EmbeddingStoreName("documents")
+    WeaviateEmbeddingStore documentsEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("documents")
+    WeaviateClient documentsClient;
+
+    @Test
+    void testBothNamed() {
+        assertThat(productsEmbeddingStore).isNotNull();
+        assertThat(productsClient).isNotNull();
+        assertThat(documentsEmbeddingStore).isNotNull();
+        assertThat(documentsClient).isNotNull();
+    }
+
+    @Test
+    void testNotSame() {
+        assertThat(productsEmbeddingStore).isNotSameAs(documentsEmbeddingStore);
+        assertThat(productsClient).isNotSameAs(documentsClient);
+    }
+}

--- a/embedding-stores/weaviate/deployment/src/test/java/io/quarkiverse/langchain4j/weaviate/deployment/WeaviateNamedStoreMissingHostTest.java
+++ b/embedding-stores/weaviate/deployment/src/test/java/io/quarkiverse/langchain4j/weaviate/deployment/WeaviateNamedStoreMissingHostTest.java
@@ -1,0 +1,39 @@
+package io.quarkiverse.langchain4j.weaviate.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.store.embedding.weaviate.WeaviateEmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+import io.weaviate.client.WeaviateClient;
+
+public class WeaviateNamedStoreMissingHostTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.weaviate.devservices.enabled", "false")
+            .overrideConfigKey("quarkus.langchain4j.weaviate.default-store-enabled", "false")
+            .overrideConfigKey("quarkus.langchain4j.weaviate.products.object-class", "ProductClass");
+
+    @Inject
+    @EmbeddingStoreName("products")
+    WeaviateEmbeddingStore productsEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("products")
+    WeaviateClient productsClient;
+
+    @Test
+    void testNamedStoreUsesDefaultHost() {
+        assertThat(productsEmbeddingStore).isNotNull();
+        assertThat(productsClient).isNotNull();
+    }
+}

--- a/embedding-stores/weaviate/deployment/src/test/java/io/quarkiverse/langchain4j/weaviate/deployment/WeaviateNamedStoreTest.java
+++ b/embedding-stores/weaviate/deployment/src/test/java/io/quarkiverse/langchain4j/weaviate/deployment/WeaviateNamedStoreTest.java
@@ -1,0 +1,56 @@
+package io.quarkiverse.langchain4j.weaviate.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.store.embedding.weaviate.WeaviateEmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+import io.weaviate.client.WeaviateClient;
+
+public class WeaviateNamedStoreTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.weaviate.products.object-class", "ProductClass")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.weaviate.products.metadata.keys", "tags");
+
+    @Inject
+    WeaviateEmbeddingStore defaultEmbeddingStore;
+
+    @Inject
+    WeaviateClient defaultClient;
+
+    @Inject
+    @EmbeddingStoreName("products")
+    WeaviateEmbeddingStore productsEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("products")
+    WeaviateClient productsClient;
+
+    @Test
+    void testDefault() {
+        assertThat(defaultEmbeddingStore).isNotNull();
+        assertThat(defaultClient).isNotNull();
+    }
+
+    @Test
+    void testNamed() {
+        assertThat(productsEmbeddingStore).isNotNull();
+        assertThat(productsClient).isNotNull();
+    }
+
+    @Test
+    void testNotSame() {
+        assertThat(defaultEmbeddingStore).isNotSameAs(productsEmbeddingStore);
+        assertThat(defaultClient).isNotSameAs(productsClient);
+    }
+}

--- a/embedding-stores/weaviate/runtime/src/main/java/io/quarkiverse/langchain4j/weaviate/runtime/WeaviateEmbeddingStoreConfig.java
+++ b/embedding-stores/weaviate/runtime/src/main/java/io/quarkiverse/langchain4j/weaviate/runtime/WeaviateEmbeddingStoreConfig.java
@@ -1,0 +1,32 @@
+package io.quarkiverse.langchain4j.weaviate.runtime;
+
+import static io.quarkus.runtime.annotations.ConfigPhase.RUN_TIME;
+
+import java.util.Map;
+
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigDocSection;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefaults;
+import io.smallrye.config.WithParentName;
+
+@ConfigRoot(phase = RUN_TIME)
+@ConfigMapping(prefix = "quarkus.langchain4j.weaviate")
+public interface WeaviateEmbeddingStoreConfig {
+
+    /**
+     * Default store config.
+     */
+    @WithParentName
+    WeaviateStoreRuntimeConfig defaultConfig();
+
+    /**
+     * Named store configurations.
+     */
+    @ConfigDocSection
+    @ConfigDocMapKey("store-name")
+    @WithParentName
+    @WithDefaults
+    Map<String, WeaviateStoreRuntimeConfig> namedConfig();
+}

--- a/embedding-stores/weaviate/runtime/src/main/java/io/quarkiverse/langchain4j/weaviate/runtime/WeaviateRecorder.java
+++ b/embedding-stores/weaviate/runtime/src/main/java/io/quarkiverse/langchain4j/weaviate/runtime/WeaviateRecorder.java
@@ -3,6 +3,7 @@ package io.quarkiverse.langchain4j.weaviate.runtime;
 import java.util.function.Supplier;
 
 import dev.langchain4j.store.embedding.weaviate.WeaviateEmbeddingStore;
+import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.weaviate.client.Config;
@@ -10,39 +11,41 @@ import io.weaviate.client.WeaviateClient;
 
 @Recorder
 public class WeaviateRecorder {
-    private final RuntimeValue<WeaviateRuntimeConfig> runtimeConfig;
+    private final RuntimeValue<WeaviateEmbeddingStoreConfig> runtimeConfig;
 
-    public WeaviateRecorder(RuntimeValue<WeaviateRuntimeConfig> runtimeConfig) {
+    public WeaviateRecorder(RuntimeValue<WeaviateEmbeddingStoreConfig> runtimeConfig) {
         this.runtimeConfig = runtimeConfig;
     }
 
-    public Supplier<WeaviateClient> weaviateClientSupplier() {
-        return new Supplier<>() {
-            @Override
-            public WeaviateClient get() {
-                return new WeaviateClient(new Config(runtimeConfig.getValue().scheme(),
-                        runtimeConfig.getValue().host() + ":" + runtimeConfig.getValue().port()));
-            }
-        };
+    public Supplier<WeaviateClient> weaviateClientSupplier(String storeName) {
+        WeaviateStoreRuntimeConfig storeConfig = correspondingStoreConfig(storeName);
+        return () -> new WeaviateClient(new Config(storeConfig.scheme(), storeConfig.host() + ":" + storeConfig.port()));
     }
 
-    public Supplier<WeaviateEmbeddingStore> weaviateStoreSupplier() {
-        return new Supplier<>() {
-            @Override
-            public WeaviateEmbeddingStore get() {
-                return WeaviateEmbeddingStore.builder()
-                        .apiKey(runtimeConfig.getValue().apiKey().orElse(null))
-                        .scheme(runtimeConfig.getValue().scheme())
-                        .host(runtimeConfig.getValue().host())
-                        .port(runtimeConfig.getValue().port())
-                        .objectClass(runtimeConfig.getValue().objectClass())
-                        .textFieldName(runtimeConfig.getValue().textFieldName())
-                        .avoidDups(runtimeConfig.getValue().avoidDups())
-                        .consistencyLevel(runtimeConfig.getValue().consistencyLevel().toString())
-                        .metadataKeys(runtimeConfig.getValue().metadata().keys())
-                        .metadataFieldName(runtimeConfig.getValue().metadata().fieldName())
-                        .build();
-            }
-        };
+    public Supplier<WeaviateEmbeddingStore> weaviateStoreSupplier(String storeName) {
+        WeaviateStoreRuntimeConfig storeConfig = correspondingStoreConfig(storeName);
+        return () -> WeaviateEmbeddingStore.builder()
+                .apiKey(storeConfig.apiKey().orElse(null))
+                .scheme(storeConfig.scheme())
+                .host(storeConfig.host())
+                .port(storeConfig.port())
+                .objectClass(storeConfig.objectClass())
+                .textFieldName(storeConfig.textFieldName())
+                .avoidDups(storeConfig.avoidDups())
+                .consistencyLevel(storeConfig.consistencyLevel().toString())
+                .metadataKeys(storeConfig.metadata().keys())
+                .metadataFieldName(storeConfig.metadata().fieldName())
+                .build();
+    }
+
+    WeaviateStoreRuntimeConfig correspondingStoreConfig(String storeName) {
+        if (NamedConfigUtil.isDefault(storeName)) {
+            return runtimeConfig.getValue().defaultConfig();
+        }
+        WeaviateStoreRuntimeConfig namedConfig = runtimeConfig.getValue().namedConfig().get(storeName);
+        if (namedConfig != null) {
+            return namedConfig;
+        }
+        return runtimeConfig.getValue().defaultConfig();
     }
 }

--- a/embedding-stores/weaviate/runtime/src/main/java/io/quarkiverse/langchain4j/weaviate/runtime/WeaviateStoreRuntimeConfig.java
+++ b/embedding-stores/weaviate/runtime/src/main/java/io/quarkiverse/langchain4j/weaviate/runtime/WeaviateStoreRuntimeConfig.java
@@ -1,17 +1,13 @@
 package io.quarkiverse.langchain4j.weaviate.runtime;
 
-import static io.quarkus.runtime.annotations.ConfigPhase.RUN_TIME;
-
 import java.util.List;
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigRoot;
-import io.smallrye.config.ConfigMapping;
+import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
-@ConfigRoot(phase = RUN_TIME)
-@ConfigMapping(prefix = "quarkus.langchain4j.weaviate")
-public interface WeaviateRuntimeConfig {
+@ConfigGroup
+public interface WeaviateStoreRuntimeConfig {
 
     /**
      * The Weaviate API key to authenticate with.
@@ -31,13 +27,13 @@ public interface WeaviateRuntimeConfig {
     String host();
 
     /**
-     * The gRPC port of the Weaviate server. Defaults to 8080
+     * The port of the Weaviate server. Defaults to 8080
      */
     @WithDefault("8080")
     Integer port();
 
     /**
-     * The gRPC connection is secured.
+     * gRPC configuration.
      */
     Grpc grpc();
 
@@ -48,13 +44,14 @@ public interface WeaviateRuntimeConfig {
     String objectClass();
 
     /**
-     * The name of the field that contains the text of a {@link TextSegment}. Default is "text"
+     * The name of the field that contains the text of a {@link dev.langchain4j.data.segment.TextSegment}. Default is
+     * "text"
      */
     @WithDefault("text")
     String textFieldName();
 
     /**
-     * If true (default), then <code>WeaviateEmbeddingStore</code> will generate a hashed ID based on
+     * If true (default), then {@code WeaviateEmbeddingStore} will generate a hashed ID based on
      * provided text segment, which avoids duplicated entries in DB.
      * If false, then random ID will be generated.
      */
@@ -68,11 +65,13 @@ public interface WeaviateRuntimeConfig {
     ConsistencyLevel consistencyLevel();
 
     /**
-     * Metadata configuration
+     * Metadata configuration.
      */
     Metadata metadata();
 
+    @ConfigGroup
     interface Grpc {
+
         /**
          * The gRPC port of the Weaviate server. Defaults to 50051
          */
@@ -99,6 +98,7 @@ public interface WeaviateRuntimeConfig {
         ALL
     }
 
+    @ConfigGroup
     interface Metadata {
 
         /**
@@ -110,10 +110,9 @@ public interface WeaviateRuntimeConfig {
         List<String> keys();
 
         /**
-         * The name of the field where {@link Metadata} entries are stored
+         * The name of the field where {@link dev.langchain4j.data.segment.Metadata} entries are stored
          */
         @WithDefault("_metadata")
         String fieldName();
-
     }
 }


### PR DESCRIPTION
Enables configuring multiple Weaviate embedding stores, each with independent configuration and injectable via `@EmbeddingStoreName`.

Each named store can point to a different Weaviate instance (different scheme/host/port) and use a different object class. The `objectClass` property serves as the build-time discovery key — when set, a named store bean is registered. This follows the same pattern as Chroma (`collection-name`), Milvus (`host`), and pgvector (`datasource`).

## Configuration

Default store (backward compatible):

```properties
quarkus.langchain4j.weaviate.object-class=DefaultCollection
quarkus.langchain4j.weaviate.dimension=1536
```

Named stores:

```properties
quarkus.langchain4j.weaviate.products.object-class=ProductCollection
quarkus.langchain4j.weaviate.products.host=localhost
quarkus.langchain4j.weaviate.products.port=8081
quarkus.langchain4j.weaviate.products.dimension=768
```

## Injection

```java
@Inject
EmbeddingStore<TextSegment> defaultStore;

@Inject
@EmbeddingStoreName("products")
EmbeddingStore<TextSegment> productsStore;
```

- Closes: #2435