### PR TITLE
Add audio transcription support to the Azure OpenAI extension

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -76,6 +76,7 @@
 *** xref:mistral-moderation-model.adoc[Mistral AI]
 *** xref:openai-moderation-model.adoc[OpenAI]
 ** Audio Transcription Models
+*** xref:azure-openai-audio-transcription-model.adoc[Azure OpenAI]
 *** xref:openai-audio-transcription-model.adoc[OpenAI]
 ** xref:enable-disable-integrations.adoc[Enabling and Disabling Integrations]
 * xref:testing.adoc[Testing & Evaluation]

--- a/docs/modules/ROOT/pages/azure-openai-audio-transcription-model.adoc
+++ b/docs/modules/ROOT/pages/azure-openai-audio-transcription-model.adoc
@@ -1,0 +1,82 @@
+= Azure OpenAI Audio Transcription Models
+
+include::./includes/attributes.adoc[]
+include::./includes/customization.adoc[]
+
+Azure OpenAI provides audio transcription models (Whisper) that convert spoken audio into text. These models are useful for use cases such as building voice assistants, transcribing meetings, or indexing podcast content.
+
+== Prerequisites
+
+include::./azure-openai-chat-model.adoc[tags=azure-openai-prerequisites]
+
+=== Azure OpenAI Quarkus Extension
+
+To use Azure OpenAI audio transcription models in your Quarkus application, add the following extension:
+
+:provider-artifact: quarkus-langchain4j-azure-openai
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[]
+
+[NOTE]
+====
+This extension also supports Azure OpenAI chat, embedding and image models. Moderation models are not currently supported by Azure OpenAI.
+====
+
+== Configuration
+
+include::includes/quarkus-langchain4j-azure-openai.adoc[leveloffset=+1,opts=optional]
+
+The transcription model is reached through your Azure OpenAI Whisper deployment, named by `deployment-name`:
+
+[source,properties,subs=attributes+]
+----
+quarkus.langchain4j.azure-openai.api-key=...
+quarkus.langchain4j.azure-openai.resource-name=...
+quarkus.langchain4j.azure-openai.deployment-name=...
+----
+
+Use the per-model `quarkus.langchain4j.azure-openai.audio-transcription-model.deployment-name` only when you run several model types on different deployments and need to point transcription at a specific one.
+
+== Using Audio Transcription Models
+
+Inject the `AudioTranscriptionModel` bean and call `transcribeToText(...)` with an `Audio`:
+
+[source,java]
+----
+package org.acme;
+
+import dev.langchain4j.data.audio.Audio;
+import dev.langchain4j.model.audio.AudioTranscriptionModel;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class TranscriptionService {
+
+    @Inject
+    AudioTranscriptionModel audioTranscriptionModel;
+
+    public String transcribe(byte[] audioBytes, String mimeType) {
+        Audio audio = Audio.builder().binaryData(audioBytes).mimeType(mimeType).build();
+        return audioTranscriptionModel.transcribeToText(audio);
+    }
+}
+----
+
+For per-request options such as `language`, `prompt`, and `temperature`, build an `AudioTranscriptionRequest` and call `transcribe(request).text()` instead.
+
+You can configure multiple Azure OpenAI audio transcription models using named configurations, and select one with the `@ModelName` annotation:
+
+[source,java]
+----
+import io.quarkiverse.langchain4j.ModelName;
+import dev.langchain4j.model.audio.AudioTranscriptionModel;
+import jakarta.inject.Inject;
+
+@Inject AudioTranscriptionModel defaultModel;
+@Inject @ModelName("my-transcription") AudioTranscriptionModel namedModel;
+----
+
+[NOTE]
+====
+Unlike chat, embedding or image models, the audio transcription model is not part of the xref:ai-services.adoc[AI Services] abstraction. It is a specialized single-shot model (audio in, text out, with no messages, tools or guardrails), so it is injected and called directly as shown above rather than driven through a `@RegisterAiService` interface.
+====

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-azure-openai.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-azure-openai.adoc
@@ -91,6 +91,27 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-enabled]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-enabled[`+++quarkus.langchain4j.azure-openai.audio-transcription-model.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.audio-transcription-model.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the model should be enabled
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-resource-name]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-resource-name[`+++quarkus.langchain4j.azure-openai.resource-name+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.azure-openai.resource-name+++[]
@@ -1351,6 +1372,216 @@ Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPEN
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_IMAGE_MODEL_LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-resource-name]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-resource-name[`+++quarkus.langchain4j.azure-openai.audio-transcription-model.resource-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.audio-transcription-model.resource-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+This property will override the `quarkus.langchain4j.azure-openai.resource-name` specifically for audio transcription models if it is set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_RESOURCE_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_RESOURCE_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-domain-name]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-domain-name[`+++quarkus.langchain4j.azure-openai.audio-transcription-model.domain-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.audio-transcription-model.domain-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+This property will override the `quarkus.langchain4j.azure-openai.domain-name` specifically for audio transcription models if it is set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_DOMAIN_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_DOMAIN_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-deployment-name]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-deployment-name[`+++quarkus.langchain4j.azure-openai.audio-transcription-model.deployment-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.audio-transcription-model.deployment-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+This property will override the `quarkus.langchain4j.azure-openai.deployment-name` specifically for audio transcription models if it is set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_DEPLOYMENT_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_DEPLOYMENT_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-endpoint]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-endpoint[`+++quarkus.langchain4j.azure-openai.audio-transcription-model.endpoint+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.audio-transcription-model.endpoint+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+This property will override the `quarkus.langchain4j.azure-openai.endpoint` specifically for audio transcription models if it is set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_ENDPOINT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_ENDPOINT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-ad-token]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-ad-token[`+++quarkus.langchain4j.azure-openai.audio-transcription-model.ad-token+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.audio-transcription-model.ad-token+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The Azure AD token to use for this operation. If present, then the requests towards OpenAI will include this in the Authorization header. Note that this property overrides the functionality of `quarkus.langchain4j.azure-openai.audio-transcription-model.api-key`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_AD_TOKEN+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_AD_TOKEN+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-api-version]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-api-version[`+++quarkus.langchain4j.azure-openai.audio-transcription-model.api-version+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.audio-transcription-model.api-version+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The API version to use for this operation. This follows the YYYY-MM-DD format
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_API_VERSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_API_VERSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-api-key]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-api-key[`+++quarkus.langchain4j.azure-openai.audio-transcription-model.api-key+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.audio-transcription-model.api-key+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Azure OpenAI API key
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_API_KEY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_API_KEY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-model-name]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-model-name[`+++quarkus.langchain4j.azure-openai.audio-transcription-model.model-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.audio-transcription-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Model name to use
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++whisper-1+++`
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-log-requests]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-log-requests[`+++quarkus.langchain4j.azure-openai.audio-transcription-model.log-requests+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.audio-transcription-model.log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether audio transcription model requests should be logged
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-log-responses]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-log-responses[`+++quarkus.langchain4j.azure-openai.audio-transcription-model.log-responses+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.audio-transcription-model.log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether audio transcription model responses should be logged
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_LOG_RESPONSES+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
@@ -2620,6 +2851,216 @@ Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPEN
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__IMAGE_MODEL_LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-resource-name]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-resource-name[`+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.resource-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.resource-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+This property will override the `quarkus.langchain4j.azure-openai.resource-name` specifically for audio transcription models if it is set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_RESOURCE_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_RESOURCE_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-domain-name]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-domain-name[`+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.domain-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.domain-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+This property will override the `quarkus.langchain4j.azure-openai.domain-name` specifically for audio transcription models if it is set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_DOMAIN_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_DOMAIN_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-deployment-name]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-deployment-name[`+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.deployment-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.deployment-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+This property will override the `quarkus.langchain4j.azure-openai.deployment-name` specifically for audio transcription models if it is set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_DEPLOYMENT_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_DEPLOYMENT_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-endpoint]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-endpoint[`+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.endpoint+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.endpoint+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+This property will override the `quarkus.langchain4j.azure-openai.endpoint` specifically for audio transcription models if it is set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_ENDPOINT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_ENDPOINT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-ad-token]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-ad-token[`+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.ad-token+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.ad-token+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The Azure AD token to use for this operation. If present, then the requests towards OpenAI will include this in the Authorization header. Note that this property overrides the functionality of `quarkus.langchain4j.azure-openai.audio-transcription-model.api-key`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_AD_TOKEN+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_AD_TOKEN+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-api-version]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-api-version[`+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.api-version+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.api-version+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The API version to use for this operation. This follows the YYYY-MM-DD format
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_API_VERSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_API_VERSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-api-key]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-api-key[`+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.api-key+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.api-key+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Azure OpenAI API key
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_API_KEY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_API_KEY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-model-name]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-model-name[`+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.model-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Model name to use
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++whisper-1+++`
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-log-requests]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-log-requests[`+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.log-requests+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether audio transcription model requests should be logged
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-log-responses]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-log-responses[`+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.log-responses+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether audio transcription model responses should be logged
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_LOG_RESPONSES+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-azure-openai_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-azure-openai_quarkus.langchain4j.adoc
@@ -91,6 +91,27 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-enabled]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-enabled[`+++quarkus.langchain4j.azure-openai.audio-transcription-model.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.audio-transcription-model.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the model should be enabled
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-resource-name]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-resource-name[`+++quarkus.langchain4j.azure-openai.resource-name+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.azure-openai.resource-name+++[]
@@ -1351,6 +1372,216 @@ Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPEN
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_IMAGE_MODEL_LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-resource-name]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-resource-name[`+++quarkus.langchain4j.azure-openai.audio-transcription-model.resource-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.audio-transcription-model.resource-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+This property will override the `quarkus.langchain4j.azure-openai.resource-name` specifically for audio transcription models if it is set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_RESOURCE_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_RESOURCE_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-domain-name]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-domain-name[`+++quarkus.langchain4j.azure-openai.audio-transcription-model.domain-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.audio-transcription-model.domain-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+This property will override the `quarkus.langchain4j.azure-openai.domain-name` specifically for audio transcription models if it is set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_DOMAIN_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_DOMAIN_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-deployment-name]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-deployment-name[`+++quarkus.langchain4j.azure-openai.audio-transcription-model.deployment-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.audio-transcription-model.deployment-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+This property will override the `quarkus.langchain4j.azure-openai.deployment-name` specifically for audio transcription models if it is set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_DEPLOYMENT_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_DEPLOYMENT_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-endpoint]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-endpoint[`+++quarkus.langchain4j.azure-openai.audio-transcription-model.endpoint+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.audio-transcription-model.endpoint+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+This property will override the `quarkus.langchain4j.azure-openai.endpoint` specifically for audio transcription models if it is set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_ENDPOINT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_ENDPOINT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-ad-token]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-ad-token[`+++quarkus.langchain4j.azure-openai.audio-transcription-model.ad-token+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.audio-transcription-model.ad-token+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The Azure AD token to use for this operation. If present, then the requests towards OpenAI will include this in the Authorization header. Note that this property overrides the functionality of `quarkus.langchain4j.azure-openai.audio-transcription-model.api-key`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_AD_TOKEN+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_AD_TOKEN+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-api-version]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-api-version[`+++quarkus.langchain4j.azure-openai.audio-transcription-model.api-version+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.audio-transcription-model.api-version+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The API version to use for this operation. This follows the YYYY-MM-DD format
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_API_VERSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_API_VERSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-api-key]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-api-key[`+++quarkus.langchain4j.azure-openai.audio-transcription-model.api-key+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.audio-transcription-model.api-key+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Azure OpenAI API key
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_API_KEY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_API_KEY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-model-name]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-model-name[`+++quarkus.langchain4j.azure-openai.audio-transcription-model.model-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.audio-transcription-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Model name to use
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++whisper-1+++`
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-log-requests]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-log-requests[`+++quarkus.langchain4j.azure-openai.audio-transcription-model.log-requests+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.audio-transcription-model.log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether audio transcription model requests should be logged
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-log-responses]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-audio-transcription-model-log-responses[`+++quarkus.langchain4j.azure-openai.audio-transcription-model.log-responses+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.audio-transcription-model.log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether audio transcription model responses should be logged
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_LOG_RESPONSES+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
@@ -2620,6 +2851,216 @@ Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPEN
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__IMAGE_MODEL_LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-resource-name]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-resource-name[`+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.resource-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.resource-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+This property will override the `quarkus.langchain4j.azure-openai.resource-name` specifically for audio transcription models if it is set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_RESOURCE_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_RESOURCE_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-domain-name]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-domain-name[`+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.domain-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.domain-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+This property will override the `quarkus.langchain4j.azure-openai.domain-name` specifically for audio transcription models if it is set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_DOMAIN_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_DOMAIN_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-deployment-name]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-deployment-name[`+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.deployment-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.deployment-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+This property will override the `quarkus.langchain4j.azure-openai.deployment-name` specifically for audio transcription models if it is set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_DEPLOYMENT_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_DEPLOYMENT_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-endpoint]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-endpoint[`+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.endpoint+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.endpoint+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+This property will override the `quarkus.langchain4j.azure-openai.endpoint` specifically for audio transcription models if it is set.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_ENDPOINT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_ENDPOINT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-ad-token]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-ad-token[`+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.ad-token+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.ad-token+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The Azure AD token to use for this operation. If present, then the requests towards OpenAI will include this in the Authorization header. Note that this property overrides the functionality of `quarkus.langchain4j.azure-openai.audio-transcription-model.api-key`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_AD_TOKEN+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_AD_TOKEN+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-api-version]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-api-version[`+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.api-version+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.api-version+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The API version to use for this operation. This follows the YYYY-MM-DD format
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_API_VERSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_API_VERSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-api-key]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-api-key[`+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.api-key+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.api-key+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Azure OpenAI API key
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_API_KEY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_API_KEY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-model-name]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-model-name[`+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.model-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Model name to use
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++whisper-1+++`
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-log-requests]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-log-requests[`+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.log-requests+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether audio transcription model requests should be logged
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-log-responses]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-audio-transcription-model-log-responses[`+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.log-responses+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".audio-transcription-model.log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether audio transcription model responses should be logged
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__AUDIO_TRANSCRIPTION_MODEL_LOG_RESPONSES+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean

--- a/docs/modules/ROOT/pages/openai-audio-transcription-model.adoc
+++ b/docs/modules/ROOT/pages/openai-audio-transcription-model.adoc
@@ -32,7 +32,7 @@ Any OpenAI-compatible transcription endpoint can be used by overriding `quarkus.
 
 == Using Audio Transcription Models
 
-Inject the `AudioTranscriptionModel` bean and call `transcribe(...)` with an `AudioTranscriptionRequest`:
+Inject the `AudioTranscriptionModel` bean and call `transcribeToText(...)` with an `Audio`:
 
 [source,java]
 ----
@@ -40,7 +40,6 @@ package org.acme;
 
 import dev.langchain4j.data.audio.Audio;
 import dev.langchain4j.model.audio.AudioTranscriptionModel;
-import dev.langchain4j.model.audio.AudioTranscriptionRequest;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -51,17 +50,15 @@ public class TranscriptionService {
     AudioTranscriptionModel audioTranscriptionModel;
 
     public String transcribe(byte[] audioBytes, String mimeType) {
-        AudioTranscriptionRequest request = AudioTranscriptionRequest.builder()
-                .audio(Audio.builder().binaryData(audioBytes).mimeType(mimeType).build())
-                .build();
-        return audioTranscriptionModel.transcribe(request).text();
+        Audio audio = Audio.builder().binaryData(audioBytes).mimeType(mimeType).build();
+        return audioTranscriptionModel.transcribeToText(audio);
     }
 }
 ----
 
-Per-request options such as `language`, `prompt`, and `temperature` are passed via the `AudioTranscriptionRequest` builder.
+For per-request options such as `language`, `prompt`, and `temperature`, build an `AudioTranscriptionRequest` and call `transcribe(request).text()` instead.
 
-== Additional Resources
-
-[.lead]
-* Explore xref:ai-services.adoc[AI Services] for orchestrating multiple models
+[NOTE]
+====
+Unlike chat, embedding or image models, the audio transcription model is not part of the xref:ai-services.adoc[AI Services] abstraction. It is a specialized single-shot model (audio in, text out, with no messages, tools or guardrails), so it is injected and called directly as shown above rather than driven through a `@RegisterAiService` interface.
+====

--- a/model-providers/openai/azure-openai/deployment/src/main/java/io/quarkiverse/langchain4j/azure/openai/deployment/AudioTranscriptionModelBuildConfig.java
+++ b/model-providers/openai/azure-openai/deployment/src/main/java/io/quarkiverse/langchain4j/azure/openai/deployment/AudioTranscriptionModelBuildConfig.java
@@ -1,0 +1,16 @@
+package io.quarkiverse.langchain4j.azure.openai.deployment;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigDocDefault;
+import io.quarkus.runtime.annotations.ConfigGroup;
+
+@ConfigGroup
+public interface AudioTranscriptionModelBuildConfig {
+
+    /**
+     * Whether the model should be enabled
+     */
+    @ConfigDocDefault("true")
+    Optional<Boolean> enabled();
+}

--- a/model-providers/openai/azure-openai/deployment/src/main/java/io/quarkiverse/langchain4j/azure/openai/deployment/AzureOpenAiProcessor.java
+++ b/model-providers/openai/azure-openai/deployment/src/main/java/io/quarkiverse/langchain4j/azure/openai/deployment/AzureOpenAiProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.langchain4j.azure.openai.deployment;
 
+import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.AUDIO_TRANSCRIPTION_MODEL;
 import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.CHAT_MODEL;
 import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.EMBEDDING_MODEL;
 import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.IMAGE_MODEL;
@@ -17,16 +18,19 @@ import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 
 import io.quarkiverse.langchain4j.ModelName;
+import io.quarkiverse.langchain4j.azure.openai.AzureOpenAiAudioTranscriptionModel;
 import io.quarkiverse.langchain4j.azure.openai.AzureOpenAiChatModel;
 import io.quarkiverse.langchain4j.azure.openai.AzureOpenAiEmbeddingModel;
 import io.quarkiverse.langchain4j.azure.openai.AzureOpenAiImageModel;
 import io.quarkiverse.langchain4j.azure.openai.AzureOpenAiStreamingChatModel;
 import io.quarkiverse.langchain4j.azure.openai.runtime.AzureOpenAiRecorder;
 import io.quarkiverse.langchain4j.deployment.DotNames;
+import io.quarkiverse.langchain4j.deployment.items.AudioTranscriptionModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.ChatModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.EmbeddingModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.ImageModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.ModerationModelProviderCandidateBuildItem;
+import io.quarkiverse.langchain4j.deployment.items.SelectedAudioTranscriptionModelProviderBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedChatModelProviderBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedEmbeddingModelCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedImageModelProviderBuildItem;
@@ -52,6 +56,8 @@ public class AzureOpenAiProcessor {
             .createSimple(AzureOpenAiEmbeddingModel.Builder.class);
     private static final DotName AZURE_OPENAI_IMAGE_MODEL_BUILDER = DotName
             .createSimple(AzureOpenAiImageModel.Builder.class);
+    private static final DotName AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_BUILDER = DotName
+            .createSimple(AzureOpenAiAudioTranscriptionModel.Builder.class);
 
     private static final AnnotationInstance ANY = AnnotationInstance.builder(DotName.createSimple(
             Any.class)).build();
@@ -66,6 +72,7 @@ public class AzureOpenAiProcessor {
             BuildProducer<EmbeddingModelProviderCandidateBuildItem> embeddingProducer,
             BuildProducer<ModerationModelProviderCandidateBuildItem> moderationProducer,
             BuildProducer<ImageModelProviderCandidateBuildItem> imageProducer,
+            BuildProducer<AudioTranscriptionModelProviderCandidateBuildItem> audioTranscriptionProducer,
             LangChain4jAzureOpenAiBuildConfig config) {
         if (config.chatModel().enabled().isEmpty() || config.chatModel().enabled().get()) {
             chatProducer.produce(new ChatModelProviderCandidateBuildItem(PROVIDER));
@@ -76,6 +83,9 @@ public class AzureOpenAiProcessor {
         if (config.imageModel().enabled().isEmpty() || config.imageModel().enabled().get()) {
             imageProducer.produce(new ImageModelProviderCandidateBuildItem(PROVIDER));
         }
+        if (config.audioTranscriptionModel().enabled().isEmpty() || config.audioTranscriptionModel().enabled().get()) {
+            audioTranscriptionProducer.produce(new AudioTranscriptionModelProviderCandidateBuildItem(PROVIDER));
+        }
     }
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
@@ -85,6 +95,7 @@ public class AzureOpenAiProcessor {
             List<SelectedChatModelProviderBuildItem> selectedChatItem,
             List<SelectedEmbeddingModelCandidateBuildItem> selectedEmbedding,
             List<SelectedImageModelProviderBuildItem> selectedImage,
+            List<SelectedAudioTranscriptionModelProviderBuildItem> selectedAudioTranscription,
             BuildProducer<SyntheticBeanBuildItem> beanProducer) {
         for (var selected : selectedChatItem) {
             if (PROVIDER.equals(selected.getProvider())) {
@@ -169,6 +180,29 @@ public class AzureOpenAiProcessor {
                                         new Type[] { ClassType.create(AZURE_OPENAI_IMAGE_MODEL_BUILDER) }, null) },
                                 null), ANY)
                         .createWith(imageModel);
+                addQualifierIfNecessary(builder, configName);
+                beanProducer.produce(builder.done());
+            }
+        }
+
+        for (var selected : selectedAudioTranscription) {
+            if (PROVIDER.equals(selected.getProvider())) {
+                String configName = selected.getConfigName();
+
+                var audioTranscriptionModel = recorder.audioTranscriptionModel(configName);
+                var builder = SyntheticBeanBuildItem
+                        .configure(AUDIO_TRANSCRIPTION_MODEL)
+                        .setRuntimeInit()
+                        .defaultBean()
+                        .scope(ApplicationScoped.class)
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ClassType.create(DotNames.MODEL_AUTH_PROVIDER) }, null))
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(AZURE_OPENAI_AUDIO_TRANSCRIPTION_MODEL_BUILDER) },
+                                        null) },
+                                null), ANY)
+                        .createWith(audioTranscriptionModel);
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }

--- a/model-providers/openai/azure-openai/deployment/src/main/java/io/quarkiverse/langchain4j/azure/openai/deployment/LangChain4jAzureOpenAiBuildConfig.java
+++ b/model-providers/openai/azure-openai/deployment/src/main/java/io/quarkiverse/langchain4j/azure/openai/deployment/LangChain4jAzureOpenAiBuildConfig.java
@@ -28,4 +28,9 @@ public interface LangChain4jAzureOpenAiBuildConfig {
      * Image model related settings
      */
     ImageModelBuildConfig imageModel();
+
+    /**
+     * Audio transcription model related settings
+     */
+    AudioTranscriptionModelBuildConfig audioTranscriptionModel();
 }

--- a/model-providers/openai/azure-openai/deployment/src/test/java/io/quarkiverse/langchain4j/azure/openai/test/AzureOpenAiAudioTranscriptionModelTest.java
+++ b/model-providers/openai/azure-openai/deployment/src/test/java/io/quarkiverse/langchain4j/azure/openai/test/AzureOpenAiAudioTranscriptionModelTest.java
@@ -1,0 +1,62 @@
+package io.quarkiverse.langchain4j.azure.openai.test;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+
+import dev.langchain4j.data.audio.Audio;
+import dev.langchain4j.model.audio.AudioTranscriptionModel;
+import dev.langchain4j.model.audio.AudioTranscriptionRequest;
+import dev.langchain4j.model.audio.AudioTranscriptionResponse;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class AzureOpenAiAudioTranscriptionModelTest extends OpenAiBaseTest {
+
+    private static final String TOKEN = "whatever";
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.azure-openai.api-key", TOKEN)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.azure-openai.endpoint",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    AudioTranscriptionModel audioTranscriptionModel;
+
+    @Test
+    public void transcribesAudioViaMultipartRequest() {
+        AudioTranscriptionRequest request = AudioTranscriptionRequest.builder()
+                .audio(Audio.builder().binaryData(new byte[] { 1, 2, 3 }).mimeType("audio/mpeg").build())
+                .build();
+
+        AudioTranscriptionResponse response = audioTranscriptionModel.transcribe(request);
+
+        assertThat(response.text()).isEqualTo("Hello, world!");
+
+        LoggedRequest loggedRequest = singleLoggedRequest();
+        assertThat(loggedRequest.getUrl())
+                .startsWith("/v1/audio/transcriptions")
+                .contains("api-version=2024-10-21");
+        assertThat(loggedRequest.getHeader("Content-Type")).startsWith("multipart/form-data");
+        assertThat(loggedRequest.getHeader("User-Agent")).isEqualTo("langchain4j-quarkus-azure-openai");
+
+        String body = new String(requestBodyOfSingleRequest(), UTF_8);
+        assertThat(body)
+                .contains("name=\"model\"")
+                .contains("whisper-1")
+                .contains("name=\"file\"")
+                .contains("filename=\"audio_file.mp3\"")
+                .contains("content-type: audio/mpeg");
+    }
+}

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/AzureOpenAiAudioTranscriptionModel.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/AzureOpenAiAudioTranscriptionModel.java
@@ -1,0 +1,154 @@
+package io.quarkiverse.langchain4j.azure.openai;
+
+import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static io.quarkiverse.langchain4j.azure.openai.Consts.DEFAULT_USER_AGENT;
+
+import java.time.Duration;
+import java.util.concurrent.Callable;
+
+import dev.langchain4j.model.audio.AudioTranscriptionModel;
+import dev.langchain4j.model.audio.AudioTranscriptionRequest;
+import dev.langchain4j.model.audio.AudioTranscriptionResponse;
+import dev.langchain4j.model.openai.internal.SyncOrAsync;
+import dev.langchain4j.model.openai.internal.audio.transcription.AudioFile;
+import dev.langchain4j.model.openai.internal.audio.transcription.OpenAiAudioTranscriptionRequest;
+import dev.langchain4j.model.openai.internal.audio.transcription.OpenAiAudioTranscriptionResponse;
+import io.quarkiverse.langchain4j.openai.common.QuarkusOpenAiClient;
+
+public class AzureOpenAiAudioTranscriptionModel implements AudioTranscriptionModel {
+
+    private final String modelName;
+    private final Integer maxRetries;
+
+    private final QuarkusOpenAiClient client;
+
+    public AzureOpenAiAudioTranscriptionModel(String endpoint, String apiKey, String adToken, String apiVersion,
+            String modelName, Duration timeout, Integer maxRetries, Boolean logRequests, Boolean logResponses,
+            Boolean logCurl, String configName) {
+        this.modelName = modelName;
+        this.maxRetries = maxRetries;
+
+        this.client = QuarkusOpenAiClient.builder()
+                .baseUrl(ensureNotBlank(endpoint, "endpoint"))
+                .apiVersion(apiVersion)
+                .callTimeout(timeout)
+                .connectTimeout(timeout)
+                .readTimeout(timeout)
+                .writeTimeout(timeout)
+                .logRequests(logRequests)
+                .logResponses(logResponses)
+                .logCurl(logCurl != null && logCurl)
+                .userAgent(DEFAULT_USER_AGENT)
+                .azureAdToken(adToken)
+                .azureApiKey(apiKey)
+                .configName(configName)
+                .build();
+    }
+
+    @Override
+    public AudioTranscriptionResponse transcribe(AudioTranscriptionRequest request) {
+        var openAiRequest = OpenAiAudioTranscriptionRequest.builder()
+                .model(modelName)
+                .file(AudioFile.from(request.audio()))
+                .language(request.language())
+                .prompt(request.prompt())
+                .temperature(request.temperature())
+                .build();
+
+        var response = withRetry(new AudioTranscriber(openAiRequest), maxRetries).execute();
+
+        return AudioTranscriptionResponse.from(response.text());
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String endpoint;
+        private String apiKey;
+        private String adToken;
+        private String apiVersion;
+        private String modelName;
+        private Duration timeout;
+        private Integer maxRetries;
+        private Boolean logRequests;
+        private Boolean logResponses;
+        private Boolean logCurl;
+        private String configName;
+
+        public Builder endpoint(String endpoint) {
+            this.endpoint = endpoint;
+            return this;
+        }
+
+        public Builder apiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        public Builder adToken(String adToken) {
+            this.adToken = adToken;
+            return this;
+        }
+
+        public Builder apiVersion(String apiVersion) {
+            this.apiVersion = apiVersion;
+            return this;
+        }
+
+        public Builder modelName(String modelName) {
+            this.modelName = modelName;
+            return this;
+        }
+
+        public Builder timeout(Duration timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        public Builder maxRetries(Integer maxRetries) {
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        public Builder logRequests(Boolean logRequests) {
+            this.logRequests = logRequests;
+            return this;
+        }
+
+        public Builder logResponses(Boolean logResponses) {
+            this.logResponses = logResponses;
+            return this;
+        }
+
+        public Builder logCurl(Boolean logCurl) {
+            this.logCurl = logCurl;
+            return this;
+        }
+
+        public Builder configName(String configName) {
+            this.configName = configName;
+            return this;
+        }
+
+        public AzureOpenAiAudioTranscriptionModel build() {
+            return new AzureOpenAiAudioTranscriptionModel(endpoint, apiKey, adToken, apiVersion, modelName, timeout,
+                    maxRetries, logRequests, logResponses, logCurl, configName);
+        }
+    }
+
+    private class AudioTranscriber implements Callable<SyncOrAsync<OpenAiAudioTranscriptionResponse>> {
+        private final OpenAiAudioTranscriptionRequest request;
+
+        private AudioTranscriber(OpenAiAudioTranscriptionRequest request) {
+            this.request = request;
+        }
+
+        @Override
+        public SyncOrAsync<OpenAiAudioTranscriptionResponse> call() {
+            return client.audioTranscription(request);
+        }
+    }
+}

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/DisabledAudioTranscriptionModel.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/DisabledAudioTranscriptionModel.java
@@ -1,0 +1,14 @@
+package io.quarkiverse.langchain4j.azure.openai;
+
+import dev.langchain4j.model.ModelDisabledException;
+import dev.langchain4j.model.audio.AudioTranscriptionModel;
+import dev.langchain4j.model.audio.AudioTranscriptionRequest;
+import dev.langchain4j.model.audio.AudioTranscriptionResponse;
+
+public class DisabledAudioTranscriptionModel implements AudioTranscriptionModel {
+
+    @Override
+    public AudioTranscriptionResponse transcribe(AudioTranscriptionRequest request) {
+        throw new ModelDisabledException("AudioTranscriptionModel is disabled");
+    }
+}

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
@@ -19,6 +19,7 @@ import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.util.TypeLiteral;
 
+import dev.langchain4j.model.audio.AudioTranscriptionModel;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.DisabledChatModel;
 import dev.langchain4j.model.chat.DisabledStreamingChatModel;
@@ -30,10 +31,12 @@ import dev.langchain4j.model.image.DisabledImageModel;
 import dev.langchain4j.model.image.ImageModel;
 import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
 import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
+import io.quarkiverse.langchain4j.azure.openai.AzureOpenAiAudioTranscriptionModel;
 import io.quarkiverse.langchain4j.azure.openai.AzureOpenAiChatModel;
 import io.quarkiverse.langchain4j.azure.openai.AzureOpenAiEmbeddingModel;
 import io.quarkiverse.langchain4j.azure.openai.AzureOpenAiImageModel;
 import io.quarkiverse.langchain4j.azure.openai.AzureOpenAiStreamingChatModel;
+import io.quarkiverse.langchain4j.azure.openai.DisabledAudioTranscriptionModel;
 import io.quarkiverse.langchain4j.azure.openai.runtime.config.ChatModelConfig;
 import io.quarkiverse.langchain4j.azure.openai.runtime.config.LangChain4jAzureOpenAiConfig;
 import io.quarkiverse.langchain4j.azure.openai.runtime.config.LangChain4jAzureOpenAiConfig.AzureAiConfig.EndpointType;
@@ -64,6 +67,8 @@ public class AzureOpenAiRecorder {
     private static final TypeLiteral<Instance<ModelBuilderCustomizer<AzureOpenAiEmbeddingModel.Builder>>> EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
     };
     private static final TypeLiteral<Instance<ModelBuilderCustomizer<AzureOpenAiImageModel.Builder>>> IMAGE_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<AzureOpenAiAudioTranscriptionModel.Builder>>> AUDIO_TRANSCRIPTION_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
     };
 
     private final RuntimeValue<LangChain4jAzureOpenAiConfig> runtimeConfig;
@@ -302,6 +307,52 @@ public class AzureOpenAiRecorder {
                 @Override
                 public ImageModel apply(SyntheticCreationalContext<ImageModel> context) {
                     return new DisabledImageModel();
+                }
+            };
+        }
+    }
+
+    public Function<SyntheticCreationalContext<AudioTranscriptionModel>, AudioTranscriptionModel> audioTranscriptionModel(
+            String configName) {
+        LangChain4jAzureOpenAiConfig.AzureAiConfig azureAiConfig = correspondingAzureOpenAiConfig(runtimeConfig.getValue(),
+                configName);
+
+        if (azureAiConfig.enableIntegration()) {
+            var audioTranscriptionModelConfig = azureAiConfig.audioTranscriptionModel();
+            var apiKey = firstOrDefault(null, audioTranscriptionModelConfig.apiKey(), azureAiConfig.apiKey());
+            var adToken = firstOrDefault(null, audioTranscriptionModelConfig.adToken(), azureAiConfig.adToken());
+            var builder = AzureOpenAiAudioTranscriptionModel.builder()
+                    .endpoint(getEndpoint(azureAiConfig, configName, EndpointType.AUDIO_TRANSCRIPTION))
+                    .apiKey(apiKey)
+                    .adToken(adToken)
+                    .apiVersion(audioTranscriptionModelConfig.apiVersion().orElse(azureAiConfig.apiVersion()))
+                    .timeout(azureAiConfig.timeout().orElse(Duration.ofSeconds(10)))
+                    .maxRetries(azureAiConfig.maxRetries())
+                    .logRequests(
+                            firstOrDefault(false, audioTranscriptionModelConfig.logRequests(), azureAiConfig.logRequests()))
+                    .logResponses(
+                            firstOrDefault(false, audioTranscriptionModelConfig.logResponses(), azureAiConfig.logResponses()))
+                    .logCurl(firstOrDefault(false, azureAiConfig.logRequestsCurl()))
+                    .modelName(audioTranscriptionModelConfig.modelName())
+                    .configName(NamedConfigUtil.isDefault(configName) ? null : configName);
+
+            return new Function<>() {
+                @Override
+                public AudioTranscriptionModel apply(SyntheticCreationalContext<AudioTranscriptionModel> context) {
+                    throwIfApiKeysNotConfigured(apiKey, adToken, isAuthProviderAvailable(context, configName),
+                            configName);
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(AUDIO_TRANSCRIPTION_MODEL_CUSTOMIZER_TYPE_LITERAL,
+                                    Any.Literal.INSTANCE),
+                            builder, configName);
+                    return builder.build();
+                }
+            };
+        } else {
+            return new Function<>() {
+                @Override
+                public AudioTranscriptionModel apply(SyntheticCreationalContext<AudioTranscriptionModel> context) {
+                    return new DisabledAudioTranscriptionModel();
                 }
             };
         }

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/AudioTranscriptionModelConfig.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/AudioTranscriptionModelConfig.java
@@ -1,0 +1,70 @@
+package io.quarkiverse.langchain4j.azure.openai.runtime.config;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigDocDefault;
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+
+@ConfigGroup
+public interface AudioTranscriptionModelConfig {
+    /**
+     * This property will override the {@code quarkus.langchain4j.azure-openai.resource-name}
+     * specifically for audio transcription models if it is set.
+     */
+    Optional<String> resourceName();
+
+    /**
+     * This property will override the {@code quarkus.langchain4j.azure-openai.domain-name}
+     * specifically for audio transcription models if it is set.
+     */
+    Optional<String> domainName();
+
+    /**
+     * This property will override the {@code quarkus.langchain4j.azure-openai.deployment-name}
+     * specifically for audio transcription models if it is set.
+     */
+    Optional<String> deploymentName();
+
+    /**
+     * This property will override the {@code quarkus.langchain4j.azure-openai.endpoint}
+     * specifically for audio transcription models if it is set.
+     */
+    Optional<String> endpoint();
+
+    /**
+     * The Azure AD token to use for this operation.
+     * If present, then the requests towards OpenAI will include this in the Authorization header.
+     * Note that this property overrides the functionality of
+     * {@code quarkus.langchain4j.azure-openai.audio-transcription-model.api-key}.
+     */
+    Optional<String> adToken();
+
+    /**
+     * The API version to use for this operation. This follows the YYYY-MM-DD format
+     */
+    Optional<String> apiVersion();
+
+    /**
+     * Azure OpenAI API key
+     */
+    Optional<String> apiKey();
+
+    /**
+     * Model name to use
+     */
+    @WithDefault("whisper-1")
+    String modelName();
+
+    /**
+     * Whether audio transcription model requests should be logged
+     */
+    @ConfigDocDefault("false")
+    Optional<Boolean> logRequests();
+
+    /**
+     * Whether audio transcription model responses should be logged
+     */
+    @ConfigDocDefault("false")
+    Optional<Boolean> logResponses();
+}

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/LangChain4jAzureOpenAiConfig.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/LangChain4jAzureOpenAiConfig.java
@@ -177,11 +177,17 @@ public interface LangChain4jAzureOpenAiConfig {
          */
         ImageModelConfig imageModel();
 
+        /**
+         * Audio transcription model related settings
+         */
+        AudioTranscriptionModelConfig audioTranscriptionModel();
+
         default Optional<String> domainNameFor(EndpointType type) {
             var deepDomainName = switch (type) {
                 case CHAT -> chatModel().domainName();
                 case EMBEDDING -> embeddingModel().domainName();
                 case IMAGE -> imageModel().domainName();
+                case AUDIO_TRANSCRIPTION -> audioTranscriptionModel().domainName();
             };
             return deepDomainName
                     .filter(v -> !ConfigConstants.DUMMY_VALUE.equals(v))
@@ -198,6 +204,7 @@ public interface LangChain4jAzureOpenAiConfig {
                 case CHAT -> chatModel().endpoint();
                 case EMBEDDING -> embeddingModel().endpoint();
                 case IMAGE -> imageModel().endpoint();
+                case AUDIO_TRANSCRIPTION -> audioTranscriptionModel().endpoint();
             };
             return deepEndpoint
                     .filter(v -> !ConfigConstants.DUMMY_VALUE.equals(v))
@@ -214,6 +221,7 @@ public interface LangChain4jAzureOpenAiConfig {
                 case CHAT -> chatModel().resourceName();
                 case EMBEDDING -> embeddingModel().resourceName();
                 case IMAGE -> imageModel().resourceName();
+                case AUDIO_TRANSCRIPTION -> audioTranscriptionModel().resourceName();
             };
             return deepResourceName
                     .filter(v -> !ConfigConstants.DUMMY_VALUE.equals(v))
@@ -230,6 +238,7 @@ public interface LangChain4jAzureOpenAiConfig {
                 case CHAT -> chatModel().deploymentName();
                 case EMBEDDING -> embeddingModel().deploymentName();
                 case IMAGE -> imageModel().deploymentName();
+                case AUDIO_TRANSCRIPTION -> audioTranscriptionModel().deploymentName();
             };
             return deepDeploymentName
                     .filter(v -> !ConfigConstants.DUMMY_VALUE.equals(v))
@@ -244,7 +253,8 @@ public interface LangChain4jAzureOpenAiConfig {
         enum EndpointType {
             CHAT,
             EMBEDDING,
-            IMAGE
+            IMAGE,
+            AUDIO_TRANSCRIPTION
         }
     }
 }

--- a/model-providers/openai/azure-openai/runtime/src/test/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorderEndpointTests.java
+++ b/model-providers/openai/azure-openai/runtime/src/test/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorderEndpointTests.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkiverse.langchain4j.azure.openai.runtime.config.AudioTranscriptionModelConfig;
 import io.quarkiverse.langchain4j.azure.openai.runtime.config.ChatModelConfig;
 import io.quarkiverse.langchain4j.azure.openai.runtime.config.EmbeddingModelConfig;
 import io.quarkiverse.langchain4j.azure.openai.runtime.config.ImageModelConfig;
@@ -434,6 +435,61 @@ class AzureOpenAiRecorderEndpointTests {
                 @Override
                 public Optional<String> user() {
                     return Optional.empty();
+                }
+
+                @Override
+                public Optional<Boolean> logRequests() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<Boolean> logResponses() {
+                    return Optional.empty();
+                }
+            };
+        }
+
+        @Override
+        public AudioTranscriptionModelConfig audioTranscriptionModel() {
+            return new AudioTranscriptionModelConfig() {
+                @Override
+                public Optional<String> resourceName() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> domainName() {
+                    return Optional.of("domainName");
+                }
+
+                @Override
+                public Optional<String> deploymentName() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> endpoint() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> adToken() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> apiVersion() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> apiKey() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public String modelName() {
+                    return null;
                 }
 
                 @Override

--- a/model-providers/openai/testing-internal/src/main/resources/openai/mappings/completions.json
+++ b/model-providers/openai/testing-internal/src/main/resources/openai/mappings/completions.json
@@ -108,9 +108,6 @@
         "headers": {
           "Content-Type": {
             "matches": "multipart/form-data.*"
-          },
-          "Authorization": {
-            "matches": "Bearer .+"
           }
         }
       },


### PR DESCRIPTION
## Describe your changes

Exposes `AudioTranscriptionModel` (Whisper) as an injectable CDI bean in the `quarkus-langchain4j-openai-azure` extension.

Like the other Azure models (`AzureOpenAiChatModel`, `AzureOpenAiImageModel`, ...), the new `AzureOpenAiAudioTranscriptionModel` is built on `QuarkusOpenAiClient` rather than the langchain4j Azure SDK. Since #2497 already added `audioTranscription(...)` to `QuarkusOpenAiClient`, the transcription call (including the multipart handling) is reused as-is, so this PR is mostly Azure config and bean wiring.

The shared WireMock mapping for `/v1/audio/transcriptions` had a `Bearer` matcher; it is relaxed so the same endpoint also matches Azure's `api-key` auth, consistent with the chat mapping which does not match on auth.

The second commit clarifies in both transcription doc pages that the model is used directly (it is a specialized single-shot model with no messages/tools/guardrails) and is not part of the AI Services abstraction.

## Configuration

```properties
quarkus.langchain4j.azure-openai.api-key=...
quarkus.langchain4j.azure-openai.resource-name=...
quarkus.langchain4j.azure-openai.audio-transcription-model.deployment-name=whisper
```

## Injection

```java
@ApplicationScoped
public class TranscriptionService {

    @Inject
    AudioTranscriptionModel audioTranscriptionModel;

    public String transcribe(byte[] audioBytes, String mimeType) {
        Audio audio = Audio.builder().binaryData(audioBytes).mimeType(mimeType).build();
        return audioTranscriptionModel.transcribeToText(audio);
    }
}
```

---

- Closes #2514
