### PR TITLE
Allow persistent ChatMemoryStore to survive AI service bean destruction

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ChatMemoryClearOnCloseDisabledTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ChatMemoryClearOnCloseDisabledTest.java
@@ -1,0 +1,138 @@
+package io.quarkiverse.langchain4j.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.memory.ChatMemoryAccess;
+import dev.langchain4j.store.memory.chat.ChatMemoryStore;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verifies that when {@code quarkus.langchain4j.chat-memory.clear-on-close=false},
+ * the {@link ChatMemoryStore} is not wiped when the AI service bean is closed
+ * (e.g., on application shutdown), so conversations backed by a persistent store
+ * survive application restarts.
+ */
+public class ChatMemoryClearOnCloseDisabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.langchain4j.chat-memory.clear-on-close", "false")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyAiService.class, CountingChatMemoryStore.class,
+                            ChatMemoryProviderSupplier.class, MirrorChatModelSupplier.class));
+
+    @Inject
+    MyAiService service;
+
+    @Test
+    @ActivateRequestContext
+    void closeShouldNotDeleteMessagesWhenClearOnCloseIsFalse() throws Exception {
+        service.chat("user-1", "hello");
+
+        int deletesBefore = CountingChatMemoryStore.DELETE_COUNT.get();
+
+        ((AutoCloseable) service).close();
+
+        int deletesAfter = CountingChatMemoryStore.DELETE_COUNT.get();
+        assertThat(deletesAfter - deletesBefore)
+                .as("ChatMemoryStore.deleteMessages must not be invoked on close "
+                        + "when clear-on-close=false")
+                .isZero();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void closeShouldStillReleaseInMemoryReferencesWhenClearOnCloseIsFalse() throws Exception {
+        service.chat("leak-test-1", "hi");
+        service.chat("leak-test-2", "hi");
+
+        ChatMemoryAccess access = (ChatMemoryAccess) service;
+        assertThat(access.getChatMemory("leak-test-1")).isNotNull();
+
+        ((AutoCloseable) service).close();
+
+        assertThat(access.getChatMemory("leak-test-1"))
+                .as("in-memory bookkeeping must be released on close to prevent leaks, "
+                        + "even when the persistent store is preserved")
+                .isNull();
+        assertThat(access.getChatMemory("leak-test-2")).isNull();
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = MirrorChatModelSupplier.class, chatMemoryProviderSupplier = ChatMemoryProviderSupplier.class)
+    public interface MyAiService {
+        String chat(@MemoryId String memoryId, @UserMessage String message);
+    }
+
+    public static class CountingChatMemoryStore implements ChatMemoryStore {
+
+        static final CountingChatMemoryStore INSTANCE = new CountingChatMemoryStore();
+        static final AtomicInteger DELETE_COUNT = new AtomicInteger();
+
+        private final ConcurrentHashMap<Object, List<ChatMessage>> store = new ConcurrentHashMap<>();
+
+        @Override
+        public List<ChatMessage> getMessages(Object memoryId) {
+            return store.getOrDefault(memoryId, List.of());
+        }
+
+        @Override
+        public void updateMessages(Object memoryId, List<ChatMessage> messages) {
+            store.put(memoryId, List.copyOf(messages));
+        }
+
+        @Override
+        public void deleteMessages(Object memoryId) {
+            DELETE_COUNT.incrementAndGet();
+            store.remove(memoryId);
+        }
+    }
+
+    public static class ChatMemoryProviderSupplier implements Supplier<ChatMemoryProvider> {
+        @Override
+        public ChatMemoryProvider get() {
+            return memoryId -> MessageWindowChatMemory.builder()
+                    .id(memoryId)
+                    .maxMessages(10)
+                    .chatMemoryStore(CountingChatMemoryStore.INSTANCE)
+                    .build();
+        }
+    }
+
+    public static class MirrorChatModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new ChatModel() {
+                @Override
+                public ChatResponse doChat(ChatRequest chatRequest) {
+                    ChatMessage last = chatRequest.messages().get(chatRequest.messages().size() - 1);
+                    return ChatResponse.builder()
+                            .aiMessage(new AiMessage(last.toString()))
+                            .build();
+                }
+            };
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ChatMemoryClearOnCloseEnabledTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ChatMemoryClearOnCloseEnabledTest.java
@@ -1,0 +1,117 @@
+package io.quarkiverse.langchain4j.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.store.memory.chat.ChatMemoryStore;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Locks the default behavior: when no override is set, closing the AI service
+ * still triggers {@link ChatMemoryStore#deleteMessages(Object)} to avoid leaking
+ * memory IDs accumulated during runtime.
+ */
+public class ChatMemoryClearOnCloseEnabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyAiService.class, CountingChatMemoryStore.class,
+                            ChatMemoryProviderSupplier.class, MirrorChatModelSupplier.class));
+
+    @Inject
+    MyAiService service;
+
+    @Test
+    @ActivateRequestContext
+    void closeShouldDeleteMessagesByDefault() throws Exception {
+        service.chat("user-1", "hello");
+
+        int deletesBefore = CountingChatMemoryStore.DELETE_COUNT.get();
+
+        ((AutoCloseable) service).close();
+
+        int deletesAfter = CountingChatMemoryStore.DELETE_COUNT.get();
+        assertThat(deletesAfter - deletesBefore)
+                .as("ChatMemoryStore.deleteMessages must be invoked at least once on close "
+                        + "when clear-on-close defaults to true")
+                .isGreaterThanOrEqualTo(1);
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = MirrorChatModelSupplier.class, chatMemoryProviderSupplier = ChatMemoryProviderSupplier.class)
+    public interface MyAiService {
+        String chat(@MemoryId String memoryId, @UserMessage String message);
+    }
+
+    public static class CountingChatMemoryStore implements ChatMemoryStore {
+
+        static final CountingChatMemoryStore INSTANCE = new CountingChatMemoryStore();
+        static final AtomicInteger DELETE_COUNT = new AtomicInteger();
+
+        private final ConcurrentHashMap<Object, List<ChatMessage>> store = new ConcurrentHashMap<>();
+
+        @Override
+        public List<ChatMessage> getMessages(Object memoryId) {
+            return store.getOrDefault(memoryId, List.of());
+        }
+
+        @Override
+        public void updateMessages(Object memoryId, List<ChatMessage> messages) {
+            store.put(memoryId, List.copyOf(messages));
+        }
+
+        @Override
+        public void deleteMessages(Object memoryId) {
+            DELETE_COUNT.incrementAndGet();
+            store.remove(memoryId);
+        }
+    }
+
+    public static class ChatMemoryProviderSupplier implements Supplier<ChatMemoryProvider> {
+        @Override
+        public ChatMemoryProvider get() {
+            return memoryId -> MessageWindowChatMemory.builder()
+                    .id(memoryId)
+                    .maxMessages(10)
+                    .chatMemoryStore(CountingChatMemoryStore.INSTANCE)
+                    .build();
+        }
+    }
+
+    public static class MirrorChatModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new ChatModel() {
+                @Override
+                public ChatResponse doChat(ChatRequest chatRequest) {
+                    ChatMessage last = chatRequest.messages().get(chatRequest.messages().size() - 1);
+                    return ChatResponse.builder()
+                            .aiMessage(new AiMessage(last.toString()))
+                            .build();
+                }
+            };
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ChatMemoryReplayValidationTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ChatMemoryReplayValidationTest.java
@@ -1,0 +1,116 @@
+package io.quarkiverse.langchain4j.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.store.memory.chat.ChatMemoryStore;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ChatMemoryReplayValidationTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.langchain4j.chat-memory.clear-on-close", "false")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyAiService.class, RecordingStore.class,
+                            ProviderSupplier.class, RecordingChatModelSupplier.class));
+
+    @Inject
+    MyAiService service;
+
+    @Test
+    @ActivateRequestContext
+    void secondRequestReplaysFirstRequestMessagesFromStore() throws Exception {
+        String firstMessage = "first message content";
+        service.chat("conv-1", firstMessage);
+        ((AutoCloseable) service).close();
+        RecordingChatModelSupplier.RECEIVED.clear();
+
+        service.chat("conv-1", "second message");
+
+        List<ChatMessage> sentToLlm = RecordingChatModelSupplier.RECEIVED;
+        assertThat(sentToLlm)
+                .as("with clear-on-close=false, a new invocation on the same memoryId "
+                        + "should reload prior messages from the persistent store")
+                .hasSizeGreaterThan(1);
+        assertThat(sentToLlm.toString())
+                .as("the reloaded messages should include the content sent in the first invocation")
+                .contains(firstMessage);
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = RecordingChatModelSupplier.class, chatMemoryProviderSupplier = ProviderSupplier.class)
+    public interface MyAiService {
+        String chat(@MemoryId String memoryId, @UserMessage String message);
+    }
+
+    public static class RecordingStore implements ChatMemoryStore {
+        static final RecordingStore INSTANCE = new RecordingStore();
+        private final ConcurrentHashMap<Object, List<ChatMessage>> store = new ConcurrentHashMap<>();
+
+        @Override
+        public List<ChatMessage> getMessages(Object memoryId) {
+            return store.getOrDefault(memoryId, List.of());
+        }
+
+        @Override
+        public void updateMessages(Object memoryId, List<ChatMessage> messages) {
+            store.put(memoryId, List.copyOf(messages));
+        }
+
+        @Override
+        public void deleteMessages(Object memoryId) {
+            store.remove(memoryId);
+        }
+    }
+
+    public static class ProviderSupplier implements Supplier<ChatMemoryProvider> {
+        @Override
+        public ChatMemoryProvider get() {
+            return memoryId -> MessageWindowChatMemory.builder()
+                    .id(memoryId)
+                    .maxMessages(50)
+                    .chatMemoryStore(RecordingStore.INSTANCE)
+                    .build();
+        }
+    }
+
+    public static class RecordingChatModelSupplier implements Supplier<ChatModel> {
+        static final List<ChatMessage> RECEIVED = new ArrayList<>();
+
+        @Override
+        public ChatModel get() {
+            return new ChatModel() {
+                @Override
+                public ChatResponse doChat(ChatRequest chatRequest) {
+                    RECEIVED.clear();
+                    RECEIVED.addAll(chatRequest.messages());
+                    return ChatResponse.builder()
+                            .aiMessage(new AiMessage("ack"))
+                            .build();
+                }
+            };
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/ChatMemoryConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/ChatMemoryConfig.java
@@ -31,6 +31,23 @@ public interface ChatMemoryConfig {
      */
     TokenWindow tokenWindow();
 
+    /**
+     * Whether to delete chat memory from the underlying
+     * {@link dev.langchain4j.store.memory.chat.ChatMemoryStore} when the owning AI service bean
+     * is destroyed (typically at application shutdown, or at the end of each request for
+     * {@link jakarta.enterprise.context.RequestScoped} AI services).
+     * <p>
+     * When {@code true} (the default), historical behavior is preserved: every known memory id is
+     * removed from the store. This is appropriate for the in-memory default store.
+     * <p>
+     * When {@code false}, the in-memory bookkeeping is still released to avoid leaks, but the
+     * persistent store is left untouched, so conversations backed by a custom
+     * {@link dev.langchain4j.store.memory.chat.ChatMemoryStore} (e.g., Redis, Couchbase, JDBC)
+     * survive pod or application restarts.
+     */
+    @WithDefault("true")
+    boolean clearOnClose();
+
     @ConfigGroup
     interface MemoryWindow {
 

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceContext.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceContext.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.langchain4j.runtime.aiservice;
 
 import java.lang.annotation.Annotation;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -8,6 +9,8 @@ import java.util.Set;
 
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
+
+import org.eclipse.microprofile.config.ConfigProvider;
 
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.model.chat.ChatModel;
@@ -42,10 +45,30 @@ public class QuarkusAiServiceContext extends AiServiceContext {
 
     /**
      * This is called by the {@code close} method of AiServices registered with {@link RegisterAiService}
-     * when the bean's scope is closed
+     * when the bean's scope is closed.
+     * <p>
+     * In-memory references to known memory ids are always released to avoid leaks for long-lived
+     * AI services. The underlying {@link dev.langchain4j.store.memory.chat.ChatMemoryStore} is only
+     * cleared when {@code quarkus.langchain4j.chat-memory.clear-on-close} is {@code true} (the default);
+     * setting it to {@code false} lets persistent stores keep their data across application restarts.
      */
     public void close() {
-        clearChatMemory();
+        if (!hasChatMemory()) {
+            return;
+        }
+        if (shouldClearOnClose()) {
+            chatMemoryService.clearAll();
+        } else {
+            for (Object id : new ArrayList<>(chatMemoryService.getChatMemoryIDs())) {
+                chatMemoryService.evictChatMemory(id);
+            }
+        }
+    }
+
+    private static boolean shouldClearOnClose() {
+        return ConfigProvider.getConfig()
+                .getOptionalValue("quarkus.langchain4j.chat-memory.clear-on-close", Boolean.class)
+                .orElse(Boolean.TRUE);
     }
 
     public void clearChatMemory() {

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-core.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-core.adoc
@@ -162,6 +162,31 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++1000+++`
 
+a| [[quarkus-langchain4j-core_quarkus-langchain4j-chat-memory-clear-on-close]] [.property-path]##link:#quarkus-langchain4j-core_quarkus-langchain4j-chat-memory-clear-on-close[`+++quarkus.langchain4j.chat-memory.clear-on-close+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chat-memory.clear-on-close+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to delete chat memory from the underlying `dev.langchain4j.store.memory.chat.ChatMemoryStore` when the owning AI service bean is destroyed (typically at application shutdown, or at the end of each request for `jakarta.enterprise.context.RequestScoped` AI services).
+
+When `true` (the default), historical behavior is preserved: every known memory id is removed from the store. This is appropriate for the in-memory default store.
+
+When `false`, the in-memory bookkeeping is still released to avoid leaks, but the persistent store is left untouched, so conversations backed by a custom `dev.langchain4j.store.memory.chat.ChatMemoryStore` (e.g., Redis, Couchbase, JDBC) survive pod or application restarts.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHAT_MEMORY_CLEAR_ON_CLOSE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHAT_MEMORY_CLEAR_ON_CLOSE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a| [[quarkus-langchain4j-core_quarkus-langchain4j-log-requests]] [.property-path]##link:#quarkus-langchain4j-core_quarkus-langchain4j-log-requests[`+++quarkus.langchain4j.log-requests+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.log-requests+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-core_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-core_quarkus.langchain4j.adoc
@@ -162,6 +162,31 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++1000+++`
 
+a| [[quarkus-langchain4j-core_quarkus-langchain4j-chat-memory-clear-on-close]] [.property-path]##link:#quarkus-langchain4j-core_quarkus-langchain4j-chat-memory-clear-on-close[`+++quarkus.langchain4j.chat-memory.clear-on-close+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chat-memory.clear-on-close+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to delete chat memory from the underlying `dev.langchain4j.store.memory.chat.ChatMemoryStore` when the owning AI service bean is destroyed (typically at application shutdown, or at the end of each request for `jakarta.enterprise.context.RequestScoped` AI services).
+
+When `true` (the default), historical behavior is preserved: every known memory id is removed from the store. This is appropriate for the in-memory default store.
+
+When `false`, the in-memory bookkeeping is still released to avoid leaks, but the persistent store is left untouched, so conversations backed by a custom `dev.langchain4j.store.memory.chat.ChatMemoryStore` (e.g., Redis, Couchbase, JDBC) survive pod or application restarts.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHAT_MEMORY_CLEAR_ON_CLOSE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHAT_MEMORY_CLEAR_ON_CLOSE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a| [[quarkus-langchain4j-core_quarkus-langchain4j-log-requests]] [.property-path]##link:#quarkus-langchain4j-core_quarkus-langchain4j-log-requests[`+++quarkus.langchain4j.log-requests+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.log-requests+++[]

--- a/docs/modules/ROOT/pages/messages-and-memory.adoc
+++ b/docs/modules/ROOT/pages/messages-and-memory.adoc
@@ -129,6 +129,10 @@ quarkus.langchain4j.chat-memory.type=MESSAGE_WINDOW|TOKEN_WINDOW
 quarkus.langchain4j.chat-memory.memory-window.max-messages=10
 # Maximum tokens in memory (for TOKEN_WINDOW)
 quarkus.langchain4j.chat-memory.token-window.max-tokens=1000
+# Whether to delete chat memory from the ChatMemoryStore when the
+# owning AI service bean is destroyed (default: true).
+# Set to false to keep conversations in a persistent store across restarts.
+quarkus.langchain4j.chat-memory.clear-on-close=true
 ----
 
 When using `MESSAGE_WINDOW`, the memory retains the most recent messages up to the specified limit.
@@ -137,6 +141,12 @@ Note that using `TOKEN_WINDOW` requires a `TokenCountEstimator` bean to be avail
 
 These memories are then stored in a `ChatMemoryStore`, which is an abstraction for storing and retrieving chat messages.
 By default, it uses an in-memory store, meaning messages are lost when the application stops or restarts.
+
+[NOTE]
+====
+When backing chat memory with a persistent `ChatMemoryStore` (Redis, Couchbase, JDBC, etc.), set `quarkus.langchain4j.chat-memory.clear-on-close=false` so that conversations are not wiped from the store when the AI service bean is destroyed.
+With the default `RequestScoped` AI service, the bean is destroyed at the end of every HTTP request; with `clear-on-close=true` this propagates a `deleteMessages` call to the store, which is rarely what you want for a persistent backend.
+====
 
 == Custom Memory Implementations
 


### PR DESCRIPTION
## Describe your changes

`QuarkusAiServiceContext.close()` currently calls `chatMemoryService.clearAll()` unconditionally, which propagates `deleteMessages` to the underlying `ChatMemoryStore`. Because `@RegisterAiService` defaults to `@RequestScoped`, this happens at the end of every HTTP request wiping a persistent backend (Redis, Couchbase, JDBC, etc.) between requests, not just on application shutdown.

Introduce `quarkus.langchain4j.chat-memory.clear-on-close` (default: `true`, preserves historical behavior). When set to `false`, `close()` still releases the in-memory bookkeeping in `chatMemoryService` to avoid leaking memory ids for long-lived AI services, but skips the `deleteMessages` propagation to the store.

---

- Closes: #1761