### PR TITLE
Add chat history recording for AI services

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
@@ -379,6 +379,7 @@ public class AiServicesProcessor {
     @BuildStep
     public void findDeclarativeServices(CombinedIndexBuildItem indexBuildItem,
             CustomScopeAnnotationsBuildItem customScopes,
+            LangChain4jBuildConfig config,
             List<AnnotationsImpliesAiServiceBuildItem> annotationsImpliesAiServiceItems,
             BuildProducer<RequestChatModelBeanBuildItem> requestChatModelBeanProducer,
             BuildProducer<RequestModerationModelBeanBuildItem> requestModerationModelBeanProducer,
@@ -589,7 +590,8 @@ public class AiServicesProcessor {
                             // we need to make these @DefaultBean because there could be other CDI beans of the same type that need to take precedence
                             impliedRegisterAiServiceTarget.contains(declarativeAiServiceClassInfo.name()),
                             shouldThrowExceptionOnEventError,
-                            chatMemoryFlushStrategySupplierClassDotName));
+                            chatMemoryFlushStrategySupplierClassDotName,
+                            hasRecordChatHistory(declarativeAiServiceClassInfo, config.chatHistoryEnabled())));
 
         }
         toolProviderProducer.produce(new ToolProviderMetaBuildItem(toolProviderInfos));
@@ -665,6 +667,10 @@ public class AiServicesProcessor {
             beanName = Optional.ofNullable(namedAnno.value().asString());
         }
         return beanName;
+    }
+
+    private static boolean hasRecordChatHistory(ClassInfo declarativeAiServiceClassInfo, boolean globalEnabled) {
+        return globalEnabled || declarativeAiServiceClassInfo.hasAnnotation(LangChain4jDotNames.RECORD_CHAT_HISTORY);
     }
 
     private static DotName cdiScope(CustomScopeAnnotationsBuildItem customScopes, ClassInfo declarativeAiServiceClassInfo) {
@@ -935,6 +941,7 @@ public class AiServicesProcessor {
         boolean needsModerationModelBean = false;
         boolean needsImageModelBean = false;
         boolean needsToolProviderBean = false;
+        boolean needsChatHistoryStoreBean = false;
         Set<DotName> allToolNames = new HashSet<>();
         Set<DotName> allToolProviders = new HashSet<>();
         Set<DotName> allToolHallucinationStrategies = new HashSet<>();
@@ -1098,7 +1105,8 @@ public class AiServicesProcessor {
                                     bi.getMaxToolCallsPerResponse(),
                                     allowContinuousForcedToolCalling,
                                     bi.isShouldThrowExceptionOnEventError(),
-                                    defaultMemoryIdProviderClassName)))
+                                    defaultMemoryIdProviderClassName,
+                                    bi.isRecordChatHistory())))
                     .setRuntimeInit()
                     .addQualifier()
                     .annotation(LangChain4jDotNames.QUARKUS_AI_SERVICE_CONTEXT_QUALIFIER).addValue("value", serviceClassName)
@@ -1219,6 +1227,11 @@ public class AiServicesProcessor {
                             new Type[] { ClassType.create(OutputGuardrail.class) }, null))
                     .done();
 
+            if (bi.isRecordChatHistory()) {
+                configurator.addInjectionPoint(ClassType.create(LangChain4jDotNames.CHAT_HISTORY_STORE));
+                needsChatHistoryStoreBean = true;
+            }
+
             syntheticBeanProducer.produce(configurator.done());
         }
 
@@ -1254,6 +1267,9 @@ public class AiServicesProcessor {
         }
         if (!allToolHallucinationStrategies.isEmpty()) {
             unremovableProducer.produce(UnremovableBeanBuildItem.beanTypes(allToolHallucinationStrategies));
+        }
+        if (needsChatHistoryStoreBean) {
+            unremovableProducer.produce(UnremovableBeanBuildItem.beanTypes(LangChain4jDotNames.CHAT_HISTORY_STORE));
         }
     }
 
@@ -1818,8 +1834,13 @@ public class AiServicesProcessor {
                         .map(AiServicesProcessor::classOutputGuardrails)
                         .orElse(null);
 
+                var recordChatHistory = aiServiceBuildItem
+                        .map(DeclarativeAiServiceBuildItem::isRecordChatHistory)
+                        .orElse(false);
+
                 perClassMetadata.put(ifaceName,
-                        new AiServiceClassCreateInfo(perMethodMetadata, implClassName, inputGuardrails, outputGuardrails));
+                        new AiServiceClassCreateInfo(perMethodMetadata, implClassName, inputGuardrails, outputGuardrails,
+                                recordChatHistory));
                 // make the constructor accessible reflectively since that is how we create the instance
                 reflectiveClassProducer.produce(ReflectiveClassBuildItem.builder(implClassName).build());
             }

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/DeclarativeAiServiceBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/DeclarativeAiServiceBuildItem.java
@@ -43,6 +43,7 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
     private final boolean makeDefaultBean;
     private final boolean shouldThrowExceptionOnEventError;
     private final DotName chatMemoryFlushStrategySupplierClassDotName;
+    private final boolean recordChatHistory;
 
     public DeclarativeAiServiceBuildItem(
             ClassInfo serviceClassInfo,
@@ -71,7 +72,8 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
             Integer maxToolCallsPerResponse,
             boolean allowContinuousForcedToolCalling,
             boolean makeDefaultBean, boolean shouldThrowExceptionOnEventError,
-            DotName chatMemoryFlushStrategySupplierClassDotName) {
+            DotName chatMemoryFlushStrategySupplierClassDotName,
+            boolean recordChatHistory) {
         this.serviceClassInfo = serviceClassInfo;
         this.chatLanguageModelSupplierClassDotName = chatLanguageModelSupplierClassDotName;
         this.streamingChatLanguageModelSupplierClassDotName = streamingChatLanguageModelSupplierClassDotName;
@@ -100,6 +102,7 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
         this.makeDefaultBean = makeDefaultBean;
         this.shouldThrowExceptionOnEventError = shouldThrowExceptionOnEventError;
         this.chatMemoryFlushStrategySupplierClassDotName = chatMemoryFlushStrategySupplierClassDotName;
+        this.recordChatHistory = recordChatHistory;
     }
 
     public ClassInfo getServiceClassInfo() {
@@ -241,5 +244,9 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
 
     public void setDefaultMemoryIdProviderClassDotName(DotName defaultMemoryIdProviderClassDotName) {
         this.defaultMemoryIdProviderClassDotName = defaultMemoryIdProviderClassDotName;
+    }
+
+    public boolean isRecordChatHistory() {
+        return recordChatHistory;
     }
 }

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/LangChain4jDotNames.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/LangChain4jDotNames.java
@@ -37,12 +37,14 @@ import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.web.search.WebSearchEngine;
 import dev.langchain4j.web.search.WebSearchTool;
 import io.quarkiverse.langchain4j.AudioUrl;
+import io.quarkiverse.langchain4j.ChatHistoryStore;
 import io.quarkiverse.langchain4j.CreatedAware;
 import io.quarkiverse.langchain4j.HandleToolArgumentError;
 import io.quarkiverse.langchain4j.HandleToolExecutionError;
 import io.quarkiverse.langchain4j.ImageUrl;
 import io.quarkiverse.langchain4j.ModelName;
 import io.quarkiverse.langchain4j.PdfUrl;
+import io.quarkiverse.langchain4j.RecordChatHistory;
 import io.quarkiverse.langchain4j.RegisterAiService;
 import io.quarkiverse.langchain4j.SeedMemory;
 import io.quarkiverse.langchain4j.VideoUrl;
