### PR TITLE
Add audio transcription support to the OpenAI extension

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/BeansProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/BeansProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.langchain4j.deployment;
 
+import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.AUDIO_TRANSCRIPTION_MODEL;
 import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.CHAT_MODEL;
 import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.EMBEDDING_MODEL;
 import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.IMAGE_MODEL;
@@ -21,6 +22,7 @@ import org.jboss.jandex.DotName;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import dev.langchain4j.model.audio.AudioTranscriptionModel;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.image.ImageModel;
@@ -30,6 +32,7 @@ import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
 import io.quarkiverse.langchain4j.QuarkusJsonCodecFactory;
 import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
 import io.quarkiverse.langchain4j.deployment.config.LangChain4jBuildConfig;
+import io.quarkiverse.langchain4j.deployment.items.AudioTranscriptionModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.AutoCreateEmbeddingModelBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.ChatModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.EmbeddingModelProviderCandidateBuildItem;
@@ -39,6 +42,7 @@ import io.quarkiverse.langchain4j.deployment.items.InProcessEmbeddingBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.ModerationModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.ProviderHolder;
 import io.quarkiverse.langchain4j.deployment.items.ScoringModelProviderCandidateBuildItem;
+import io.quarkiverse.langchain4j.deployment.items.SelectedAudioTranscriptionModelProviderBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedChatModelProviderBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedEmbeddingModelCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedImageModelProviderBuildItem;
@@ -83,6 +87,7 @@ public class BeansProcessor {
             List<EmbeddingModelProviderCandidateBuildItem> embeddingCandidateItems,
             List<ModerationModelProviderCandidateBuildItem> moderationCandidateItems,
             List<ImageModelProviderCandidateBuildItem> imageCandidateItems,
+            List<AudioTranscriptionModelProviderCandidateBuildItem> audioTranscriptionCandidateItems,
             List<RequestChatModelBeanBuildItem> requestChatModelBeanItems,
             List<RequestModerationModelBeanBuildItem> requestModerationModelBeanBuildItems,
             List<RequestImageModelBeanBuildItem> requestImageModelBeanBuildItems,
@@ -94,6 +99,7 @@ public class BeansProcessor {
             BuildProducer<SelectedEmbeddingModelCandidateBuildItem> selectedEmbeddingProducer,
             BuildProducer<SelectedModerationModelProviderBuildItem> selectedModerationProducer,
             BuildProducer<SelectedImageModelProviderBuildItem> selectedImageProducer,
+            BuildProducer<SelectedAudioTranscriptionModelProviderBuildItem> selectedAudioTranscriptionProducer,
             List<InProcessEmbeddingBuildItem> inProcessEmbeddingBuildItems) {
 
         Set<String> requestedChatModels = new HashSet<>();
@@ -102,6 +108,7 @@ public class BeansProcessor {
         Set<String> requestEmbeddingModels = new HashSet<>();
         Set<String> requestedModerationModels = new HashSet<>();
         Set<String> requestedImageModels = new HashSet<>();
+        Set<String> requestedAudioTranscriptionModels = new HashSet<>();
         Set<String> tokenCountEstimators = new HashSet<>();
 
         // detection of injection points for default models
@@ -110,6 +117,7 @@ public class BeansProcessor {
         boolean defaultEmbeddingModelRequested = false;
         boolean defaultModerationModelRequested = false;
         boolean defaultImageModelRequested = false;
+        boolean defaultAudioTranscriptionModelRequested = false;
 
         // default model names
         final String chatModelConfigNamespace = "chat-model";
@@ -117,6 +125,7 @@ public class BeansProcessor {
         final String scoringModelConfigNamespace = "scoring-model";
         final String moderationModelConfigNamespace = "moderation-model";
         final String imageModelConfigNamespace = "image-model";
+        final String audioTranscriptionModelConfigNamespace = "audio-transcription-model";
 
         // separator symbol for named configs
         final String dot = ".";
@@ -127,6 +136,7 @@ public class BeansProcessor {
         final String scoringModelBeanType = "ScoringModel";
         final String moderationModelBeanType = "ModerationModel";
         final String imageModelBeanType = "ImageModel";
+        final String audioTranscriptionModelBeanType = "AudioTranscriptionModel";
 
         for (InjectionPointInfo ip : beanDiscoveryFinished.getInjectionPoints()) {
             DotName requiredName = ip.getRequiredType().name();
@@ -146,6 +156,8 @@ public class BeansProcessor {
                 requestedModerationModels.add(modelName);
             } else if (IMAGE_MODEL.equals(requiredName)) {
                 requestedImageModels.add(modelName);
+            } else if (AUDIO_TRANSCRIPTION_MODEL.equals(requiredName)) {
+                requestedAudioTranscriptionModels.add(modelName);
             }
         }
         for (var bi : requestChatModelBeanItems) {
@@ -323,6 +335,34 @@ public class BeansProcessor {
             }
         }
 
+        for (String modelName : requestedAudioTranscriptionModels) {
+            Optional<String> userSelectedProvider;
+            String configNamespace;
+            if (NamedConfigUtil.isDefault(modelName)) {
+                userSelectedProvider = buildConfig.defaultConfig().audioTranscriptionModel().provider();
+                configNamespace = audioTranscriptionModelConfigNamespace;
+                defaultAudioTranscriptionModelRequested = true;
+            } else {
+                if (buildConfig.namedConfig().containsKey(modelName)) {
+                    userSelectedProvider = buildConfig.namedConfig().get(modelName).audioTranscriptionModel().provider();
+                } else {
+                    userSelectedProvider = Optional.empty();
+                }
+                configNamespace = modelName + dot + audioTranscriptionModelConfigNamespace;
+            }
+
+            String provider = selectProvider(
+                    audioTranscriptionCandidateItems,
+                    beanDiscoveryFinished.beanStream().withBeanType(AudioTranscriptionModel.class),
+                    userSelectedProvider,
+                    audioTranscriptionModelBeanType,
+                    configNamespace);
+            if (provider != null) {
+                selectedAudioTranscriptionProducer
+                        .produce(new SelectedAudioTranscriptionModelProviderBuildItem(provider, modelName));
+            }
+        }
+
         // There can be configured models for which we found no injection points.
         // While we cannot perform full validation of those, we can still add them as beans.
         // This enabled injection such as @Inject @Any Instance<ChatModel>
@@ -392,6 +432,19 @@ public class BeansProcessor {
                     imageModelConfigNamespace);
             if (provider != null) {
                 selectedImageProducer.produce(new SelectedImageModelProviderBuildItem(provider, NamedConfigUtil.DEFAULT_NAME));
+            }
+        }
+        if (!defaultAudioTranscriptionModelRequested && !defaultConfig.audioTranscriptionModel().provider().isEmpty()) {
+            Optional<String> userSelectedProvider = defaultConfig.audioTranscriptionModel().provider();
+            String provider = selectProvider(
+                    audioTranscriptionCandidateItems,
+                    beanDiscoveryFinished.beanStream().withBeanType(AudioTranscriptionModel.class),
+                    userSelectedProvider,
+                    audioTranscriptionModelBeanType,
+                    audioTranscriptionModelConfigNamespace);
+            if (provider != null) {
+                selectedAudioTranscriptionProducer.produce(
+                        new SelectedAudioTranscriptionModelProviderBuildItem(provider, NamedConfigUtil.DEFAULT_NAME));
             }
         }
 
@@ -464,6 +517,21 @@ public class BeansProcessor {
                         configNamespace);
                 if (provider != null) {
                     selectedImageProducer.produce(new SelectedImageModelProviderBuildItem(provider, entry.getKey()));
+                }
+            }
+            if (!requestedAudioTranscriptionModels.contains(entry.getKey())
+                    && !value.audioTranscriptionModel().provider().isEmpty()) {
+                Optional<String> userSelectedProvider = value.audioTranscriptionModel().provider();
+                String configNamespace = entry.getKey() + dot + audioTranscriptionModelConfigNamespace;
+                String provider = selectProvider(
+                        audioTranscriptionCandidateItems,
+                        beanDiscoveryFinished.beanStream().withBeanType(AudioTranscriptionModel.class),
+                        userSelectedProvider,
+                        audioTranscriptionModelBeanType,
+                        configNamespace);
+                if (provider != null) {
+                    selectedAudioTranscriptionProducer
+                            .produce(new SelectedAudioTranscriptionModelProviderBuildItem(provider, entry.getKey()));
                 }
             }
         }

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/LangChain4jDotNames.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/LangChain4jDotNames.java
@@ -10,6 +10,7 @@ import dev.langchain4j.exception.ToolArgumentsException;
 import dev.langchain4j.exception.ToolExecutionException;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.model.audio.AudioTranscriptionModel;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
@@ -62,6 +63,7 @@ public class LangChain4jDotNames {
     public static final DotName EMBEDDING_MODEL = DotName.createSimple(EmbeddingModel.class);
     public static final DotName MODERATION_MODEL = DotName.createSimple(ModerationModel.class);
     public static final DotName IMAGE_MODEL = DotName.createSimple(ImageModel.class);
+    public static final DotName AUDIO_TRANSCRIPTION_MODEL = DotName.createSimple(AudioTranscriptionModel.class);
     public static final DotName CHAT_MESSAGE = DotName.createSimple(ChatMessage.class);
     public static final DotName TOKEN_STREAM = DotName.createSimple(TokenStream.class);
     public static final DotName OUTPUT_GUARDRAILS = DotName.createSimple(OutputGuardrails.class);

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/config/AudioTranscriptionModelConfig.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/config/AudioTranscriptionModelConfig.java
@@ -1,0 +1,14 @@
+package io.quarkiverse.langchain4j.deployment.config;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+
+@ConfigGroup
+public interface AudioTranscriptionModelConfig {
+
+    /**
+     * The model provider to use
+     */
+    Optional<String> provider();
+}

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/config/LangChain4jBuildConfig.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/config/LangChain4jBuildConfig.java
@@ -68,6 +68,11 @@ public interface LangChain4jBuildConfig {
          * Image model
          */
         ImageModelConfig imageModel();
+
+        /**
+         * Audio transcription model
+         */
+        AudioTranscriptionModelConfig audioTranscriptionModel();
     }
 
     @ConfigGroup

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/items/AudioTranscriptionModelProviderCandidateBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/items/AudioTranscriptionModelProviderCandidateBuildItem.java
@@ -1,0 +1,16 @@
+package io.quarkiverse.langchain4j.deployment.items;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class AudioTranscriptionModelProviderCandidateBuildItem extends MultiBuildItem implements ProviderHolder {
+
+    private final String provider;
+
+    public AudioTranscriptionModelProviderCandidateBuildItem(String provider) {
+        this.provider = provider;
+    }
+
+    public String getProvider() {
+        return provider;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/items/SelectedAudioTranscriptionModelProviderBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/items/SelectedAudioTranscriptionModelProviderBuildItem.java
@@ -1,0 +1,22 @@
+package io.quarkiverse.langchain4j.deployment.items;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class SelectedAudioTranscriptionModelProviderBuildItem extends MultiBuildItem {
+
+    private final String provider;
+    private final String configName;
+
+    public SelectedAudioTranscriptionModelProviderBuildItem(String provider, String configName) {
+        this.provider = provider;
+        this.configName = configName;
+    }
+
+    public String getProvider() {
+        return provider;
+    }
+
+    public String getConfigName() {
+        return configName;
+    }
+}

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -75,6 +75,8 @@
 ** Moderation Models
 *** xref:mistral-moderation-model.adoc[Mistral AI]
 *** xref:openai-moderation-model.adoc[OpenAI]
+** Audio Transcription Models
+*** xref:openai-audio-transcription-model.adoc[OpenAI]
 ** xref:enable-disable-integrations.adoc[Enabling and Disabling Integrations]
 * xref:testing.adoc[Testing & Evaluation]
 // 	Handling Model Errors and Timeouts

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
 :project-version: 1.10.0
-:langchain4j-version: 1.14.1
+:langchain4j-version: 1.15.0
 :langchain4j-embeddings-version: ${langchain4j-embeddings.version}
 :examples-dir: ./../examples/

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-core.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-core.adoc
@@ -523,6 +523,27 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-core_quarkus-langchain4j-audio-transcription-model-provider]] [.property-path]##link:#quarkus-langchain4j-core_quarkus-langchain4j-audio-transcription-model-provider[`+++quarkus.langchain4j.audio-transcription-model.provider+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.audio-transcription-model.provider+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The model provider to use
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AUDIO_TRANSCRIPTION_MODEL_PROVIDER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AUDIO_TRANSCRIPTION_MODEL_PROVIDER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
 a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-core_quarkus-langchain4j-model-name-chat-model-provider]] [.property-path]##link:#quarkus-langchain4j-core_quarkus-langchain4j-model-name-chat-model-provider[`+++quarkus.langchain4j."model-name".chat-model.provider+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j."model-name".chat-model.provider+++[]
@@ -623,6 +644,27 @@ Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J__MODEL_NAM
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J__MODEL_NAME__IMAGE_MODEL_PROVIDER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-core_quarkus-langchain4j-model-name-audio-transcription-model-provider]] [.property-path]##link:#quarkus-langchain4j-core_quarkus-langchain4j-model-name-audio-transcription-model-provider[`+++quarkus.langchain4j."model-name".audio-transcription-model.provider+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j."model-name".audio-transcription-model.provider+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The model provider to use
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_PROVIDER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_PROVIDER+++`
 endif::add-copy-button-to-env-var[]
 --
 |string

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-core_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-core_quarkus.langchain4j.adoc
@@ -523,6 +523,27 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-core_quarkus-langchain4j-audio-transcription-model-provider]] [.property-path]##link:#quarkus-langchain4j-core_quarkus-langchain4j-audio-transcription-model-provider[`+++quarkus.langchain4j.audio-transcription-model.provider+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.audio-transcription-model.provider+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The model provider to use
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AUDIO_TRANSCRIPTION_MODEL_PROVIDER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AUDIO_TRANSCRIPTION_MODEL_PROVIDER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
 a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-core_quarkus-langchain4j-model-name-chat-model-provider]] [.property-path]##link:#quarkus-langchain4j-core_quarkus-langchain4j-model-name-chat-model-provider[`+++quarkus.langchain4j."model-name".chat-model.provider+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j."model-name".chat-model.provider+++[]
