### PR TITLE
Introduce @OnThinking annotation for reasoning output handlers

### DIFF
--- a/chat-scopes/core/deployment/src/test/java/io/quarkiverse/langchain4j/tests/scopes/chat/ChatScopeThinkingForwarderTest.java
+++ b/chat-scopes/core/deployment/src/test/java/io/quarkiverse/langchain4j/tests/scopes/chat/ChatScopeThinkingForwarderTest.java
@@ -1,0 +1,102 @@
+package io.quarkiverse.langchain4j.tests.scopes.chat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.OnThinking;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.chatscopes.ChatRoute;
+import io.quarkiverse.langchain4j.chatscopes.ChatRouteConstants;
+import io.quarkiverse.langchain4j.chatscopes.ChatRouteThinking;
+import io.quarkiverse.langchain4j.chatscopes.ChatScoped;
+import io.quarkiverse.langchain4j.chatscopes.LocalChatRoutes;
+import io.quarkiverse.langchain4j.runtime.aiservice.ThinkingEmitted;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ChatScopeThinkingForwarderTest {
+
+    static final String THINKING_TEXT = "Let me think step by step about this problem.";
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class).addClasses(
+                            ThinkingAssistant.class, ThinkingModelSupplier.class, ThinkingRoute.class));
+
+    public static class ThinkingModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new ChatModel() {
+                @Override
+                public ChatResponse doChat(ChatRequest chatRequest) {
+                    return ChatResponse.builder()
+                            .aiMessage(AiMessage.builder().text("4").thinking(THINKING_TEXT).build())
+                            .build();
+                }
+            };
+        }
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = ThinkingModelSupplier.class)
+    @ChatScoped
+    interface ThinkingAssistant {
+        String solve(@UserMessage String input);
+
+        @OnThinking
+        static void onThinking(ThinkingEmitted event) {
+            ChatRouteThinking.forward(event);
+        }
+    }
+
+    @ApplicationScoped
+    public static class ThinkingRoute {
+
+        @Inject
+        ThinkingAssistant assistant;
+
+        @ChatRoute("solve")
+        public String solve(@UserMessage String input) {
+            return assistant.solve(input);
+        }
+    }
+
+    @Inject
+    LocalChatRoutes.Client localChatRouter;
+
+    @Test
+    public void thinkingHandlerForwardsToResponseChannel() throws Exception {
+        Map<String, List<Object>> events = new HashMap<>();
+        Semaphore semaphore = new Semaphore(0);
+        try (LocalChatRoutes.Session session = localChatRouter.builder().defaultHandler((event, data) -> {
+            events.computeIfAbsent(event, k -> new ArrayList<>()).add(data);
+            semaphore.release();
+        }).connect("solve")) {
+            session.chat("What is 2+2?");
+            semaphore.tryAcquire(2, 500, TimeUnit.MILLISECONDS);
+        }
+
+        List<Object> thinkingEvents = events.get(ChatRouteConstants.THINKING);
+        Assertions.assertNotNull(thinkingEvents, "Expected at least one Thinking event, got: " + events.keySet());
+        Assertions.assertEquals(1, thinkingEvents.size());
+        Assertions.assertEquals(THINKING_TEXT, thinkingEvents.get(0));
+    }
+}

