### PR TITLE
fix(agentic): guard invokeAgent against arbitrary class reflection

### DIFF
--- a/agentic/deployment/src/main/java/io/quarkiverse/langchain4j/agentic/deployment/devui/AgenticDevUIProcessor.java
+++ b/agentic/deployment/src/main/java/io/quarkiverse/langchain4j/agentic/deployment/devui/AgenticDevUIProcessor.java
@@ -103,6 +103,15 @@ public class AgenticDevUIProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
     @Record(ExecutionTime.RUNTIME_INIT)
+    void registerDevUIAllowedAgentClassNames(List<DetectedAiAgentBuildItem> agents, AgenticRecorder recorder) {
+        Set<String> classNames = filterUserAgents(agents).stream()
+                .map(a -> a.getIface().name().toString())
+                .collect(Collectors.toSet());
+        recorder.setDevUIAllowedAgentClassNames(classNames);
+    }
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
     @Consume(SyntheticBeansRuntimeInitBuildItem.class)
     void enableDevModeMonitoring(List<DetectedAiAgentBuildItem> agents,
             AgenticRecorder recorder) {

--- a/agentic/pom.xml
+++ b/agentic/pom.xml
@@ -14,6 +14,7 @@
   <modules>
     <module>deployment</module>
     <module>runtime</module>
+    <module>runtime-dev</module>
   </modules>
 
 

--- a/agentic/runtime-dev/pom.xml
+++ b/agentic/runtime-dev/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.quarkiverse.langchain4j</groupId>
+    <artifactId>quarkus-langchain4j-agentic-parent</artifactId>
+    <version>999-SNAPSHOT</version>
+  </parent>
+  <artifactId>quarkus-langchain4j-agentic-dev</artifactId>
+  <name>Quarkus LangChain4j - Agentic - Dev</name>
+
+  <description>
+    Dev-mode-only classes for the agentic module. This module is included in the deployment
+    classpath (which is on the runtime classpath in dev mode) but is excluded from production
+    binaries. JSON-RPC services for Dev UI live here.
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkiverse.langchain4j</groupId>
+      <artifactId>quarkus-langchain4j-agentic</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/agentic/runtime-dev/src/main/java/io/quarkiverse/langchain4j/agentic/runtime/devui/AgenticJsonRpcService.java
+++ b/agentic/runtime-dev/src/main/java/io/quarkiverse/langchain4j/agentic/runtime/devui/AgenticJsonRpcService.java
@@ -1,0 +1,233 @@
+package io.quarkiverse.langchain4j.agentic.runtime.devui;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.UUID;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+
+import org.jboss.logging.Logger;
+
+import dev.langchain4j.agentic.observability.AgentInvocation;
+import dev.langchain4j.agentic.observability.AgentMonitor;
+import dev.langchain4j.agentic.observability.MonitoredExecution;
+import dev.langchain4j.agentic.planner.AgentInstance;
+import io.quarkus.arc.Arc;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class AgenticJsonRpcService {
+
+    private static final Logger log = Logger.getLogger(AgenticJsonRpcService.class);
+
+    public JsonArray getRootAgentEntries() {
+        List<Object> rootAgents = DevAgentMonitorHolder.rootAgents();
+        JsonArray entries = new JsonArray();
+        for (int i = 0; i < rootAgents.size(); i++) {
+            entries.add(new JsonObject()
+                    .put("name", ((AgentInstance) rootAgents.get(i)).name())
+                    .put("index", i));
+        }
+        List<JsonObject> sorted = new java.util.ArrayList<>();
+        for (int i = 0; i < entries.size(); i++) {
+            sorted.add(entries.getJsonObject(i));
+        }
+        sorted.sort(java.util.Comparator.comparing(o -> o.getString("name")));
+        return new JsonArray(sorted);
+    }
+
+    public JsonObject getTopologyJson(int index) {
+        List<Object> rootAgents = DevAgentMonitorHolder.rootAgents();
+        if (rootAgents.isEmpty()) {
+            return new JsonObject().put("error", "No root agents detected");
+        }
+        int i = (index >= 0 && index < rootAgents.size()) ? index : 0;
+        try {
+            AgentInstance rootAgent = (AgentInstance) rootAgents.get(i);
+            return serializeAgentTopology(rootAgent);
+        } catch (Exception e) {
+            log.warn("Failed to generate topology", e);
+            return new JsonObject().put("error", "Failed to generate topology: " + e.getMessage());
+        }
+    }
+
+    private JsonObject serializeAgentTopology(AgentInstance agent) {
+        JsonObject node = new JsonObject()
+                .put("name", agent.name())
+                .put("type", agent.topology() != null ? agent.topology().name() : "AGENT")
+                .put("agentId", agent.agentId());
+
+        if (agent.description() != null) {
+            node.put("description", agent.description());
+        }
+
+        List<AgentInstance> subAgents = agent.subagents();
+        if (subAgents != null && !subAgents.isEmpty()) {
+            JsonArray children = new JsonArray();
+            for (AgentInstance sub : subAgents) {
+                children.add(serializeAgentTopology(sub));
+            }
+            node.put("subAgents", children);
+        }
+        return node;
+    }
+
+    public JsonObject getExecutionReportJson(int index) {
+        List<AgentMonitor> monitors = DevAgentMonitorHolder.monitors();
+        if (monitors.isEmpty()) {
+            return new JsonObject().put("error", "No execution data available");
+        }
+        int i = (index >= 0 && index < monitors.size()) ? index : 0;
+        try {
+            AgentMonitor monitor = monitors.get(i);
+            JsonArray executions = new JsonArray();
+
+            for (MonitoredExecution exec : monitor.successfulExecutions()) {
+                executions.add(serializeExecution(exec, "success"));
+            }
+            for (MonitoredExecution exec : monitor.failedExecutions()) {
+                executions.add(serializeExecution(exec, "failed"));
+            }
+            for (MonitoredExecution exec : monitor.ongoingExecutions().values()) {
+                executions.add(serializeExecution(exec, "ongoing"));
+            }
+
+            return new JsonObject().put("executions", executions);
+        } catch (Exception e) {
+            log.warn("Failed to generate execution report", e);
+            return new JsonObject().put("error", "Failed: " + e.getMessage());
+        }
+    }
+
+    private JsonObject serializeExecution(MonitoredExecution exec, String status) {
+        JsonObject obj = new JsonObject()
+                .put("memoryId", String.valueOf(exec.memoryId()))
+                .put("status", status)
+                .put("topLevel", serializeInvocation(exec.topLevelInvocations()));
+        if (exec.hasError()) {
+            obj.put("error", exec.error().error().getMessage());
+        }
+        return obj;
+    }
+
+    private JsonObject serializeInvocation(AgentInvocation inv) {
+        JsonObject obj = new JsonObject()
+                .put("agentName", inv.agent().name())
+                .put("startTime", inv.startTime().toString());
+        if (inv.done()) {
+            obj.put("duration", inv.duration().toMillis());
+            obj.put("tokenCount", inv.totalTokenCount());
+            obj.put("output", inv.output() != null ? String.valueOf(inv.output()) : null);
+        } else {
+            obj.put("status", "in_progress");
+        }
+        if (inv.iterationIndex() >= 0) {
+            obj.put("iterationIndex", inv.iterationIndex());
+        }
+
+        if (!inv.toolExecutions().isEmpty()) {
+            JsonArray tools = new JsonArray();
+            for (var toolExec : inv.toolExecutions()) {
+                tools.add(new JsonObject()
+                        .put("name", toolExec.request().name())
+                        .put("arguments", toolExec.request().arguments())
+                        .put("result", toolExec.result()));
+            }
+            obj.put("toolExecutions", tools);
+        }
+
+        if (!inv.nestedInvocations().isEmpty()) {
+            JsonArray nested = new JsonArray();
+            for (AgentInvocation sub : inv.nestedInvocations()) {
+                nested.add(serializeInvocation(sub));
+            }
+            obj.put("nestedInvocations", nested);
+        }
+        return obj;
+    }
+
+    @ActivateRequestContext
+    public JsonObject invokeAgent(String agentClassName, String methodName, String inputJson) {
+        if (!DevAgentMonitorHolder.allowedAgentClassNames.contains(agentClassName)) {
+            return new JsonObject()
+                    .put("success", false)
+                    .put("error", "Unknown agent class: " + agentClassName);
+        }
+        try {
+            Class<?> agentClass = Class.forName(agentClassName, true, Thread.currentThread().getContextClassLoader());
+            Object agent = Arc.container().select(agentClass).get();
+
+            Method targetMethod = null;
+            for (Method m : agentClass.getMethods()) {
+                if (m.getName().equals(methodName)) {
+                    targetMethod = m;
+                    break;
+                }
+            }
+            if (targetMethod == null) {
+                return new JsonObject()
+                        .put("success", false)
+                        .put("error", "Method '" + methodName + "' not found on " + agentClassName);
+            }
+
+            Object[] args = resolveArguments(targetMethod, inputJson);
+            Object result = targetMethod.invoke(agent, args);
+
+            return new JsonObject()
+                    .put("success", true)
+                    .put("result", result != null ? String.valueOf(result) : "null");
+        } catch (Exception e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            return new JsonObject()
+                    .put("success", false)
+                    .put("error", cause.getClass().getSimpleName() + ": " + cause.getMessage());
+        }
+    }
+
+    private Object[] resolveArguments(Method method, String inputJson) {
+        Class<?>[] paramTypes = method.getParameterTypes();
+        if (paramTypes.length == 0) {
+            return new Object[0];
+        }
+
+        JsonObject inputs = (inputJson != null && !inputJson.isBlank()) ? new JsonObject(inputJson) : new JsonObject();
+        java.lang.reflect.Parameter[] params = method.getParameters();
+        Object[] args = new Object[paramTypes.length];
+
+        for (int i = 0; i < paramTypes.length; i++) {
+            Class<?> type = paramTypes[i];
+            String paramName = params[i].getName();
+
+            if (type.getName().equals("dev.langchain4j.agentic.scope.AgenticScope")) {
+                args[i] = null;
+                continue;
+            }
+
+            if (params[i].isAnnotationPresent(dev.langchain4j.service.MemoryId.class)
+                    || paramName.equals("memoryId")) {
+                args[i] = inputs.containsKey(paramName) ? inputs.getString(paramName) : UUID.randomUUID().toString();
+                continue;
+            }
+
+            if (!inputs.containsKey(paramName)) {
+                args[i] = null;
+                continue;
+            }
+
+            if (type == String.class) {
+                args[i] = inputs.getString(paramName);
+            } else if (type == int.class || type == Integer.class) {
+                args[i] = inputs.getInteger(paramName);
+            } else if (type == long.class || type == Long.class) {
+                args[i] = inputs.getLong(paramName);
+            } else if (type == double.class || type == Double.class) {
+                args[i] = inputs.getDouble(paramName);
+            } else if (type == boolean.class || type == Boolean.class) {
+                args[i] = inputs.getBoolean(paramName);
+            } else {
+                args[i] = inputs.getString(paramName);
+            }
+        }
+        return args;
+    }
+}

--- a/agentic/runtime-dev/src/test/java/io/quarkiverse/langchain4j/agentic/runtime/devui/AgenticJsonRpcServiceAllowListTest.java
+++ b/agentic/runtime-dev/src/test/java/io/quarkiverse/langchain4j/agentic/runtime/devui/AgenticJsonRpcServiceAllowListTest.java
@@ -1,0 +1,58 @@
+package io.quarkiverse.langchain4j.agentic.runtime.devui;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.json.JsonObject;
+
+class AgenticJsonRpcServiceAllowListTest {
+
+    private AgenticJsonRpcService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AgenticJsonRpcService();
+        DevAgentMonitorHolder.allowedAgentClassNames = Collections.emptySet();
+    }
+
+    @AfterEach
+    void tearDown() {
+        DevAgentMonitorHolder.allowedAgentClassNames = Collections.emptySet();
+    }
+
+    @Test
+    void rejectsClassNotInAllowList() {
+        DevAgentMonitorHolder.allowedAgentClassNames = Set.of("com.example.AllowedAgent");
+
+        JsonObject result = service.invokeAgent("com.example.OtherClass", "chat", null);
+
+        Assertions.assertFalse(result.getBoolean("success"));
+        Assertions.assertEquals("Unknown agent class: com.example.OtherClass", result.getString("error"));
+    }
+
+    @Test
+    void rejectsAllClassesWhenAllowListIsEmpty() {
+        JsonObject result = service.invokeAgent("java.lang.String", "valueOf", null);
+
+        Assertions.assertFalse(result.getBoolean("success"));
+        Assertions.assertEquals("Unknown agent class: java.lang.String", result.getString("error"));
+    }
+
+    @Test
+    void passesGuardForAllowedClass() {
+        // Use a real classpath class so Class.forName succeeds — CDI will be absent in
+        // this unit test context but the guard itself must not reject the call.
+        DevAgentMonitorHolder.allowedAgentClassNames = Set.of("java.lang.String");
+
+        JsonObject result = service.invokeAgent("java.lang.String", "valueOf", null);
+
+        Assertions.assertFalse(result.getBoolean("success"));
+        Assertions.assertFalse(result.getString("error").startsWith("Unknown agent class:"),
+                "Guard should be bypassed for an allowed class; got: " + result.getString("error"));
+    }
+}

