### PR TITLE
Skip flaky WebSocketsNextTest on the push build with ci=true

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -42,4 +42,4 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        run: ./mvnw -B clean install -Dno-format
+        run: ./mvnw -B clean install -Dci=true -Dno-format


### PR DESCRIPTION
## Describe your changes

The push build ran the reactor without `-Dci=true`, so `WebSocketsNextTest` (guarded by `@DisabledIfSystemProperty(named = "ci")`) still ran there and failed intermittently, unlike the pull request build which already passes `-Dci=true`. This aligns the push build with the pull request build.

---

- Failing run: https://github.com/quarkiverse/quarkus-langchain4j/actions/runs/26779495510/job/78939831393
