### PR TITLE
Fix NPE for single shared ChatMemory in active request scope

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/StreamingSingleSharedChatMemoryInRequestScopeTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/StreamingSingleSharedChatMemoryInRequestScopeTest.java
@@ -1,0 +1,86 @@
+package io.quarkiverse.langchain4j.test;
+
+import static io.restassured.RestAssured.get;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.function.Supplier;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.service.AiServices;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+
+/**
+ * Verifies that a programmatically built streaming AiService with a single shared ChatMemory
+ * (no ChatMemoryProvider, no @MemoryId) can be invoked from within an active request scope, using
+ * the shared memory instead of resolving a non-default request-scope memory id it cannot handle.
+ */
+public class StreamingSingleSharedChatMemoryInRequestScopeTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(StreamingAssistant.class, ChatResource.class, FakeStreamingChatModelSupplier.class));
+
+    @Test
+    public void streamingServiceWithSingleSharedMemoryDoesNotFailInsideRequestScope() {
+        get("/streaming-shared-memory")
+                .then()
+                .statusCode(200)
+                .body(equalTo("42"));
+    }
+
+    @RegisterAiService(streamingChatLanguageModelSupplier = FakeStreamingChatModelSupplier.class, chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
+    public interface StreamingAssistant {
+
+        Multi<String> chat(String message);
+    }
+
+    @Path("/streaming-shared-memory")
+    public static class ChatResource {
+
+        private static final ChatMemory SHARED_MEMORY = MessageWindowChatMemory.withMaxMessages(20);
+
+        @GET
+        public Multi<String> chat() {
+            StreamingAssistant assistant = AiServices.builder(StreamingAssistant.class)
+                    .streamingChatModel(new FakeStreamingChatModel())
+                    .chatMemory(SHARED_MEMORY)
+                    .build();
+            return assistant.chat("hello");
+        }
+    }
+
+    public static class FakeStreamingChatModelSupplier implements Supplier<StreamingChatModel> {
+
+        @Override
+        public StreamingChatModel get() {
+            return new FakeStreamingChatModel();
+        }
+    }
+
+    static class FakeStreamingChatModel implements StreamingChatModel {
+
+        @Override
+        public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+            handler.onPartialResponse("4");
+            handler.onPartialResponse("2");
+            handler.onCompleteResponse(ChatResponse.builder().aiMessage(new AiMessage("42")).build());
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
@@ -175,7 +175,8 @@ public class AiServiceMethodImplementationSupport {
                 .interfaceName(context.aiServiceClass.getName())
                 .methodName(createInfo.getMethodName())
                 .methodArguments((methodArgs != null) ? Arrays.asList(methodArgs) : List.of())
-                .chatMemoryId(memoryId(createInfo, methodArgs, context.hasChatMemory(), context.defaultMemoryIdProvider))
+                .chatMemoryId(
+                        memoryId(createInfo, methodArgs, context.hasChatMemoryProvider(), context.defaultMemoryIdProvider))
                 .invocationParameters(findInvocationParams(methodArgs))
                 .managedParameters(LangChain4jManaged.current())
                 .timestampNow()

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceContext.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceContext.java
@@ -10,6 +10,7 @@ import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 
 import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.image.ImageModel;
@@ -31,6 +32,8 @@ public class QuarkusAiServiceContext extends AiServiceContext {
     public DefaultMemoryIdProvider defaultMemoryIdProvider;
     public ChatMemoryFlushStrategy chatMemoryFlushStrategy = ChatMemoryFlushStrategy.DEFERRED;
 
+    private boolean hasChatMemoryProvider;
+
     // needed by Arc
     public QuarkusAiServiceContext() {
         super(null);
@@ -38,6 +41,29 @@ public class QuarkusAiServiceContext extends AiServiceContext {
 
     public QuarkusAiServiceContext(Class<?> aiServiceClass) {
         super(aiServiceClass);
+    }
+
+    /**
+     * Tracks whether a {@link ChatMemoryProvider} (as opposed to a single shared {@link ChatMemory}) backs this
+     * context. The {@link DefaultMemoryIdProvider} chain must only be consulted when a provider is configured;
+     * consulting it for a single shared memory yields a non-default memory id that the single-memory
+     * {@code ChatMemoryService} cannot resolve, leading to a {@link NullPointerException} when the service is
+     * invoked inside an active request scope.
+     */
+    public boolean hasChatMemoryProvider() {
+        return hasChatMemoryProvider;
+    }
+
+    @Override
+    public void initChatMemories(ChatMemory chatMemory) {
+        super.initChatMemories(chatMemory);
+        this.hasChatMemoryProvider = false;
+    }
+
+    @Override
+    public void initChatMemories(ChatMemoryProvider chatMemoryProvider) {
+        super.initChatMemories(chatMemoryProvider);
+        this.hasChatMemoryProvider = true;
     }
 
     /**


### PR DESCRIPTION
## Describe your changes

When an AiService is built programmatically with a single shared `ChatMemory` (no `ChatMemoryProvider` and no `@MemoryId` parameter) and invoked inside an active request scope, the `DefaultMemoryIdProvider` chain produced a non-default memory id (the request-scope state). A single-memory `ChatMemoryService` cannot resolve that id, so `getChatMemory(memoryId)` returned `null` and the streaming response handler threw a `NullPointerException`.

`memoryId()` now consults the `DefaultMemoryIdProvider` chain only when a `ChatMemoryProvider` is actually configured, tracked via a new `hasChatMemoryProvider` flag on `QuarkusAiServiceContext`.

---

- Closes #2381

---

> Validated locally against the reporter's reproducer (https://github.com/Colprit/issue-2381-repro) built against this branch (`999-SNAPSHOT`): `GET /ask` now returns `200 ok` with no NPE. A streaming regression test reproduces the original SSE scenario and the existing memory/scope/streaming suite passes.