### PR TITLE
Strengthen MCP tools sample system prompt to enforce tool usage

### DIFF
--- a/samples/mcp-tools/src/main/java/io/quarkiverse/langchain4j/sample/chatbot/Bot.java
+++ b/samples/mcp-tools/src/main/java/io/quarkiverse/langchain4j/sample/chatbot/Bot.java
@@ -13,6 +13,9 @@ public interface Bot {
     @SystemMessage("""
             You have tools to interact with the local filesystem and the users
             will ask you to perform operations like reading and writing files.
+            Always use the available tools immediately to perform the requested
+            operation. Never describe what you intend to do — execute the tool
+            call right away and return the result.
 
             The only directory allowed to interact with is the 'playground' directory relative
             to the current working directory. If a user specifies a relative path to a file and


### PR DESCRIPTION
## Summary
- Strengthen the system prompt in the MCP tools sample `Bot.java` to instruct the LLM to always invoke tools immediately rather than describing its intent
- Needed for QQE-2544: the `OpenShiftToolsIT.askAI` test in quarkus-test-suite fails intermittently because the model responds with conversational filler instead of calling the `readFileContent` tool

## Test plan
- [ ] Verify the mcp-tools sample still works correctly with the updated prompt
- [ ] Run `OpenShiftToolsIT.askAI` in quarkus-test-suite to confirm reduced flakiness