### PR TITLE
Migrate OpenAI image model from dall-e to gpt-image API

### DIFF
--- a/docs/modules/ROOT/pages/guide-generating-image.adoc
+++ b/docs/modules/ROOT/pages/guide-generating-image.adoc
@@ -10,12 +10,12 @@ With Quarkus LangChain4j’s Image model support, you can declare a service meth
 
 * A Quarkus project with the `quarkus-langchain4j-openai` extension on the classpath (or another model provider that supports image models)
 * OpenAI (or another provider) API Key configured in `application.properties` or via `QUARKUS_LANGCHAIN4J_OPENAI_API_KEY`
-* An **Image Model** enabled (e.g. `dall-e-3` or `GPT-Image-1`) in your config:
+* An **Image Model** enabled (e.g. `gpt-image-1`) in your config:
 +
 [source,properties]
 ----
 quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
-quarkus.langchain4j.openai.image-model.model-name=dall-e-3 # This is the default model, but you can specify another one if needed
+quarkus.langchain4j.openai.image-model.model-name=gpt-image-1 # This is the default model, but you can specify another one if needed
 ----
 +
 * Extended timeout for image generation, which can take longer than text completions. For example:
@@ -46,9 +46,9 @@ Quarkus LangChain4j will call the configured image model and wrap the response i
 include::{examples-dir}/io/quarkiverse/langchain4j/samples/images/ImageGenerationAiService.java[tags=head;generation]
 ----
 
-When invoked, Quarkus will substitute the subject into the prompt, send it to the AI model provider, and return the generated image (URL or Base64).
+When invoked, Quarkus will substitute the subject into the prompt, send it to the AI model provider, and return the generated image.
 
-NOTE: When using OpenAI image model, the returned `Image` object contains a URL to the generated image, which you can use to display or download the image.
+NOTE: When using OpenAI image model, the returned `Image` object contains base64-encoded image data.
 
 
 == Step 3. Expose an HTTP Endpoint

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
 :project-version: 1.11.0.CR1
-:langchain4j-version: 1.15.1
+:langchain4j-version: 1.16.1
 :langchain4j-embeddings-version: ${langchain4j-embeddings.version}
 :examples-dir: ./../examples/

--- a/docs/modules/ROOT/pages/includes/quarkus-all-config.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-all-config.adoc
@@ -4838,29 +4838,6 @@ endif::add-copy-button-to-env-var[]
 |path
 |`+++${java.io.tmpdir}/dall-e-images+++`
 
