### PR TITLE
Pass tool executions in results

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolExecutionModelTest.java
@@ -302,6 +302,16 @@ public class ToolExecutionModelTest {
         }
     }
 
+    @Test
+    @ActivateRequestContext
+    void testNormalToolExecutionsSurfacedInResult() {
+        String uuid = UUID.randomUUID().toString();
+        Result<String> r = aiService.helloResult("abc", "hi - " + uuid);
+        assertThat(r.content()).isNotNull();
+        assertThat(r.toolExecutions()).hasSize(1);
+        assertThat(r.toolExecutions().get(0).request().name()).isEqualTo("hi");
+    }
+
     @RegisterAiService(chatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = MyMemoryProviderSupplier.class)
     public interface MyAiService {
 

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
@@ -422,7 +422,7 @@ public class AiServiceMethodImplementationSupport {
                         ? context.maxSequentialToolExecutions
                         : getMaxSequentialToolExecutions();
         int executionsLeft = maxSequentialToolExecutions;
-        List<ToolExecution> intermediateToolExecutions = new ArrayList<>();
+        List<ToolExecution> allToolExecutions = new ArrayList<>();
         List<ChatResponse> intermediateResponses = new ArrayList<>();
         while (true) {
             if (executionsLeft-- == 0) {
@@ -482,7 +482,7 @@ public class AiServiceMethodImplementationSupport {
                         .invocationContext(invocationContext)
                         .build();
                 toolExecutions.add(toolExecution);
-                intermediateToolExecutions.add(toolExecution);
+                allToolExecutions.add(toolExecution);
                 toolResults.add(toolExecutionResultMessage);
 
                 // If any tool does not return immediately, results must be processed by LLM
@@ -613,7 +613,7 @@ public class AiServiceMethodImplementationSupport {
                     .tokenUsage(tokenUsageAccumulator)
                     .sources(augmentationResult == null ? null : augmentationResult.contents())
                     .finishReason(response.finishReason())
-                    .toolExecutions(intermediateToolExecutions)
+                    .toolExecutions(allToolExecutions)
                     .build();
 
             context.eventListenerRegistrar.fireEvent(

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
@@ -422,6 +422,7 @@ public class AiServiceMethodImplementationSupport {
                         ? context.maxSequentialToolExecutions
                         : getMaxSequentialToolExecutions();
         int executionsLeft = maxSequentialToolExecutions;
+        List<ToolExecution> intermediateToolExecutions = new ArrayList<>();
         List<ChatResponse> intermediateResponses = new ArrayList<>();
         while (true) {
             if (executionsLeft-- == 0) {
@@ -481,6 +482,7 @@ public class AiServiceMethodImplementationSupport {
                         .invocationContext(invocationContext)
                         .build();
                 toolExecutions.add(toolExecution);
+                intermediateToolExecutions.add(toolExecution);
                 toolResults.add(toolExecutionResultMessage);
 
                 // If any tool does not return immediately, results must be processed by LLM
@@ -611,6 +613,7 @@ public class AiServiceMethodImplementationSupport {
                     .tokenUsage(tokenUsageAccumulator)
                     .sources(augmentationResult == null ? null : augmentationResult.contents())
                     .finishReason(response.finishReason())
+                    .toolExecutions(intermediateToolExecutions)
                     .build();
 
             context.eventListenerRegistrar.fireEvent(


### PR DESCRIPTION
Fix: surface tool executions in Result<T> for normal tool calls

Previously, when an AI service method returned Result<T> and used tools with the default ReturnBehavior.DEFAULT (i.e., non-IMMEDIATE), the Result.toolExecutions() list was always empty: tool execution data was collected per iteration of the internal tool-calling loop but never passed to the final result. This change introduces an accumulator list (allToolExecutions) that collects every ToolExecution across all rounds of tool calling and passes it to the Result builder when the service completes, making tool execution history accessible to callers after the service returns. Also added a test to ToolExecutionModelTest to cover this scenario.

This is useful for programatically doing things based on what tools were called or what their result was AFTER the AI service executes.