### PR TITLE
Let tools return their own ToolExecutionResult

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolReturningToolExecutionResultTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolReturningToolExecutionResultTest.java
@@ -1,0 +1,127 @@
+package io.quarkiverse.langchain4j.test.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.service.Result;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.tool.ToolExecutionResult;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.test.Lists;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Uni;
+
+public class ToolReturningToolExecutionResultTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyAiService.class, MyTools.class,
+                            MyChatModelSupplier.class, MyChatModel.class, Lists.class));
+
+    @Inject
+    MyAiService aiService;
+
+    @Test
+    @ActivateRequestContext
+    void blockingToolReturningToolExecutionResultPassesThroughResultText() {
+        Result<String> r = aiService.chat("blockingTool");
+
+        // The LLM receives resultText exactly — not a JSON-serialized ToolExecutionResult object
+        assertThat(r.content()).isEqualTo("response: custom-result-text");
+        assertThat(r.toolExecutions()).hasSize(1);
+        assertThat(r.toolExecutions().get(0).result()).isEqualTo("custom-result-text");
+        assertThat(r.toolExecutions().get(0).resultObject()).isEqualTo("custom-result-object");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void uniToolReturningToolExecutionResultPassesThroughResultText() {
+        Result<String> r = aiService.chat("uniTool");
+
+        assertThat(r.content()).isEqualTo("response: uni-result-text");
+        assertThat(r.toolExecutions()).hasSize(1);
+        assertThat(r.toolExecutions().get(0).result()).isEqualTo("uni-result-text");
+        assertThat(r.toolExecutions().get(0).resultObject()).isEqualTo("uni-result-object");
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = MyChatModelSupplier.class, tools = MyTools.class)
+    public interface MyAiService {
+        Result<String> chat(@UserMessage String toolName);
+    }
+
+    @ApplicationScoped
+    public static class MyTools {
+
+        @Tool
+        public ToolExecutionResult blockingTool() {
+            return ToolExecutionResult.builder()
+                    .resultText("custom-result-text")
+                    .result("custom-result-object")
+                    .build();
+        }
+
+        @Tool
+        public Uni<ToolExecutionResult> uniTool() {
+            return Uni.createFrom().item(() -> ToolExecutionResult.builder()
+                    .resultText("uni-result-text")
+                    .result("uni-result-object")
+                    .build());
+        }
+    }
+
+    public static class MyChatModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new MyChatModel();
+        }
+    }
+
+    public static class MyChatModel implements ChatModel {
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            List<ChatMessage> messages = chatRequest.messages();
+            if (messages.size() == 1) {
+                String toolName = ((dev.langchain4j.data.message.UserMessage) messages.get(0)).singleText();
+                return ChatResponse.builder()
+                        .aiMessage(new AiMessage("", List.of(
+                                ToolExecutionRequest.builder()
+                                        .id("tool-" + toolName)
+                                        .name(toolName)
+                                        .arguments("{}")
+                                        .build())))
+                        .tokenUsage(new TokenUsage(0, 0))
+                        .finishReason(FinishReason.TOOL_EXECUTION)
+                        .build();
+            } else if (messages.size() == 3) {
+                ToolExecutionResultMessage toolResult = (ToolExecutionResultMessage) Lists.last(messages);
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.from("response: " + toolResult.text()))
+                        .finishReason(FinishReason.STOP)
+                        .build();
+            }
+            throw new RuntimeException("Unexpected number of messages: " + messages.size());
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/QuarkusToolExecutor.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/QuarkusToolExecutor.java
@@ -124,7 +124,8 @@ public class QuarkusToolExecutor implements ToolExecutor {
                 invocationResult = ((Uni<?>) invocationResult).await().indefinitely();
             }
             if (invocationResult instanceof ToolExecutionResult ter) {
-                log.debugv("Tool execution result passed through. result: {0} | resultText: {1}", ter.result(), ter.resultText());
+                log.debugv("Tool execution result passed through. result: {0} | resultText: {1}", ter.result(),
+                        ter.resultText());
                 return ter;
             }
             String result = handleResult(invokerInstance, invocationResult);

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/QuarkusToolExecutor.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/QuarkusToolExecutor.java
@@ -116,16 +116,18 @@ public class QuarkusToolExecutor implements ToolExecutor {
                 log.debugv("Attempting to invoke tool {0} with parameters {1}", context.tool, Arrays.toString(params));
             }
             Object invocationResult = invokerInstance.invoke(context.tool, params);
-            String result;
             if (invocationResult instanceof Uni<?>) { // TODO CS
                 if (io.vertx.core.Context.isOnEventLoopThread()) {
                     throw new BlockingToolNotAllowedException(
                             "Cannot execute tools returning Uni on event loop thread due to a tool executor limitation");
                 }
-                result = handleResult(invokerInstance, ((Uni<?>) invocationResult).await().indefinitely());
-            } else {
-                result = handleResult(invokerInstance, invocationResult);
+                invocationResult = ((Uni<?>) invocationResult).await().indefinitely();
             }
+            if (invocationResult instanceof ToolExecutionResult ter) {
+                log.debugv("Tool execution result passed through: {0}", ter.resultText());
+                return ter;
+            }
+            String result = handleResult(invokerInstance, invocationResult);
             log.debugv("Tool execution result: {0}", result);
             return ToolExecutionResult.builder().result(invocationResult).resultText(result).build();
         } catch (Exception e) {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/QuarkusToolExecutor.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/QuarkusToolExecutor.java
@@ -124,7 +124,7 @@ public class QuarkusToolExecutor implements ToolExecutor {
                 invocationResult = ((Uni<?>) invocationResult).await().indefinitely();
             }
             if (invocationResult instanceof ToolExecutionResult ter) {
-                log.debugv("Tool execution result passed through: {0}", ter.resultText());
+                log.debugv("Tool execution result passed through. result: {0} | resultText: {1}", ter.result(), ter.resultText());
                 return ter;
             }
             String result = handleResult(invokerInstance, invocationResult);


### PR DESCRIPTION
Right now, `QuarkusToolExecutor` always serialized a tool's return value through `Json.toJson()` to produce `resultText`, meaning that even if a tool returned a `ToolExecutionResult` directly, the LLM would just receive a JSON-serialized dump of the wrapper object rather than benefiting over the manual return type. This made it impossible to control the structured result and the LLM-facing text — for example, returning a valid complex object as the result of a tool while sending a formatted, human-readable summary as `resultText` to the model.

This change adds a passthrough: if the invocation result (or the resolved value of a Uni) is already a `ToolExecutionResult`, it is returned as-is, giving programmers control over the fields if they want/need it. It still preserves the existing serialization behavior for all other return types.