### PR TITLE
docs(security): fix moved Quarkus Credentials Provider guide link

### DIFF
--- a/docs/modules/ROOT/pages/security.adoc
+++ b/docs/modules/ROOT/pages/security.adoc
@@ -23,7 +23,7 @@ Your interactions with LLM providers are typically authenticated using API keys 
 === Best Practices
 
 * *Avoid Hardcoding Secrets*: Never embed API keys, tokens, or other credentials directly in your source code, prompts, or user-controlled inputs.
-* *Use Quarkus Vaults*: Store your secrets securely using Quarkus's built-in support for credential management. You can manage secrets in `application.properties` and protect them with the https://quarkus.io/guides/credentials[Quarkus Credentials Provider].
+* *Use Quarkus Vaults*: Store your secrets securely using Quarkus's built-in support for credential management. You can manage secrets in `application.properties` and protect them with the https://quarkus.io/guides/credentials-provider[Quarkus Credentials Provider].
 
 For example, store your OpenAI API key as property in `application.properties`:
 


### PR DESCRIPTION
## Summary

The quarkus.io/guides/credentials guide was renamed to
quarkus.io/guides/credentials-provider; the old URL now 404s. This updates the
link in security.adoc. Content-only, no behavior change.

## Files

- docs/modules/ROOT/pages/security.adoc (1 occurrence)
