### PR TITLE
Gemini vertex ai base url

### DIFF
--- a/model-providers/google/vertex-ai/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/VertexAiChatLanguageModel.java
+++ b/model-providers/google/vertex-ai/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/VertexAiChatLanguageModel.java
@@ -47,6 +47,7 @@ public class VertexAiChatLanguageModel implements ChatModel {
                 .location(builder.location)
                 .projectId(builder.projectId)
                 .publisher(builder.publisher)
+                .baseUrl(builder.baseUrl.get())
                 .build();
 
         try {

--- a/model-providers/google/vertex-ai/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/VertxAiRestApi.java
+++ b/model-providers/google/vertex-ai/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/VertxAiRestApi.java
@@ -51,11 +51,15 @@ public interface VertxAiRestApi {
         @RestPath
         public final String publisher;
 
+        @RestPath
+        public final String baseUrl;
+
         private ApiMetadata(Builder builder) {
             this.projectId = builder.projectId;
             this.location = builder.location;
             this.modelId = builder.modelId;
             this.publisher = builder.publisher;
+            this.baseUrl = builder.baseUrl;
         }
 
         public static Builder builder() {
@@ -67,6 +71,7 @@ public interface VertxAiRestApi {
             private String location;
             private String modelId;
             private String publisher;
+            private String baseUrl;
 
             public Builder projectId(String projectId) {
                 this.projectId = projectId;
@@ -85,6 +90,11 @@ public interface VertxAiRestApi {
 
             public Builder publisher(String publisherId) {
                 this.publisher = publisherId;
+                return this;
+            }
+
+            public Builder baseUrl(String baseUrl) {
+                this.baseUrl = baseUrl;
                 return this;
             }
 

--- a/model-providers/google/vertex-ai/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/config/LangChain4jVertexAiConfig.java
+++ b/model-providers/google/vertex-ai/runtime/src/main/java/io/quarkiverse/langchain4j/vertexai/runtime/config/LangChain4jVertexAiConfig.java
@@ -55,7 +55,7 @@ public interface LangChain4jVertexAiConfig {
         String publisher();
 
         /**
-         * Meant to be used for testing only in order to override the base URL used by the client
+         * Base URL used by the client, it is not required.
          */
         Optional<String> baseUrl();
 


### PR DESCRIPTION
This pr will allow gemini ai vertex user to specify base url of google endpoint used for different models.
I discovered the issue when I was playing with gemini-3.5-flash, this url https://{location}-aiplatform.googleapis.com/v1/projects/{Project_ID}/locations/{}location/publishers/google/models/gemini-3.5-flash:generateContent will generate 404  where [https://aiplatform.googleapis.com/v1/projects/{Project_ID}/locations/{location}/publishers/google/models/gemini-3.1-pro-preview:generateContent](https://aiplatform.googleapis.com/v1/projects/%7BProject_ID%7D/locations/%7Blocation%7D/publishers/google/models/gemini-3.1-pro-preview:generateContent) will work.
In current code base you can't override base url of gemini ai vertex, this pr is the proposed solution.
I tested with my corporate  account and it works fine.