--- a/chat-scopes/core/runtime/src/main/java/io/quarkiverse/langchain4j/chatscopes/ChatRouteThinking.java
+++ b/chat-scopes/core/runtime/src/main/java/io/quarkiverse/langchain4j/chatscopes/ChatRouteThinking.java
@@ -1,0 +1,76 @@
+package io.quarkiverse.langchain4j.chatscopes;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
+
+import io.quarkiverse.langchain4j.runtime.aiservice.ThinkingEmitted;
+
+/**
+ * Helper for forwarding model thinking output to the active chat route's
+ * response channel from within an {@link io.quarkiverse.langchain4j.OnThinking
+ * &#64;OnThinking}-annotated handler on a {@link ChatScoped &#64;ChatScoped} AI
+ * service.
+ *
+ * <pre>
+ * {
+ *     &#64;code
+ *     &#64;RegisterAiService
+ *     &#64;ChatScoped
+ *     interface WeaponBuilder {
+ *         &#64;ChatRoute("weaponBuilder")
+ *         String build(@UserMessage String msg);
+ *
+ *         @OnThinking
+ *         static void onThinking(ThinkingEmitted event) {
+ *             ChatRouteThinking.forward(event);
+ *         }
+ *     }
+ * }
+ * </pre>
+ *
+ * When called outside an active chat scope (or when no chat route context is
+ * resolvable in CDI), the call is a no-op so the same handler can be reused
+ * across services that may or may not run inside a chat route.
+ */
+public final class ChatRouteThinking {
+
+    private ChatRouteThinking() {
+    }
+
+    /**
+     * Forwards the thinking text carried by the event to the active chat
+     * route response channel as a {@link ChatRouteConstants#THINKING} event.
+     *
+     * @param event the thinking event emitted by the AI service runtime
+     */
+    public static void forward(ThinkingEmitted event) {
+        if (event == null) {
+            return;
+        }
+        forward(event.text());
+    }
+
+    /**
+     * Forwards an arbitrary message (typically a transformed or redacted
+     * version of {@code event.text()}) to the active chat route response
+     * channel.
+     *
+     * @param text the message to send; ignored when blank
+     */
+    public static void forward(String text) {
+        if (text == null || text.isBlank()) {
+            return;
+        }
+        if (!ChatScope.isActive()) {
+            return;
+        }
+        Instance<ChatRouteContext> instance = CDI.current().select(ChatRouteContext.class);
+        if (!instance.isResolvable()) {
+            return;
+        }
+        ChatRouteContext.ResponseChannel response = instance.get().response();
+        if (response != null) {
+            response.thinking(text);
+        }
+    }
+}

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
@@ -120,6 +120,8 @@ import io.quarkiverse.langchain4j.runtime.aiservice.MetricsCountedWrapper;
 import io.quarkiverse.langchain4j.runtime.aiservice.MetricsTimedWrapper;
 import io.quarkiverse.langchain4j.runtime.aiservice.QuarkusAiServiceContext;
 import io.quarkiverse.langchain4j.runtime.aiservice.SpanWrapper;
+import io.quarkiverse.langchain4j.runtime.aiservice.ThinkingEmitted;
+import io.quarkiverse.langchain4j.runtime.aiservice.ThinkingHandler;
 import io.quarkiverse.langchain4j.runtime.config.GuardrailsConfig;
 import io.quarkiverse.langchain4j.runtime.types.TypeSignatureParser;
 import io.quarkiverse.langchain4j.runtime.types.TypeUtil;
