### PR TITLE
docs: fix duplicate anchor IDs in config reference

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-all-config.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-all-config.adoc
@@ -2887,7 +2887,7 @@ h|[[quarkus-langchain4j-chroma_section_quarkus-langchain4j-chroma]] [.section-na
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-collection-name]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-collection-name[`+++quarkus.langchain4j.chroma."store-name".collection-name+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-collection-name-bt]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-collection-name-bt[`+++quarkus.langchain4j.chroma."store-name".collection-name+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.chroma."store-name".collection-name+++[]
 endif::add-copy-button-to-config-props[]
@@ -5539,7 +5539,7 @@ h|[[quarkus-langchain4j-milvus_section_quarkus-langchain4j-milvus]] [.section-na
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-host]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-host[`+++quarkus.langchain4j.milvus."store-name".host+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-host-bt]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-host-bt[`+++quarkus.langchain4j.milvus."store-name".host+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".host+++[]
 endif::add-copy-button-to-config-props[]
@@ -6932,7 +6932,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-database-name]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-database-name[`+++quarkus.langchain4j.neo4j.database-name+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-database-name-bt]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-database-name-bt[`+++quarkus.langchain4j.neo4j.database-name+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.neo4j.database-name+++[]
 endif::add-copy-button-to-config-props[]
@@ -7179,7 +7179,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-database-name]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-database-name[`+++quarkus.langchain4j.neo4j."store-name".database-name+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-database-name-bt]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-database-name-bt[`+++quarkus.langchain4j.neo4j."store-name".database-name+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.neo4j."store-name".database-name+++[]
 endif::add-copy-button-to-config-props[]
@@ -11811,7 +11811,7 @@ h|[[quarkus-langchain4j-pinecone_section_quarkus-langchain4j-pinecone]] [.sectio
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-store-name-index-name]] [.property-path]##link:#quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-store-name-index-name[`+++quarkus.langchain4j.pinecone."store-name".index-name+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-store-name-index-name-bt]] [.property-path]##link:#quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-store-name-index-name-bt[`+++quarkus.langchain4j.pinecone."store-name".index-name+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.pinecone."store-name".index-name+++[]
 endif::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-chroma.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-chroma.adoc
@@ -294,7 +294,7 @@ h|[[quarkus-langchain4j-chroma_section_quarkus-langchain4j-chroma]] [.section-na
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-collection-name]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-collection-name[`+++quarkus.langchain4j.chroma."store-name".collection-name+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-collection-name-bt]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-collection-name-bt[`+++quarkus.langchain4j.chroma."store-name".collection-name+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.chroma."store-name".collection-name+++[]
 endif::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-chroma_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-chroma_quarkus.langchain4j.adoc
@@ -294,7 +294,7 @@ h|[[quarkus-langchain4j-chroma_section_quarkus-langchain4j-chroma]] [.section-na
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-collection-name]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-collection-name[`+++quarkus.langchain4j.chroma."store-name".collection-name+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-collection-name-bt]] [.property-path]##link:#quarkus-langchain4j-chroma_quarkus-langchain4j-chroma-store-name-collection-name-bt[`+++quarkus.langchain4j.chroma."store-name".collection-name+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.chroma."store-name".collection-name+++[]
 endif::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-milvus.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-milvus.adoc
@@ -515,7 +515,7 @@ h|[[quarkus-langchain4j-milvus_section_quarkus-langchain4j-milvus]] [.section-na
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-host]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-host[`+++quarkus.langchain4j.milvus."store-name".host+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-host-bt]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-host-bt[`+++quarkus.langchain4j.milvus."store-name".host+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".host+++[]
 endif::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-milvus_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-milvus_quarkus.langchain4j.adoc
@@ -515,7 +515,7 @@ h|[[quarkus-langchain4j-milvus_section_quarkus-langchain4j-milvus]] [.section-na
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-host]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-host[`+++quarkus.langchain4j.milvus."store-name".host+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-host-bt]] [.property-path]##link:#quarkus-langchain4j-milvus_quarkus-langchain4j-milvus-store-name-host-bt[`+++quarkus.langchain4j.milvus."store-name".host+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.milvus."store-name".host+++[]
 endif::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-neo4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-neo4j.adoc
@@ -28,7 +28,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-database-name]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-database-name[`+++quarkus.langchain4j.neo4j.database-name+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-database-name-bt]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-database-name-bt[`+++quarkus.langchain4j.neo4j.database-name+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.neo4j.database-name+++[]
 endif::add-copy-button-to-config-props[]
@@ -275,7 +275,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-database-name]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-database-name[`+++quarkus.langchain4j.neo4j."store-name".database-name+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-database-name-bt]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-database-name-bt[`+++quarkus.langchain4j.neo4j."store-name".database-name+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.neo4j."store-name".database-name+++[]
 endif::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-neo4j_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-neo4j_quarkus.langchain4j.adoc
@@ -28,7 +28,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-database-name]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-database-name[`+++quarkus.langchain4j.neo4j.database-name+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-database-name-bt]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-database-name-bt[`+++quarkus.langchain4j.neo4j.database-name+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.neo4j.database-name+++[]
 endif::add-copy-button-to-config-props[]
@@ -275,7 +275,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-database-name]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-database-name[`+++quarkus.langchain4j.neo4j."store-name".database-name+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-database-name-bt]] [.property-path]##link:#quarkus-langchain4j-neo4j_quarkus-langchain4j-neo4j-store-name-database-name-bt[`+++quarkus.langchain4j.neo4j."store-name".database-name+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.neo4j."store-name".database-name+++[]
 endif::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-pinecone.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-pinecone.adoc
@@ -242,7 +242,7 @@ h|[[quarkus-langchain4j-pinecone_section_quarkus-langchain4j-pinecone]] [.sectio
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-store-name-index-name]] [.property-path]##link:#quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-store-name-index-name[`+++quarkus.langchain4j.pinecone."store-name".index-name+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-store-name-index-name-bt]] [.property-path]##link:#quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-store-name-index-name-bt[`+++quarkus.langchain4j.pinecone."store-name".index-name+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.pinecone."store-name".index-name+++[]
 endif::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-pinecone_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-pinecone_quarkus.langchain4j.adoc
@@ -242,7 +242,7 @@ h|[[quarkus-langchain4j-pinecone_section_quarkus-langchain4j-pinecone]] [.sectio
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-store-name-index-name]] [.property-path]##link:#quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-store-name-index-name[`+++quarkus.langchain4j.pinecone."store-name".index-name+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-store-name-index-name-bt]] [.property-path]##link:#quarkus-langchain4j-pinecone_quarkus-langchain4j-pinecone-store-name-index-name-bt[`+++quarkus.langchain4j.pinecone."store-name".index-name+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.pinecone."store-name".index-name+++[]
 endif::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-qdrant.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-qdrant.adoc
@@ -305,7 +305,7 @@ h|[[quarkus-langchain4j-qdrant_section_quarkus-langchain4j-qdrant]] [.section-na
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-collection-name]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-collection-name[`+++quarkus.langchain4j.qdrant."store-name".collection-name+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-collection-name-bt]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-collection-name-bt[`+++quarkus.langchain4j.qdrant."store-name".collection-name+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.qdrant."store-name".collection-name+++[]
 endif::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-qdrant_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-qdrant_quarkus.langchain4j.adoc
@@ -305,7 +305,7 @@ h|[[quarkus-langchain4j-qdrant_section_quarkus-langchain4j-qdrant]] [.section-na
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-collection-name]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-collection-name[`+++quarkus.langchain4j.qdrant."store-name".collection-name+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-collection-name-bt]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-store-name-collection-name-bt[`+++quarkus.langchain4j.qdrant."store-name".collection-name+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.qdrant."store-name".collection-name+++[]
 endif::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-weaviate.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-weaviate.adoc
@@ -441,7 +441,7 @@ h|[[quarkus-langchain4j-weaviate_section_quarkus-langchain4j-weaviate]] [.sectio
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-object-class]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-object-class[`+++quarkus.langchain4j.weaviate."store-name".object-class+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-object-class-bt]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-object-class-bt[`+++quarkus.langchain4j.weaviate."store-name".object-class+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".object-class+++[]
 endif::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-weaviate_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-weaviate_quarkus.langchain4j.adoc
@@ -441,7 +441,7 @@ h|[[quarkus-langchain4j-weaviate_section_quarkus-langchain4j-weaviate]] [.sectio
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-object-class]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-object-class[`+++quarkus.langchain4j.weaviate."store-name".object-class+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-object-class-bt]] [.property-path]##link:#quarkus-langchain4j-weaviate_quarkus-langchain4j-weaviate-store-name-object-class-bt[`+++quarkus.langchain4j.weaviate."store-name".object-class+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.weaviate."store-name".object-class+++[]
 endif::add-copy-button-to-config-props[]


### PR DESCRIPTION
## Summary
- Fix duplicate anchor IDs in embedding store config reference includes
- Affects chroma, milvus, neo4j, pinecone, qdrant, and weaviate config docs
- Fixes 26 warnings during the quarkiverse-docs Antora build

## Root cause

The `quarkus-config-doc-maven-plugin` generates these config reference `.adoc` files. The duplicate anchors occur because build-time config properties (defined in `*NamedStoreBuildTimeConfig` classes, e.g. `ChromaNamedStoreBuildTimeConfig.collectionName()`) share the same config property key path as their runtime counterparts (defined in `*StoreRuntimeConfig` classes, e.g. `ChromaStoreRuntimeConfig.collectionName()`). When both are mapped under `quarkus.langchain4j.<store>."store-name".<property>`, the generator produces identical anchor IDs for both entries.

## Fix

Appends a `-bt` suffix to the anchor IDs of the build-time property entries to make them unique. The runtime property anchors remain unchanged since they are the canonical references.

## Important note

These files are **auto-generated** by `quarkus-config-doc-maven-plugin` (configured in `docs/pom.xml`). The generated files were manually fixed, but the generator should also be updated to prevent regression when the docs are regenerated. Ideally, the generator should detect when a build-time and runtime config property share the same key path and automatically disambiguate their anchor IDs.

## Affected files
- `quarkus-langchain4j-chroma.adoc` (and `_quarkus.langchain4j.adoc` variant)
- `quarkus-langchain4j-milvus.adoc` (and variant)
- `quarkus-langchain4j-neo4j.adoc` (and variant) - 2 duplicate pairs
- `quarkus-langchain4j-pinecone.adoc` (and variant)
- `quarkus-langchain4j-qdrant.adoc` (and variant)
- `quarkus-langchain4j-weaviate.adoc` (and variant)
- `quarkus-all-config.adoc`