### PR TITLE
Fix serialization/deserialization of gemini types

### DIFF
--- a/model-providers/google/gemini/ai-gemini/deployment/src/main/java/io/quarkiverse/langchain4j/ai/gemini/deployment/AiGeminiProcessor.java
+++ b/model-providers/google/gemini/ai-gemini/deployment/src/main/java/io/quarkiverse/langchain4j/ai/gemini/deployment/AiGeminiProcessor.java
@@ -34,6 +34,8 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
 import io.quarkus.resteasy.reactive.spi.MessageBodyReaderOverrideBuildItem;
 import io.quarkus.resteasy.reactive.spi.MessageBodyWriterOverrideBuildItem;
 import io.smallrye.config.Priorities;
@@ -170,5 +172,19 @@ public class AiGeminiProcessor {
             writerOverrideProducer.produce(new MessageBodyWriterOverrideBuildItem(
                     "org.jboss.resteasy.reactive.server.jsonb.JsonbMessageBodyWriter", Priorities.APPLICATION + 1, true));
         }
+    }
+
+    @BuildStep
+    IndexDependencyBuildItem indexUpstreamOllamaModule() {
+        return new IndexDependencyBuildItem("dev.langchain4j", "langchain4j-google-ai-gemini");
+    }
+
+    @BuildStep
+    public void nativeSupport(BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchyProducer) {
+        reflectiveHierarchyProducer.produce(
+                ReflectiveHierarchyBuildItem.builder("dev.langchain4j.model.googleai.GeminiGenerateContentRequest")
+                        .build());
+        reflectiveHierarchyProducer.produce(
+                ReflectiveHierarchyBuildItem.builder("dev.langchain4j.model.googleai.GeminiGenerateContentResponse").build());
     }
 }

--- a/model-providers/google/gemini/gemini-common/deployment/src/main/java/io/quarkiverse/langchain4j/gemini/common/GeminiCommonProcessor.java
+++ b/model-providers/google/gemini/gemini-common/deployment/src/main/java/io/quarkiverse/langchain4j/gemini/common/GeminiCommonProcessor.java
@@ -1,0 +1,14 @@
+package io.quarkiverse.langchain4j.gemini.common;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
+
+public class GeminiCommonProcessor {
+
+    @BuildStep
+    public void nativeSupport(BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchyProducer) {
+        reflectiveHierarchyProducer.produce(ReflectiveHierarchyBuildItem.builder(GenerateContentRequest.class).build());
+        reflectiveHierarchyProducer.produce(ReflectiveHierarchyBuildItem.builder(GenerateContentResponse.class).build());
+    }
+}


### PR DESCRIPTION
Meant to overcome:

```
{
  "error": {
    "code": 400,
    "message": "* GenerateContentRequest.contents: contents is not specified\n",
    "status": "INVALID_ARGUMENT"
  }
}
```

issues observed because the payload was empty.

Originally reported [here]([#dev > langchain4j @ 💬](https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/langchain4j/near/596470228))