@@ -569,6 +571,7 @@ public class AiServicesProcessor {
                             moderationModelSupplierClassName,
                             imageModelSupplierClassName(reflectiveClassProducer, unremovableBeanProducer, instance, index),
                             determineChatMemorySeeder(declarativeAiServiceClassInfo, generatedClassOutput),
+                            determineThinkingHandler(declarativeAiServiceClassInfo, generatedClassOutput),
                             systemMessageProviderClassDotName,
                             cdiScope(customScopes, declarativeAiServiceClassInfo),
                             chatModelName,
@@ -1003,6 +1006,10 @@ public class AiServicesProcessor {
                     ? bi.getChatMemorySeederClassDotName().toString()
                     : null);
 
+            String thinkingHandlerClassName = (bi.getThinkingHandlerClassDotName() != null
+                    ? bi.getThinkingHandlerClassDotName().toString()
+                    : null);
+
             String systemMessageProviderClassName = (bi.getSystemMessageProviderClassDotName() != null
                     ? bi.getSystemMessageProviderClassDotName().toString()
                     : null);
@@ -1080,6 +1087,7 @@ public class AiServicesProcessor {
                                     moderationModelSupplierClassName,
                                     imageModelSupplierClassName,
                                     chatMemorySeederClassName,
+                                    thinkingHandlerClassName,
                                     systemMessageProviderClassName,
                                     chatModelName,
                                     moderationModelName,
@@ -2632,6 +2640,78 @@ public class AiServicesProcessor {
         }
 
         return Arrays.asList(mcpClientNames);
+    }
+
+    private DotName determineThinkingHandler(ClassInfo iface, ClassOutput classOutput) {
+        List<AnnotationInstance> annotations = iface.annotations(LangChain4jDotNames.ON_THINKING);
+        if (annotations.isEmpty()) {
+            return null;
+        }
+        if (annotations.size() > 1) {
+            throw new IllegalConfigurationException(
+                    "Only a single @OnThinking annotation is allowed per AiService. Offending class is '" + iface.name() + "'");
+        }
+        AnnotationTarget target = annotations.get(0).target();
+        if (target.kind() != AnnotationTarget.Kind.METHOD) {
+            throw new IllegalConfigurationException(
+                    "The @OnThinking annotation can only be placed on methods. Offending target is '" + target + "'");
+        }
+        MethodInfo method = target.asMethod();
+        String location = method.declaringClass().name() + "#" + method.name();
+        if (!Modifier.isStatic(method.flags())) {
+            throw new IllegalConfigurationException(
+                    "The @OnThinking annotation can only be placed on static methods. Offending method is '" + location + "'");
+        }
+        if (method.returnType().kind() != Type.Kind.VOID) {
+            throw new IllegalConfigurationException(
+                    "The @OnThinking annotation can only be placed on methods that return void. Offending method is '"
+                            + location + "'");
+        }
+        if (method.parameterTypes().size() != 1
+                || !LangChain4jDotNames.THINKING_EMITTED.equals(method.parameterTypes().get(0).name())) {
+            throw new IllegalConfigurationException(
+                    "The @OnThinking annotation can only be placed on methods that take a single "
+                            + LangChain4jDotNames.THINKING_EMITTED + " parameter. Offending method is '" + location + "'");
+        }
+        return DotName.createSimple(generateAiServiceThinkingHandler(iface, method, classOutput));
+    }
+
+    /**
+     * Generates a class that looks like the following:
+     *
+     * <pre>
+     * {@code
+     * public class SomeAiService$$QuarkusThinkingHandler implements ThinkingHandler {
+     *
+     *     &#64;Override
+     *     public void emit(ThinkingEmitted event) {
+     *         SomeAiService.onThinking(event);
+     *     }
+     * }
+     * }
+     * </pre>
+     */
+    private String generateAiServiceThinkingHandler(ClassInfo iface, MethodInfo thinkingTargetMethod,
+            ClassOutput classOutput) {
+        String implClassName = iface.name() + "$$QuarkusThinkingHandler";
+
+        ClassCreator.Builder classCreatorBuilder = ClassCreator.builder()
+                .classOutput(classOutput)
+                .className(implClassName)
+                .interfaces(ThinkingHandler.class.getName());
+        try (ClassCreator classCreator = classCreatorBuilder.build()) {
+            MethodCreator methodCreator = classCreator.getMethodCreator("emit", void.class, ThinkingEmitted.class);
+            methodCreator.invokeStaticInterfaceMethod(
+                    MethodDescriptor.ofMethod(
+                            thinkingTargetMethod.declaringClass().name().toString(),
+                            thinkingTargetMethod.name(),
+                            void.class,
+                            ThinkingEmitted.class),
+                    methodCreator.getMethodParam(0));
+            methodCreator.returnVoid();
+        }
+
+        return implClassName;
     }
 
     private DotName determineChatMemorySeeder(ClassInfo iface, ClassOutput classOutput) {

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/DeclarativeAiServiceBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/DeclarativeAiServiceBuildItem.java
@@ -26,6 +26,7 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
     private final DotName moderationModelSupplierDotName;
     private final DotName imageModelSupplierDotName;
     private final DotName chatMemorySeederClassDotName;
+    private final DotName thinkingHandlerClassDotName;
     private final DotName systemMessageProviderClassDotName;
     private final DotName cdiScope;
     private DotName defaultMemoryIdProviderClassDotName;
@@ -55,6 +56,7 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
             DotName moderationModelSupplierDotName,
             DotName imageModelSupplierDotName,
             DotName chatMemorySeederClassDotName,
+            DotName thinkingHandlerClassDotName,
             DotName systemMessageProviderClassDotName,
             DotName cdiScope,
             String chatModelName,
@@ -82,6 +84,7 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
         this.moderationModelSupplierDotName = moderationModelSupplierDotName;
         this.imageModelSupplierDotName = imageModelSupplierDotName;
         this.chatMemorySeederClassDotName = chatMemorySeederClassDotName;
+        this.thinkingHandlerClassDotName = thinkingHandlerClassDotName;
         this.systemMessageProviderClassDotName = systemMessageProviderClassDotName;
         this.cdiScope = cdiScope;
         this.chatModelName = chatModelName;
@@ -140,6 +143,10 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
 
     public DotName getChatMemorySeederClassDotName() {
         return chatMemorySeederClassDotName;
+    }
+
+    public DotName getThinkingHandlerClassDotName() {
+        return thinkingHandlerClassDotName;
     }
 
     public DotName getSystemMessageProviderClassDotName() {

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/LangChain4jDotNames.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/LangChain4jDotNames.java
@@ -42,6 +42,7 @@ import io.quarkiverse.langchain4j.HandleToolArgumentError;
 import io.quarkiverse.langchain4j.HandleToolExecutionError;
 import io.quarkiverse.langchain4j.ImageUrl;
 import io.quarkiverse.langchain4j.ModelName;
+import io.quarkiverse.langchain4j.OnThinking;
 import io.quarkiverse.langchain4j.PdfUrl;
 import io.quarkiverse.langchain4j.RegisterAiService;
 import io.quarkiverse.langchain4j.SeedMemory;
@@ -52,6 +53,7 @@ import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrail;
 import io.quarkiverse.langchain4j.guardrails.ToolOutputGuardrails;
 import io.quarkiverse.langchain4j.runtime.aiservice.ChatEvent;
 import io.quarkiverse.langchain4j.runtime.aiservice.QuarkusAiServiceContextQualifier;
+import io.quarkiverse.langchain4j.runtime.aiservice.ThinkingEmitted;
 
 public class LangChain4jDotNames {
     public static final DotName CHAT_MODEL = DotName.createSimple(ChatModel.class);
@@ -79,6 +81,8 @@ public class LangChain4jDotNames {
     static final DotName PDF_URL = DotName.createSimple(PdfUrl.class);
     static final DotName VIDEO_URL = DotName.createSimple(VideoUrl.class);
     static final DotName MODERATE = DotName.createSimple(Moderate.class);
+    public static final DotName ON_THINKING = DotName.createSimple(OnThinking.class);
+    public static final DotName THINKING_EMITTED = DotName.createSimple(ThinkingEmitted.class);
     static final DotName MEMORY_ID = DotName.createSimple(MemoryId.class);
     static final DotName DESCRIPTION = DotName.createSimple(Description.class);
     static final DotName STRUCTURED_PROMPT = DotName.createSimple(StructuredPrompt.class);

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/OnThinking.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/OnThinking.java
@@ -1,0 +1,49 @@
+package io.quarkiverse.langchain4j;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a {@code static} method on an AI service interface as the handler for
+ * the model's thinking/reasoning output. The method is invoked after any
+ * non-streaming response of that service whose {@code AiMessage.thinking()}
+ * is non-blank.
+ * <p>
+ * The handler must be {@code static}, return {@code void}, and take a single
+ * {@link io.quarkiverse.langchain4j.runtime.aiservice.ThinkingEmitted}
+ * parameter. Only one such handler is allowed per AI service interface.
+ *
+ * <pre>
+ * {
+ *     &#64;code
+ *     &#64;RegisterAiService
+ *     interface MathAssistant {
+ *         String solve(String problem);
+ *
+ *         @OnThinking
+ *         static void onThinking(ThinkingEmitted event) {
+ *             Log.infof("[%s] %s", event.methodName(), event.text());
+ *         }
+ *     }
+ * }
+ * </pre>
+ *
+ * This annotation does <strong>not</strong> enable thinking on the model
+ * itself. Each provider exposes its own configuration knob for that (for
+ * example {@code quarkus.langchain4j.ollama.chat-model.model-options.think}
+ * on Ollama, or the equivalent reasoning parameter on Anthropic, Gemini,
+ * OpenAI, etc.).
+ * <p>
+ * For the streaming path, use the {@code onPartialThinking} handler exposed
+ * by {@code TokenStream} or observe {@code ChatEvent.PartialThinkingEvent}
+ * when returning {@code Multi<ChatEvent>}.
+ */
+@Target(ElementType.METHOD)
+@Retention(RUNTIME)
+@Documented
+public @interface OnThinking {
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/QuarkusAiServicesFactory.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/QuarkusAiServicesFactory.java
@@ -19,6 +19,7 @@ import io.quarkiverse.langchain4j.runtime.aiservice.ChatMemoryFlushStrategy;
 import io.quarkiverse.langchain4j.runtime.aiservice.ChatMemorySeeder;
 import io.quarkiverse.langchain4j.runtime.aiservice.QuarkusAiServiceContext;
 import io.quarkiverse.langchain4j.runtime.aiservice.SystemMessageProvider;
+import io.quarkiverse.langchain4j.runtime.aiservice.ThinkingHandler;
 
 public class QuarkusAiServicesFactory implements AiServicesFactory {
 
@@ -57,6 +58,11 @@ public class QuarkusAiServicesFactory implements AiServicesFactory {
 
         public AiServices<T> chatMemorySeeder(ChatMemorySeeder chatMemorySeeder) {
             quarkusAiServiceContext().chatMemorySeeder = chatMemorySeeder;
+            return this;
+        }
+
+        public AiServices<T> thinkingHandler(ThinkingHandler thinkingHandler) {
+            quarkusAiServiceContext().thinkingHandler = thinkingHandler;
             return this;
         }
 

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/AiServicesRecorder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/AiServicesRecorder.java
@@ -34,6 +34,7 @@ import io.quarkiverse.langchain4j.runtime.aiservice.ChatMemorySeeder;
 import io.quarkiverse.langchain4j.runtime.aiservice.DeclarativeAiServiceCreateInfo;
 import io.quarkiverse.langchain4j.runtime.aiservice.QuarkusAiServiceContext;
 import io.quarkiverse.langchain4j.runtime.aiservice.SystemMessageProvider;
+import io.quarkiverse.langchain4j.runtime.aiservice.ThinkingHandler;
 import io.quarkiverse.langchain4j.spi.DefaultMemoryIdProvider;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InstanceHandle;
@@ -319,6 +320,12 @@ public class AiServicesRecorder {
                     if (info.chatMemorySeederClassName() != null) {
                         quarkusAiServices.chatMemorySeeder((ChatMemorySeeder) loadClass(
                                 info.chatMemorySeederClassName())
+                                .getConstructor().newInstance());
+                    }
+
+                    if (info.thinkingHandlerClassName() != null) {
+                        quarkusAiServices.thinkingHandler((ThinkingHandler) loadClass(
+                                info.thinkingHandlerClassName())
                                 .getConstructor().newInstance());
                     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
@@ -15,6 +15,7 @@ import java.lang.reflect.Type;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -594,6 +595,8 @@ public class AiServiceMethodImplementationSupport {
 
         response = ChatResponse.builder().aiMessage(response.aiMessage()).metadata(response.metadata()).build();
 
+        emitThinkingIfPresent(response, context, invocationContext);
+
         if (TypeUtil.isResult(returnType)) {
             var parsedResponse = SERVICE_OUTPUT_PARSER.parse(
                     ChatResponse.builder().aiMessage(response.aiMessage()).build(),
@@ -626,6 +629,32 @@ public class AiServiceMethodImplementationSupport {
                         .build());
 
         return augmentedResponse;
+    }
+
+    private static void emitThinkingIfPresent(ChatResponse response,
+            QuarkusAiServiceContext context,
+            InvocationContext invocationContext) {
+        ThinkingHandler handler = context.thinkingHandler;
+        if (handler == null) {
+            return;
+        }
+        if (response == null || response.aiMessage() == null) {
+            return;
+        }
+        String thinking = response.aiMessage().thinking();
+        if (thinking == null || thinking.isBlank()) {
+            return;
+        }
+        ThinkingEmitted event = new DefaultThinkingEmitted(thinking,
+                invocationContext.methodName(),
+                context.aiServiceClass,
+                invocationContext.chatMemoryId(),
+                Instant.now());
+        try {
+            handler.emit(event);
+        } catch (Throwable e) {
+            log.debugf(e, "@OnThinking handler on %s threw an exception", context.aiServiceClass.getName());
+        }
     }
 
     private static InvocationParameters findInvocationParams(Object[] args) {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/DeclarativeAiServiceCreateInfo.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/DeclarativeAiServiceCreateInfo.java
@@ -19,6 +19,7 @@ public record DeclarativeAiServiceCreateInfo(
         String moderationModelSupplierClassName,
         String imageModelSupplierClassName,
         String chatMemorySeederClassName,
+        String thinkingHandlerClassName,
         String systemMessageProviderClassName,
         String chatModelName,
         String moderationModelName,

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/DefaultThinkingEmitted.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/DefaultThinkingEmitted.java
@@ -1,0 +1,14 @@
+package io.quarkiverse.langchain4j.runtime.aiservice;
+
+import java.time.Instant;
+
+/**
+ * Default {@link ThinkingEmitted} implementation built by the AI service
+ * runtime when a non-streaming response carries thinking content.
+ */
+record DefaultThinkingEmitted(String text,
+        String methodName,
+        Class<?> serviceClass,
+        Object memoryId,
+        Instant emittedAt) implements ThinkingEmitted {
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceContext.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceContext.java
@@ -23,6 +23,7 @@ import io.quarkus.arc.InstanceHandle;
 public class QuarkusAiServiceContext extends AiServiceContext {
 
     public ChatMemorySeeder chatMemorySeeder;
+    public ThinkingHandler thinkingHandler;
     public ImageModel imageModel;
     public Integer maxSequentialToolExecutions;
     public Integer maxToolCallsPerResponse;

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/ThinkingEmitted.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/ThinkingEmitted.java
@@ -1,0 +1,37 @@
+package io.quarkiverse.langchain4j.runtime.aiservice;
+
+import java.time.Instant;
+
+/**
+ * Carries the thinking/reasoning content returned by the model on a
+ * non-streaming response. Passed to the
+ * {@link io.quarkiverse.langchain4j.OnThinking @OnThinking}-annotated static
+ * handler declared on the AI service interface.
+ */
+public interface ThinkingEmitted {
+
+    /**
+     * @return the thinking text returned by the model
+     */
+    String text();
+
+    /**
+     * @return the AI service method whose call produced the thinking
+     */
+    String methodName();
+
+    /**
+     * @return the AI service interface that declared the method
+     */
+    Class<?> serviceClass();
+
+    /**
+     * @return the chat memory id associated with the invocation, or {@code null}
+     */
+    Object memoryId();
+
+    /**
+     * @return timestamp captured when the event was built
+     */
+    Instant emittedAt();
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/ThinkingHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/ThinkingHandler.java
@@ -1,0 +1,14 @@
+package io.quarkiverse.langchain4j.runtime.aiservice;
+
+/**
+ * Receives thinking/reasoning events produced by an AI service.
+ * <p>
+ * Implementations are generated at build time, one per AI service that declares
+ * an {@link io.quarkiverse.langchain4j.OnThinking @OnThinking}-annotated static
+ * method on its interface. The generated class simply forwards the event to
+ * that static method, so there is no reflection on the hot path.
+ */
+public interface ThinkingHandler {
+
+    void emit(ThinkingEmitted event);
+}

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/OpenAiThinkingEmittedTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/OpenAiThinkingEmittedTest.java
@@ -1,0 +1,116 @@
+package io.quarkiverse.langchain4j.openai.test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
+import io.quarkiverse.langchain4j.OnThinking;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.runtime.aiservice.ThinkingEmitted;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OpenAiThinkingEmittedTest extends OpenAiBaseTest {
+
+    static final List<ThinkingEmitted> EVENTS = new ArrayList<>();
+
+    @ApplicationScoped
+    public static class ReturnThinkingCustomizer implements ModelBuilderCustomizer<OpenAiChatModel.OpenAiChatModelBuilder> {
+        @Override
+        public void customize(OpenAiChatModel.OpenAiChatModelBuilder builder) {
+            builder.returnThinking(true);
+        }
+    }
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ThinkingAssistant.class, ReturnThinkingCustomizer.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "whatever")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    ThinkingAssistant assistant;
+
+    @BeforeEach
+    void clearEvents() {
+        EVENTS.clear();
+        wiremock().resetMappings();
+        wiremock().resetRequests();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void invokesStaticHandlerWhenResponseCarriesThinking() {
+        stubChatWithThinking();
+
+        String answer = assistant.solve("What is 2+2?");
+        assertThat(answer).isEqualTo("4");
+
+        assertThat(EVENTS).hasSize(1);
+        ThinkingEmitted event = EVENTS.get(0);
+        assertThat(event.text()).isEqualTo("Let me compute: 2+2 = 4.");
+        assertThat(event.methodName()).isEqualTo("solve");
+        assertThat(event.serviceClass()).isEqualTo(ThinkingAssistant.class);
+        assertThat(event.emittedAt()).isNotNull();
+    }
+
+    private void stubChatWithThinking() {
+        wiremock().register(
+                post(urlEqualTo("/v1/chat/completions"))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("""
+                                        {
+                                          "id": "chatcmpl-thinking",
+                                          "object": "chat.completion",
+                                          "created": 1733923283,
+                                          "model": "gpt-4o-mini",
+                                          "choices": [
+                                            {
+                                              "index": 0,
+                                              "message": {
+                                                "role": "assistant",
+                                                "content": "4",
+                                                "reasoning_content": "Let me compute: 2+2 = 4."
+                                              },
+                                              "finish_reason": "stop"
+                                            }
+                                          ],
+                                          "usage": {
+                                            "prompt_tokens": 12,
+                                            "completion_tokens": 8,
+                                            "total_tokens": 20
+                                          }
+                                        }
+                                        """)));
+    }
+
+    @RegisterAiService
+    public interface ThinkingAssistant {
+        String solve(String input);
+
+        @OnThinking
+        static void onThinking(ThinkingEmitted event) {
+            EVENTS.add(event);
+        }
+    }
+}


### PR DESCRIPTION
## Describe your changes

Reasoning models return a "thinking" field alongside the final answer, but Quarkus had no way to surface that content to the application. This PR adds a provider-agnostic consumption mechanism for non-streaming AI service responses.

A new `@OnThinking` annotation marks a `static` method on the AI service interface as the handler for the model's reasoning output. The handler is invoked whenever the response carries a non-blank `AiMessage.thinking()`. The return type and signatures of the regular AI service methods do not change.

```java
@RegisterAiService
interface MathAssistant {
    String solve(String problem);

    @OnThinking
    static void onThinking(ThinkingEmitted event) {
        Log.infof("[%s] %s", event.methodName(), event.text());
    }
}
```

The annotation does not enable thinking on the model itself - that remains each provider's responsibility (e.g. `model-options.think=true` on Ollama), because langchain4j does not unify the request-side knob across providers.

### Chat Scopes integration

For `@ChatScoped` AI services that want to forward reasoning to the connected client through the existing `ChatRouteContext.response().thinking(...)` channel, the `chat-scopes` module ships a one-line helper:

```java
@RegisterAiService
@ChatScoped
interface WeaponBuilder {
    @ChatRoute("weaponBuilder")
    String build(@UserMessage String msg);

    @OnThinking
    static void onThinking(ThinkingEmitted event) {
        ChatRouteThinking.forward(event);
    }
}
```

Forwarding is opt-in by design: thinking content can be large or sensitive, so the framework never sends it to clients implicitly.

---

- Closes: #1685