### PR TITLE
refactor: align max sequential tool invocations naming with upstream API maxToolCallingRoundTrips

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
@@ -517,9 +517,16 @@ public class AiServicesProcessor {
                 throw new IllegalArgumentException("Tool usage requires chat memory. Offending AiService is '"
                         + declarativeAiServiceClassInfo.name() + "'");
             }
-            Integer maxSequentialToolInvocations = instance.value("maxSequentialToolInvocations") != null
-                    ? instance.value("maxSequentialToolInvocations").asInt()
-                    : 0;
+            Integer maxToolCallingRoundTrips = 0;
+            AnnotationValue newAnnoValue = instance.value("maxToolCallingRoundTrips");
+            AnnotationValue legacyAnnoValue = instance.value("maxSequentialToolInvocations");
+
+            if (newAnnoValue != null) {
+                maxToolCallingRoundTrips = newAnnoValue.asInt();
+            } else if (legacyAnnoValue != null) {
+                // Fallback to deprecated property
+                maxToolCallingRoundTrips = legacyAnnoValue.asInt();
+            }
 
             Integer maxToolCallsPerResponse = instance.value("maxToolCallsPerResponse") != null
                     ? instance.value("maxToolCallsPerResponse").asInt()
@@ -584,7 +591,7 @@ public class AiServicesProcessor {
                             classOutputGuardrails(declarativeAiServiceClassInfo, index),
                             toolArgumentsErrorHandlerDotName(declarativeAiServiceClassInfo, generatedBeanProducer),
                             toolExecutionErrorHandlerDotName(declarativeAiServiceClassInfo, generatedBeanProducer),
-                            maxSequentialToolInvocations,
+                            maxToolCallingRoundTrips,
                             maxToolCallsPerResponse,
                             allowContinuousForcedToolCalling,
                             // we need to make these @DefaultBean because there could be other CDI beans of the same type that need to take precedence
@@ -943,7 +950,7 @@ public class AiServicesProcessor {
         for (DeclarativeAiServiceBuildItem bi : declarativeAiServiceItems) {
             ClassInfo declarativeAiServiceClassInfo = bi.getServiceClassInfo();
             String serviceClassName = declarativeAiServiceClassInfo.name().toString();
-            Integer maxSequentialToolInvocations = bi.getMaxSequentialToolInvocations();
+            Integer maxToolCallingRoundTrips = bi.getMaxToolCallingRoundTrips();
             boolean allowContinuousForcedToolCalling = bi.isAllowContinuousForcedToolCalling();
 
             String chatLanguageModelSupplierClassName = (bi.getChatLanguageModelSupplierClassDotName() != null
@@ -1100,7 +1107,7 @@ public class AiServicesProcessor {
                                     toolExecutionErrorHandlerDotName,
                                     classInputGuardrails(bi),
                                     classOutputGuardrails(bi),
-                                    maxSequentialToolInvocations,
+                                    maxToolCallingRoundTrips,
                                     bi.getMaxToolCallsPerResponse(),
                                     allowContinuousForcedToolCalling,
                                     bi.isShouldThrowExceptionOnEventError(),

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/DeclarativeAiServiceBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/DeclarativeAiServiceBuildItem.java
@@ -38,7 +38,7 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
     private final DeclarativeAiServiceOutputGuardrails outputGuardrails;
     private final DotName toolArgumentsErrorHandlerDotName;
     private final DotName toolExecutionErrorHandlerDotName;
-    private final Integer maxSequentialToolInvocations;
+    private final Integer maxToolCallingRoundTrips;
     private final Integer maxToolCallsPerResponse;
     private final boolean allowContinuousForcedToolCalling;
     private final boolean makeDefaultBean;
@@ -69,7 +69,7 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
             DeclarativeAiServiceOutputGuardrails outputGuardrails,
             DotName toolArgumentsErrorHandlerDotName,
             DotName toolExecutionErrorHandlerDotName,
-            Integer maxSequentialToolInvocations,
+            Integer maxToolCallingRoundTrips,
             Integer maxToolCallsPerResponse,
             boolean allowContinuousForcedToolCalling,
             boolean makeDefaultBean, boolean shouldThrowExceptionOnEventError,
@@ -97,7 +97,7 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
         this.outputGuardrails = outputGuardrails;
         this.toolArgumentsErrorHandlerDotName = toolArgumentsErrorHandlerDotName;
         this.toolExecutionErrorHandlerDotName = toolExecutionErrorHandlerDotName;
-        this.maxSequentialToolInvocations = maxSequentialToolInvocations;
+        this.maxToolCallingRoundTrips = maxToolCallingRoundTrips;
         this.maxToolCallsPerResponse = maxToolCallsPerResponse;
         this.allowContinuousForcedToolCalling = allowContinuousForcedToolCalling;
         this.makeDefaultBean = makeDefaultBean;
@@ -226,8 +226,8 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
         }
     }
 
-    public Integer getMaxSequentialToolInvocations() {
-        return maxSequentialToolInvocations;
+    public Integer getMaxToolCallingRoundTrips() {
+        return maxToolCallingRoundTrips;
     }
 
     public Integer getMaxToolCallsPerResponse() {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/QuarkusAiServicesFactory.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/QuarkusAiServicesFactory.java
@@ -76,9 +76,17 @@ public class QuarkusAiServicesFactory implements AiServicesFactory {
             return this;
         }
 
+        /**
+         * @deprecated Use {@link #maxToolCallingRoundTrips(int)} instead.
+         */
+        @Deprecated(forRemoval = true)
         @Override
         public AiServices<T> maxSequentialToolsInvocations(int maxSequentialToolsInvocations) {
-            quarkusAiServiceContext().maxSequentialToolExecutions = maxSequentialToolsInvocations;
+            return maxToolCallingRoundTrips(maxSequentialToolsInvocations);
+        }
+
+        public AiServices<T> maxToolCallingRoundTrips(int maxToolCallingRoundTrips) {
+            quarkusAiServiceContext().maxToolCallingRoundTrips = maxToolCallingRoundTrips;
             return this;
         }
 

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/RegisterAiService.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/RegisterAiService.java
@@ -90,8 +90,21 @@ public @interface RegisterAiService {
      * If not specified (left to zero) for a specific AI service,
      * the AI service will use the value of the common {@code quarkus.langchain4j.ai-service.max-tool-executions} property.
      * If that property is unset too, the default is 10 invocations.
+     *
+     * @deprecated Use {@link #maxToolCallingRoundTrips()} instead.
      */
-    int maxSequentialToolInvocations() default 0;
+    @Deprecated(forRemoval = true, since = "1.11.0")
+    int maxSequentialToolInvocations() default 10;
+
+    /**
+     * Defines the maximum number of LLM request/response round trips while handling a single chat request.
+     * If this number is exceeded, the chat request will fail.
+     * If not specified (left to zero) for a specific AI service,
+     * the AI service will use the value of the common {@code quarkus.langchain4j.ai-service.max-tool-calling-round-trips}
+     * property.
+     * If that property is unset too, the default is 10 round trips.
+     */
+    int maxToolCallingRoundTrips() default 0;
 
     /**
      * Defines the maximum number of tool calls allowed per single LLM response.

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/AiServicesRecorder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/AiServicesRecorder.java
@@ -335,8 +335,8 @@ public class AiServicesRecorder {
                                 .getConstructor().newInstance());
                     }
 
-                    if (info.maxSequentialToolInvocations() != null && info.maxSequentialToolInvocations() > 0) {
-                        quarkusAiServices.maxSequentialToolsInvocations(info.maxSequentialToolInvocations());
+                    if (info.maxToolCallingRoundTrips() != null && info.maxToolCallingRoundTrips() > 0) {
+                        quarkusAiServices.maxToolCallingRoundTrips(info.maxToolCallingRoundTrips());
                     }
 
                     if (info.maxToolCallsPerResponse() != null && info.maxToolCallsPerResponse() != 0) {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
@@ -418,9 +418,9 @@ public class AiServiceMethodImplementationSupport {
 
         verifyModerationIfNeeded(moderationFuture);
 
-        int maxSequentialToolExecutions = context.maxSequentialToolExecutions != null
-                && context.maxSequentialToolExecutions > 0
-                        ? context.maxSequentialToolExecutions
+        int maxSequentialToolExecutions = context.maxToolCallingRoundTrips != null
+                && context.maxToolCallingRoundTrips > 0
+                        ? context.maxToolCallingRoundTrips
                         : getMaxSequentialToolExecutions();
         int executionsLeft = maxSequentialToolExecutions;
         List<ToolExecution> allToolExecutions = new ArrayList<>();

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/DeclarativeAiServiceCreateInfo.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/DeclarativeAiServiceCreateInfo.java
@@ -32,7 +32,7 @@ public record DeclarativeAiServiceCreateInfo(
         String toolExecutionErrorHandlerClassName,
         InputGuardrailsLiteral inputGuardrails,
         OutputGuardrailsLiteral outputGuardrails,
-        Integer maxSequentialToolInvocations,
+        Integer maxToolCallingRoundTrips,
         Integer maxToolCallsPerResponse,
         boolean allowContinuousForcedToolCalling,
         boolean shouldThrowExceptionOnEventError,

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceContext.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceContext.java
@@ -25,7 +25,7 @@ public class QuarkusAiServiceContext extends AiServiceContext {
     public ChatMemorySeeder chatMemorySeeder;
     public ThinkingHandler thinkingHandler;
     public ImageModel imageModel;
-    public Integer maxSequentialToolExecutions;
+    public Integer maxToolCallingRoundTrips;
     public Integer maxToolCallsPerResponse;
     public boolean allowContinuousForcedToolCalling;
     public DefaultMemoryIdProvider defaultMemoryIdProvider;

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/config/AiServiceConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/config/AiServiceConfig.java
@@ -16,9 +16,19 @@ public interface AiServiceConfig {
     int maxToolCallsPerResponse();
 
     /**
-     * Maximum number of sequential tool executions while handling a single chat request.
+     * Maximum number of tool executions while handling a single chat request.
+     * If this number is exceeded, the chat request will fail.
+     *
+     * @deprecated Use {@link #maxToolCallingRoundTrips()} instead.
+     */
+    @Deprecated(forRemoval = true, since = "1.11.0")
+    @WithDefault("10")
+    int maxToolExecutions();
+
+    /**
+     * Maximum number of LLM request/response round trips while handling a single chat request.
      * If this number is exceeded, the chat request will fail.
      */
     @WithDefault("10")
-    int maxToolExecutions();
+    int maxToolCallingRoundTrips();
 }


### PR DESCRIPTION
## Related Issues
* **Resolves:** #2396
* **Related to:** #2393, [Upstream Issue #5063](https://github.com/langchain4j/langchain4j/issues/5063), [Upstream PR #5148](https://github.com/langchain4j/langchain4j/pull/5148)

## Change
Renames `maxSequentialToolInvocations` (and its configuration counterparts) to `maxToolCallingRoundTrips` across the Quarkus extension (`RegisterAiService`, `AiServiceConfig`, `AiServicesProcessor`, and internal runtime components).

Following the upstream library changes, the old name was semantically misleading — it limits LLM request/response round trips, not the total number of individual tool invocations. This PR permanently fixes the naming fragmentation across the annotation, configuration, and internal layers, aligning them perfectly with the upstream API.

Old methods and config properties (like `max-tool-executions`) are kept as `@Deprecated(forRemoval = true)` and act as safe fallbacks. Existing applications will continue to compile and work without changes.