@@ -623,6 +644,27 @@ Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J__MODEL_NAM
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J__MODEL_NAME__IMAGE_MODEL_PROVIDER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-core_quarkus-langchain4j-model-name-audio-transcription-model-provider]] [.property-path]##link:#quarkus-langchain4j-core_quarkus-langchain4j-model-name-audio-transcription-model-provider[`+++quarkus.langchain4j."model-name".audio-transcription-model.provider+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j."model-name".audio-transcription-model.provider+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The model provider to use
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_PROVIDER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_PROVIDER+++`
 endif::add-copy-button-to-env-var[]
 --
 |string

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai.adoc
@@ -91,6 +91,27 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-audio-transcription-model-enabled]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-audio-transcription-model-enabled[`+++quarkus.langchain4j.openai.audio-transcription-model.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.audio-transcription-model.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the model should be enabled
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_AUDIO_TRANSCRIPTION_MODEL_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_AUDIO_TRANSCRIPTION_MODEL_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-base-url]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-base-url[`+++quarkus.langchain4j.openai.base-url+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.openai.base-url+++[]
@@ -999,6 +1020,69 @@ Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_IMA
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-audio-transcription-model-model-name]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-audio-transcription-model-model-name[`+++quarkus.langchain4j.openai.audio-transcription-model.model-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.audio-transcription-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Model name to use
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_AUDIO_TRANSCRIPTION_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_AUDIO_TRANSCRIPTION_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++whisper-1+++`
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-audio-transcription-model-log-requests]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-audio-transcription-model-log-requests[`+++quarkus.langchain4j.openai.audio-transcription-model.log-requests+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.audio-transcription-model.log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether audio transcription model requests should be logged
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_AUDIO_TRANSCRIPTION_MODEL_LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_AUDIO_TRANSCRIPTION_MODEL_LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-audio-transcription-model-log-responses]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-audio-transcription-model-log-responses[`+++quarkus.langchain4j.openai.audio-transcription-model.log-responses+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.audio-transcription-model.log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether audio transcription model responses should be logged
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_AUDIO_TRANSCRIPTION_MODEL_LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_AUDIO_TRANSCRIPTION_MODEL_LOG_RESPONSES+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
@@ -2008,6 +2092,69 @@ Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MO
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-audio-transcription-model-model-name]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-audio-transcription-model-model-name[`+++quarkus.langchain4j.openai."model-name".audio-transcription-model.model-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".audio-transcription-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Model name to use
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++whisper-1+++`
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-audio-transcription-model-log-requests]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-audio-transcription-model-log-requests[`+++quarkus.langchain4j.openai."model-name".audio-transcription-model.log-requests+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".audio-transcription-model.log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether audio transcription model requests should be logged
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-audio-transcription-model-log-responses]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-audio-transcription-model-log-responses[`+++quarkus.langchain4j.openai."model-name".audio-transcription-model.log-responses+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".audio-transcription-model.log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether audio transcription model responses should be logged
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_LOG_RESPONSES+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai_quarkus.langchain4j.adoc
@@ -91,6 +91,27 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-audio-transcription-model-enabled]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-audio-transcription-model-enabled[`+++quarkus.langchain4j.openai.audio-transcription-model.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.audio-transcription-model.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the model should be enabled
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_AUDIO_TRANSCRIPTION_MODEL_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_AUDIO_TRANSCRIPTION_MODEL_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-base-url]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-base-url[`+++quarkus.langchain4j.openai.base-url+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.openai.base-url+++[]
@@ -999,6 +1020,69 @@ Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_IMA
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-audio-transcription-model-model-name]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-audio-transcription-model-model-name[`+++quarkus.langchain4j.openai.audio-transcription-model.model-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.audio-transcription-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Model name to use
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_AUDIO_TRANSCRIPTION_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_AUDIO_TRANSCRIPTION_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++whisper-1+++`
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-audio-transcription-model-log-requests]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-audio-transcription-model-log-requests[`+++quarkus.langchain4j.openai.audio-transcription-model.log-requests+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.audio-transcription-model.log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether audio transcription model requests should be logged
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_AUDIO_TRANSCRIPTION_MODEL_LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_AUDIO_TRANSCRIPTION_MODEL_LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-audio-transcription-model-log-responses]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-audio-transcription-model-log-responses[`+++quarkus.langchain4j.openai.audio-transcription-model.log-responses+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.audio-transcription-model.log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether audio transcription model responses should be logged
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_AUDIO_TRANSCRIPTION_MODEL_LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_AUDIO_TRANSCRIPTION_MODEL_LOG_RESPONSES+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
@@ -2008,6 +2092,69 @@ Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MO
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-audio-transcription-model-model-name]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-audio-transcription-model-model-name[`+++quarkus.langchain4j.openai."model-name".audio-transcription-model.model-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".audio-transcription-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Model name to use
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++whisper-1+++`
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-audio-transcription-model-log-requests]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-audio-transcription-model-log-requests[`+++quarkus.langchain4j.openai."model-name".audio-transcription-model.log-requests+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".audio-transcription-model.log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether audio transcription model requests should be logged
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-audio-transcription-model-log-responses]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-audio-transcription-model-log-responses[`+++quarkus.langchain4j.openai."model-name".audio-transcription-model.log-responses+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".audio-transcription-model.log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether audio transcription model responses should be logged
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_LOG_RESPONSES+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean

--- a/docs/modules/ROOT/pages/openai-audio-transcription-model.adoc
+++ b/docs/modules/ROOT/pages/openai-audio-transcription-model.adoc
@@ -1,0 +1,67 @@
+= OpenAI Audio Transcription Models
+
+include::./includes/attributes.adoc[]
+include::./includes/customization.adoc[]
+
+OpenAI provides audio transcription models (Whisper) capable of converting spoken audio into text.
+These models are useful for use cases such as building voice assistants, transcribing meetings, or indexing podcast content.
+
+== Prerequisites
+
+include::./openai-chat-model.adoc[tags=openai-prerequisites]
+
+=== OpenAI Quarkus Extension
+
+To use OpenAI audio transcription models in your Quarkus application, add the `quarkus-langchain4j-openai` extension:
+
+:provider-artifact: quarkus-langchain4j-openai
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[]
+
+== Configuration
+
+include::includes/quarkus-langchain4j-openai.adoc[leveloffset=+1,opts=optional]
+
+The minimum configuration to use audio transcription is the OpenAI API key (the model name defaults to `whisper-1`):
+
+[source,properties]
+----
+quarkus.langchain4j.openai.api-key=sk-...
+----
+
+Any OpenAI-compatible transcription endpoint can be used by overriding `quarkus.langchain4j.openai.base-url`.
+
+== Using Audio Transcription Models
+
+Inject the `AudioTranscriptionModel` bean and call `transcribe(...)` with an `AudioTranscriptionRequest`:
+
+[source,java]
+----
+package org.acme;
+
+import dev.langchain4j.data.audio.Audio;
+import dev.langchain4j.model.audio.AudioTranscriptionModel;
+import dev.langchain4j.model.audio.AudioTranscriptionRequest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class TranscriptionService {
+
+    @Inject
+    AudioTranscriptionModel audioTranscriptionModel;
+
+    public String transcribe(byte[] audioBytes, String mimeType) {
+        AudioTranscriptionRequest request = AudioTranscriptionRequest.builder()
+                .audio(Audio.builder().binaryData(audioBytes).mimeType(mimeType).build())
+                .build();
+        return audioTranscriptionModel.transcribe(request).text();
+    }
+}
+----
+
+Per-request options such as `language`, `prompt`, and `temperature` are passed via the `AudioTranscriptionRequest` builder.
+
+== Additional Resources
+
+[.lead]
+* Explore xref:ai-services.adoc[AI Services] for orchestrating multiple models

--- a/model-providers/openai/openai-common/runtime/src/main/java/io/quarkiverse/langchain4j/openai/common/OpenAiRestApi.java
+++ b/model-providers/openai/openai-common/runtime/src/main/java/io/quarkiverse/langchain4j/openai/common/OpenAiRestApi.java
@@ -41,6 +41,7 @@ import org.jboss.resteasy.reactive.RestStreamElementType;
 import org.jboss.resteasy.reactive.client.SseEvent;
 import org.jboss.resteasy.reactive.client.SseEventFilter;
 import org.jboss.resteasy.reactive.client.api.ClientLogger;
+import org.jboss.resteasy.reactive.client.api.ClientMultipartForm;
 import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientRequestContext;
 import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientRequestFilter;
 import org.jboss.resteasy.reactive.common.providers.serialisers.AbstractJsonMessageBodyReader;
@@ -49,6 +50,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 
 import dev.langchain4j.exception.HttpException;
+import dev.langchain4j.model.openai.internal.audio.transcription.OpenAiAudioTranscriptionResponse;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionRequest;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionResponse;
 import dev.langchain4j.model.openai.internal.completion.CompletionRequest;
@@ -169,6 +171,21 @@ public interface OpenAiRestApi {
     @Path("images/generations")
     @POST
     Uni<GenerateImagesResponse> imagesGenerations(GenerateImagesRequest request, @BeanParam ApiMetadata input);
+
+    /**
+     * Perform a blocking multipart/form-data request for an audio transcription response.
+     * The form is built programmatically so the {@code file} part carries the actual
+     * filename derived from the audio's mime type (Whisper uses it as a format hint).
+     */
+    @Path("audio/transcriptions")
+    @POST
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    OpenAiAudioTranscriptionResponse blockingAudioTranscription(ClientMultipartForm form, @BeanParam ApiMetadata input);
+
+    @Path("audio/transcriptions")
+    @POST
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    Uni<OpenAiAudioTranscriptionResponse> audioTranscription(ClientMultipartForm form, @BeanParam ApiMetadata input);
 
     @ClientExceptionMapper
     static RuntimeException toException(Response response) {

--- a/model-providers/openai/openai-common/runtime/src/main/java/io/quarkiverse/langchain4j/openai/common/QuarkusOpenAiClient.java
+++ b/model-providers/openai/openai-common/runtime/src/main/java/io/quarkiverse/langchain4j/openai/common/QuarkusOpenAiClient.java
@@ -19,10 +19,12 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.ws.rs.client.ClientRequestContext;
 import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 
 import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
+import org.jboss.resteasy.reactive.client.api.ClientMultipartForm;
 import org.jboss.resteasy.reactive.client.api.LoggingScope;
 
 import dev.langchain4j.model.chat.response.StreamingHandle;
@@ -35,6 +37,8 @@ import dev.langchain4j.model.openai.internal.StreamingCompletionHandling;
 import dev.langchain4j.model.openai.internal.StreamingResponseHandling;
 import dev.langchain4j.model.openai.internal.SyncOrAsync;
 import dev.langchain4j.model.openai.internal.SyncOrAsyncOrStreaming;
+import dev.langchain4j.model.openai.internal.audio.transcription.OpenAiAudioTranscriptionRequest;
+import dev.langchain4j.model.openai.internal.audio.transcription.OpenAiAudioTranscriptionResponse;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionRequest;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionResponse;
 import dev.langchain4j.model.openai.internal.completion.CompletionRequest;
@@ -46,6 +50,7 @@ import dev.langchain4j.model.openai.internal.image.GenerateImagesResponse;
 import dev.langchain4j.model.openai.internal.moderation.ModerationRequest;
 import dev.langchain4j.model.openai.internal.moderation.ModerationResponse;
 import dev.langchain4j.model.openai.internal.spi.OpenAiClientBuilderFactory;
+import io.netty.buffer.Unpooled;
 import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
 import io.quarkiverse.langchain4j.openai.common.runtime.AdditionalPropertiesHack;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
@@ -54,6 +59,7 @@ import io.quarkus.tls.TlsConfigurationRegistry;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.subscription.Cancellable;
+import io.vertx.core.buffer.Buffer;
 
 /**
  * Implements feature set of {@link OpenAiClient} using Quarkus functionality
@@ -378,6 +384,72 @@ public class QuarkusOpenAiClient extends OpenAiClient {
                         responseHandler);
             }
         };
+    }
+
+    @Override
+    public SyncOrAsync<OpenAiAudioTranscriptionResponse> audioTranscription(OpenAiAudioTranscriptionRequest request) {
+        return new SyncOrAsync<>() {
+            @Override
+            public OpenAiAudioTranscriptionResponse execute() {
+                return restApi.blockingAudioTranscription(
+                        buildAudioTranscriptionForm(request),
+                        OpenAiRestApi.ApiMetadata.builder()
+                                .azureApiKey(azureApiKey)
+                                .azureAdToken(azureAdToken)
+                                .openAiApiKey(openaiApiKey)
+                                .apiVersion(apiVersion)
+                                .organizationId(organizationId)
+                                .build());
+            }
+
+            @Override
+            public AsyncResponseHandling onResponse(Consumer<OpenAiAudioTranscriptionResponse> responseHandler) {
+                return new AsyncResponseHandlingImpl<>(
+                        new Supplier<>() {
+                            @Override
+                            public Uni<OpenAiAudioTranscriptionResponse> get() {
+                                return restApi.audioTranscription(
+                                        buildAudioTranscriptionForm(request),
+                                        OpenAiRestApi.ApiMetadata.builder()
+                                                .azureApiKey(azureApiKey)
+                                                .azureAdToken(azureAdToken)
+                                                .openAiApiKey(openaiApiKey)
+                                                .apiVersion(apiVersion)
+                                                .organizationId(organizationId)
+                                                .build());
+                            }
+                        },
+                        responseHandler);
+            }
+        };
+    }
+
+    /**
+     * Wraps the in-memory {@code byte[]} instead of copying it ({@code Buffer.buffer(byte[])} would copy). The
+     * {@code Buffer.buffer(ByteBuf)} overload is deprecated, removed in Vert.x 5 — migrate to {@code BufferInternal} when
+     * needed.
+     */
+    @SuppressWarnings("deprecation")
+    private static ClientMultipartForm buildAudioTranscriptionForm(OpenAiAudioTranscriptionRequest request) {
+        String fileName = request.file().fileName();
+        String mimeType = request.file().mimeType();
+        if (mimeType == null || mimeType.isBlank()) {
+            mimeType = MediaType.APPLICATION_OCTET_STREAM;
+        }
+        ClientMultipartForm form = ClientMultipartForm.create()
+                .binaryFileUpload("file", fileName, Buffer.buffer(Unpooled.wrappedBuffer(request.file().content())),
+                        mimeType)
+                .attribute("model", request.model(), null);
+        if (request.language() != null) {
+            form.attribute("language", request.language(), null);
+        }
+        if (request.prompt() != null) {
+            form.attribute("prompt", request.prompt(), null);
+        }
+        if (request.temperature() != null) {
+            form.attribute("temperature", String.valueOf(request.temperature()), null);
+        }
+        return form;
     }
 
     public static class QuarkusOpenAiClientBuilderFactory implements OpenAiClientBuilderFactory {

--- a/model-providers/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/AudioTranscriptionModelBuildConfig.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/AudioTranscriptionModelBuildConfig.java
@@ -1,0 +1,16 @@
+package io.quarkiverse.langchain4j.openai.deployment;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigDocDefault;
+import io.quarkus.runtime.annotations.ConfigGroup;
+
+@ConfigGroup
+public interface AudioTranscriptionModelBuildConfig {
+
+    /**
+     * Whether the model should be enabled
+     */
+    @ConfigDocDefault("true")
+    Optional<Boolean> enabled();
+}

--- a/model-providers/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/LangChain4jOpenAiBuildConfig.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/LangChain4jOpenAiBuildConfig.java
@@ -28,4 +28,9 @@ public interface LangChain4jOpenAiBuildConfig {
      * Image model related settings
      */
     ImageModelBuildConfig imageModel();
+
+    /**
+     * Audio transcription model related settings
+     */
+    AudioTranscriptionModelBuildConfig audioTranscriptionModel();
 }

--- a/model-providers/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/OpenAiProcessor.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/OpenAiProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.langchain4j.openai.deployment;
 
+import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.AUDIO_TRANSCRIPTION_MODEL;
 import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.CHAT_MODEL;
 import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.EMBEDDING_MODEL;
 import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.IMAGE_MODEL;
@@ -19,24 +20,29 @@ import org.jboss.jandex.Type;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
+import dev.langchain4j.model.openai.OpenAiAudioTranscriptionModel;
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.model.openai.OpenAiEmbeddingModel;
 import dev.langchain4j.model.openai.OpenAiModerationModel;
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
+import dev.langchain4j.model.openai.spi.OpenAiAudioTranscriptionModelBuilderFactory;
 import dev.langchain4j.model.openai.spi.OpenAiChatModelBuilderFactory;
 import dev.langchain4j.model.openai.spi.OpenAiEmbeddingModelBuilderFactory;
 import dev.langchain4j.model.openai.spi.OpenAiModerationModelBuilderFactory;
 import dev.langchain4j.model.openai.spi.OpenAiStreamingChatModelBuilderFactory;
 import io.quarkiverse.langchain4j.ModelName;
 import io.quarkiverse.langchain4j.deployment.DotNames;
+import io.quarkiverse.langchain4j.deployment.items.AudioTranscriptionModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.ChatModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.EmbeddingModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.ImageModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.ModerationModelProviderCandidateBuildItem;
+import io.quarkiverse.langchain4j.deployment.items.SelectedAudioTranscriptionModelProviderBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedChatModelProviderBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedEmbeddingModelCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedImageModelProviderBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedModerationModelProviderBuildItem;
+import io.quarkiverse.langchain4j.openai.QuarkusOpenAiAudioTranscriptionModelBuilderFactory;
 import io.quarkiverse.langchain4j.openai.QuarkusOpenAiChatModelBuilderFactory;
 import io.quarkiverse.langchain4j.openai.QuarkusOpenAiEmbeddingModelBuilderFactory;
 import io.quarkiverse.langchain4j.openai.QuarkusOpenAiImageModel;
@@ -71,6 +77,8 @@ public class OpenAiProcessor {
             .createSimple(OpenAiModerationModel.OpenAiModerationModelBuilder.class);
     private static final DotName OPENAI_IMAGE_MODEL_BUILDER = DotName
             .createSimple(QuarkusOpenAiImageModel.Builder.class);
+    private static final DotName OPENAI_AUDIO_TRANSCRIPTION_MODEL_BUILDER = DotName
+            .createSimple(OpenAiAudioTranscriptionModel.Builder.class);
 
     private static final AnnotationInstance ANY = AnnotationInstance.builder(DotName.createSimple(
             Any.class)).build();
@@ -85,6 +93,7 @@ public class OpenAiProcessor {
             BuildProducer<EmbeddingModelProviderCandidateBuildItem> embeddingProducer,
             BuildProducer<ModerationModelProviderCandidateBuildItem> moderationProducer,
             BuildProducer<ImageModelProviderCandidateBuildItem> imageProducer,
+            BuildProducer<AudioTranscriptionModelProviderCandidateBuildItem> audioTranscriptionProducer,
             LangChain4jOpenAiBuildConfig config) {
         if (config.chatModel().enabled().isEmpty() || config.chatModel().enabled().get()) {
             chatProducer.produce(new ChatModelProviderCandidateBuildItem(PROVIDER));
@@ -98,6 +107,9 @@ public class OpenAiProcessor {
         if (config.imageModel().enabled().isEmpty() || config.imageModel().enabled().get()) {
             imageProducer.produce(new ImageModelProviderCandidateBuildItem(PROVIDER));
         }
+        if (config.audioTranscriptionModel().enabled().isEmpty() || config.audioTranscriptionModel().enabled().get()) {
+            audioTranscriptionProducer.produce(new AudioTranscriptionModelProviderCandidateBuildItem(PROVIDER));
+        }
     }
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
@@ -108,6 +120,7 @@ public class OpenAiProcessor {
             List<SelectedEmbeddingModelCandidateBuildItem> selectedEmbedding,
             List<SelectedModerationModelProviderBuildItem> selectedModeration,
             List<SelectedImageModelProviderBuildItem> selectedImage,
+            List<SelectedAudioTranscriptionModelProviderBuildItem> selectedAudioTranscription,
             BuildProducer<SyntheticBeanBuildItem> beanProducer) {
 
         for (var selected : selectedChatItem) {
@@ -204,6 +217,25 @@ public class OpenAiProcessor {
                 beanProducer.produce(builder.done());
             }
         }
+
+        for (var selected : selectedAudioTranscription) {
+            if (PROVIDER.equals(selected.getProvider())) {
+                String configName = selected.getConfigName();
+                var builder = SyntheticBeanBuildItem
+                        .configure(AUDIO_TRANSCRIPTION_MODEL)
+                        .setRuntimeInit()
+                        .defaultBean()
+                        .scope(ApplicationScoped.class)
+                        .addInjectionPoint(Type.create(ProxyConfigurationRegistry.class))
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(OPENAI_AUDIO_TRANSCRIPTION_MODEL_BUILDER) }, null) },
+                                null), ANY)
+                        .createWith(recorder.audioTranscriptionModel(configName));
+                addQualifierIfNecessary(builder, configName);
+                beanProducer.produce(builder.done());
+            }
+        }
     }
 
     private void addQualifierIfNecessary(SyntheticBeanBuildItem.ExtendedBeanConfigurator builder, String configName) {
@@ -233,6 +265,9 @@ public class OpenAiProcessor {
         serviceProviderProducer
                 .produce(new ServiceProviderBuildItem(OpenAiStreamingChatModelBuilderFactory.class.getName(),
                         QuarkusOpenAiStreamingChatModelBuilderFactory.class.getName()));
+        serviceProviderProducer
+                .produce(new ServiceProviderBuildItem(OpenAiAudioTranscriptionModelBuilderFactory.class.getName(),
+                        QuarkusOpenAiAudioTranscriptionModelBuilderFactory.class.getName()));
         reflectiveClassProducer
                 .produce(ReflectiveClassBuildItem.builder(PropertyNamingStrategies.SnakeCaseStrategy.class).build());
         reflectiveClassProducer.produce(ReflectiveClassBuildItem.builder(OPEN_AI_EMBEDDING_DESERIALIZER).build());

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/org/acme/examples/aiservices/AudioTranscriptionModelTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/org/acme/examples/aiservices/AudioTranscriptionModelTest.java
@@ -1,0 +1,57 @@
+package org.acme.examples.aiservices;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+
+import dev.langchain4j.data.audio.Audio;
+import dev.langchain4j.model.audio.AudioTranscriptionModel;
+import dev.langchain4j.model.audio.AudioTranscriptionRequest;
+import dev.langchain4j.model.audio.AudioTranscriptionResponse;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class AudioTranscriptionModelTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    AudioTranscriptionModel audioTranscriptionModel;
+
+    @Test
+    public void transcribesAudioViaMultipartRequest() {
+        AudioTranscriptionRequest request = AudioTranscriptionRequest.builder()
+                .audio(Audio.builder().binaryData(new byte[] { 1, 2, 3 }).mimeType("audio/mpeg").build())
+                .build();
+
+        AudioTranscriptionResponse response = audioTranscriptionModel.transcribe(request);
+
+        assertThat(response.text()).isEqualTo("Hello, world!");
+
+        LoggedRequest loggedRequest = singleLoggedRequest();
+        assertThat(loggedRequest.getUrl()).isEqualTo("/v1/audio/transcriptions");
+        assertThat(loggedRequest.getHeader("Content-Type")).startsWith("multipart/form-data");
+
+        String body = new String(requestBodyOfSingleRequest(), UTF_8);
+        assertThat(body)
+                .contains("name=\"model\"")
+                .contains("whisper-1")
+                .contains("name=\"file\"")
+                .contains("filename=\"audio_file.mp3\"")
+                .contains("content-type: audio/mpeg");
+    }
+}

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/DisabledAudioTranscriptionModel.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/DisabledAudioTranscriptionModel.java
@@ -1,0 +1,14 @@
+package io.quarkiverse.langchain4j.openai;
+
+import dev.langchain4j.model.ModelDisabledException;
+import dev.langchain4j.model.audio.AudioTranscriptionModel;
+import dev.langchain4j.model.audio.AudioTranscriptionRequest;
+import dev.langchain4j.model.audio.AudioTranscriptionResponse;
+
+public class DisabledAudioTranscriptionModel implements AudioTranscriptionModel {
+
+    @Override
+    public AudioTranscriptionResponse transcribe(AudioTranscriptionRequest request) {
+        throw new ModelDisabledException("AudioTranscriptionModel is disabled");
+    }
+}

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/QuarkusOpenAiAudioTranscriptionModelBuilderFactory.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/QuarkusOpenAiAudioTranscriptionModelBuilderFactory.java
@@ -1,0 +1,45 @@
+package io.quarkiverse.langchain4j.openai;
+
+import java.net.Proxy;
+
+import dev.langchain4j.model.openai.OpenAiAudioTranscriptionModel;
+import dev.langchain4j.model.openai.spi.OpenAiAudioTranscriptionModelBuilderFactory;
+import io.quarkiverse.langchain4j.openai.common.runtime.AdditionalPropertiesHack;
+
+public class QuarkusOpenAiAudioTranscriptionModelBuilderFactory implements OpenAiAudioTranscriptionModelBuilderFactory {
+
+    @Override
+    public OpenAiAudioTranscriptionModel.Builder get() {
+        return new Builder();
+    }
+
+    public static class Builder extends OpenAiAudioTranscriptionModel.Builder {
+
+        private String configName;
+        private String tlsConfigurationName;
+        private Proxy proxy;
+
+        public Builder configName(String configName) {
+            this.configName = configName;
+            return this;
+        }
+
+        public Builder tlsConfigurationName(String tlsConfigurationName) {
+            this.tlsConfigurationName = tlsConfigurationName;
+            return this;
+        }
+
+        public Builder proxy(Proxy proxy) {
+            this.proxy = proxy;
+            return this;
+        }
+
+        @Override
+        public OpenAiAudioTranscriptionModel build() {
+            AdditionalPropertiesHack.setConfigName(configName);
+            AdditionalPropertiesHack.setTlsConfigurationName(tlsConfigurationName);
+            AdditionalPropertiesHack.setProxy(proxy);
+            return super.build();
+        }
+    }
+}

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
@@ -19,6 +19,7 @@ import jakarta.enterprise.util.TypeLiteral;
 
 import org.jboss.logging.Logger;
 
+import dev.langchain4j.model.audio.AudioTranscriptionModel;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.DisabledChatModel;
 import dev.langchain4j.model.chat.DisabledStreamingChatModel;
@@ -30,12 +31,15 @@ import dev.langchain4j.model.image.DisabledImageModel;
 import dev.langchain4j.model.image.ImageModel;
 import dev.langchain4j.model.moderation.DisabledModerationModel;
 import dev.langchain4j.model.moderation.ModerationModel;
+import dev.langchain4j.model.openai.OpenAiAudioTranscriptionModel;
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
 import dev.langchain4j.model.openai.OpenAiEmbeddingModel;
 import dev.langchain4j.model.openai.OpenAiModerationModel;
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
 import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
+import io.quarkiverse.langchain4j.openai.DisabledAudioTranscriptionModel;
+import io.quarkiverse.langchain4j.openai.QuarkusOpenAiAudioTranscriptionModelBuilderFactory;
 import io.quarkiverse.langchain4j.openai.QuarkusOpenAiChatModelBuilderFactory;
 import io.quarkiverse.langchain4j.openai.QuarkusOpenAiEmbeddingModelBuilderFactory;
 import io.quarkiverse.langchain4j.openai.QuarkusOpenAiImageModel;
@@ -43,6 +47,7 @@ import io.quarkiverse.langchain4j.openai.QuarkusOpenAiModerationModelBuilderFact
 import io.quarkiverse.langchain4j.openai.QuarkusOpenAiStreamingChatModelBuilderFactory;
 import io.quarkiverse.langchain4j.openai.common.QuarkusOpenAiClient;
 import io.quarkiverse.langchain4j.openai.common.runtime.AdditionalPropertiesHack;
+import io.quarkiverse.langchain4j.openai.runtime.config.AudioTranscriptionModelConfig;
 import io.quarkiverse.langchain4j.openai.runtime.config.ChatModelConfig;
 import io.quarkiverse.langchain4j.openai.runtime.config.EmbeddingModelConfig;
 import io.quarkiverse.langchain4j.openai.runtime.config.ImageModelConfig;
@@ -73,6 +78,8 @@ public class OpenAiRecorder {
     private static final TypeLiteral<Instance<ModelBuilderCustomizer<OpenAiModerationModel.OpenAiModerationModelBuilder>>> MODERATION_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
     };
     private static final TypeLiteral<Instance<ModelBuilderCustomizer<QuarkusOpenAiImageModel.Builder>>> IMAGE_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<OpenAiAudioTranscriptionModel.Builder>>> AUDIO_TRANSCRIPTION_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
     };
 
     private static final String DUMMY_KEY = "dummy";
@@ -410,6 +417,60 @@ public class OpenAiRecorder {
             };
         }
 
+    }
+
+    public Function<SyntheticCreationalContext<AudioTranscriptionModel>, AudioTranscriptionModel> audioTranscriptionModel(
+            String configName) {
+        LangChain4jOpenAiConfig.OpenAiConfig openAiConfig = correspondingOpenAiConfig(runtimeConfig.getValue(), configName);
+
+        if (openAiConfig.enableIntegration()) {
+            String apiKey = openAiConfig.apiKey();
+            if (DUMMY_KEY.equals(apiKey) && OPENAI_BASE_URL.equals(openAiConfig.baseUrl())) {
+                throw new ConfigValidationException(createApiKeyConfigProblems(configName));
+            }
+            if (openAiConfig.maxRetries() < 1) {
+                throw new ConfigValidationException(createMaxRetriesConfigProblems(configName));
+            }
+            AudioTranscriptionModelConfig audioTranscriptionModelConfig = openAiConfig.audioTranscriptionModel();
+            var builder = (QuarkusOpenAiAudioTranscriptionModelBuilderFactory.Builder) OpenAiAudioTranscriptionModel.builder();
+            builder
+                    .tlsConfigurationName(openAiConfig.tlsConfigurationName().orElse(null))
+                    .configName(configName)
+                    .baseUrl(openAiConfig.baseUrl())
+                    .apiKey(apiKey)
+                    .timeout(openAiConfig.timeout().orElse(Duration.ofSeconds(10)))
+                    .maxRetries(openAiConfig.maxRetries())
+                    .logRequests(
+                            firstOrDefault(false, audioTranscriptionModelConfig.logRequests(), openAiConfig.logRequests()))
+                    .logResponses(
+                            firstOrDefault(false, audioTranscriptionModelConfig.logResponses(), openAiConfig.logResponses()))
+                    .modelName(audioTranscriptionModelConfig.modelName());
+
+            openAiConfig.organizationId().ifPresent(builder::organizationId);
+
+            return new Function<>() {
+                @Override
+                public AudioTranscriptionModel apply(SyntheticCreationalContext<AudioTranscriptionModel> context) {
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(AUDIO_TRANSCRIPTION_MODEL_CUSTOMIZER_TYPE_LITERAL,
+                                    Any.Literal.INSTANCE),
+                            builder, configName);
+                    ProxyConfigurationRegistry proxyRegistry = context.getInjectedReference(ProxyConfigurationRegistry.class);
+                    Optional<Proxy> audioProxy = resolveProxy(openAiConfig, proxyRegistry);
+                    if (audioProxy.isPresent()) {
+                        builder.proxy(audioProxy.get());
+                    }
+                    return builder.build();
+                }
+            };
+        } else {
+            return new Function<>() {
+                @Override
+                public AudioTranscriptionModel apply(SyntheticCreationalContext<AudioTranscriptionModel> context) {
+                    return new DisabledAudioTranscriptionModel();
+                }
+            };
+        }
     }
 
     @SuppressWarnings({ "removal" })

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/AudioTranscriptionModelConfig.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/AudioTranscriptionModelConfig.java
@@ -1,0 +1,29 @@
+package io.quarkiverse.langchain4j.openai.runtime.config;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigDocDefault;
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+
+@ConfigGroup
+public interface AudioTranscriptionModelConfig {
+
+    /**
+     * Model name to use
+     */
+    @WithDefault("whisper-1")
+    String modelName();
+
+    /**
+     * Whether audio transcription model requests should be logged
+     */
+    @ConfigDocDefault("false")
+    Optional<Boolean> logRequests();
+
+    /**
+     * Whether audio transcription model responses should be logged
+     */
+    @ConfigDocDefault("false")
+    Optional<Boolean> logResponses();
+}

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/LangChain4jOpenAiConfig.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/LangChain4jOpenAiConfig.java
@@ -167,5 +167,10 @@ public interface LangChain4jOpenAiConfig {
          * Image model related settings
          */
         ImageModelConfig imageModel();
+
+        /**
+         * Audio transcription model related settings
+         */
+        AudioTranscriptionModelConfig audioTranscriptionModel();
     }
 }

--- a/model-providers/openai/openai-vanilla/runtime/src/main/resources/META-INF/services/dev.langchain4j.model.openai.spi.OpenAiAudioTranscriptionModelBuilderFactory
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/resources/META-INF/services/dev.langchain4j.model.openai.spi.OpenAiAudioTranscriptionModelBuilderFactory
@@ -1,0 +1,1 @@
+io.quarkiverse.langchain4j.openai.QuarkusOpenAiAudioTranscriptionModelBuilderFactory

--- a/model-providers/openai/openai-vanilla/runtime/src/test/java/io/quarkiverse/langchain4j/openai/runtime/DisabledModelsOpenAiRecorderTest.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/test/java/io/quarkiverse/langchain4j/openai/runtime/DisabledModelsOpenAiRecorderTest.java
@@ -17,6 +17,7 @@ import dev.langchain4j.model.image.DisabledImageModel;
 import dev.langchain4j.model.image.ImageModel;
 import dev.langchain4j.model.moderation.DisabledModerationModel;
 import dev.langchain4j.model.moderation.ModerationModel;
+import io.quarkiverse.langchain4j.openai.DisabledAudioTranscriptionModel;
 import io.quarkiverse.langchain4j.openai.runtime.config.LangChain4jOpenAiConfig;
 import io.quarkiverse.langchain4j.openai.runtime.config.LangChain4jOpenAiConfig.OpenAiConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
@@ -76,5 +77,12 @@ class DisabledModelsOpenAiRecorderTest {
         assertThat(recorder.moderationModel(NamedConfigUtil.DEFAULT_NAME).apply(mock))
                 .isNotNull()
                 .isExactlyInstanceOf(DisabledModerationModel.class);
+    }
+
+    @Test
+    void disabledAudioTranscriptionModel() {
+        assertThat(recorder.audioTranscriptionModel(NamedConfigUtil.DEFAULT_NAME).apply(null))
+                .isNotNull()
+                .isExactlyInstanceOf(DisabledAudioTranscriptionModel.class);
     }
 }

--- a/model-providers/openai/testing-internal/src/main/resources/openai/mappings/completions.json
+++ b/model-providers/openai/testing-internal/src/main/resources/openai/mappings/completions.json
@@ -100,6 +100,27 @@
           "openai-processing-ms": "15000"
         }
       }
+    }  ,
+    {
+      "request": {
+        "urlPath": "/v1/audio/transcriptions",
+        "method": "POST",
+        "headers": {
+          "Content-Type": {
+            "matches": "multipart/form-data.*"
+          },
+          "Authorization": {
+            "matches": "Bearer .+"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"text\":\"Hello, world!\"}",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## Describe your changes

Exposes `AudioTranscriptionModel` (Whisper) as an injectable CDI bean in `quarkus-langchain4j-openai`, backed by langchain4j's `OpenAiAudioTranscriptionModel`.

It follows the pattern of the other auxiliary models (`EmbeddingModel`, `ImageModel`, `ModerationModel`): the bean is selected by provider/config and used directly, rather than through a declarative `@RegisterAiService` method.

Compared to building `OpenAiAudioTranscriptionModel` directly, the bean reuses the Quarkus REST client (native-image friendly), the TLS and proxy registries, externalized configuration and the CDI lifecycle, instead of langchain4j's default HTTP stack.

The non-trivial part is in `openai-common`: `QuarkusOpenAiClient` did not implement `audioTranscription`, so the upstream default threw `UnsupportedOperationException` and the bean would fail on first call. This PR adds the `audio/transcriptions` endpoint to `OpenAiRestApi` and builds the multipart body programmatically through `ClientMultipartForm`, so the `file` part carries the real filename derived from the audio's mime type (Whisper uses the extension as a format hint).

Per-request options (`language`, `prompt`, `temperature`) are passed via `AudioTranscriptionRequest`; only `model-name`, `log-requests` and `log-responses` are configuration keys, plus the build-time `enabled` flag that mirrors the other models.

Validated end-to-end against an OpenAI-compatible Whisper endpoint (Groq `whisper-large-v3`), with both `mp3` and `ogg` inputs.

## Configuration

```properties
quarkus.langchain4j.openai.api-key=sk-...
quarkus.langchain4j.openai.audio-transcription-model.model-name=whisper-1
```

## Injection

```java
@ApplicationScoped
public class TranscriptionService {

    @Inject
    AudioTranscriptionModel audioTranscriptionModel;

    public String transcribe(byte[] audioBytes, String mimeType) {
        AudioTranscriptionRequest request = AudioTranscriptionRequest.builder()
                .audio(Audio.builder().binaryData(audioBytes).mimeType(mimeType).build())
                .build();
        return audioTranscriptionModel.transcribe(request).text();
    }
}
```

The `mimeType` determines the filename sent in the multipart request (e.g. `audio.mp3`), which Whisper uses as a format hint.

---

- Closes #1502
