### PR TITLE
Fix native mode substitution for AiServices.builder() to use context lookup

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/graalvm/Substitutions.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/graalvm/Substitutions.java
@@ -15,13 +15,13 @@ import dev.langchain4j.spi.prompt.PromptTemplateFactory;
 import dev.langchain4j.spi.prompt.structured.StructuredPromptFactory;
 import dev.langchain4j.store.embedding.inmemory.InMemoryEmbeddingStore;
 import dev.langchain4j.store.embedding.inmemory.InMemoryEmbeddingStoreJsonCodec;
+import io.quarkiverse.langchain4j.QuarkusAiServiceContextFactory;
 import io.quarkiverse.langchain4j.QuarkusAiServicesFactory;
 import io.quarkiverse.langchain4j.QuarkusChatMessageJsonCodecFactory;
 import io.quarkiverse.langchain4j.QuarkusInMemoryEmbeddingJsonCodecFactory;
 import io.quarkiverse.langchain4j.QuarkusJsonCodecFactory;
 import io.quarkiverse.langchain4j.QuarkusPromptTemplateFactory;
 import io.quarkiverse.langchain4j.QuarkusStructuredPromptFactory;
-import io.quarkiverse.langchain4j.runtime.aiservice.QuarkusAiServiceContext;
 import opennlp.tools.util.ext.ExtensionNotLoadedException;
 
 public class Substitutions {
@@ -49,7 +49,7 @@ public class Substitutions {
 
         @Substitute
         public static <T> AiServices<T> builder(Class<T> aiService) {
-            return new QuarkusAiServicesFactory.QuarkusAiServices<>(new QuarkusAiServiceContext(aiService));
+            return new QuarkusAiServicesFactory.QuarkusAiServices<>(new QuarkusAiServiceContextFactory().create(aiService));
         }
     }
 


### PR DESCRIPTION
Fix `AiServices.builder()` GraalVM substitution to use CDI context lookup, aligning native mode behavior
  with JVM mode.

  The native substitution in `Substitutions.Target_AiServices` was creating a bare
  `QuarkusAiServiceContext` directly (`new QuarkusAiServiceContext(aiService)`), bypassing the
  `QuarkusAiServiceContextFactory` CDI lookup that JVM mode uses via ServiceLoader. This caused
  `chatMemoryService` to be null in native mode, making `hasChatMemory()` return false even when a
  `ChatMemoryProvider` bean was configured. As a result, `NoopChatMemory` was used instead, breaking tool
  execution loops with `"messages cannot be null or empty"`.

  The fix changes the substitution to delegate to `QuarkusAiServiceContextFactory().create(aiService)`,
  which performs the same `Arc.container().instance()` lookup as JVM mode.

- Fixes: https://github.com/quarkiverse/quarkus-langchain4j/issues/2538