-a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-image-model-response-format]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-image-model-response-format[`+++quarkus.langchain4j.azure-openai.image-model.response-format+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.azure-openai.image-model.response-format+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The format in which the generated images are returned.
-
-Must be one of `url` or `b64_json`
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_IMAGE_MODEL_RESPONSE_FORMAT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_IMAGE_MODEL_RESPONSE_FORMAT+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++url+++`
-
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-image-model-size]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-image-model-size[`+++quarkus.langchain4j.azure-openai.image-model.size+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.azure-openai.image-model.size+++[]
@@ -4935,31 +4912,6 @@ endif::add-copy-button-to-env-var[]
 --
 |int
 |`+++1+++`
-
-a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-image-model-style]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-image-model-style[`+++quarkus.langchain4j.azure-openai.image-model.style+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.azure-openai.image-model.style+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The style of the generated images.
-
-Must be one of `vivid` or `natural`. Vivid causes the model to lean towards generating hyper-real and dramatic images. Natural causes the model to produce more natural, less hyper-real looking images.
-
-This param is only supported for when the model is `dall-e-3`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_IMAGE_MODEL_STYLE+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_IMAGE_MODEL_STYLE+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++vivid+++`
 
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-image-model-user]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-image-model-user[`+++quarkus.langchain4j.azure-openai.image-model.user+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -6317,29 +6269,6 @@ endif::add-copy-button-to-env-var[]
 |path
 |`+++${java.io.tmpdir}/dall-e-images+++`
 
-a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-image-model-response-format]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-image-model-response-format[`+++quarkus.langchain4j.azure-openai."model-name".image-model.response-format+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".image-model.response-format+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The format in which the generated images are returned.
-
-Must be one of `url` or `b64_json`
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__IMAGE_MODEL_RESPONSE_FORMAT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__IMAGE_MODEL_RESPONSE_FORMAT+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++url+++`
-
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-image-model-size]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-image-model-size[`+++quarkus.langchain4j.azure-openai."model-name".image-model.size+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".image-model.size+++[]
@@ -6414,31 +6343,6 @@ endif::add-copy-button-to-env-var[]
 --
 |int
 |`+++1+++`
-
-a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-image-model-style]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-image-model-style[`+++quarkus.langchain4j.azure-openai."model-name".image-model.style+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".image-model.style+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The style of the generated images.
-
-Must be one of `vivid` or `natural`. Vivid causes the model to lean towards generating hyper-real and dramatic images. Natural causes the model to produce more natural, less hyper-real looking images.
-
-This param is only supported for when the model is `dall-e-3`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__IMAGE_MODEL_STYLE+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__IMAGE_MODEL_STYLE+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++vivid+++`
 
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-image-model-user]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-image-model-user[`+++quarkus.langchain4j.azure-openai."model-name".image-model.user+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -19545,7 +19449,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_MODEL_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`+++dall-e-3+++`
+|`+++gpt-image-1+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-persist]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-persist[`+++quarkus.langchain4j.openai.image-model.persist+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -19587,30 +19491,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_PERSIST_DIRECTO
 endif::add-copy-button-to-env-var[]
 --
 |path
-|`+++${java.io.tmpdir}/dall-e-images+++`
-
-a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-response-format]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-response-format[`+++quarkus.langchain4j.openai.image-model.response-format+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.openai.image-model.response-format+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The format in which the generated images are returned.
-
-Must be one of `url` or `b64_json`
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_RESPONSE_FORMAT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_RESPONSE_FORMAT+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++url+++`
+|`+++${java.io.tmpdir}/openai-images+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-size]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-size[`+++quarkus.langchain4j.openai.image-model.size+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -19622,9 +19503,7 @@ endif::add-copy-button-to-config-props[]
 --
 The size of the generated images.
 
-Must be one of `1024x1024`, `1792x1024`, or `1024x1792` when the model is `dall-e-3`.
-
-Must be one of `256x256`, `512x512`, or `1024x1024` when the model is `dall-e-2`.
+Supported values: `1024x1024`, `1536x1024`, `1024x1536`, or `auto`.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -19647,9 +19526,7 @@ endif::add-copy-button-to-config-props[]
 --
 The quality of the image that will be generated.
 
-`hd` creates images with finer details and greater consistency across the image.
-
-This param is only supported for when the model is `dall-e-3`.
+Supported values: `auto`, `low`, `medium`, or `high`.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -19660,7 +19537,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_QUALITY+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`+++standard+++`
+|`+++auto+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-number]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-number[`+++quarkus.langchain4j.openai.image-model.number+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -19673,8 +19550,6 @@ endif::add-copy-button-to-config-props[]
 The number of images to generate.
 
 Must be between 1 and 10.
-
-When the model is dall-e-3, only n=1 is supported.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -19703,6 +19578,104 @@ Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_IMA
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-output-format]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-output-format[`+++quarkus.langchain4j.openai.image-model.output-format+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.image-model.output-format+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The output format of the generated image.
+
+Supported values: `png`, `jpeg`, `webp`.
+
+Only supported for `gpt-image-1` and newer models.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_OUTPUT_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_OUTPUT_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-background]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-background[`+++quarkus.langchain4j.openai.image-model.background+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.image-model.background+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The background type for the generated image.
+
+Supported values: `transparent`, `opaque`, `auto`.
+
+Only supported for `gpt-image-1` and newer models. Transparent backgrounds require `output-format` set to `png` or `webp`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_BACKGROUND+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_BACKGROUND+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-output-compression]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-output-compression[`+++quarkus.langchain4j.openai.image-model.output-compression+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.image-model.output-compression+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The compression level for the generated image (0-100).
+
+Only supported for `gpt-image-1` and newer models with `jpeg` or `webp` output formats.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_OUTPUT_COMPRESSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_OUTPUT_COMPRESSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-moderation]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-moderation[`+++quarkus.langchain4j.openai.image-model.moderation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.image-model.moderation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The moderation level for the image generation request.
+
+Supported values: `low`, `auto`.
+
+Only supported for `gpt-image-1` and newer models.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_MODERATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_MODERATION+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
@@ -20592,7 +20565,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_MO
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`+++dall-e-3+++`
+|`+++gpt-image-1+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-persist]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-persist[`+++quarkus.langchain4j.openai."model-name".image-model.persist+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -20634,30 +20607,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_PE
 endif::add-copy-button-to-env-var[]
 --
 |path
-|`+++${java.io.tmpdir}/dall-e-images+++`
-
-a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-response-format]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-response-format[`+++quarkus.langchain4j.openai."model-name".image-model.response-format+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.openai."model-name".image-model.response-format+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The format in which the generated images are returned.
-
-Must be one of `url` or `b64_json`
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_RESPONSE_FORMAT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_RESPONSE_FORMAT+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++url+++`
+|`+++${java.io.tmpdir}/openai-images+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-size]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-size[`+++quarkus.langchain4j.openai."model-name".image-model.size+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -20669,9 +20619,7 @@ endif::add-copy-button-to-config-props[]
 --
 The size of the generated images.
 
-Must be one of `1024x1024`, `1792x1024`, or `1024x1792` when the model is `dall-e-3`.
-
-Must be one of `256x256`, `512x512`, or `1024x1024` when the model is `dall-e-2`.
+Supported values: `1024x1024`, `1536x1024`, `1024x1536`, or `auto`.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -20694,9 +20642,7 @@ endif::add-copy-button-to-config-props[]
 --
 The quality of the image that will be generated.
 
-`hd` creates images with finer details and greater consistency across the image.
-
-This param is only supported for when the model is `dall-e-3`.
+Supported values: `auto`, `low`, `medium`, or `high`.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -20707,7 +20653,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_QU
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`+++standard+++`
+|`+++auto+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-number]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-number[`+++quarkus.langchain4j.openai."model-name".image-model.number+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -20720,8 +20666,6 @@ endif::add-copy-button-to-config-props[]
 The number of images to generate.
 
 Must be between 1 and 10.
-
-When the model is dall-e-3, only n=1 is supported.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -20750,6 +20694,104 @@ Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MO
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-output-format]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-output-format[`+++quarkus.langchain4j.openai."model-name".image-model.output-format+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".image-model.output-format+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The output format of the generated image.
+
+Supported values: `png`, `jpeg`, `webp`.
+
+Only supported for `gpt-image-1` and newer models.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_OUTPUT_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_OUTPUT_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-background]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-background[`+++quarkus.langchain4j.openai."model-name".image-model.background+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".image-model.background+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The background type for the generated image.
+
+Supported values: `transparent`, `opaque`, `auto`.
+
+Only supported for `gpt-image-1` and newer models. Transparent backgrounds require `output-format` set to `png` or `webp`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_BACKGROUND+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_BACKGROUND+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-output-compression]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-output-compression[`+++quarkus.langchain4j.openai."model-name".image-model.output-compression+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".image-model.output-compression+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The compression level for the generated image (0-100).
+
+Only supported for `gpt-image-1` and newer models with `jpeg` or `webp` output formats.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_OUTPUT_COMPRESSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_OUTPUT_COMPRESSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-moderation]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-moderation[`+++quarkus.langchain4j.openai."model-name".image-model.moderation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".image-model.moderation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The moderation level for the image generation request.
+
+Supported values: `low`, `auto`.
+
+Only supported for `gpt-image-1` and newer models.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_MODERATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_MODERATION+++`
 endif::add-copy-button-to-env-var[]
 --
 |string

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-azure-openai.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-azure-openai.adoc
@@ -1191,29 +1191,6 @@ endif::add-copy-button-to-env-var[]
 |path
 |`+++${java.io.tmpdir}/dall-e-images+++`
 
-a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-image-model-response-format]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-image-model-response-format[`+++quarkus.langchain4j.azure-openai.image-model.response-format+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.azure-openai.image-model.response-format+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The format in which the generated images are returned.
-
-Must be one of `url` or `b64_json`
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_IMAGE_MODEL_RESPONSE_FORMAT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_IMAGE_MODEL_RESPONSE_FORMAT+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++url+++`
-
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-image-model-size]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-image-model-size[`+++quarkus.langchain4j.azure-openai.image-model.size+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.azure-openai.image-model.size+++[]
@@ -1288,31 +1265,6 @@ endif::add-copy-button-to-env-var[]
 --
 |int
 |`+++1+++`
-
-a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-image-model-style]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-image-model-style[`+++quarkus.langchain4j.azure-openai.image-model.style+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.azure-openai.image-model.style+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The style of the generated images.
-
-Must be one of `vivid` or `natural`. Vivid causes the model to lean towards generating hyper-real and dramatic images. Natural causes the model to produce more natural, less hyper-real looking images.
-
-This param is only supported for when the model is `dall-e-3`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_IMAGE_MODEL_STYLE+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_IMAGE_MODEL_STYLE+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++vivid+++`
 
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-image-model-user]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-image-model-user[`+++quarkus.langchain4j.azure-openai.image-model.user+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -2670,29 +2622,6 @@ endif::add-copy-button-to-env-var[]
 |path
 |`+++${java.io.tmpdir}/dall-e-images+++`
 
-a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-image-model-response-format]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-image-model-response-format[`+++quarkus.langchain4j.azure-openai."model-name".image-model.response-format+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".image-model.response-format+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The format in which the generated images are returned.
-
-Must be one of `url` or `b64_json`
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__IMAGE_MODEL_RESPONSE_FORMAT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__IMAGE_MODEL_RESPONSE_FORMAT+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++url+++`
-
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-image-model-size]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-image-model-size[`+++quarkus.langchain4j.azure-openai."model-name".image-model.size+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".image-model.size+++[]
@@ -2767,31 +2696,6 @@ endif::add-copy-button-to-env-var[]
 --
 |int
 |`+++1+++`
-
-a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-image-model-style]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-image-model-style[`+++quarkus.langchain4j.azure-openai."model-name".image-model.style+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".image-model.style+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The style of the generated images.
-
-Must be one of `vivid` or `natural`. Vivid causes the model to lean towards generating hyper-real and dramatic images. Natural causes the model to produce more natural, less hyper-real looking images.
-
-This param is only supported for when the model is `dall-e-3`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__IMAGE_MODEL_STYLE+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__IMAGE_MODEL_STYLE+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++vivid+++`
 
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-image-model-user]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-image-model-user[`+++quarkus.langchain4j.azure-openai."model-name".image-model.user+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-azure-openai_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-azure-openai_quarkus.langchain4j.adoc
@@ -1191,29 +1191,6 @@ endif::add-copy-button-to-env-var[]
 |path
 |`+++${java.io.tmpdir}/dall-e-images+++`
 
-a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-image-model-response-format]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-image-model-response-format[`+++quarkus.langchain4j.azure-openai.image-model.response-format+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.azure-openai.image-model.response-format+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The format in which the generated images are returned.
-
-Must be one of `url` or `b64_json`
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_IMAGE_MODEL_RESPONSE_FORMAT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_IMAGE_MODEL_RESPONSE_FORMAT+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++url+++`
-
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-image-model-size]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-image-model-size[`+++quarkus.langchain4j.azure-openai.image-model.size+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.azure-openai.image-model.size+++[]
@@ -1288,31 +1265,6 @@ endif::add-copy-button-to-env-var[]
 --
 |int
 |`+++1+++`
-
-a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-image-model-style]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-image-model-style[`+++quarkus.langchain4j.azure-openai.image-model.style+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.azure-openai.image-model.style+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The style of the generated images.
-
-Must be one of `vivid` or `natural`. Vivid causes the model to lean towards generating hyper-real and dramatic images. Natural causes the model to produce more natural, less hyper-real looking images.
-
-This param is only supported for when the model is `dall-e-3`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_IMAGE_MODEL_STYLE+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_IMAGE_MODEL_STYLE+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++vivid+++`
 
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-image-model-user]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-image-model-user[`+++quarkus.langchain4j.azure-openai.image-model.user+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -2670,29 +2622,6 @@ endif::add-copy-button-to-env-var[]
 |path
 |`+++${java.io.tmpdir}/dall-e-images+++`
 
-a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-image-model-response-format]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-image-model-response-format[`+++quarkus.langchain4j.azure-openai."model-name".image-model.response-format+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".image-model.response-format+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The format in which the generated images are returned.
-
-Must be one of `url` or `b64_json`
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__IMAGE_MODEL_RESPONSE_FORMAT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__IMAGE_MODEL_RESPONSE_FORMAT+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++url+++`
-
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-image-model-size]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-image-model-size[`+++quarkus.langchain4j.azure-openai."model-name".image-model.size+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".image-model.size+++[]
@@ -2767,31 +2696,6 @@ endif::add-copy-button-to-env-var[]
 --
 |int
 |`+++1+++`
-
-a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-image-model-style]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-image-model-style[`+++quarkus.langchain4j.azure-openai."model-name".image-model.style+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".image-model.style+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The style of the generated images.
-
-Must be one of `vivid` or `natural`. Vivid causes the model to lean towards generating hyper-real and dramatic images. Natural causes the model to produce more natural, less hyper-real looking images.
-
-This param is only supported for when the model is `dall-e-3`.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__IMAGE_MODEL_STYLE+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__IMAGE_MODEL_STYLE+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++vivid+++`
 
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-image-model-user]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-image-model-user[`+++quarkus.langchain4j.azure-openai."model-name".image-model.user+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai.adoc
@@ -795,7 +795,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_MODEL_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`+++dall-e-3+++`
+|`+++gpt-image-1+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-persist]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-persist[`+++quarkus.langchain4j.openai.image-model.persist+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -837,30 +837,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_PERSIST_DIRECTO
 endif::add-copy-button-to-env-var[]
 --
 |path
-|`+++${java.io.tmpdir}/dall-e-images+++`
-
-a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-response-format]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-response-format[`+++quarkus.langchain4j.openai.image-model.response-format+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.openai.image-model.response-format+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The format in which the generated images are returned.
-
-Must be one of `url` or `b64_json`
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_RESPONSE_FORMAT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_RESPONSE_FORMAT+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++url+++`
+|`+++${java.io.tmpdir}/openai-images+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-size]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-size[`+++quarkus.langchain4j.openai.image-model.size+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -872,9 +849,7 @@ endif::add-copy-button-to-config-props[]
 --
 The size of the generated images.
 
-Must be one of `1024x1024`, `1792x1024`, or `1024x1792` when the model is `dall-e-3`.
-
-Must be one of `256x256`, `512x512`, or `1024x1024` when the model is `dall-e-2`.
+Supported values: `1024x1024`, `1536x1024`, `1024x1536`, or `auto`.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -897,9 +872,7 @@ endif::add-copy-button-to-config-props[]
 --
 The quality of the image that will be generated.
 
-`hd` creates images with finer details and greater consistency across the image.
-
-This param is only supported for when the model is `dall-e-3`.
+Supported values: `auto`, `low`, `medium`, or `high`.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -910,7 +883,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_QUALITY+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`+++standard+++`
+|`+++auto+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-number]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-number[`+++quarkus.langchain4j.openai.image-model.number+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -923,8 +896,6 @@ endif::add-copy-button-to-config-props[]
 The number of images to generate.
 
 Must be between 1 and 10.
-
-When the model is dall-e-3, only n=1 is supported.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -953,6 +924,104 @@ Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_IMA
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-output-format]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-output-format[`+++quarkus.langchain4j.openai.image-model.output-format+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.image-model.output-format+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The output format of the generated image.
+
+Supported values: `png`, `jpeg`, `webp`.
+
+Only supported for `gpt-image-1` and newer models.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_OUTPUT_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_OUTPUT_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-background]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-background[`+++quarkus.langchain4j.openai.image-model.background+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.image-model.background+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The background type for the generated image.
+
+Supported values: `transparent`, `opaque`, `auto`.
+
+Only supported for `gpt-image-1` and newer models. Transparent backgrounds require `output-format` set to `png` or `webp`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_BACKGROUND+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_BACKGROUND+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-output-compression]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-output-compression[`+++quarkus.langchain4j.openai.image-model.output-compression+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.image-model.output-compression+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The compression level for the generated image (0-100).
+
+Only supported for `gpt-image-1` and newer models with `jpeg` or `webp` output formats.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_OUTPUT_COMPRESSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_OUTPUT_COMPRESSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-moderation]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-moderation[`+++quarkus.langchain4j.openai.image-model.moderation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.image-model.moderation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The moderation level for the image generation request.
+
+Supported values: `low`, `auto`.
+
+Only supported for `gpt-image-1` and newer models.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_MODERATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_MODERATION+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
@@ -1842,7 +1911,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_MO
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`+++dall-e-3+++`
+|`+++gpt-image-1+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-persist]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-persist[`+++quarkus.langchain4j.openai."model-name".image-model.persist+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -1884,30 +1953,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_PE
 endif::add-copy-button-to-env-var[]
 --
 |path
-|`+++${java.io.tmpdir}/dall-e-images+++`
-
-a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-response-format]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-response-format[`+++quarkus.langchain4j.openai."model-name".image-model.response-format+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.openai."model-name".image-model.response-format+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The format in which the generated images are returned.
-
-Must be one of `url` or `b64_json`
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_RESPONSE_FORMAT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_RESPONSE_FORMAT+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++url+++`
+|`+++${java.io.tmpdir}/openai-images+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-size]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-size[`+++quarkus.langchain4j.openai."model-name".image-model.size+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -1919,9 +1965,7 @@ endif::add-copy-button-to-config-props[]
 --
 The size of the generated images.
 
-Must be one of `1024x1024`, `1792x1024`, or `1024x1792` when the model is `dall-e-3`.
-
-Must be one of `256x256`, `512x512`, or `1024x1024` when the model is `dall-e-2`.
+Supported values: `1024x1024`, `1536x1024`, `1024x1536`, or `auto`.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -1944,9 +1988,7 @@ endif::add-copy-button-to-config-props[]
 --
 The quality of the image that will be generated.
 
-`hd` creates images with finer details and greater consistency across the image.
-
-This param is only supported for when the model is `dall-e-3`.
+Supported values: `auto`, `low`, `medium`, or `high`.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -1957,7 +1999,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_QU
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`+++standard+++`
+|`+++auto+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-number]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-number[`+++quarkus.langchain4j.openai."model-name".image-model.number+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -1970,8 +2012,6 @@ endif::add-copy-button-to-config-props[]
 The number of images to generate.
 
 Must be between 1 and 10.
-
-When the model is dall-e-3, only n=1 is supported.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -2000,6 +2040,104 @@ Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MO
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-output-format]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-output-format[`+++quarkus.langchain4j.openai."model-name".image-model.output-format+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".image-model.output-format+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The output format of the generated image.
+
+Supported values: `png`, `jpeg`, `webp`.
+
+Only supported for `gpt-image-1` and newer models.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_OUTPUT_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_OUTPUT_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-background]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-background[`+++quarkus.langchain4j.openai."model-name".image-model.background+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".image-model.background+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The background type for the generated image.
+
+Supported values: `transparent`, `opaque`, `auto`.
+
+Only supported for `gpt-image-1` and newer models. Transparent backgrounds require `output-format` set to `png` or `webp`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_BACKGROUND+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_BACKGROUND+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-output-compression]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-output-compression[`+++quarkus.langchain4j.openai."model-name".image-model.output-compression+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".image-model.output-compression+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The compression level for the generated image (0-100).
+
+Only supported for `gpt-image-1` and newer models with `jpeg` or `webp` output formats.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_OUTPUT_COMPRESSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_OUTPUT_COMPRESSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-moderation]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-moderation[`+++quarkus.langchain4j.openai."model-name".image-model.moderation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".image-model.moderation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The moderation level for the image generation request.
+
+Supported values: `low`, `auto`.
+
+Only supported for `gpt-image-1` and newer models.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_MODERATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_MODERATION+++`
 endif::add-copy-button-to-env-var[]
 --
 |string

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai_quarkus.langchain4j.adoc
@@ -795,7 +795,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_MODEL_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`+++dall-e-3+++`
+|`+++gpt-image-1+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-persist]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-persist[`+++quarkus.langchain4j.openai.image-model.persist+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -837,30 +837,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_PERSIST_DIRECTO
 endif::add-copy-button-to-env-var[]
 --
 |path
-|`+++${java.io.tmpdir}/dall-e-images+++`
-
-a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-response-format]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-response-format[`+++quarkus.langchain4j.openai.image-model.response-format+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.openai.image-model.response-format+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The format in which the generated images are returned.
-
-Must be one of `url` or `b64_json`
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_RESPONSE_FORMAT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_RESPONSE_FORMAT+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++url+++`
+|`+++${java.io.tmpdir}/openai-images+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-size]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-size[`+++quarkus.langchain4j.openai.image-model.size+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -872,9 +849,7 @@ endif::add-copy-button-to-config-props[]
 --
 The size of the generated images.
 
-Must be one of `1024x1024`, `1792x1024`, or `1024x1792` when the model is `dall-e-3`.
-
-Must be one of `256x256`, `512x512`, or `1024x1024` when the model is `dall-e-2`.
+Supported values: `1024x1024`, `1536x1024`, `1024x1536`, or `auto`.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -897,9 +872,7 @@ endif::add-copy-button-to-config-props[]
 --
 The quality of the image that will be generated.
 
-`hd` creates images with finer details and greater consistency across the image.
-
-This param is only supported for when the model is `dall-e-3`.
+Supported values: `auto`, `low`, `medium`, or `high`.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -910,7 +883,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_QUALITY+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`+++standard+++`
+|`+++auto+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-number]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-number[`+++quarkus.langchain4j.openai.image-model.number+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -923,8 +896,6 @@ endif::add-copy-button-to-config-props[]
 The number of images to generate.
 
 Must be between 1 and 10.
-
-When the model is dall-e-3, only n=1 is supported.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -953,6 +924,104 @@ Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_IMA
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-output-format]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-output-format[`+++quarkus.langchain4j.openai.image-model.output-format+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.image-model.output-format+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The output format of the generated image.
+
+Supported values: `png`, `jpeg`, `webp`.
+
+Only supported for `gpt-image-1` and newer models.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_OUTPUT_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_OUTPUT_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-background]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-background[`+++quarkus.langchain4j.openai.image-model.background+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.image-model.background+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The background type for the generated image.
+
+Supported values: `transparent`, `opaque`, `auto`.
+
+Only supported for `gpt-image-1` and newer models. Transparent backgrounds require `output-format` set to `png` or `webp`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_BACKGROUND+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_BACKGROUND+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-output-compression]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-output-compression[`+++quarkus.langchain4j.openai.image-model.output-compression+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.image-model.output-compression+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The compression level for the generated image (0-100).
+
+Only supported for `gpt-image-1` and newer models with `jpeg` or `webp` output formats.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_OUTPUT_COMPRESSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_OUTPUT_COMPRESSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-moderation]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-image-model-moderation[`+++quarkus.langchain4j.openai.image-model.moderation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.image-model.moderation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The moderation level for the image generation request.
+
+Supported values: `low`, `auto`.
+
+Only supported for `gpt-image-1` and newer models.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_MODERATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_IMAGE_MODEL_MODERATION+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
@@ -1842,7 +1911,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_MO
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`+++dall-e-3+++`
+|`+++gpt-image-1+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-persist]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-persist[`+++quarkus.langchain4j.openai."model-name".image-model.persist+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -1884,30 +1953,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_PE
 endif::add-copy-button-to-env-var[]
 --
 |path
-|`+++${java.io.tmpdir}/dall-e-images+++`
-
-a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-response-format]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-response-format[`+++quarkus.langchain4j.openai."model-name".image-model.response-format+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.openai."model-name".image-model.response-format+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The format in which the generated images are returned.
-
-Must be one of `url` or `b64_json`
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_RESPONSE_FORMAT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_RESPONSE_FORMAT+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++url+++`
+|`+++${java.io.tmpdir}/openai-images+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-size]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-size[`+++quarkus.langchain4j.openai."model-name".image-model.size+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -1919,9 +1965,7 @@ endif::add-copy-button-to-config-props[]
 --
 The size of the generated images.
 
-Must be one of `1024x1024`, `1792x1024`, or `1024x1792` when the model is `dall-e-3`.
-
-Must be one of `256x256`, `512x512`, or `1024x1024` when the model is `dall-e-2`.
+Supported values: `1024x1024`, `1536x1024`, `1024x1536`, or `auto`.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -1944,9 +1988,7 @@ endif::add-copy-button-to-config-props[]
 --
 The quality of the image that will be generated.
 
-`hd` creates images with finer details and greater consistency across the image.
-
-This param is only supported for when the model is `dall-e-3`.
+Supported values: `auto`, `low`, `medium`, or `high`.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -1957,7 +1999,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_QU
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`+++standard+++`
+|`+++auto+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-number]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-number[`+++quarkus.langchain4j.openai."model-name".image-model.number+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -1970,8 +2012,6 @@ endif::add-copy-button-to-config-props[]
 The number of images to generate.
 
 Must be between 1 and 10.
-
-When the model is dall-e-3, only n=1 is supported.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -2000,6 +2040,104 @@ Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MO
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-output-format]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-output-format[`+++quarkus.langchain4j.openai."model-name".image-model.output-format+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".image-model.output-format+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The output format of the generated image.
+
+Supported values: `png`, `jpeg`, `webp`.
+
+Only supported for `gpt-image-1` and newer models.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_OUTPUT_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_OUTPUT_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-background]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-background[`+++quarkus.langchain4j.openai."model-name".image-model.background+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".image-model.background+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The background type for the generated image.
+
+Supported values: `transparent`, `opaque`, `auto`.
+
+Only supported for `gpt-image-1` and newer models. Transparent backgrounds require `output-format` set to `png` or `webp`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_BACKGROUND+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_BACKGROUND+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-output-compression]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-output-compression[`+++quarkus.langchain4j.openai."model-name".image-model.output-compression+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".image-model.output-compression+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The compression level for the generated image (0-100).
+
+Only supported for `gpt-image-1` and newer models with `jpeg` or `webp` output formats.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_OUTPUT_COMPRESSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_OUTPUT_COMPRESSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-moderation]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-image-model-moderation[`+++quarkus.langchain4j.openai."model-name".image-model.moderation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".image-model.moderation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The moderation level for the image generation request.
+
+Supported values: `low`, `auto`.
+
+Only supported for `gpt-image-1` and newer models.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_MODERATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__IMAGE_MODEL_MODERATION+++`
 endif::add-copy-button-to-env-var[]
 --
 |string

--- a/model-providers/openai/openai-vanilla/deployment/src/main/resources/dev-ui/qwc-images.js
+++ b/model-providers/openai/openai-vanilla/deployment/src/main/resources/dev-ui/qwc-images.js
@@ -61,25 +61,22 @@ export class QwcImages extends LitElement {
     `;
 
     supportedModels = [
-        { label: "dall-e-2",  value: "dall-e-2"},
-        { label: "dall-e-3",  value: "dall-e-3"}]
+        { label: "gpt-image-1",  value: "gpt-image-1"},
+        { label: "gpt-image-1.5",  value: "gpt-image-1.5"},
+        { label: "gpt-image-1-mini",  value: "gpt-image-1-mini"},
+        { label: "gpt-image-2",  value: "gpt-image-2"}]
 
     supportedSizes = [
-        { label: "256x256",  value: "256x256", supportedModels: ["dall-e-2"]},
-        { label: "512x512",  value: "512x512", supportedModels: ["dall-e-2"]},
-        { label: "1024x1024",  value: "1024x1024", supportedModels: ["dall-e-2", "dall-e-3"]},
-        { label: "1792x1024",  value: "1792x1024", supportedModels: ["dall-e-3"]},
-        { label: "1024x1792",  value: "1024x1792", supportedModels: ["dall-e-3"]},
-        { label: "1792x1024",  value: "1792x1024", supportedModels: ["dall-e-3"]}
+        { label: "1024x1024",  value: "1024x1024", supportedModels: ["gpt-image-1", "gpt-image-1.5", "gpt-image-1-mini", "gpt-image-2"]},
+        { label: "1536x1024",  value: "1536x1024", supportedModels: ["gpt-image-1", "gpt-image-1.5", "gpt-image-1-mini", "gpt-image-2"]},
+        { label: "1024x1536",  value: "1024x1536", supportedModels: ["gpt-image-1", "gpt-image-1.5", "gpt-image-1-mini", "gpt-image-2"]}
     ]
 
     supportedQualities = [
-        { label: "standard",  value: "standard", supportedModels: ["dall-e-2", "dall-e-3"]},
-        { label: "hd",  value: "hd", supportedModels: ["dall-e-3"]}]
-
-    supportedStyles = [
-        { label: "vivid",  value: "vivid", supportedModels: ["dall-e-2", "dall-e-3"]},
-        { label: "natural",  value: "natural", supportedModels: ["dall-e-3"]}]
+        { label: "auto",  value: "auto", supportedModels: ["gpt-image-1", "gpt-image-1.5", "gpt-image-1-mini", "gpt-image-2"]},
+        { label: "low",  value: "low", supportedModels: ["gpt-image-1", "gpt-image-1.5", "gpt-image-1-mini", "gpt-image-2"]},
+        { label: "medium",  value: "medium", supportedModels: ["gpt-image-1", "gpt-image-1.5", "gpt-image-1-mini", "gpt-image-2"]},
+        { label: "high",  value: "high", supportedModels: ["gpt-image-1", "gpt-image-1.5", "gpt-image-1-mini", "gpt-image-2"]}]
 
     static properties = {
         _progressBarClass: {state: true},
@@ -113,23 +110,17 @@ export class QwcImages extends LitElement {
 
         const availableSizes = this._getSupportedSizesForModel(this.selectedModel);
         const availableQualities = this._getSupportedQualitiesForModel(this.selectedModel);
-        const availableStyles = this._getSupportedStylesForModel(this.selectedModel);
-        
+
         this.selectedSize = this._getSupportedSizesForModel(this.selectedModel)[0].value;
         this.selectedQuality = this._getSupportedQualitiesForModel(this.selectedModel)[0].value;
-        this.selectedStyle = this._getSupportedStylesForModel(this.selectedModel)[0].value;
-       
+
         // Reset the values if the selected model does not support the current value
         if (!availableSizes.map(s => s.value).includes(this.shadowRoot.getElementById('size').value)) {
           this.shadowRoot.getElementById('size').value = availableSizes[0].value;
         }
-        
+
         if (!availableQualities.map(s => s.value).includes(this.shadowRoot.getElementById('quality').value)) {
           this.shadowRoot.getElementById('quality').value = availableQualities[0].value;
-        }
-        
-        if (!availableStyles.map(s => s.value).includes(this.shadowRoot.getElementById('style').value)) {
-          this.shadowRoot.getElementById('style').value = availableStyles[0].value;
         }
     }
      
@@ -139,10 +130,6 @@ export class QwcImages extends LitElement {
 
     _getSupportedQualitiesForModel(model) {
         return this.supportedQualities.filter(quality => quality.supportedModels.includes(model));
-    }
-    
-    _getSupportedStylesForModel(model) {
-        return this.supportedStyles.filter(style => style.supportedModels.includes(model));
     }
 
     _renderConfig() {
@@ -169,8 +156,7 @@ export class QwcImages extends LitElement {
                             id="size"
                             .items="${this._getSupportedSizesForModel(this.selectedModel) }"
                             .value="${this._getSupportedSizesForModel(this.selectedModel)[0].value}">
-                            <vaadin-tooltip slot="tooltip" text="Must be one of 1024x1024, 1792x1024, or 1024x1792 when the model is dall-e-3. 
-                                Must be one of 256x256, 512x512, or 1024x1024 when the model is dall-e-2." position="bottom"></vaadin-tooltip>
+                            <vaadin-tooltip slot="tooltip" text="Supported sizes: 1024x1024, 1536x1024, 1024x1536, or auto." position="bottom"></vaadin-tooltip>
                     </vaadin-select>
                     <vaadin-select
                             label="Quality"
@@ -178,17 +164,7 @@ export class QwcImages extends LitElement {
                             .items="${this._getSupportedQualitiesForModel(this.selectedModel) }"
                             .value="${this._getSupportedQualitiesForModel(this.selectedModel)[0].value}">
                             <vaadin-tooltip slot="tooltip" text="The quality of the image that will be generated.
-                                'hd' creates images with finer details and greater consistency across the image.
-                                This param is only supported for when the model is dall-e-3." position="bottom"></vaadin-tooltip>
-                    </vaadin-select>
-                    <vaadin-select
-                            label="Style"
-                            id="style"
-                            .items="${this._getSupportedStylesForModel(this.selectedModel) }"
-                            .value="${this._getSupportedStylesForModel(this.selectedModel)[0].value}">
-                            <vaadin-tooltip slot="tooltip" text="Vivid causes the model to lean towards generating hyper-real and dramatic images.
-                                Natural causes the model to produce more natural, less hyper-real looking images. 
-                                This param is only supported for when the model is dall-e-3." position="bottom"></vaadin-tooltip>
+                                Supported values: auto, low, medium, or high." position="bottom"></vaadin-tooltip>
                     </vaadin-select>
                 </vaadin-vertical-layout>
             </div>
@@ -206,8 +182,7 @@ export class QwcImages extends LitElement {
                             this.shadowRoot.getElementById('model-name').value,
                             this.shadowRoot.getElementById('image-prompt').value,
                             this.shadowRoot.getElementById('size').value,
-                            this.shadowRoot.getElementById('quality').value,
-                            this.shadowRoot.getElementById('style').value
+                            this.shadowRoot.getElementById('quality').value
                         )}>Generate image
                     </vaadin-button>
                     <vaadin-progress-bar class="${this._progressBarClass}" indeterminate></vaadin-progress-bar>
@@ -220,10 +195,10 @@ export class QwcImages extends LitElement {
         `;
     }
 
-    _doGenerate(configuration, modelName, prompt, size, quality, style) {
+    _doGenerate(configuration, modelName, prompt, size, quality) {
         this._showProgressBar();
         this.jsonRpc.generate({configuration: configuration, modelName: modelName,
-                prompt: prompt, size: size, quality: quality, style: style}).then((jsonRpcResponse) => {
+                prompt: prompt, size: size, quality: quality}).then((jsonRpcResponse) => {
                     this._hideProgressBar();
                     this._generatedImages = [jsonRpcResponse.result].concat(this._generatedImages)
         }).catch((error) => {

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/proxy/ProxyImageModelTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/proxy/ProxyImageModelTest.java
@@ -44,7 +44,7 @@ public class ProxyImageModelTest extends OpenAiBaseTest {
         Response<Image> response = imageModel.generate("whatever");
         SoftAssertions softly = new SoftAssertions();
         softly.assertThat(response).isNotNull();
-        softly.assertThat(response.content().url().getHost()).isEqualTo("somewhere.com");
+        softly.assertThat(response.content().base64Data()).isNotNull();
 
         LoggedRequest loggedRequest = singleLoggedRequest();
         softly.assertThat(loggedRequest.getHost()).isEqualTo("localhost");

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/org/acme/examples/aiservices/ImageModelTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/org/acme/examples/aiservices/ImageModelTest.java
@@ -33,7 +33,7 @@ public class ImageModelTest extends OpenAiBaseTest {
     public void test() {
         Response<Image> response = imageModel.generate("whatever");
         assertNotNull(response);
-        assertNotNull(response.content().url());
+        assertNotNull(response.content().base64Data());
 
         assertThat(wiremock().getServeEvents()).hasSize(1);
     }

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/QuarkusOpenAiImageModel.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/QuarkusOpenAiImageModel.java
@@ -35,6 +35,10 @@ public class QuarkusOpenAiImageModel implements ImageModel {
     private final Optional<String> user;
     private final Integer maxRetries;
     private final Optional<Path> persistDirectory;
+    private final String outputFormat;
+    private final String background;
+    private final Integer outputCompression;
+    private final String moderation;
 
     private final QuarkusOpenAiClient client;
 
@@ -48,6 +52,10 @@ public class QuarkusOpenAiImageModel implements ImageModel {
             throw new IllegalArgumentException("max-retries must be at least 1");
         }
         this.persistDirectory = builder.persistDirectory;
+        this.outputFormat = builder.outputFormat;
+        this.background = builder.background;
+        this.outputCompression = builder.outputCompression;
+        this.moderation = builder.moderation;
 
         this.client = QuarkusOpenAiClient.builder()
                 .baseUrl(builder.baseUrl)
@@ -68,7 +76,7 @@ public class QuarkusOpenAiImageModel implements ImageModel {
 
     @Override
     public Response<Image> generate(String prompt) {
-        GenerateImagesRequest request = requestBuilder(prompt).build();
+        var request = buildRequest(prompt);
 
         GenerateImagesResponse response = withRetry(() -> client.imagesGeneration(request), maxRetries).execute();
         persistIfNecessary(response);
@@ -78,7 +86,7 @@ public class QuarkusOpenAiImageModel implements ImageModel {
 
     @Override
     public Response<List<Image>> generate(String prompt, int n) {
-        GenerateImagesRequest request = requestBuilder(prompt).n(n).build();
+        var request = buildRequest(prompt, n);
 
         GenerateImagesResponse response = withRetry(() -> client.imagesGeneration(request), maxRetries).execute();
         persistIfNecessary(response);
@@ -113,19 +121,35 @@ public class QuarkusOpenAiImageModel implements ImageModel {
         return Image.builder().url(data.url()).base64Data(data.b64Json()).revisedPrompt(data.revisedPrompt()).build();
     }
 
-    private GenerateImagesRequest.Builder requestBuilder(String prompt) {
-        var builder = GenerateImagesRequest
-                .builder()
+    private GenerateImagesRequest buildRequest(String prompt) {
+        return buildRequest(prompt, 1);
+    }
+
+    private GenerateImagesRequest buildRequest(String prompt, int n) {
+        var builder = GenerateImagesRequest.builder()
                 .prompt(prompt)
                 .model(modelName)
+                .n(n)
                 .size(size)
                 .quality(quality);
 
         if (user.isPresent()) {
             builder.user(user.get());
         }
+        if (outputFormat != null) {
+            builder.outputFormat(outputFormat);
+        }
+        if (background != null) {
+            builder.background(background);
+        }
+        if (outputCompression != null) {
+            builder.outputCompression(outputCompression);
+        }
+        if (moderation != null) {
+            builder.moderation(moderation);
+        }
 
-        return builder;
+        return builder.build();
     }
 
     public static Builder builder() {
@@ -149,6 +173,10 @@ public class QuarkusOpenAiImageModel implements ImageModel {
         private Boolean logCurl;
         private Optional<Path> persistDirectory;
         private Proxy proxy;
+        private String outputFormat;
+        private String background;
+        private Integer outputCompression;
+        private String moderation;
 
         public Builder baseUrl(String baseUrl) {
             this.baseUrl = baseUrl;
@@ -227,6 +255,26 @@ public class QuarkusOpenAiImageModel implements ImageModel {
 
         public Builder proxy(Proxy proxy) {
             this.proxy = proxy;
+            return this;
+        }
+
+        public Builder outputFormat(String outputFormat) {
+            this.outputFormat = outputFormat;
+            return this;
+        }
+
+        public Builder background(String background) {
+            this.background = background;
+            return this;
+        }
+
+        public Builder outputCompression(Integer outputCompression) {
+            this.outputCompression = outputCompression;
+            return this;
+        }
+
+        public Builder moderation(String moderation) {
+            this.moderation = moderation;
             return this;
         }
 

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
@@ -370,6 +370,11 @@ public class OpenAiRecorder {
                     .quality(imageModelConfig.quality())
                     .user(imageModelConfig.user());
 
+            imageModelConfig.outputFormat().ifPresent(builder::outputFormat);
+            imageModelConfig.background().ifPresent(builder::background);
+            imageModelConfig.outputCompression().ifPresent(builder::outputCompression);
+            imageModelConfig.moderation().ifPresent(builder::moderation);
+
             openAiConfig.organizationId().ifPresent(builder::organizationId);
 
             // we persist if the directory was set explicitly and the boolean flag was not set to false
@@ -380,7 +385,7 @@ public class OpenAiRecorder {
                     persistDirectory = imageModelConfig.persistDirectory().or(new Supplier<>() {
                         @Override
                         public Optional<? extends Path> get() {
-                            return Optional.of(Paths.get(System.getProperty("java.io.tmpdir"), "dall-e-images"));
+                            return Optional.of(Paths.get(System.getProperty("java.io.tmpdir"), "openai-images"));
                         }
                     });
                 }

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/ImageModelConfig.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/ImageModelConfig.java
@@ -13,7 +13,7 @@ public interface ImageModelConfig {
     /**
      * Model name to use
      */
-    @WithDefault("dall-e-3")
+    @WithDefault("gpt-image-1")
     String modelName();
 
     /**
@@ -28,15 +28,13 @@ public interface ImageModelConfig {
      * The path where the generated images will be persisted to disk.
      * This only applies of {@code quarkus.langchain4j.openai.image-mode.persist} is not set to {@code false}.
      */
-    @ConfigDocDefault("${java.io.tmpdir}/dall-e-images")
+    @ConfigDocDefault("${java.io.tmpdir}/openai-images")
     Optional<Path> persistDirectory();
 
     /**
      * The size of the generated images.
      * <p>
-     * Must be one of {@code 1024x1024}, {@code 1792x1024}, or {@code 1024x1792} when the model is {@code dall-e-3}.
-     * <p>
-     * Must be one of {@code 256x256}, {@code 512x512}, or {@code 1024x1024} when the model is {@code dall-e-2}.
+     * Supported values: {@code 1024x1024}, {@code 1536x1024}, {@code 1024x1536}, or {@code auto}.
      */
     @WithDefault("1024x1024")
     String size();
@@ -44,19 +42,15 @@ public interface ImageModelConfig {
     /**
      * The quality of the image that will be generated.
      * <p>
-     * {@code hd} creates images with finer details and greater consistency across the image.
-     * <p>
-     * This param is only supported for when the model is {@code dall-e-3}.
+     * Supported values: {@code auto}, {@code low}, {@code medium}, or {@code high}.
      */
-    @WithDefault("standard")
+    @WithDefault("auto")
     String quality();
 
     /**
      * The number of images to generate.
      * <p>
      * Must be between 1 and 10.
-     * <p>
-     * When the model is dall-e-3, only n=1 is supported.
      */
     @WithDefault("1")
     int number();
@@ -65,6 +59,41 @@ public interface ImageModelConfig {
      * A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
      */
     Optional<String> user();
+
+    /**
+     * The output format of the generated image.
+     * <p>
+     * Supported values: {@code png}, {@code jpeg}, {@code webp}.
+     * <p>
+     * Only supported for {@code gpt-image-1} and newer models.
+     */
+    Optional<String> outputFormat();
+
+    /**
+     * The background type for the generated image.
+     * <p>
+     * Supported values: {@code transparent}, {@code opaque}, {@code auto}.
+     * <p>
+     * Only supported for {@code gpt-image-1} and newer models.
+     * Transparent backgrounds require {@code output-format} set to {@code png} or {@code webp}.
+     */
+    Optional<String> background();
+
+    /**
+     * The compression level for the generated image (0-100).
+     * <p>
+     * Only supported for {@code gpt-image-1} and newer models with {@code jpeg} or {@code webp} output formats.
+     */
+    Optional<Integer> outputCompression();
+
+    /**
+     * The moderation level for the image generation request.
+     * <p>
+     * Supported values: {@code low}, {@code auto}.
+     * <p>
+     * Only supported for {@code gpt-image-1} and newer models.
+     */
+    Optional<String> moderation();
 
     /**
      * Whether image model requests should be logged

--- a/model-providers/openai/testing-internal/src/main/resources/openai/mappings/completions.json
+++ b/model-providers/openai/testing-internal/src/main/resources/openai/mappings/completions.json
@@ -80,13 +80,13 @@
             "matchesJsonPath": "$[?(@.size == '1024x1024')]"
           },
           {
-            "matchesJsonPath": "$[?(@.quality == 'standard')]"
+            "matchesJsonPath": "$[?(@.quality == 'auto')]"
           }
         ]
       },
       "response": {
         "status": 200,
-        "body": "{\n  \"created\": 1708633271,\n  \"data\": [\n    {\n      \"revised_prompt\": \"Some revised prompt.\",\n      \"url\": \"https://somewhere.com/someImage.png\"\n    }\n   ]\n  }\n",
+        "body": "{\n  \"created\": 1708633271,\n  \"data\": [\n    {\n      \"b64_json\": \"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==\"\n    }\n   ]\n  }\n",
         "headers": {
           "Content-Type": "application/json",
           "openai-organization": "my-org-1234",


### PR DESCRIPTION
## Summary

- Migrates the vanilla OpenAI image model integration from the deprecated dall-e API to the new GPT-Image API (`gpt-image-1`)
- Creates `QuarkusGenerateImagesRequest` subclass with `@JsonIgnoreProperties` to suppress `style`/`response_format` and add new API fields (`output_format`, `background`, `output_compression`, `moderation`)
- Creates `QuarkusGenerateImagesResponse` subclass with Jackson mixin to capture new response fields (`output_format`, `background`, `quality`, `size`, `usage` with token details)
- Updates config defaults, DevUI, WireMock mappings, tests, and documentation

----

- Closes: #2540