@@ -158,4 +160,7 @@ public class LangChain4jDotNames {
     public static final DotName TOOL_ARGUMENTS_EXCEPTION = DotName.createSimple(ToolArgumentsException.class);
     public static final DotName TOOL_EXECUTION_EXCEPTION = DotName.createSimple(ToolExecutionException.class);
     public static final DotName TOOL_ERROR_CONTEXT = DotName.createSimple(ToolErrorContext.class);
+
+    public static final DotName RECORD_CHAT_HISTORY = DotName.createSimple(RecordChatHistory.class);
+    public static final DotName CHAT_HISTORY_STORE = DotName.createSimple(ChatHistoryStore.class);
 }

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/config/LangChain4jBuildConfig.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/config/LangChain4jBuildConfig.java
@@ -43,6 +43,14 @@ public interface LangChain4jBuildConfig {
     @WithDefault("true")
     boolean responseSchema();
 
+    /**
+     * If enabled, all AI services will record chat history via the {@code ChatHistoryStore} CDI bean,
+     * without needing the {@code @RecordChatHistory} annotation.
+     * If disabled, only AI services annotated with {@code @RecordChatHistory} will record chat history.
+     */
+    @WithDefault("false")
+    boolean chatHistoryEnabled();
+
     interface BaseConfig {
         /**
          * Chat model

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/RecordChatHistoryChatEventStreamingTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/RecordChatHistoryChatEventStreamingTest.java
@@ -1,0 +1,113 @@
+package io.quarkiverse.langchain4j.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.ChatHistoryStore;
+import io.quarkiverse.langchain4j.RecordChatHistory;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.runtime.aiservice.ChatEvent;
+import io.quarkiverse.langchain4j.test.streaming.StreamTestUtils;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+
+public class RecordChatHistoryChatEventStreamingTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ChatEventAiService.class, StreamTestUtils.class,
+                            TestChatEventChatHistoryStore.class));
+
+    @Inject
+    ChatEventAiService chatEventService;
+
+    @Inject
+    TestChatEventChatHistoryStore recorder;
+
+    @BeforeEach
+    void cleanup() {
+        recorder.clearEntries();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testChatEventStreamingRecording() {
+        List<ChatEvent> events = chatEventService.chat("789", "Say hello")
+                .collect().asList().await().indefinitely();
+
+        assertThat(events.stream()
+                .filter(e -> e instanceof ChatEvent.PartialResponseEvent)
+                .map(e -> ((ChatEvent.PartialResponseEvent) e).getChunk())
+                .toList()).containsExactly("Hi!", " ", "World!");
+
+        List<ChatEventRecordedEntry> entries = recorder.getRecordedEntries();
+        assertThat(entries).hasSize(3);
+        assertThat(entries.get(0)).isInstanceOfSatisfying(ChatEventRecordedEntry.class, e -> {
+            assertThat(e.type()).isEqualTo("user");
+            assertThat(e.memoryId()).isEqualTo("789");
+            assertThat(e.message()).isEqualTo("Say hello");
+        });
+        assertThat(entries.get(1)).isInstanceOfSatisfying(ChatEventRecordedEntry.class, e -> {
+            assertThat(e.type()).isEqualTo("agent");
+            assertThat(e.memoryId()).isEqualTo("789");
+            assertThat(e.message()).isEqualTo("Hi! World!");
+        });
+        assertThat(entries.get(2)).isInstanceOfSatisfying(ChatEventRecordedEntry.class, e -> {
+            assertThat(e.type()).isEqualTo("completed");
+            assertThat(e.memoryId()).isEqualTo("789");
+        });
+    }
+
+    @RecordChatHistory
+    @RegisterAiService(streamingChatLanguageModelSupplier = StreamTestUtils.FakeStreamedChatModelSupplier.class, chatMemoryProviderSupplier = StreamTestUtils.FakeMemoryProviderSupplier.class)
+    interface ChatEventAiService {
+        Multi<ChatEvent> chat(@MemoryId String id, @UserMessage String msg);
+    }
+
+    @ApplicationScoped
+    public static class TestChatEventChatHistoryStore implements ChatHistoryStore {
+
+        private final List<ChatEventRecordedEntry> recordedEntries = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void onUserMessage(Object memoryId, String userMessage) {
+            recordedEntries.add(new ChatEventRecordedEntry("user", memoryId, userMessage));
+        }
+
+        @Override
+        public void onAgentMessage(Object memoryId, String agentMessage) {
+            recordedEntries.add(new ChatEventRecordedEntry("agent", memoryId, agentMessage));
+        }
+
+        @Override
+        public void onCompleted(Object memoryId) {
+            recordedEntries.add(new ChatEventRecordedEntry("completed", memoryId, null));
+        }
+
+        public List<ChatEventRecordedEntry> getRecordedEntries() {
+            return recordedEntries;
+        }
+
+        public void clearEntries() {
+            recordedEntries.clear();
+        }
+    }
+
+    record ChatEventRecordedEntry(String type, Object memoryId, String message) {
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/RecordChatHistoryGlobalDisabledTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/RecordChatHistoryGlobalDisabledTest.java
@@ -1,0 +1,94 @@
+package io.quarkiverse.langchain4j.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.ChatHistoryStore;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class RecordChatHistoryGlobalDisabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(SyncAiService.class, FakeChatModelSupplier.class,
+                            TestChatHistoryStore.class))
+            .overrideConfigKey("quarkus.langchain4j.chat-history-enabled", "false");
+
+    @Inject
+    SyncAiService service;
+
+    @Inject
+    TestChatHistoryStore store;
+
+    @Test
+    @ActivateRequestContext
+    void testGlobalDisabledDoesNotRecord() {
+        service.chat("hello");
+        assertThat(store.getRecordedEntries()).isEmpty();
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = FakeChatModelSupplier.class, chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
+    interface SyncAiService {
+        @UserMessage("{msg}")
+        String chat(String msg);
+    }
+
+    public static class FakeChatModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new ChatModel() {
+                @Override
+                public ChatResponse doChat(ChatRequest chatRequest) {
+                    return ChatResponse.builder().aiMessage(new AiMessage("Echo")).build();
+                }
+            };
+        }
+    }
+
+    @ApplicationScoped
+    public static class TestChatHistoryStore implements ChatHistoryStore {
+
+        private final List<RecordedEntry> recordedEntries = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void onUserMessage(Object memoryId, String userMessage) {
+            recordedEntries.add(new RecordedEntry("user", memoryId, userMessage));
+        }
+
+        @Override
+        public void onAgentMessage(Object memoryId, String agentMessage) {
+            recordedEntries.add(new RecordedEntry("agent", memoryId, agentMessage));
+        }
+
+        @Override
+        public void onCompleted(Object memoryId) {
+            recordedEntries.add(new RecordedEntry("completed", memoryId, null));
+        }
+
+        public List<RecordedEntry> getRecordedEntries() {
+            return recordedEntries;
+        }
+    }
+
+    record RecordedEntry(String type, Object memoryId, String message) {
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/RecordChatHistoryGlobalEnabledTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/RecordChatHistoryGlobalEnabledTest.java
@@ -1,0 +1,124 @@
+package io.quarkiverse.langchain4j.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.ChatHistoryStore;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class RecordChatHistoryGlobalEnabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(SyncAiService.class, FakeChatModelSupplier.class,
+                            TestChatHistoryStore.class))
+            .overrideConfigKey("quarkus.langchain4j.chat-history-enabled", "true");
+
+    @Inject
+    SyncAiService syncService;
+
+    @Inject
+    TestChatHistoryStore recorder;
+
+    @BeforeEach
+    void cleanup() {
+        recorder.clearEntries();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testGlobalConfigEnablesRecordingWithoutAnnotation() {
+        String result = syncService.chat("hello global");
+        assertThat(result).isEqualTo("Echo: hello global");
+
+        List<RecordedEntry> entries = recorder.getRecordedEntries();
+        assertThat(entries).hasSize(3);
+        assertThat(entries.get(0)).isInstanceOfSatisfying(RecordedEntry.class, e -> {
+            assertThat(e.type()).isEqualTo("user");
+            assertThat(e.memoryId()).isEqualTo("default");
+            assertThat(e.message()).isEqualTo("hello global");
+        });
+        assertThat(entries.get(1)).isInstanceOfSatisfying(RecordedEntry.class, e -> {
+            assertThat(e.type()).isEqualTo("agent");
+            assertThat(e.memoryId()).isEqualTo("default");
+            assertThat(e.message()).isEqualTo("Echo: hello global");
+        });
+        assertThat(entries.get(2)).isInstanceOfSatisfying(RecordedEntry.class, e -> {
+            assertThat(e.type()).isEqualTo("completed");
+            assertThat(e.memoryId()).isEqualTo("default");
+        });
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = FakeChatModelSupplier.class, chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
+    interface SyncAiService {
+        @UserMessage("{msg}")
+        String chat(String msg);
+    }
+
+    public static class FakeChatModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new ChatModel() {
+                @Override
+                public ChatResponse doChat(ChatRequest chatRequest) {
+                    var lastMsg = chatRequest.messages().get(chatRequest.messages().size() - 1);
+                    String userText = (lastMsg instanceof dev.langchain4j.data.message.UserMessage um) ? um.singleText()
+                            : lastMsg.toString();
+                    return ChatResponse.builder().aiMessage(new AiMessage("Echo: " + userText)).build();
+                }
+            };
+        }
+    }
+
+    @ApplicationScoped
+    public static class TestChatHistoryStore implements ChatHistoryStore {
+
+        private final List<RecordedEntry> recordedEntries = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void onUserMessage(Object memoryId, String userMessage) {
+            recordedEntries.add(new RecordedEntry("user", memoryId, userMessage));
+        }
+
+        @Override
+        public void onAgentMessage(Object memoryId, String agentMessage) {
+            recordedEntries.add(new RecordedEntry("agent", memoryId, agentMessage));
+        }
+
+        @Override
+        public void onCompleted(Object memoryId) {
+            recordedEntries.add(new RecordedEntry("completed", memoryId, null));
+        }
+
+        public List<RecordedEntry> getRecordedEntries() {
+            return recordedEntries;
+        }
+
+        public void clearEntries() {
+            recordedEntries.clear();
+        }
+    }
+
+    record RecordedEntry(String type, Object memoryId, String message) {
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/RecordChatHistoryStreamingCallbacksTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/RecordChatHistoryStreamingCallbacksTest.java
@@ -1,0 +1,221 @@
+package io.quarkiverse.langchain4j.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.ChatHistoryStore;
+import io.quarkiverse.langchain4j.RecordChatHistory;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.test.streaming.StreamTestUtils;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.subscription.Cancellable;
+
+public class RecordChatHistoryStreamingCallbacksTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(StreamingAiService.class,
+                            FailingAiService.class,
+                            HangingAiService.class,
+                            StreamTestUtils.class,
+                            FailingStreamedChatModelSupplier.class,
+                            HangingStreamedChatModelSupplier.class,
+                            TestStreamingCallbacksStore.class));
+
+    @Inject
+    StreamingAiService streamingService;
+
+    @Inject
+    FailingAiService failingService;
+
+    @Inject
+    HangingAiService hangingService;
+
+    @Inject
+    TestStreamingCallbacksStore store;
+
+    @BeforeEach
+    void cleanup() {
+        store.clearEntries();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testOnAgentPartialCalledForEachChunk() {
+        List<String> result = streamingService.chat("p1", "Say hello")
+                .collect().asList().await().indefinitely();
+        assertThat(result).containsExactly("Hi!", " ", "World!");
+
+        List<String> partials = store.getEntries().stream()
+                .filter(e -> e.type().equals("partial"))
+                .map(CallbackEntry::message)
+                .toList();
+
+        assertThat(partials).containsExactly("Hi!", " ", "World!");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testOnErrorCalledWhenStreamFails() {
+        Throwable thrown = null;
+        try {
+            failingService.chat("e1", "Say hello")
+                    .collect().asList().await().atMost(Duration.ofSeconds(5));
+        } catch (Throwable t) {
+            thrown = t;
+        }
+        assertThat(thrown).isNotNull();
+
+        List<CallbackEntry> errors = store.getEntries().stream()
+                .filter(e -> e.type().equals("error"))
+                .toList();
+        assertThat(errors).hasSize(1);
+        assertThat(errors.get(0).memoryId()).isEqualTo("e1");
+        assertThat(errors.get(0).message()).isEqualTo("partial-");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testOnCancelledCalledWhenSubscriberCancels() throws InterruptedException {
+        CountDownLatch cancelledLatch = new CountDownLatch(1);
+        store.setOnCancelledLatch(cancelledLatch);
+
+        Cancellable subscription = hangingService.chat("c1", "Say hello")
+                .subscribe().with(item -> {
+                }, failure -> {
+                });
+
+        subscription.cancel();
+
+        boolean cancelledFired = cancelledLatch.await(5, TimeUnit.SECONDS);
+        assertThat(cancelledFired).isTrue();
+
+        List<CallbackEntry> cancellations = store.getEntries().stream()
+                .filter(e -> e.type().equals("cancelled"))
+                .toList();
+        assertThat(cancellations).hasSize(1);
+        assertThat(cancellations.get(0).memoryId()).isEqualTo("c1");
+    }
+
+    @RecordChatHistory
+    @RegisterAiService(streamingChatLanguageModelSupplier = StreamTestUtils.FakeStreamedChatModelSupplier.class, chatMemoryProviderSupplier = StreamTestUtils.FakeMemoryProviderSupplier.class)
+    interface StreamingAiService {
+        Multi<String> chat(@MemoryId String id, @UserMessage String msg);
+    }
+
+    @RecordChatHistory
+    @RegisterAiService(streamingChatLanguageModelSupplier = FailingStreamedChatModelSupplier.class, chatMemoryProviderSupplier = StreamTestUtils.FakeMemoryProviderSupplier.class)
+    interface FailingAiService {
+        Multi<String> chat(@MemoryId String id, @UserMessage String msg);
+    }
+
+    @RecordChatHistory
+    @RegisterAiService(streamingChatLanguageModelSupplier = HangingStreamedChatModelSupplier.class, chatMemoryProviderSupplier = StreamTestUtils.FakeMemoryProviderSupplier.class)
+    interface HangingAiService {
+        Multi<String> chat(@MemoryId String id, @UserMessage String msg);
+    }
+
+    public static class FailingStreamedChatModelSupplier implements Supplier<StreamingChatModel> {
+        @Override
+        public StreamingChatModel get() {
+            return new StreamingChatModel() {
+                @Override
+                public void doChat(ChatRequest request, StreamingChatResponseHandler handler) {
+                    handler.onPartialResponse("partial-");
+                    handler.onError(new RuntimeException("boom"));
+                }
+            };
+        }
+    }
+
+    public static class HangingStreamedChatModelSupplier implements Supplier<StreamingChatModel> {
+        @Override
+        public StreamingChatModel get() {
+            return new StreamingChatModel() {
+                @Override
+                public void doChat(ChatRequest request, StreamingChatResponseHandler handler) {
+                    // never emits — gives the subscriber time to cancel
+                }
+            };
+        }
+    }
+
+    @ApplicationScoped
+    public static class TestStreamingCallbacksStore implements ChatHistoryStore {
+
+        private final List<CallbackEntry> entries = new CopyOnWriteArrayList<>();
+        private volatile CountDownLatch onCancelledLatch;
+
+        void setOnCancelledLatch(CountDownLatch latch) {
+            this.onCancelledLatch = latch;
+        }
+
+        @Override
+        public void onUserMessage(Object memoryId, String userMessage) {
+            entries.add(new CallbackEntry("user", memoryId, userMessage));
+        }
+
+        @Override
+        public void onAgentMessage(Object memoryId, String agentMessage) {
+            entries.add(new CallbackEntry("agent", memoryId, agentMessage));
+        }
+
+        @Override
+        public void onAgentPartial(Object memoryId, String chunk) {
+            entries.add(new CallbackEntry("partial", memoryId, chunk));
+        }
+
+        @Override
+        public void onCompleted(Object memoryId) {
+            entries.add(new CallbackEntry("completed", memoryId, null));
+        }
+
+        @Override
+        public void onCancelled(Object memoryId, String partialAgentMessage) {
+            entries.add(new CallbackEntry("cancelled", memoryId, partialAgentMessage));
+            CountDownLatch latch = onCancelledLatch;
+            if (latch != null) {
+                latch.countDown();
+            }
+        }
+
+        @Override
+        public void onError(Object memoryId, Throwable error, String partialAgentMessage) {
+            entries.add(new CallbackEntry("error", memoryId, partialAgentMessage));
+        }
+
+        List<CallbackEntry> getEntries() {
+            return entries;
+        }
+
+        void clearEntries() {
+            entries.clear();
+        }
+    }
+
+    record CallbackEntry(String type, Object memoryId, String message) {
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/RecordChatHistoryStreamingTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/RecordChatHistoryStreamingTest.java
@@ -1,0 +1,108 @@
+package io.quarkiverse.langchain4j.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.ChatHistoryStore;
+import io.quarkiverse.langchain4j.RecordChatHistory;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.test.streaming.StreamTestUtils;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+
+public class RecordChatHistoryStreamingTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(StreamingAiService.class, StreamTestUtils.class,
+                            TestStreamingChatHistoryStore.class));
+
+    @Inject
+    StreamingAiService streamingService;
+
+    @Inject
+    TestStreamingChatHistoryStore recorder;
+
+    @BeforeEach
+    void cleanup() {
+        recorder.clearEntries();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testStreamingRecording() {
+        List<String> result = streamingService.chat("123", "Say hello")
+                .collect().asList().await().indefinitely();
+        assertThat(result).containsExactly("Hi!", " ", "World!");
+
+        List<StreamingRecordedEntry> entries = recorder.getRecordedEntries();
+        assertThat(entries).hasSize(3);
+        assertThat(entries.get(0)).isInstanceOfSatisfying(StreamingRecordedEntry.class, e -> {
+            assertThat(e.type()).isEqualTo("user");
+            assertThat(e.memoryId()).isEqualTo("123");
+            assertThat(e.message()).isEqualTo("Say hello");
+        });
+        assertThat(entries.get(1)).isInstanceOfSatisfying(StreamingRecordedEntry.class, e -> {
+            assertThat(e.type()).isEqualTo("agent");
+            assertThat(e.memoryId()).isEqualTo("123");
+            assertThat(e.message()).isEqualTo("Hi! World!");
+        });
+        assertThat(entries.get(2)).isInstanceOfSatisfying(StreamingRecordedEntry.class, e -> {
+            assertThat(e.type()).isEqualTo("completed");
+            assertThat(e.memoryId()).isEqualTo("123");
+        });
+    }
+
+    @RecordChatHistory
+    @RegisterAiService(streamingChatLanguageModelSupplier = StreamTestUtils.FakeStreamedChatModelSupplier.class, chatMemoryProviderSupplier = StreamTestUtils.FakeMemoryProviderSupplier.class)
+    interface StreamingAiService {
+        Multi<String> chat(@MemoryId String id, @UserMessage String msg);
+    }
+
+    @ApplicationScoped
+    public static class TestStreamingChatHistoryStore implements ChatHistoryStore {
+
+        private final List<StreamingRecordedEntry> recordedEntries = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void onUserMessage(Object memoryId, String userMessage) {
+            recordedEntries.add(new StreamingRecordedEntry("user", memoryId, userMessage));
+        }
+
+        @Override
+        public void onAgentMessage(Object memoryId, String agentMessage) {
+            recordedEntries.add(new StreamingRecordedEntry("agent", memoryId, agentMessage));
+        }
+
+        @Override
+        public void onCompleted(Object memoryId) {
+            recordedEntries.add(new StreamingRecordedEntry("completed", memoryId, null));
+        }
+
+        public List<StreamingRecordedEntry> getRecordedEntries() {
+            return recordedEntries;
+        }
+
+        public void clearEntries() {
+            recordedEntries.clear();
+        }
+    }
+
+    record StreamingRecordedEntry(String type, Object memoryId, String message) {
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/RecordChatHistoryTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/RecordChatHistoryTest.java
@@ -1,0 +1,125 @@
+package io.quarkiverse.langchain4j.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.ChatHistoryStore;
+import io.quarkiverse.langchain4j.RecordChatHistory;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class RecordChatHistoryTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(SyncAiService.class, FakeChatModelSupplier.class,
+                            TestChatHistoryStore.class));
+
+    @Inject
+    SyncAiService syncService;
+
+    @Inject
+    TestChatHistoryStore recorder;
+
+    @BeforeEach
+    void cleanup() {
+        recorder.clearEntries();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testSyncRecording() {
+        String result = syncService.chat("hello");
+        assertThat(result).isEqualTo("Echo: hello");
+
+        List<RecordedEntry> entries = recorder.getRecordedEntries();
+        assertThat(entries).hasSize(3);
+        assertThat(entries.get(0)).isInstanceOfSatisfying(RecordedEntry.class, e -> {
+            assertThat(e.type()).isEqualTo("user");
+            assertThat(e.memoryId()).isEqualTo("default");
+            assertThat(e.message()).isEqualTo("hello");
+        });
+        assertThat(entries.get(1)).isInstanceOfSatisfying(RecordedEntry.class, e -> {
+            assertThat(e.type()).isEqualTo("agent");
+            assertThat(e.memoryId()).isEqualTo("default");
+            assertThat(e.message()).isEqualTo("Echo: hello");
+        });
+        assertThat(entries.get(2)).isInstanceOfSatisfying(RecordedEntry.class, e -> {
+            assertThat(e.type()).isEqualTo("completed");
+            assertThat(e.memoryId()).isEqualTo("default");
+        });
+    }
+
+    @RecordChatHistory
+    @RegisterAiService(chatLanguageModelSupplier = FakeChatModelSupplier.class, chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
+    interface SyncAiService {
+        @UserMessage("{msg}")
+        String chat(String msg);
+    }
+
+    public static class FakeChatModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new ChatModel() {
+                @Override
+                public ChatResponse doChat(ChatRequest chatRequest) {
+                    var lastMsg = chatRequest.messages().get(chatRequest.messages().size() - 1);
+                    String userText = (lastMsg instanceof dev.langchain4j.data.message.UserMessage um) ? um.singleText()
+                            : lastMsg.toString();
+                    return ChatResponse.builder().aiMessage(new AiMessage("Echo: " + userText)).build();
+                }
+            };
+        }
+    }
+
+    @ApplicationScoped
+    public static class TestChatHistoryStore implements ChatHistoryStore {
+
+        private final List<RecordedEntry> recordedEntries = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void onUserMessage(Object memoryId, String userMessage) {
+            recordedEntries.add(new RecordedEntry("user", memoryId, userMessage));
+        }
+
+        @Override
+        public void onAgentMessage(Object memoryId, String agentMessage) {
+            recordedEntries.add(new RecordedEntry("agent", memoryId, agentMessage));
+        }
+
+        @Override
+        public void onCompleted(Object memoryId) {
+            recordedEntries.add(new RecordedEntry("completed", memoryId, null));
+        }
+
+        public List<RecordedEntry> getRecordedEntries() {
+            return recordedEntries;
+        }
+
+        public void clearEntries() {
+            recordedEntries.clear();
+        }
+    }
+
+    record RecordedEntry(String type, Object memoryId, String message) {
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/RecordChatHistoryTokenStreamTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/RecordChatHistoryTokenStreamTest.java
@@ -1,0 +1,154 @@
+package io.quarkiverse.langchain4j.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.TokenStream;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.ChatHistoryStore;
+import io.quarkiverse.langchain4j.RecordChatHistory;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.runtime.aiservice.NoopChatMemory;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class RecordChatHistoryTokenStreamTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TokenStreamAiService.class,
+                            TestTokenStreamChatHistoryStore.class,
+                            SimpleStreamedChatModelSupplier.class,
+                            NoopMemoryProviderSupplier.class));
+
+    @Inject
+    TokenStreamAiService tokenStreamService;
+
+    @Inject
+    TestTokenStreamChatHistoryStore recorder;
+
+    @BeforeEach
+    void cleanup() {
+        recorder.clearEntries();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testTokenStreamRecording() throws InterruptedException {
+        var latch = new CountDownLatch(1);
+        var chunks = new CopyOnWriteArrayList<String>();
+
+        tokenStreamService.chat("456", "Say hello")
+                .onPartialResponse(chunks::add)
+                .onCompleteResponse(response -> latch.countDown())
+                .onError(t -> {
+                    throw new RuntimeException(t);
+                })
+                .start();
+
+        boolean completed = latch.await(10, TimeUnit.SECONDS);
+        assertThat(completed).isTrue();
+        assertThat(chunks).containsExactly("Hi!", " ", "World!");
+
+        List<StreamingRecordedEntry> entries = recorder.getRecordedEntries();
+        assertThat(entries).hasSize(3);
+        assertThat(entries.get(0)).isInstanceOfSatisfying(StreamingRecordedEntry.class, e -> {
+            assertThat(e.type()).isEqualTo("user");
+            assertThat(e.memoryId()).isEqualTo("456");
+            assertThat(e.message()).isEqualTo("Say hello");
+        });
+        assertThat(entries.get(1)).isInstanceOfSatisfying(StreamingRecordedEntry.class, e -> {
+            assertThat(e.type()).isEqualTo("agent");
+            assertThat(e.memoryId()).isEqualTo("456");
+            assertThat(e.message()).isEqualTo("Hi! World!");
+        });
+        assertThat(entries.get(2)).isInstanceOfSatisfying(StreamingRecordedEntry.class, e -> {
+            assertThat(e.type()).isEqualTo("completed");
+            assertThat(e.memoryId()).isEqualTo("456");
+        });
+    }
+
+    @RecordChatHistory
+    @RegisterAiService(streamingChatLanguageModelSupplier = SimpleStreamedChatModelSupplier.class, chatMemoryProviderSupplier = NoopMemoryProviderSupplier.class)
+    interface TokenStreamAiService {
+        TokenStream chat(@MemoryId String id, @UserMessage String msg);
+    }
+
+    public static class SimpleStreamedChatModelSupplier implements Supplier<StreamingChatModel> {
+        @Override
+        public StreamingChatModel get() {
+            return new SimpleStreamedChatModel();
+        }
+    }
+
+    public static class SimpleStreamedChatModel implements StreamingChatModel {
+        @Override
+        public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+            handler.onPartialResponse("Hi!");
+            handler.onPartialResponse(" ");
+            handler.onPartialResponse("World!");
+            handler.onCompleteResponse(ChatResponse.builder().aiMessage(new AiMessage("")).build());
+        }
+    }
+
+    public static class NoopMemoryProviderSupplier implements Supplier<ChatMemoryProvider> {
+        @Override
+        public ChatMemoryProvider get() {
+            return memoryId -> new NoopChatMemory();
+        }
+    }
+
+    @ApplicationScoped
+    public static class TestTokenStreamChatHistoryStore implements ChatHistoryStore {
+
+        private final List<StreamingRecordedEntry> recordedEntries = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void onUserMessage(Object memoryId, String userMessage) {
+            recordedEntries.add(new StreamingRecordedEntry("user", memoryId, userMessage));
+        }
+
+        @Override
+        public void onAgentMessage(Object memoryId, String agentMessage) {
+            recordedEntries.add(new StreamingRecordedEntry("agent", memoryId, agentMessage));
+        }
+
+        @Override
+        public void onCompleted(Object memoryId) {
+            recordedEntries.add(new StreamingRecordedEntry("completed", memoryId, null));
+        }
+
+        public List<StreamingRecordedEntry> getRecordedEntries() {
+            return recordedEntries;
+        }
+
+        public void clearEntries() {
+            recordedEntries.clear();
+        }
+    }
+
+    record StreamingRecordedEntry(String type, Object memoryId, String message) {
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/RecordChatHistoryWithMemoryIdTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/RecordChatHistoryWithMemoryIdTest.java
@@ -1,0 +1,140 @@
+package io.quarkiverse.langchain4j.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.ChatHistoryStore;
+import io.quarkiverse.langchain4j.RecordChatHistory;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class RecordChatHistoryWithMemoryIdTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MemoryIdAiService.class, FakeChatModelSupplier.class,
+                            TestMemoryIdChatHistoryStore.class));
+
+    @Inject
+    MemoryIdAiService service;
+
+    @Inject
+    TestMemoryIdChatHistoryStore recorder;
+
+    @BeforeEach
+    void cleanup() {
+        recorder.clearEntries();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testRecordingWithMemoryId() {
+        String result = service.chat("user1", "hello");
+        assertThat(result).isEqualTo("Echo: hello");
+
+        List<MemoryIdRecordedEntry> entries = recorder.getRecordedEntries();
+        assertThat(entries).hasSize(3);
+        assertThat(entries.get(0)).isInstanceOfSatisfying(MemoryIdRecordedEntry.class, e -> {
+            assertThat(e.type()).isEqualTo("user");
+            assertThat(e.memoryId()).isEqualTo("user1");
+            assertThat(e.message()).isEqualTo("hello");
+        });
+        assertThat(entries.get(1)).isInstanceOfSatisfying(MemoryIdRecordedEntry.class, e -> {
+            assertThat(e.type()).isEqualTo("agent");
+            assertThat(e.memoryId()).isEqualTo("user1");
+            assertThat(e.message()).isEqualTo("Echo: hello");
+        });
+        assertThat(entries.get(2)).isInstanceOfSatisfying(MemoryIdRecordedEntry.class, e -> {
+            assertThat(e.type()).isEqualTo("completed");
+            assertThat(e.memoryId()).isEqualTo("user1");
+        });
+    }
+
+    @Test
+    @ActivateRequestContext
+    void testRecordingWithDifferentMemoryIds() {
+        service.chat("userA", "hi A");
+        service.chat("userB", "hi B");
+
+        List<MemoryIdRecordedEntry> entries = recorder.getRecordedEntries();
+        assertThat(entries).hasSize(6);
+        assertThat(entries.get(0).memoryId()).isEqualTo("userA");
+        assertThat(entries.get(0).message()).isEqualTo("hi A");
+        assertThat(entries.get(3).memoryId()).isEqualTo("userB");
+        assertThat(entries.get(3).message()).isEqualTo("hi B");
+    }
+
+    @RecordChatHistory
+    @RegisterAiService(chatLanguageModelSupplier = FakeChatModelSupplier.class, chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
+    interface MemoryIdAiService {
+        @UserMessage("{msg}")
+        String chat(@MemoryId String userId, String msg);
+    }
+
+    public static class FakeChatModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new ChatModel() {
+                @Override
+                public ChatResponse doChat(ChatRequest chatRequest) {
+                    var lastMsg = chatRequest.messages().get(chatRequest.messages().size() - 1);
+                    String userText = (lastMsg instanceof dev.langchain4j.data.message.UserMessage um) ? um.singleText()
+                            : lastMsg.toString();
+                    return ChatResponse.builder().aiMessage(new AiMessage("Echo: " + userText)).build();
+                }
+            };
+        }
+    }
+
+    @ApplicationScoped
+    public static class TestMemoryIdChatHistoryStore implements ChatHistoryStore {
+
+        private final List<MemoryIdRecordedEntry> recordedEntries = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void onUserMessage(Object memoryId, String userMessage) {
+            recordedEntries.add(new MemoryIdRecordedEntry("user", memoryId, userMessage));
+        }
+
+        @Override
+        public void onAgentMessage(Object memoryId, String agentMessage) {
+            recordedEntries.add(new MemoryIdRecordedEntry("agent", memoryId, agentMessage));
+        }
+
+        @Override
+        public void onCompleted(Object memoryId) {
+            recordedEntries.add(new MemoryIdRecordedEntry("completed", memoryId, null));
+        }
+
+        public List<MemoryIdRecordedEntry> getRecordedEntries() {
+            return recordedEntries;
+        }
+
+        public void clearEntries() {
+            recordedEntries.clear();
+        }
+    }
+
+    record MemoryIdRecordedEntry(String type, Object memoryId, String message) {
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/RecordChatHistoryWithoutStoreBeanTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/RecordChatHistoryWithoutStoreBeanTest.java
@@ -1,0 +1,59 @@
+package io.quarkiverse.langchain4j.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.function.Supplier;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RecordChatHistory;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class RecordChatHistoryWithoutStoreBeanTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ServiceWithNoStore.class, FakeChatModelSupplier.class))
+            .assertException(t -> assertThat(t).isInstanceOf(jakarta.enterprise.inject.spi.DeploymentException.class)
+                    .rootCause().isInstanceOf(jakarta.enterprise.inject.UnsatisfiedResolutionException.class));
+
+    @Inject
+    ServiceWithNoStore service;
+
+    @Test
+    void test() {
+        fail("Should not be called");
+    }
+
+    @RecordChatHistory
+    @RegisterAiService(chatLanguageModelSupplier = FakeChatModelSupplier.class, chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
+    interface ServiceWithNoStore {
+        @UserMessage("{msg}")
+        String chat(String msg);
+    }
+
+    public static class FakeChatModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new ChatModel() {
+                @Override
+                public ChatResponse doChat(ChatRequest chatRequest) {
+                    return ChatResponse.builder().aiMessage(new AiMessage("nope")).build();
+                }
+            };
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/ChatHistoryStore.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/ChatHistoryStore.java
@@ -1,0 +1,83 @@
+package io.quarkiverse.langchain4j;
+
+/**
+ * SPI that users implement to record the conversation history
+ * of AI service methods annotated with {@link RecordChatHistory}.
+ * <p>
+ * The store is called with the resolved memory id (the value of
+ * the {@code @MemoryId} parameter, or the default) and the
+ * user/agent message content.
+ * <p>
+ * Streaming responses dispatch {@link #onAgentPartial(Object, String)}
+ * for each chunk as it arrives, and exactly one terminal callback at the
+ * end of the turn: {@link #onAgentMessage(Object, String)} +
+ * {@link #onCompleted(Object)} on success,
+ * {@link #onCancelled(Object, String)} when the subscriber cancels, or
+ * {@link #onError(Object, Throwable, String)} when an error occurs.
+ */
+public interface ChatHistoryStore {
+
+    /**
+     * Called before the AI service method is invoked, with the
+     * user message that will be sent to the LLM.
+     *
+     * @param memoryId the conversation / memory identifier
+     * @param userMessage the text of the user message
+     */
+    void onUserMessage(Object memoryId, String userMessage);
+
+    /**
+     * Called when the agent response is fully available, with the
+     * complete agent message text. For streaming responses this is
+     * called once at the end with the accumulated text.
+     *
+     * @param memoryId the conversation / memory identifier
+     * @param agentMessage the text of the agent response
+     */
+    void onAgentMessage(Object memoryId, String agentMessage);
+
+    /**
+     * Called for each chunk of a streaming agent response as it is
+     * produced. Default implementation is a no-op; override to persist
+     * the response incrementally.
+     * <p>
+     * Not called for synchronous responses.
+     *
+     * @param memoryId the conversation / memory identifier
+     * @param chunk the text chunk produced by the model
+     */
+    default void onAgentPartial(Object memoryId, String chunk) {
+    }
+
+    /**
+     * Called after the agent response has been recorded successfully,
+     * signalling that the conversation turn is complete.
+     *
+     * @param memoryId the conversation / memory identifier
+     */
+    default void onCompleted(Object memoryId) {
+    }
+
+    /**
+     * Called when a streaming response is cancelled by the subscriber
+     * before completion. The partial message contains whatever text was
+     * accumulated up to the cancellation point.
+     *
+     * @param memoryId the conversation / memory identifier
+     * @param partialAgentMessage the agent response accumulated so far
+     */
+    default void onCancelled(Object memoryId, String partialAgentMessage) {
+    }
+
+    /**
+     * Called when the AI service method fails. For streaming responses
+     * the partial message contains whatever text was accumulated before
+     * the failure.
+     *
+     * @param memoryId the conversation / memory identifier
+     * @param error the failure that occurred
+     * @param partialAgentMessage the agent response accumulated so far (may be empty)
+     */
+    default void onError(Object memoryId, Throwable error, String partialAgentMessage) {
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/RecordChatHistory.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/RecordChatHistory.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.langchain4j;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * When placed on a {@link RegisterAiService} class, every method of that
+ * service will be recorded by the {@link ChatHistoryStore} CDI bean.
+ * <p>
+ * Recording can also be enabled globally for all AI services via the
+ * {@code quarkus.langchain4j.chat-history-enabled} build-time property.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface RecordChatHistory {
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/AiServicesRecorder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/AiServicesRecorder.java
@@ -24,6 +24,7 @@ import dev.langchain4j.rag.RetrievalAugmentor;
 import dev.langchain4j.service.tool.ToolArgumentsErrorHandler;
 import dev.langchain4j.service.tool.ToolExecutionErrorHandler;
 import dev.langchain4j.service.tool.ToolProvider;
+import io.quarkiverse.langchain4j.ChatHistoryStore;
 import io.quarkiverse.langchain4j.ModelName;
 import io.quarkiverse.langchain4j.RegisterAiService;
 import io.quarkiverse.langchain4j.observability.AiServiceEvents;
@@ -346,6 +347,11 @@ public class AiServicesRecorder {
 
                     aiServiceContext.eventListenerRegistrar
                             .shouldThrowExceptionOnEventError(info.shouldThrowExceptionOnEventError());
+
+                    if (info.recordChatHistory()) {
+                        aiServiceContext.chatHistoryStore = creationalContext
+                                .getInjectedReference(ChatHistoryStore.class);
+                    }
 
                     return aiServiceContext;
                 } catch (ClassNotFoundException e) {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceClassCreateInfo.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceClassCreateInfo.java
@@ -9,5 +9,6 @@ import io.quarkiverse.langchain4j.guardrails.OutputGuardrailsLiteral;
  * @param methodMap the key is a methodId generated at build time
  */
 public record AiServiceClassCreateInfo(Map<String, AiServiceMethodCreateInfo> methodMap, String implClassName,
-        InputGuardrailsLiteral inputGuardrails, OutputGuardrailsLiteral outputGuardrails) {
+        InputGuardrailsLiteral inputGuardrails, OutputGuardrailsLiteral outputGuardrails,
+        boolean recordChatHistory) {
 }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
@@ -91,6 +91,7 @@ import dev.langchain4j.service.AiServiceTokenStream;
 import dev.langchain4j.service.AiServiceTokenStreamParameters;
 import dev.langchain4j.service.IllegalConfigurationException;
 import dev.langchain4j.service.Result;
+import dev.langchain4j.service.TokenStream;
 import dev.langchain4j.service.output.ServiceOutputParser;
 import dev.langchain4j.service.tool.ToolArgumentsErrorHandler;
 import dev.langchain4j.service.tool.ToolErrorContext;
@@ -104,6 +105,7 @@ import dev.langchain4j.service.tool.ToolProviderRequest;
 import dev.langchain4j.service.tool.ToolProviderResult;
 import dev.langchain4j.spi.ServiceHelper;
 import io.quarkiverse.langchain4j.AudioUrl;
+import io.quarkiverse.langchain4j.ChatHistoryStore;
 import io.quarkiverse.langchain4j.ImageUrl;
 import io.quarkiverse.langchain4j.PdfUrl;
 import io.quarkiverse.langchain4j.VideoUrl;
@@ -227,6 +229,12 @@ public class AiServiceMethodImplementationSupport {
         boolean supportsJsonSchema = supportsJsonSchema(context, methodCreateInfo, methodArgs);
 
         UserMessage userMessage = prepareUserMessage(context, methodCreateInfo, methodArgs, supportsJsonSchema);
+
+        ChatHistoryStore chatHistoryStore = context.chatHistoryStore;
+        if (chatHistoryStore != null && userMessage != null) {
+            ChatHistorySupport.recordUserMessage(chatHistoryStore, memoryId, userMessage);
+        }
+
         Map<String, Object> templateVariables = getTemplateVariables(methodArgs, methodCreateInfo.getUserMessageInfo());
 
         Type returnType = methodCreateInfo.getReturnType();
@@ -337,7 +345,11 @@ public class AiServiceMethodImplementationSupport {
                                     .aiServiceListenerRegistrar(context.eventListenerRegistrar)
                                     .build())
                     .build();
-            return new AiServiceTokenStream(aiServiceTokenStreamParams);
+            TokenStream tokenStream = new AiServiceTokenStream(aiServiceTokenStreamParams);
+            if (chatHistoryStore != null) {
+                tokenStream = new RecordingTokenStream(tokenStream, chatHistoryStore, memoryId);
+            }
+            return tokenStream;
         }
 
         var actualAugmentationResult = augmentationResult;
@@ -383,9 +395,15 @@ public class AiServiceMethodImplementationSupport {
                         });
             }
 
-            return stream.plug(m -> ResponseAugmenterSupport.apply(m, methodCreateInfo,
+            stream = stream.plug(m -> ResponseAugmenterSupport.apply(m, methodCreateInfo,
                     new ResponseAugmenterParams(actualUserMessage, chatMemory, actualAugmentationResult,
                             methodCreateInfo.getUserMessageTemplate(), templateVariables)));
+
+            if (chatHistoryStore != null) {
+                stream = ChatHistorySupport.attach(stream, chatHistoryStore, memoryId, isStringMulti);
+            }
+
+            return stream;
         }
 
         Future<Moderation> moderationFuture = triggerModerationIfNeeded(context, methodCreateInfo, messagesToSend);
@@ -509,6 +527,10 @@ public class AiServiceMethodImplementationSupport {
                         .finalResponse(finalResponse)
                         .build();
 
+                if (chatHistoryStore != null) {
+                    ChatHistorySupport.recordAgentResponse(chatHistoryStore, memoryId, finalResponse.aiMessage().text());
+                }
+
                 context.eventListenerRegistrar.fireEvent(
                         AiServiceCompletedEvent.builder()
                                 .invocationContext(invocationContext)
@@ -581,6 +603,10 @@ public class AiServiceMethodImplementationSupport {
 
         // everything worked as expected so let's commit the messages
         committableChatMemory.commit();
+
+        if (chatHistoryStore != null) {
+            ChatHistorySupport.recordAgentResponse(chatHistoryStore, memoryId, response.aiMessage().text());
+        }
 
         var responseAugmenterParam = new ResponseAugmenterParams(userMessage, committableChatMemory, augmentationResult,
                 userMessageTemplate, templateVariables);

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/ChatHistorySupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/ChatHistorySupport.java
@@ -1,0 +1,87 @@
+package io.quarkiverse.langchain4j.runtime.aiservice;
+
+import org.jboss.logging.Logger;
+
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.UserMessage;
+import io.quarkiverse.langchain4j.ChatHistoryStore;
+import io.smallrye.mutiny.Multi;
+
+public class ChatHistorySupport {
+
+    private static final Logger log = Logger.getLogger(ChatHistorySupport.class);
+
+    private ChatHistorySupport() {
+        // Avoid direct instantiation
+    }
+
+    public static void recordUserMessage(ChatHistoryStore store, Object memoryId, UserMessage userMessage) {
+        safeInvoke(memoryId, "user message", () -> store.onUserMessage(memoryId, extractText(userMessage)));
+    }
+
+    public static void recordAgentResponse(ChatHistoryStore store, Object memoryId, String agentText) {
+        safeInvoke(memoryId, "agent message", () -> {
+            store.onAgentMessage(memoryId, agentText);
+            store.onCompleted(memoryId);
+        });
+    }
+
+    public static Multi<?> attach(Multi<?> stream, ChatHistoryStore store, Object memoryId, boolean isStringMulti) {
+        StringBuilder buffer = new StringBuilder();
+        return stream
+                .onItem().invoke(item -> recordPartial(store, memoryId, item, isStringMulti, buffer))
+                .onCompletion().invoke(() -> recordAgentResponse(store, memoryId, buffer.toString()))
+                .onFailure().invoke(error -> recordFailure(store, memoryId, buffer, error))
+                .onCancellation().invoke(() -> recordCancellation(store, memoryId, buffer));
+    }
+
+    private static void recordPartial(ChatHistoryStore store, Object memoryId, Object item,
+            boolean isStringMulti, StringBuilder buffer) {
+        String chunk = extractChunk(item, isStringMulti);
+        if (chunk == null) {
+            return;
+        }
+        buffer.append(chunk);
+        safeInvoke(memoryId, "partial agent message", () -> store.onAgentPartial(memoryId, chunk));
+    }
+
+    private static void recordFailure(ChatHistoryStore store, Object memoryId, StringBuilder buffer, Throwable error) {
+        safeInvoke(memoryId, "streaming failure", () -> store.onError(memoryId, error, buffer.toString()));
+    }
+
+    private static void recordCancellation(ChatHistoryStore store, Object memoryId, StringBuilder buffer) {
+        safeInvoke(memoryId, "streaming cancellation", () -> store.onCancelled(memoryId, buffer.toString()));
+    }
+
+    private static String extractChunk(Object item, boolean isStringMulti) {
+        if (isStringMulti) {
+            return (String) item;
+        }
+        if (item instanceof ChatEvent.PartialResponseEvent pre) {
+            return pre.getChunk();
+        }
+        return null;
+    }
+
+    private static String extractText(UserMessage userMessage) {
+        StringBuilder sb = new StringBuilder();
+        for (Content content : userMessage.contents()) {
+            if (content instanceof TextContent text) {
+                if (sb.length() > 0) {
+                    sb.append('\n');
+                }
+                sb.append(text.text());
+            }
+        }
+        return sb.toString();
+    }
+
+    private static void safeInvoke(Object memoryId, String operation, Runnable action) {
+        try {
+            action.run();
+        } catch (RuntimeException e) {
+            log.warnf(e, "Failed to record %s for memoryId=%s, continuing without recording.", operation, memoryId);
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/DeclarativeAiServiceCreateInfo.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/DeclarativeAiServiceCreateInfo.java
@@ -35,5 +35,6 @@ public record DeclarativeAiServiceCreateInfo(
         Integer maxToolCallsPerResponse,
         boolean allowContinuousForcedToolCalling,
         boolean shouldThrowExceptionOnEventError,
-        String defaultMemoryIdProviderClassName) {
+        String defaultMemoryIdProviderClassName,
+        boolean recordChatHistory) {
 }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceContext.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceContext.java
@@ -14,6 +14,7 @@ import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.image.ImageModel;
 import dev.langchain4j.service.AiServiceContext;
+import io.quarkiverse.langchain4j.ChatHistoryStore;
 import io.quarkiverse.langchain4j.ModelName;
 import io.quarkiverse.langchain4j.RegisterAiService;
 import io.quarkiverse.langchain4j.spi.DefaultMemoryIdProvider;
@@ -29,6 +30,7 @@ public class QuarkusAiServiceContext extends AiServiceContext {
     public boolean allowContinuousForcedToolCalling;
     public DefaultMemoryIdProvider defaultMemoryIdProvider;
     public ChatMemoryFlushStrategy chatMemoryFlushStrategy = ChatMemoryFlushStrategy.DEFERRED;
+    public ChatHistoryStore chatHistoryStore;
 
     // needed by Arc
     public QuarkusAiServiceContext() {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/RecordingTokenStream.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/RecordingTokenStream.java
@@ -1,0 +1,214 @@
+package io.quarkiverse.langchain4j.runtime.aiservice;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import org.jboss.logging.Logger;
+
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.PartialResponse;
+import dev.langchain4j.model.chat.response.PartialResponseContext;
+import dev.langchain4j.model.chat.response.PartialThinking;
+import dev.langchain4j.model.chat.response.PartialThinkingContext;
+import dev.langchain4j.model.chat.response.PartialToolCall;
+import dev.langchain4j.model.chat.response.PartialToolCallContext;
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.service.TokenStream;
+import dev.langchain4j.service.tool.BeforeToolExecution;
+import dev.langchain4j.service.tool.ToolExecution;
+import io.quarkiverse.langchain4j.ChatHistoryStore;
+
+class RecordingTokenStream implements TokenStream {
+
+    private static final Logger log = Logger.getLogger(RecordingTokenStream.class);
+
+    private final TokenStream delegate;
+    private final ChatHistoryStore chatHistoryStore;
+    private final Object memoryId;
+    private final StringBuilder buffer = new StringBuilder();
+
+    private Consumer<String> partialResponseHandler;
+    private BiConsumer<PartialResponse, PartialResponseContext> partialResponseWithContextHandler;
+    private Consumer<PartialThinking> partialThinkingHandler;
+    private BiConsumer<PartialThinking, PartialThinkingContext> partialThinkingWithContextHandler;
+    private Consumer<PartialToolCall> partialToolCallHandler;
+    private BiConsumer<PartialToolCall, PartialToolCallContext> partialToolCallWithContextHandler;
+    private Consumer<List<Content>> contentsHandler;
+    private Consumer<ChatResponse> intermediateResponseHandler;
+    private Consumer<BeforeToolExecution> beforeToolExecutionHandler;
+    private Consumer<ToolExecution> toolExecutionHandler;
+    private Consumer<ChatResponse> completeResponseHandler;
+    private Consumer<Throwable> errorHandler;
+
+    RecordingTokenStream(TokenStream delegate, ChatHistoryStore chatHistoryStore, Object memoryId) {
+        this.delegate = delegate;
+        this.chatHistoryStore = chatHistoryStore;
+        this.memoryId = memoryId;
+    }
+
+    @Override
+    public TokenStream onPartialResponse(Consumer<String> handler) {
+        this.partialResponseHandler = chunk -> {
+            recordPartial(chunk);
+            handler.accept(chunk);
+        };
+        return this;
+    }
+
+    @Override
+    public TokenStream onPartialResponseWithContext(
+            BiConsumer<PartialResponse, PartialResponseContext> handler) {
+        this.partialResponseWithContextHandler = (partialResponse, context) -> {
+            recordPartial(partialResponse.text());
+            handler.accept(partialResponse, context);
+        };
+        return this;
+    }
+
+    @Override
+    public TokenStream onPartialThinking(Consumer<PartialThinking> handler) {
+        this.partialThinkingHandler = handler;
+        return this;
+    }
+
+    @Override
+    public TokenStream onPartialThinkingWithContext(
+            BiConsumer<PartialThinking, PartialThinkingContext> handler) {
+        this.partialThinkingWithContextHandler = handler;
+        return this;
+    }
+
+    @Override
+    public TokenStream onPartialToolCall(Consumer<PartialToolCall> handler) {
+        this.partialToolCallHandler = handler;
+        return this;
+    }
+
+    @Override
+    public TokenStream onPartialToolCallWithContext(
+            BiConsumer<PartialToolCall, PartialToolCallContext> handler) {
+        this.partialToolCallWithContextHandler = handler;
+        return this;
+    }
+
+    @Override
+    public TokenStream onRetrieved(Consumer<List<Content>> handler) {
+        this.contentsHandler = handler;
+        return this;
+    }
+
+    @Override
+    public TokenStream onIntermediateResponse(Consumer<ChatResponse> handler) {
+        this.intermediateResponseHandler = handler;
+        return this;
+    }
+
+    @Override
+    public TokenStream beforeToolExecution(Consumer<BeforeToolExecution> handler) {
+        this.beforeToolExecutionHandler = handler;
+        return this;
+    }
+
+    @Override
+    public TokenStream onToolExecuted(Consumer<ToolExecution> handler) {
+        this.toolExecutionHandler = handler;
+        return this;
+    }
+
+    @Override
+    public TokenStream onCompleteResponse(Consumer<ChatResponse> handler) {
+        this.completeResponseHandler = response -> {
+            try {
+                chatHistoryStore.onAgentMessage(memoryId, buffer.toString());
+                chatHistoryStore.onCompleted(memoryId);
+            } catch (RuntimeException e) {
+                log.warnf(e,
+                        "Failed to record agent message for memoryId=%s, continuing without recording.",
+                        memoryId);
+            }
+            handler.accept(response);
+        };
+        return this;
+    }
+
+    @Override
+    public TokenStream onError(Consumer<Throwable> handler) {
+        this.errorHandler = handler;
+        return this;
+    }
+
+    @Override
+    public TokenStream ignoreErrors() {
+        this.errorHandler = null;
+        return this;
+    }
+
+    @Override
+    public void start() {
+        if (partialResponseHandler != null) {
+            delegate.onPartialResponse(partialResponseHandler);
+        }
+        if (partialResponseWithContextHandler != null) {
+            delegate.onPartialResponseWithContext(partialResponseWithContextHandler);
+        }
+        if (partialThinkingHandler != null) {
+            delegate.onPartialThinking(partialThinkingHandler);
+        }
+        if (partialThinkingWithContextHandler != null) {
+            delegate.onPartialThinkingWithContext(partialThinkingWithContextHandler);
+        }
+        if (partialToolCallHandler != null) {
+            delegate.onPartialToolCall(partialToolCallHandler);
+        }
+        if (partialToolCallWithContextHandler != null) {
+            delegate.onPartialToolCallWithContext(partialToolCallWithContextHandler);
+        }
+        if (contentsHandler != null) {
+            delegate.onRetrieved(contentsHandler);
+        }
+        if (intermediateResponseHandler != null) {
+            delegate.onIntermediateResponse(intermediateResponseHandler);
+        }
+        if (beforeToolExecutionHandler != null) {
+            delegate.beforeToolExecution(beforeToolExecutionHandler);
+        }
+        if (toolExecutionHandler != null) {
+            delegate.onToolExecuted(toolExecutionHandler);
+        }
+        if (completeResponseHandler != null) {
+            delegate.onCompleteResponse(completeResponseHandler);
+        }
+        delegate.onError(recordingErrorHandler(errorHandler));
+        delegate.start();
+    }
+
+    private void recordPartial(String chunk) {
+        if (chunk == null) {
+            return;
+        }
+        buffer.append(chunk);
+        try {
+            chatHistoryStore.onAgentPartial(memoryId, chunk);
+        } catch (RuntimeException e) {
+            log.warnf(e,
+                    "Failed to record partial agent message for memoryId=%s, continuing without recording.",
+                    memoryId);
+        }
+    }
+
+    private Consumer<Throwable> recordingErrorHandler(Consumer<Throwable> userHandler) {
+        return error -> {
+            try {
+                chatHistoryStore.onError(memoryId, error, buffer.toString());
+            } catch (RuntimeException e) {
+                log.warnf(e,
+                        "Failed to record streaming failure for memoryId=%s, continuing without recording.",
+                        memoryId);
+            }
+            if (userHandler != null) {
+                userHandler.accept(error);
+            }
+        };
+    }
+}

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -40,6 +40,7 @@
 * xref:ai-services.adoc[AI Services]
 ** xref:prompt-and-template.adoc[Prompt and Template]
 ** xref:messages-and-memory.adoc[Messages and Memory]
+** xref:chat-history-recording.adoc[Chat History Recording]
 ** xref:function-calling.adoc[Function Calling]
 ** xref:guardrails.adoc[Guardrails]
 ** xref:response-augmenter.adoc[Response Augmenter]

--- a/docs/modules/ROOT/pages/chat-history-recording.adoc
+++ b/docs/modules/ROOT/pages/chat-history-recording.adoc
@@ -1,0 +1,135 @@
+= Chat History Recording
+
+include::./includes/attributes.adoc[]
+include::./includes/customization.adoc[]
+
+Quarkus LangChain4j can persist the user/agent exchange of every AI service invocation to a sink of your choice — a database, a log, an audit pipeline, a remote API — without coupling the recording logic to the AI service itself.
+
+The integration is built around two pieces:
+
+* `@RecordChatHistory` — a marker annotation placed on a `@RegisterAiService` interface to opt in.
+* `ChatHistoryStore` — an SPI that you implement as a CDI bean. The runtime calls it at each step of the conversation turn.
+
+== Enabling Recording
+
+There are two ways to enable recording for an AI service.
+
+=== Per service
+
+Annotate the AI service with `@RecordChatHistory`:
+
+[source,java]
+----
+import io.quarkiverse.langchain4j.RecordChatHistory;
+import io.quarkiverse.langchain4j.RegisterAiService;
+
+@RecordChatHistory
+@RegisterAiService
+public interface SupportAgent {
+    String chat(@MemoryId String conversationId, @UserMessage String message);
+}
+----
+
+When `@RecordChatHistory` is present, a `ChatHistoryStore` CDI bean is required at deployment time. If no implementation is found, the deployment fails.
+
+=== Globally
+
+To enable recording for every AI service in the application without annotating each one, set the build-time property:
+
+[source,properties]
+----
+quarkus.langchain4j.chat-history-enabled=true
+----
+
+This is convenient for applications where every conversation must be recorded — for example, regulated environments. With this flag enabled, a `ChatHistoryStore` bean is required even if no `@RecordChatHistory` annotation is present.
+
+== Implementing the Store
+
+Implement `ChatHistoryStore` as an `@ApplicationScoped` bean:
+
+[source,java]
+----
+import io.quarkiverse.langchain4j.ChatHistoryStore;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class JpaChatHistoryStore implements ChatHistoryStore {
+
+    @Inject ConversationRepository repository;
+
+    @Override
+    public void onUserMessage(Object memoryId, String userMessage) {
+        repository.append(memoryId, Role.USER, userMessage);
+    }
+
+    @Override
+    public void onAgentMessage(Object memoryId, String agentMessage) {
+        repository.append(memoryId, Role.AGENT, agentMessage);
+    }
+}
+----
+
+This is enough to record every turn for synchronous and streaming responses. The remaining callbacks are optional `default` methods you can override for finer-grained behavior.
+
+== Lifecycle and Callbacks
+
+For each AI service invocation, the runtime calls the following methods, in this order, depending on the outcome:
+
+[cols="1,3,1"]
+|===
+|Callback |When it fires |Required
+
+|`onUserMessage(memoryId, userMessage)` |Before the model is called, with the resolved user message. |yes
+|`onAgentPartial(memoryId, chunk)` |For each chunk of a streaming response. Not called for synchronous responses. |no
+|`onAgentMessage(memoryId, agentMessage)` |When the agent response is fully available — once at the end for streaming. |yes
+|`onCompleted(memoryId)` |After `onAgentMessage`, when the turn completes successfully. |no
+|`onCancelled(memoryId, partial)` |When a streaming response is cancelled by the subscriber before completion. `partial` contains the accumulated text. |no
+|`onError(memoryId, error, partial)` |When a streaming response fails. `partial` contains whatever text was produced before the failure. |no
+|===
+
+The `memoryId` is the resolved `@MemoryId` parameter value, or the default memory id if the method does not declare one.
+
+The runtime catches any `RuntimeException` thrown by store methods and logs a warning — a failing store will never break the conversation.
+
+== Streaming Responses
+
+The store is wired to streaming return types (`Multi<String>`, `Multi<ChatEvent>`, `TokenStream`) the same way as synchronous methods.
+
+* Each chunk emitted by the model invokes `onAgentPartial`.
+* When the stream completes successfully, `onAgentMessage` is called with the accumulated text, then `onCompleted`.
+* If the subscriber cancels the stream before it completes, `onCancelled` is called with whatever was accumulated.
+* If the stream fails, `onError` is called with the failure and the accumulated text.
+
+If you do not override `onAgentPartial`, partial chunks are still buffered internally and the full text is delivered through `onAgentMessage` at the end. Override `onAgentPartial` only when you need to forward each chunk to a separate consumer as it is produced — for example, a real-time audit log, a WebSocket subscriber, or a parallel UI surface.
+
+== Propagating User Identity
+
+The SPI passes `memoryId` but does not pass the authenticated user. If your store needs the current user, inject it directly:
+
+[source,java]
+----
+@ApplicationScoped
+public class AuditingChatHistoryStore implements ChatHistoryStore {
+
+    @Inject SecurityIdentity identity;
+
+    @Override
+    public void onUserMessage(Object memoryId, String userMessage) {
+        repository.append(memoryId, identity.getPrincipal().getName(), Role.USER, userMessage);
+    }
+    // ...
+}
+----
+
+For synchronous methods, the store is invoked on the calling thread, so the active CDI request scope (and any propagated security context) is available. For streaming responses, `onUserMessage` still runs on the calling thread, but the terminal callbacks (`onAgentPartial`, `onAgentMessage`, `onCompleted`, `onCancelled`, `onError`) run on Mutiny worker threads — if your store depends on request-scoped state, capture it at `onUserMessage` or rely on SmallRye Context Propagation.
+
+== Multimodal User Messages
+
+The user message text passed to `onUserMessage` is extracted from all `TextContent` parts of the user message. Image, audio, PDF, and video parts are ignored — only the text representation is recorded. This keeps the SPI signature simple at the cost of dropping the non-text portions of multimodal prompts.
+
+== Limitations
+
+* **Resumption is not supported.** The store records messages but cannot replay an in-flight streaming response to a new subscriber. This is tracked separately and may be added in a future release as a complementary SPI.
+* **Synchronous failures are not signalled.** If a synchronous AI service method throws, `onError` is not invoked because the sync code path does not go through the Mutiny chain that drives streaming callbacks — the exception propagates to the caller and `onUserMessage` has already been recorded. Streaming responses do invoke `onError`.
+* **Programmatic AI services bypass the annotation.** Only services declared with `@RegisterAiService` participate in recording. Services built through the langchain4j `AiServices` builder API are not covered.

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-core.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-core.adoc
@@ -120,6 +120,27 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-core_quarkus-langchain4j-chat-history-enabled]] [.property-path]##link:#quarkus-langchain4j-core_quarkus-langchain4j-chat-history-enabled[`+++quarkus.langchain4j.chat-history-enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chat-history-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+If enabled, all AI services will record chat history via the `ChatHistoryStore` CDI bean, without needing the `@RecordChatHistory` annotation. If disabled, only AI services annotated with `@RecordChatHistory` will record chat history.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHAT_HISTORY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHAT_HISTORY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
 a| [[quarkus-langchain4j-core_quarkus-langchain4j-chat-memory-memory-window-max-messages]] [.property-path]##link:#quarkus-langchain4j-core_quarkus-langchain4j-chat-memory-memory-window-max-messages[`+++quarkus.langchain4j.chat-memory.memory-window.max-messages+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.chat-memory.memory-window.max-messages+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-core_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-core_quarkus.langchain4j.adoc
@@ -120,6 +120,27 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-core_quarkus-langchain4j-chat-history-enabled]] [.property-path]##link:#quarkus-langchain4j-core_quarkus-langchain4j-chat-history-enabled[`+++quarkus.langchain4j.chat-history-enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.chat-history-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+If enabled, all AI services will record chat history via the `ChatHistoryStore` CDI bean, without needing the `@RecordChatHistory` annotation. If disabled, only AI services annotated with `@RecordChatHistory` will record chat history.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_CHAT_HISTORY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_CHAT_HISTORY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
 a| [[quarkus-langchain4j-core_quarkus-langchain4j-chat-memory-memory-window-max-messages]] [.property-path]##link:#quarkus-langchain4j-core_quarkus-langchain4j-chat-memory-memory-window-max-messages[`+++quarkus.langchain4j.chat-memory.memory-window.max-messages+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.chat-memory.memory-window.max-messages+++[]


### PR DESCRIPTION
## Describe your changes

Applications often need to persist the conversation between a user and the model (to a database, an audit pipeline, a log, or a remote API) but Quarkus had no built-in way to intercept that exchange without coupling the recording logic to the AI service itself. This PR adds a pluggable recording mechanism.

A new `@RecordChatHistory` annotation marks a `@RegisterAiService` interface to opt in. The application provides a `ChatHistoryStore` CDI bean, and the runtime calls it at each step of the conversation turn. The two required callbacks (`onUserMessage`, `onAgentMessage`) are enough to record every turn; the remaining callbacks are optional `default` methods for finer-grained streaming behavior.

```java
@RecordChatHistory
@RegisterAiService
public interface SupportAgent {
    String chat(@MemoryId String conversationId, @UserMessage String message);
}

@ApplicationScoped
public class JpaChatHistoryStore implements ChatHistoryStore {

    @Inject ConversationRepository repository;

    @Override
    public void onUserMessage(Object memoryId, String userMessage) {
        repository.append(memoryId, Role.USER, userMessage);
    }

    @Override
    public void onAgentMessage(Object memoryId, String agentMessage) {
        repository.append(memoryId, Role.AGENT, agentMessage);
    }
}
```

Recording works for synchronous methods and for all streaming return types (`Multi<String>`, `Multi<ChatEvent>`, `TokenStream`). For streaming, partial chunks are buffered internally and the full text is delivered through `onAgentMessage` on completion; the optional `onAgentPartial`, `onCompleted`, `onCancelled`, and `onError` callbacks expose the rest of the stream lifecycle.

A store that throws is never allowed to break the conversation: every callback is invoked defensively and any `RuntimeException` is logged as a warning.

### Global mode

To record every AI service without annotating each one, set the build-time property:

```properties
quarkus.langchain4j.chat-history-enabled=true
```

### Deferred scope

The issue also describes two capabilities that are intentionally **not** part of this PR, since both are larger and orthogonal to recording:

- **Resumption**: replaying an in-flight streaming response to a new subscriber. This is a different mechanism (buffering + multicast + a replay SPI + durable storage) and is left as a complementary follow-up.
- **Automatic user identity propagation into the store**: The store is a CDI bean, so it can `@Inject SecurityIdentity` directly. This works on the calling thread for synchronous methods, but streaming callbacks run on Mutiny worker threads where the request scope may not be active; the documentation describes capturing identity at `onUserMessage` or relying on SmallRye Context Propagation. Automatic propagation could be added later.

This is why the PR references the issue without closing it.

---

- Relates to #2068