--- a/agentic/runtime/pom.xml
+++ b/agentic/runtime/pom.xml
@@ -39,6 +39,9 @@
             </goals>
             <configuration>
               <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+              <conditionalDevDependencies>
+                <artifact>${project.groupId}:quarkus-langchain4j-agentic-dev:${project.version}</artifact>
+              </conditionalDevDependencies>
             </configuration>
           </execution>
         </executions>

--- a/agentic/runtime/src/main/java/io/quarkiverse/langchain4j/agentic/runtime/AgenticRecorder.java
+++ b/agentic/runtime/src/main/java/io/quarkiverse/langchain4j/agentic/runtime/AgenticRecorder.java
@@ -59,6 +59,11 @@ public class AgenticRecorder {
     }
 
     @RuntimeInit
+    public void setDevUIAllowedAgentClassNames(Set<String> classNames) {
+        DevAgentMonitorHolder.allowedAgentClassNames = Collections.unmodifiableSet(classNames);
+    }
+
+    @RuntimeInit
     public void enableDevModeMonitoring(Set<String> rootAgentClassNames) {
         DevAgentMonitorHolder.reset();
         AgenticRecorder.devModeMonitoringEnabled = true;

--- a/agentic/runtime/src/main/java/io/quarkiverse/langchain4j/agentic/runtime/devui/DevAgentMonitorHolder.java
+++ b/agentic/runtime/src/main/java/io/quarkiverse/langchain4j/agentic/runtime/devui/DevAgentMonitorHolder.java
@@ -1,11 +1,15 @@
 package io.quarkiverse.langchain4j.agentic.runtime.devui;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import dev.langchain4j.agentic.observability.AgentMonitor;
 
 public class DevAgentMonitorHolder {
+
+    public static volatile Set<String> allowedAgentClassNames = Collections.emptySet();
 
     private static final List<AgentMonitor> MONITORS = new CopyOnWriteArrayList<>();
     private static final List<Object> ROOT_AGENTS = new CopyOnWriteArrayList<>();


### PR DESCRIPTION
> **PR chain — Agentic module Quarkus integration**
> 1. **#2526** ← this PR — invokeAgent allowlist
> 2. #2534 (draft) — build-time safety checks and CDI foundation
> 3. #2555 (draft) — CDI wiring tiers and guardrails
> 4. #2544 (draft) — parallel context propagation
> 5. #2550 (draft) — OTel, Micrometer, CDI events, health checks
>
>
> 6. #2572 (planned) — @RegisterAiService simplification and composition annotations
>
> Each PR is standalone-compilable. Merge in order — each builds on the previous.

## Summary

`AgenticJsonRpcService.invokeAgent` accepted `agentClassName` as a raw string from the browser and passed it directly to `Class.forName()` with no validation — allowing any class on the classpath to be instantiated via the DevUI JSON-RPC endpoint.

### Changes

- **Allow-list check** — server-side guard in `invokeAgent` rejects unknown classes immediately
- **Build-time registration** — `AgenticDevUIProcessor` collects user agent class names at build time, registers via `AgenticRecorder.setDevUIAllowedAgentClassNames`
- **runtime-dev module** — `AgenticJsonRpcService` moved to `agentic/runtime-dev` so it never appears in production binaries
- **Conditional dev dependency** — `conditionalDevDependencies` registered in runtime `pom.xml`

### Impact

- **Context:** Dev mode only (`AgenticJsonRpcService` lives in `runtime-dev`)
- **Vector:** Any client able to reach the DevUI JSON-RPC endpoint
- **Effect without fix:** Arbitrary class instantiation + method invocation

---

- Fixes: #2525