### PR TITLE
Expose LangChain4j Tool Search in `@RegisterAiService`

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
@@ -482,6 +482,18 @@ public class AiServicesProcessor {
                 }
             }
 
+            DotName toolSearchStrategyClassName = LangChain4jDotNames.BEAN_IF_EXISTS_TOOL_SEARCH_STRATEGY_SUPPLIER;
+            AnnotationValue toolSearchStrategyValue = instance.value("toolSearchStrategySupplier");
+            if (toolSearchStrategyValue != null) {
+                if (LangChain4jDotNames.NO_TOOL_SEARCH_STRATEGY_SUPPLIER.equals(toolSearchStrategyValue.asClass().name())) {
+                    toolSearchStrategyClassName = null;
+                } else {
+                    toolSearchStrategyClassName = toolSearchStrategyValue.asClass().name();
+                    validateSupplierAndRegister(toolSearchStrategyClassName, index, reflectiveClassProducer,
+                            unremovableBeanProducer);
+                }
+            }
+
             // determine if the AiService returns an image
             for (MethodInfo method : declarativeAiServiceClassInfo.methods()) {
                 Type returnType = method.returnType();
@@ -585,6 +597,7 @@ public class AiServicesProcessor {
                             moderationModelName,
                             imageModelName,
                             toolProviderClassName,
+                            toolSearchStrategyClassName,
                             beanName(declarativeAiServiceClassInfo),
                             toolHallucinationStrategy(instance),
                             classInputGuardrails(declarativeAiServiceClassInfo, index),
@@ -943,8 +956,10 @@ public class AiServicesProcessor {
         boolean needsModerationModelBean = false;
         boolean needsImageModelBean = false;
         boolean needsToolProviderBean = false;
+        boolean needsToolSearchStrategyBean = false;
         Set<DotName> allToolNames = new HashSet<>();
         Set<DotName> allToolProviders = new HashSet<>();
+        Set<DotName> allToolSearchStrategies = new HashSet<>();
         Set<DotName> allToolHallucinationStrategies = new HashSet<>();
 
         for (DeclarativeAiServiceBuildItem bi : declarativeAiServiceItems) {
@@ -977,6 +992,10 @@ public class AiServicesProcessor {
 
             String toolProviderSupplierClassName = (bi.getToolProviderClassDotName() != null
                     ? bi.getToolProviderClassDotName().toString()
+                    : null);
+
+            String toolSearchStrategySupplierClassName = (bi.getToolSearchStrategyClassDotName() != null
+                    ? bi.getToolSearchStrategyClassDotName().toString()
                     : null);
 
             String toolHallucinationStrategyClassName = null;
@@ -1088,6 +1107,7 @@ public class AiServicesProcessor {
                                     streamingChatLanguageModelSupplierClassName,
                                     toolToQualifierMap,
                                     toolProviderSupplierClassName,
+                                    toolSearchStrategySupplierClassName,
                                     chatMemoryProviderSupplierClassName,
                                     chatMemoryFlushStrategySupplierClassName,
                                     retrievalAugmentorSupplierClassName,
@@ -1227,6 +1247,18 @@ public class AiServicesProcessor {
                 allToolProviders.add(toolProvider);
             }
 
+            if (RegisterAiService.BeanIfExistsToolSearchStrategySupplier.class.getName()
+                    .equals(toolSearchStrategySupplierClassName)) {
+                configurator.addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                        new Type[] { ClassType.create(LangChain4jDotNames.TOOL_SEARCH_STRATEGY) }, null));
+                needsToolSearchStrategyBean = true;
+            } else if (!RegisterAiService.NoToolSearchStrategySupplier.class.getName()
+                    .equals(toolSearchStrategySupplierClassName) && toolSearchStrategySupplierClassName != null) {
+                DotName toolSearchStrategy = DotName.createSimple(toolSearchStrategySupplierClassName);
+                configurator.addInjectionPoint(ClassType.create(toolSearchStrategy));
+                allToolSearchStrategies.add(toolSearchStrategy);
+            }
+
             configurator
                     .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                             new Type[] { ClassType.create(OutputGuardrail.class) }, null))
@@ -1261,6 +1293,12 @@ public class AiServicesProcessor {
         }
         if (!allToolProviders.isEmpty()) {
             unremovableProducer.produce(UnremovableBeanBuildItem.beanTypes(allToolProviders));
+        }
+        if (needsToolSearchStrategyBean) {
+            unremovableProducer.produce(UnremovableBeanBuildItem.beanTypes(LangChain4jDotNames.TOOL_SEARCH_STRATEGY));
+        }
+        if (!allToolSearchStrategies.isEmpty()) {
+            unremovableProducer.produce(UnremovableBeanBuildItem.beanTypes(allToolSearchStrategies));
         }
         if (!allToolNames.isEmpty()) {
             unremovableProducer.produce(UnremovableBeanBuildItem.beanTypes(allToolNames));

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/DeclarativeAiServiceBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/DeclarativeAiServiceBuildItem.java
@@ -18,6 +18,7 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
     private final DotName streamingChatLanguageModelSupplierClassDotName;
     private final List<ClassInfo> toolClassInfos;
     private final DotName toolProviderClassDotName;
+    private final DotName toolSearchStrategyClassDotName;
     private final DotName toolHallucinationStrategyClassDotName;
 
     private final DotName chatMemoryProviderSupplierClassDotName;
@@ -63,6 +64,7 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
             String moderationModelName,
             String imageModelName,
             DotName toolProviderClassDotName,
+            DotName toolSearchStrategyClassDotName,
             Optional<String> beanName,
             DotName toolHallucinationStrategyClassDotName,
             DeclarativeAiServiceInputGuardrails inputGuardrails,
@@ -91,6 +93,7 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
         this.moderationModelName = moderationModelName;
         this.imageModelName = imageModelName;
         this.toolProviderClassDotName = toolProviderClassDotName;
+        this.toolSearchStrategyClassDotName = toolSearchStrategyClassDotName;
         this.beanName = beanName;
         this.toolHallucinationStrategyClassDotName = toolHallucinationStrategyClassDotName;
         this.inputGuardrails = inputGuardrails;
@@ -171,6 +174,10 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
 
     public DotName getToolProviderClassDotName() {
         return toolProviderClassDotName;
+    }
+
+    public DotName getToolSearchStrategyClassDotName() {
+        return toolSearchStrategyClassDotName;
     }
 
     public Optional<String> getBeanName() {

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/LangChain4jDotNames.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/LangChain4jDotNames.java
@@ -35,6 +35,7 @@ import dev.langchain4j.service.guardrail.OutputGuardrails;
 import dev.langchain4j.service.tool.ToolErrorContext;
 import dev.langchain4j.service.tool.ToolErrorHandlerResult;
 import dev.langchain4j.service.tool.ToolProvider;
+import dev.langchain4j.service.tool.search.ToolSearchStrategy;
 import dev.langchain4j.web.search.WebSearchEngine;
 import dev.langchain4j.web.search.WebSearchTool;
 import io.quarkiverse.langchain4j.AudioUrl;
@@ -131,6 +132,12 @@ public class LangChain4jDotNames {
     static final DotName NO_TOOL_PROVIDER_SUPPLIER = DotName.createSimple(
             RegisterAiService.NoToolProviderSupplier.class);
 
+    static final DotName BEAN_IF_EXISTS_TOOL_SEARCH_STRATEGY_SUPPLIER = DotName.createSimple(
+            RegisterAiService.BeanIfExistsToolSearchStrategySupplier.class);
+
+    static final DotName NO_TOOL_SEARCH_STRATEGY_SUPPLIER = DotName.createSimple(
+            RegisterAiService.NoToolSearchStrategySupplier.class);
+
     static final DotName QUARKUS_AI_SERVICE_CONTEXT_QUALIFIER = DotName.createSimple(
             QuarkusAiServiceContextQualifier.class);
 
@@ -156,6 +163,8 @@ public class LangChain4jDotNames {
     static final DotName VIDEO = DotName.createSimple(dev.langchain4j.data.video.Video.class);
     static final DotName RESULT = DotName.createSimple(Result.class);
     public static final DotName TOOL_PROVIDER = DotName.createSimple(ToolProvider.class);
+    public static final DotName TOOL_SEARCH_STRATEGY = DotName
+            .createSimple(ToolSearchStrategy.class);
     // Using the class name to keep the McpToolBox annotation in the mcp module
     public static final DotName MCP_TOOLBOX = DotName.createSimple("io.quarkiverse.langchain4j.mcp.runtime.McpToolBox");
     public static final DotName CHAT_EVENT = DotName.createSimple(ChatEvent.class);

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolsearch/BookingTools.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolsearch/BookingTools.java
@@ -1,0 +1,14 @@
+package io.quarkiverse.langchain4j.test.toolsearch;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import dev.langchain4j.agent.tool.Tool;
+
+@ApplicationScoped
+public class BookingTools {
+
+    @Tool("Returns booking details")
+    public String getBookingDetails() {
+        return "REAL_TOOL_RESULT";
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolsearch/FakeToolSearchStrategy.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolsearch/FakeToolSearchStrategy.java
@@ -1,0 +1,35 @@
+package io.quarkiverse.langchain4j.test.toolsearch;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.service.tool.search.ToolSearchRequest;
+import dev.langchain4j.service.tool.search.ToolSearchResult;
+import dev.langchain4j.service.tool.search.ToolSearchStrategy;
+
+/**
+ * Deterministic {@link ToolSearchStrategy} stub used to exercise the tool-search wiring without a real model or
+ * embeddings. It exposes a single {@code search_tools} tool and always "finds" the {@code getBookingDetails} tool.
+ */
+@ApplicationScoped
+public class FakeToolSearchStrategy implements ToolSearchStrategy {
+
+    public static final String SEARCH_TOOL_NAME = "search_tools";
+    public static final String FOUND_TOOL_NAME = "getBookingDetails";
+
+    @Override
+    public List<ToolSpecification> getToolSearchTools(InvocationContext invocationContext) {
+        return List.of(ToolSpecification.builder()
+                .name(SEARCH_TOOL_NAME)
+                .description("Search for the tools that are relevant to the user request")
+                .build());
+    }
+
+    @Override
+    public ToolSearchResult search(ToolSearchRequest toolSearchRequest) {
+        return new ToolSearchResult(List.of(FOUND_TOOL_NAME), "found " + FOUND_TOOL_NAME);
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolsearch/ToolSearchModel.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolsearch/ToolSearchModel.java
@@ -1,0 +1,78 @@
+package io.quarkiverse.langchain4j.test.toolsearch;
+
+import static dev.langchain4j.data.message.ChatMessageType.TOOL_EXECUTION_RESULT;
+
+import java.util.List;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
+
+/**
+ * Drives the tool-search flow deterministically and encodes the expectations of each stage so the test fails with a
+ * descriptive answer if any stage misbehaves:
+ * <ul>
+ * <li>first turn: the searchable tool must be hidden and only the search tool offered;</li>
+ * <li>after the search tool runs: the found tool must have been added to the effective tools;</li>
+ * <li>finally: the found tool result is returned as the answer.</li>
+ * </ul>
+ */
+public class ToolSearchModel implements ChatModel {
+
+    @Override
+    public ChatResponse doChat(ChatRequest chatRequest) {
+        List<ChatMessage> messages = chatRequest.messages();
+        ChatMessage lastMessage = messages.get(messages.size() - 1);
+
+        if (lastMessage.type().equals(TOOL_EXECUTION_RESULT)) {
+            ToolExecutionResultMessage result = (ToolExecutionResultMessage) lastMessage;
+            // Tool results are JSON-serialized, so the real tool result text is quoted.
+            if (result.text().contains("REAL_TOOL_RESULT")) {
+                return answer("REAL_TOOL_RESULT");
+            }
+            // The search tool just ran; the found tool must now be available.
+            if (hasTool(chatRequest, FakeToolSearchStrategy.FOUND_TOOL_NAME)) {
+                return callTool(FakeToolSearchStrategy.FOUND_TOOL_NAME);
+            }
+            return answer("FOUND_TOOL_NOT_AVAILABLE");
+        }
+
+        // First turn: the searchable tool must be hidden, only the search tool exposed.
+        if (hasTool(chatRequest, FakeToolSearchStrategy.FOUND_TOOL_NAME)) {
+            return answer("TOOL_NOT_NARROWED");
+        }
+        if (hasTool(chatRequest, FakeToolSearchStrategy.SEARCH_TOOL_NAME)) {
+            return callTool(FakeToolSearchStrategy.SEARCH_TOOL_NAME);
+        }
+        return answer("NO_SEARCH_TOOL");
+    }
+
+    private static boolean hasTool(ChatRequest chatRequest, String name) {
+        List<ToolSpecification> toolSpecifications = chatRequest.toolSpecifications();
+        if (toolSpecifications == null) {
+            return false;
+        }
+        return toolSpecifications.stream().anyMatch(spec -> spec.name().equals(name));
+    }
+
+    private static ChatResponse callTool(String name) {
+        ToolExecutionRequest toolExecutionRequest = ToolExecutionRequest.builder()
+                .name(name)
+                .id(name)
+                .build();
+        return ChatResponse.builder()
+                .aiMessage(AiMessage.from(toolExecutionRequest))
+                .finishReason(FinishReason.TOOL_EXECUTION)
+                .build();
+    }
+
+    private static ChatResponse answer(String text) {
+        return ChatResponse.builder().aiMessage(new AiMessage(text)).build();
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolsearch/ToolSearchModelSupplier.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolsearch/ToolSearchModelSupplier.java
@@ -1,0 +1,12 @@
+package io.quarkiverse.langchain4j.test.toolsearch;
+
+import java.util.function.Supplier;
+
+import dev.langchain4j.model.chat.ChatModel;
+
+public class ToolSearchModelSupplier implements Supplier<ChatModel> {
+    @Override
+    public ChatModel get() {
+        return new ToolSearchModel();
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolsearch/ToolSearchOptOutTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolsearch/ToolSearchOptOutTest.java
@@ -1,0 +1,51 @@
+package io.quarkiverse.langchain4j.test.toolsearch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.RegisterAiService.NoToolSearchStrategySupplier;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Even when a {@code ToolSearchStrategy} CDI bean exists, a service that opts out with
+ * {@link NoToolSearchStrategySupplier} must keep the full tool catalog visible upfront.
+ */
+public class ToolSearchOptOutTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ToolSearchModel.class,
+                            ToolSearchModelSupplier.class,
+                            FakeToolSearchStrategy.class,
+                            BookingTools.class,
+                            ServiceOptingOut.class));
+
+    @RegisterAiService(tools = BookingTools.class, chatLanguageModelSupplier = ToolSearchModelSupplier.class, toolSearchStrategySupplier = NoToolSearchStrategySupplier.class)
+    interface ServiceOptingOut {
+
+        String chat(@UserMessage String msg, @MemoryId Object id);
+
+    }
+
+    @Inject
+    ServiceOptingOut service;
+
+    @Test
+    @ActivateRequestContext
+    void catalogIsNotNarrowedWhenOptedOut() {
+        String answer = service.chat("get my booking details", 1);
+        assertEquals("TOOL_NOT_NARROWED", answer);
+    }
+
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolsearch/ToolSearchStrategyTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolsearch/ToolSearchStrategyTest.java
@@ -1,0 +1,50 @@
+package io.quarkiverse.langchain4j.test.toolsearch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * When a {@code ToolSearchStrategy} CDI bean exists, an AI service that does not opt out should let it narrow the
+ * upfront tool catalog and add the tools the model discovers through the search tool.
+ */
+public class ToolSearchStrategyTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ToolSearchModel.class,
+                            ToolSearchModelSupplier.class,
+                            FakeToolSearchStrategy.class,
+                            BookingTools.class,
+                            ServiceWithToolSearch.class));
+
+    @RegisterAiService(tools = BookingTools.class, chatLanguageModelSupplier = ToolSearchModelSupplier.class)
+    interface ServiceWithToolSearch {
+
+        String chat(@UserMessage String msg, @MemoryId Object id);
+
+    }
+
+    @Inject
+    ServiceWithToolSearch service;
+
+    @Test
+    @ActivateRequestContext
+    void searchedToolIsExecuted() {
+        String answer = service.chat("get my booking details", 1);
+        assertEquals("REAL_TOOL_RESULT", answer);
+    }
+
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolsearch/ToolSearchStreamingTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolsearch/ToolSearchStreamingTest.java
@@ -1,0 +1,128 @@
+package io.quarkiverse.langchain4j.test.toolsearch;
+
+import static dev.langchain4j.data.message.ChatMessageType.TOOL_EXECUTION_RESULT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+
+/**
+ * The streaming path must honor the tool search strategy the same way the blocking path does.
+ */
+public class ToolSearchStreamingTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(FakeToolSearchStrategy.class,
+                            BookingTools.class,
+                            StreamingServiceWithToolSearch.class));
+
+    @RegisterAiService(tools = BookingTools.class, streamingChatLanguageModelSupplier = StreamingModelSupplier.class)
+    interface StreamingServiceWithToolSearch {
+
+        Multi<String> chat(@UserMessage String msg, @MemoryId Object id);
+
+    }
+
+    @Inject
+    StreamingServiceWithToolSearch service;
+
+    @Test
+    @ActivateRequestContext
+    void searchedToolIsExecuted() {
+        List<String> tokens = service.chat("get my booking details", 1)
+                .collect().asList()
+                .await().atMost(Duration.ofSeconds(30));
+        assertEquals("REAL_TOOL_RESULT", String.join("", tokens));
+    }
+
+    public static class StreamingModelSupplier implements Supplier<StreamingChatModel> {
+        @Override
+        public StreamingChatModel get() {
+            return new StreamingModel();
+        }
+    }
+
+    /**
+     * Streaming counterpart of {@code ToolSearchModel}: same staged expectations, driven through a
+     * {@link StreamingChatResponseHandler}.
+     */
+    public static class StreamingModel implements StreamingChatModel {
+
+        @Override
+        public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+            List<ChatMessage> messages = chatRequest.messages();
+            ChatMessage lastMessage = messages.get(messages.size() - 1);
+
+            if (lastMessage.type().equals(TOOL_EXECUTION_RESULT)) {
+                ToolExecutionResultMessage result = (ToolExecutionResultMessage) lastMessage;
+                if (result.text().contains("REAL_TOOL_RESULT")) {
+                    answer(handler, "REAL_TOOL_RESULT");
+                } else if (hasTool(chatRequest, FakeToolSearchStrategy.FOUND_TOOL_NAME)) {
+                    callTool(handler, FakeToolSearchStrategy.FOUND_TOOL_NAME);
+                } else {
+                    answer(handler, "FOUND_TOOL_NOT_AVAILABLE");
+                }
+                return;
+            }
+
+            if (hasTool(chatRequest, FakeToolSearchStrategy.FOUND_TOOL_NAME)) {
+                answer(handler, "TOOL_NOT_NARROWED");
+            } else if (hasTool(chatRequest, FakeToolSearchStrategy.SEARCH_TOOL_NAME)) {
+                callTool(handler, FakeToolSearchStrategy.SEARCH_TOOL_NAME);
+            } else {
+                answer(handler, "NO_SEARCH_TOOL");
+            }
+        }
+
+        private static boolean hasTool(ChatRequest chatRequest, String name) {
+            List<ToolSpecification> toolSpecifications = chatRequest.toolSpecifications();
+            if (toolSpecifications == null) {
+                return false;
+            }
+            return toolSpecifications.stream().anyMatch(spec -> spec.name().equals(name));
+        }
+
+        private static void callTool(StreamingChatResponseHandler handler, String name) {
+            ToolExecutionRequest toolExecutionRequest = ToolExecutionRequest.builder().name(name).id(name).build();
+            handler.onCompleteResponse(ChatResponse.builder()
+                    .aiMessage(AiMessage.from(toolExecutionRequest))
+                    .finishReason(FinishReason.TOOL_EXECUTION)
+                    .build());
+        }
+
+        private static void answer(StreamingChatResponseHandler handler, String text) {
+            handler.onPartialResponse(text);
+            handler.onCompleteResponse(ChatResponse.builder()
+                    .aiMessage(new AiMessage(text))
+                    .finishReason(FinishReason.STOP)
+                    .build());
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolsearch/VectorToolSearchStrategyTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolsearch/VectorToolSearchStrategyTest.java
@@ -1,0 +1,182 @@
+package io.quarkiverse.langchain4j.test.toolsearch;
+
+import static dev.langchain4j.data.message.ChatMessageType.TOOL_EXECUTION_RESULT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.tool.search.ToolSearchStrategy;
+import dev.langchain4j.service.tool.search.vector.VectorToolSearchStrategy;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * The built-in {@code VectorToolSearchStrategy} must work through the {@code @RegisterAiService} pickup: given a query
+ * matching the booking tool, the vector search surfaces it (and not the weather distractor) so it can be executed.
+ */
+public class VectorToolSearchStrategyTest {
+
+    static final String SEARCH_TOOL_NAME = "tool_search_tool";
+    static final String FOUND_TOOL_NAME = "getBookingDetails";
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(BookingTools.class,
+                            WeatherTools.class,
+                            StrategyProducer.class,
+                            ServiceWithVectorToolSearch.class));
+
+    @RegisterAiService(tools = { BookingTools.class, WeatherTools.class }, chatLanguageModelSupplier = ModelSupplier.class)
+    interface ServiceWithVectorToolSearch {
+
+        String chat(@UserMessage String msg, @MemoryId Object id);
+
+    }
+
+    @Inject
+    ServiceWithVectorToolSearch service;
+
+    @Test
+    @ActivateRequestContext
+    void vectorSearchedToolIsExecuted() {
+        String answer = service.chat("get my booking details", 1);
+        assertEquals("REAL_TOOL_RESULT", answer);
+    }
+
+    @ApplicationScoped
+    public static class StrategyProducer {
+        @Produces
+        @ApplicationScoped
+        public ToolSearchStrategy toolSearchStrategy() {
+            return VectorToolSearchStrategy.builder()
+                    .embeddingModel(new KeywordEmbeddingModel())
+                    .maxResults(1)
+                    .build();
+        }
+    }
+
+    @ApplicationScoped
+    public static class WeatherTools {
+        @Tool("Returns the weather forecast")
+        public String getWeather() {
+            return "WEATHER_TOOL_RESULT";
+        }
+    }
+
+    public static class ModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new Model();
+        }
+    }
+
+    /**
+     * Calls the built-in {@code tool_search_tool} with a natural language query and then invokes whichever tool the
+     * vector search surfaced. If the search returned the wrong tool, the booking tool would not be available.
+     */
+    public static class Model implements ChatModel {
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            List<ChatMessage> messages = chatRequest.messages();
+            ChatMessage lastMessage = messages.get(messages.size() - 1);
+
+            if (lastMessage.type().equals(TOOL_EXECUTION_RESULT)) {
+                ToolExecutionResultMessage result = (ToolExecutionResultMessage) lastMessage;
+                if (result.text().contains("REAL_TOOL_RESULT")) {
+                    return answer("REAL_TOOL_RESULT");
+                }
+                if (hasTool(chatRequest, FOUND_TOOL_NAME)) {
+                    return callTool(FOUND_TOOL_NAME, null);
+                }
+                return answer("FOUND_TOOL_NOT_AVAILABLE");
+            }
+
+            if (hasTool(chatRequest, FOUND_TOOL_NAME)) {
+                return answer("TOOL_NOT_NARROWED");
+            }
+            if (hasTool(chatRequest, SEARCH_TOOL_NAME)) {
+                return callTool(SEARCH_TOOL_NAME, "{\"query\":\"booking details\"}");
+            }
+            return answer("NO_SEARCH_TOOL");
+        }
+
+        private static boolean hasTool(ChatRequest chatRequest, String name) {
+            List<ToolSpecification> toolSpecifications = chatRequest.toolSpecifications();
+            if (toolSpecifications == null) {
+                return false;
+            }
+            return toolSpecifications.stream().anyMatch(spec -> spec.name().equals(name));
+        }
+
+        private static ChatResponse callTool(String name, String arguments) {
+            ToolExecutionRequest.Builder builder = ToolExecutionRequest.builder().name(name).id(name);
+            if (arguments != null) {
+                builder.arguments(arguments);
+            }
+            return ChatResponse.builder()
+                    .aiMessage(AiMessage.from(builder.build()))
+                    .finishReason(FinishReason.TOOL_EXECUTION)
+                    .build();
+        }
+
+        private static ChatResponse answer(String text) {
+            return ChatResponse.builder().aiMessage(new AiMessage(text)).build();
+        }
+    }
+
+    /**
+     * Deterministic, dependency-free {@link EmbeddingModel}: embeds text as a bag-of-words vector over a fixed
+     * vocabulary, so cosine similarity is high when texts share vocabulary terms.
+     */
+    public static class KeywordEmbeddingModel implements EmbeddingModel {
+
+        private static final List<String> VOCABULARY = List.of("booking", "weather");
+
+        @Override
+        public Response<List<Embedding>> embedAll(List<TextSegment> segments) {
+            List<Embedding> embeddings = segments.stream()
+                    .map(segment -> Embedding.from(toVector(segment.text())))
+                    .toList();
+            return Response.from(embeddings);
+        }
+
+        private static float[] toVector(String text) {
+            String normalized = text.toLowerCase(Locale.ROOT);
+            float[] vector = new float[VOCABULARY.size()];
+            for (int i = 0; i < VOCABULARY.size(); i++) {
+                vector[i] = normalized.contains(VOCABULARY.get(i)) ? 1.0f : 0.0f;
+            }
+            return vector;
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/RegisterAiService.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/RegisterAiService.java
@@ -25,6 +25,7 @@ import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.rag.query.Query;
 import dev.langchain4j.service.AiServices;
 import dev.langchain4j.service.tool.ToolProvider;
+import dev.langchain4j.service.tool.search.ToolSearchStrategy;
 import dev.langchain4j.store.memory.chat.ChatMemoryStore;
 import dev.langchain4j.store.memory.chat.InMemoryChatMemoryStore;
 import io.quarkiverse.langchain4j.runtime.aiservice.ChatMemoryFlushStrategy;
@@ -192,6 +193,16 @@ public @interface RegisterAiService {
      * Configures a toolProviderSupplier. It is possible to use together toolProviderSupplier and "normal" tools.
      */
     Class<? extends Supplier<ToolProvider>> toolProviderSupplier() default BeanIfExistsToolProviderSupplier.class;
+
+    /**
+     * Configures the {@link ToolSearchStrategy} used to let the model discover tools dynamically at inference time
+     * instead of exposing the whole tool catalog upfront.
+     * <p>
+     * By default, Quarkus will use a CDI bean that implements {@link ToolSearchStrategy} if exactly one exists, and no
+     * tool search strategy otherwise. To use a specific instance, provide a custom {@link Supplier<ToolSearchStrategy>}.
+     * Use {@link NoToolSearchStrategySupplier} to explicitly opt out even when such a bean is present.
+     */
+    Class<? extends Supplier<ToolSearchStrategy>> toolSearchStrategySupplier() default BeanIfExistsToolSearchStrategySupplier.class;
 
     /**
      * By default, after first tool call execution, in subsequent prompts the {@code toolChoice} of
@@ -365,6 +376,30 @@ public @interface RegisterAiService {
 
         @Override
         public ToolProvider get() {
+            throw new UnsupportedOperationException("should never be called");
+        }
+    }
+
+    /**
+     * Marker that is used to tell Quarkus to use the {@link ToolSearchStrategy} that the user has configured as a CDI
+     * bean. If no such bean exists, then no tool search strategy will be used.
+     */
+    final class BeanIfExistsToolSearchStrategySupplier implements Supplier<ToolSearchStrategy> {
+
+        @Override
+        public ToolSearchStrategy get() {
+            throw new UnsupportedOperationException("should never be called");
+        }
+    }
+
+    /**
+     * Marker that is used when the user does not want any tool search strategy, even if a CDI bean implementing
+     * {@link ToolSearchStrategy} exists.
+     */
+    final class NoToolSearchStrategySupplier implements Supplier<ToolSearchStrategy> {
+
+        @Override
+        public ToolSearchStrategy get() {
             throw new UnsupportedOperationException("should never be called");
         }
     }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/AiServicesRecorder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/AiServicesRecorder.java
@@ -24,6 +24,8 @@ import dev.langchain4j.rag.RetrievalAugmentor;
 import dev.langchain4j.service.tool.ToolArgumentsErrorHandler;
 import dev.langchain4j.service.tool.ToolExecutionErrorHandler;
 import dev.langchain4j.service.tool.ToolProvider;
+import dev.langchain4j.service.tool.search.ToolSearchService;
+import dev.langchain4j.service.tool.search.ToolSearchStrategy;
 import io.quarkiverse.langchain4j.ModelName;
 import io.quarkiverse.langchain4j.RegisterAiService;
 import io.quarkiverse.langchain4j.observability.AiServiceEvents;
@@ -47,6 +49,9 @@ public class AiServicesRecorder {
     };
 
     private static final TypeLiteral<Instance<ToolProvider>> TOOL_PROVIDER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+
+    private static final TypeLiteral<Instance<ToolSearchStrategy>> TOOL_SEARCH_STRATEGY_TYPE_LITERAL = new TypeLiteral<>() {
     };
 
     // the key is the interface's class name
@@ -242,6 +247,26 @@ public class AiServicesRecorder {
                             if (instance.isResolvable() && !hasExplicitTools) {
                                 quarkusAiServices.toolProvider(instance.get());
                             }
+                        }
+                    }
+
+                    if (info.toolSearchStrategySupplier() != null) {
+                        ToolSearchStrategy toolSearchStrategy = null;
+                        if (RegisterAiService.BeanIfExistsToolSearchStrategySupplier.class.getName()
+                                .equals(info.toolSearchStrategySupplier())) {
+                            Instance<ToolSearchStrategy> instance = creationalContext
+                                    .getInjectedReference(TOOL_SEARCH_STRATEGY_TYPE_LITERAL);
+                            if (instance.isResolvable()) {
+                                toolSearchStrategy = instance.get();
+                            }
+                        } else {
+                            Class<?> supplierClass = loadClass(info.toolSearchStrategySupplier());
+                            Supplier<? extends ToolSearchStrategy> supplier = (Supplier<? extends ToolSearchStrategy>) creationalContext
+                                    .getInjectedReference(supplierClass);
+                            toolSearchStrategy = supplier.get();
+                        }
+                        if (toolSearchStrategy != null) {
+                            aiServiceContext.toolSearchService = new ToolSearchService(toolSearchStrategy);
                         }
                     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
@@ -104,6 +104,8 @@ import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.service.tool.ToolProviderRequest;
 import dev.langchain4j.service.tool.ToolProviderResult;
+import dev.langchain4j.service.tool.ToolServiceContext;
+import dev.langchain4j.service.tool.search.ToolSearchService;
 import dev.langchain4j.spi.ServiceHelper;
 import io.quarkiverse.langchain4j.AudioUrl;
 import io.quarkiverse.langchain4j.ImageUrl;
@@ -392,6 +394,22 @@ public class AiServiceMethodImplementationSupport {
 
         Future<Moderation> moderationFuture = triggerModerationIfNeeded(context, methodCreateInfo, messagesToSend);
 
+        // adjust() narrows the upfront catalog to the search tools; the full catalog survives in the returned
+        // context so tools the model later finds can be re-added each round (see addFoundTools below).
+        ToolSearchService toolSearchService = context.toolSearchService;
+        ToolServiceContext toolSearchContext = null;
+        if (toolSearchService != null) {
+            toolSearchContext = toolSearchService.adjust(
+                    new ToolServiceContext.Builder()
+                            .effectiveTools(toolSpecifications)
+                            .availableTools(toolSpecifications)
+                            .toolExecutors(toolExecutors)
+                            .build(),
+                    messagesToSend, invocationContext);
+            toolSpecifications = new ArrayList<>(toolSearchContext.effectiveTools());
+            toolExecutors = new HashMap<>(toolSearchContext.toolExecutors());
+        }
+
         log.debug("Attempting to obtain AI response");
 
         ChatRequest chatRequest = context.chatRequestTransformer
@@ -442,6 +460,7 @@ public class AiServiceMethodImplementationSupport {
 
             List<ToolExecution> toolExecutions = new ArrayList<>();
             List<ToolExecutionResultMessage> toolResults = new ArrayList<>();
+            List<ToolExecutionResult> rawToolResults = new ArrayList<>();
             List<ToolExecutionRequest> toolExecutionRequests = aiMessage.toolExecutionRequests();
             int maxToolCallsPerResponse;
             if (context.maxToolCallsPerResponse != null && context.maxToolCallsPerResponse != 0) {
@@ -487,6 +506,8 @@ public class AiServiceMethodImplementationSupport {
                 toolExecutions.add(toolExecution);
                 allToolExecutions.add(toolExecution);
                 toolResults.add(toolExecutionResultMessage);
+                rawToolResults.add(toolExecutionResult);
+
                 anyToolErrored = anyToolErrored || toolExecutionResult.isError();
                 if (toolExecutor instanceof QuarkusToolExecutor quarkusExecutor) {
                     returnBehaviors.add(quarkusExecutor.returnBehavior());
@@ -554,6 +575,11 @@ public class AiServiceMethodImplementationSupport {
                                 .build());
 
                 return result;
+            }
+
+            if (toolSearchService != null) {
+                toolSearchContext = ToolSearchService.addFoundTools(toolSearchContext, rawToolResults);
+                toolSpecifications = new ArrayList<>(toolSearchContext.effectiveTools());
             }
 
             log.debug("Attempting to obtain AI response");

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/DeclarativeAiServiceCreateInfo.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/DeclarativeAiServiceCreateInfo.java
@@ -13,6 +13,7 @@ public record DeclarativeAiServiceCreateInfo(
         String streamingChatLanguageModelSupplierClassName,
         Map<String, AnnotationLiteral<?>> toolsClassInfo,
         String toolProviderSupplier,
+        String toolSearchStrategySupplier,
         String chatMemoryProviderSupplierClassName,
         String chatMemoryFlushStrategySupplierClassName,
         String retrievalAugmentorSupplierClassName,

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceContext.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceContext.java
@@ -14,6 +14,7 @@ import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.image.ImageModel;
 import dev.langchain4j.service.AiServiceContext;
+import dev.langchain4j.service.tool.search.ToolSearchService;
 import io.quarkiverse.langchain4j.ModelName;
 import io.quarkiverse.langchain4j.RegisterAiService;
 import io.quarkiverse.langchain4j.spi.DefaultMemoryIdProvider;
@@ -30,6 +31,7 @@ public class QuarkusAiServiceContext extends AiServiceContext {
     public boolean allowContinuousForcedToolCalling;
     public DefaultMemoryIdProvider defaultMemoryIdProvider;
     public ChatMemoryFlushStrategy chatMemoryFlushStrategy = ChatMemoryFlushStrategy.DEFERRED;
+    public ToolSearchService toolSearchService;
 
     // needed by Arc
     public QuarkusAiServiceContext() {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceStreamingResponseHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceStreamingResponseHandler.java
@@ -55,6 +55,8 @@ import dev.langchain4j.service.tool.ToolExecution;
 import dev.langchain4j.service.tool.ToolExecutionErrorHandler;
 import dev.langchain4j.service.tool.ToolExecutionResult;
 import dev.langchain4j.service.tool.ToolExecutor;
+import dev.langchain4j.service.tool.ToolServiceContext;
+import dev.langchain4j.service.tool.search.ToolSearchService;
 import io.quarkiverse.langchain4j.runtime.PreventsErrorHandlerExecution;
 import io.quarkiverse.langchain4j.runtime.ToolCallsLimitExceededException;
 import io.vertx.core.Context;
@@ -88,6 +90,7 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
 
     private final List<ToolSpecification> toolSpecifications;
     private final Map<String, ToolExecutor> toolExecutors;
+    private final ToolServiceContext toolSearchContext;
     private final Context executionContext;
     private final boolean mustSwitchToWorkerThread;
     private final boolean switchToWorkerForEmission;
@@ -113,6 +116,7 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
             TokenUsage tokenUsage,
             List<ToolSpecification> toolSpecifications,
             Map<String, ToolExecutor> toolExecutors,
+            ToolServiceContext toolSearchContext,
             boolean mustSwitchToWorkerThread,
             boolean switchToWorkerForEmission,
             Context cxtx,
@@ -139,6 +143,7 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
 
         this.toolSpecifications = copyIfNotNull(toolSpecifications);
         this.toolExecutors = copyIfNotNull(toolExecutors);
+        this.toolSearchContext = toolSearchContext;
 
         this.mustSwitchToWorkerThread = mustSwitchToWorkerThread;
         this.executionContext = cxtx;
@@ -166,6 +171,7 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
             Consumer<Response<AiMessage>> completionHandler,
             Consumer<Throwable> errorHandler, List<ChatMessage> temporaryMemory, TokenUsage sum,
             List<ToolSpecification> toolSpecifications, Map<String, ToolExecutor> toolExecutors,
+            ToolServiceContext toolSearchContext,
             boolean mustSwitchToWorkerThread, boolean switchToWorkerForEmission, Context executionContext,
             ExecutorService executor, AiServiceMethodCreateInfo methodCreateInfo, Object[] methodArgs,
             AtomicBoolean cancelled) {
@@ -186,6 +192,7 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
         this.tokenUsage = sum;
         this.toolSpecifications = toolSpecifications;
         this.toolExecutors = toolExecutors;
+        this.toolSearchContext = toolSearchContext;
         this.mustSwitchToWorkerThread = mustSwitchToWorkerThread;
         this.switchToWorkerForEmission = switchToWorkerForEmission;
         this.executionContext = executionContext;
@@ -450,6 +457,7 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
                     }
                     addToMemory(aiMessage);
                     List<ToolExecutionRequest> toolExecutionRequests = aiMessage.toolExecutionRequests();
+                    List<ToolExecutionResult> rawToolResults = new ArrayList<>();
                     int maxToolCallsPerResponse;
                     if (context.maxToolCallsPerResponse != null && context.maxToolCallsPerResponse != 0) {
                         maxToolCallsPerResponse = context.maxToolCallsPerResponse;
@@ -495,6 +503,7 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
                                 context.toolService.executionErrorHandler());
 
                         fireToolExecutedEvent(toolExecutionRequest, toolExecutionResult.resultText());
+                        rawToolResults.add(toolExecutionResult);
 
                         ToolExecutionResultMessage toolExecutionResultMessage = ToolExecutionResultMessageUtil
                                 .from(toolExecutionRequest, toolExecutionResult);
@@ -515,8 +524,15 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
                         return;
                     }
 
+                    List<ToolSpecification> nextToolSpecifications = toolSpecifications;
+                    ToolServiceContext nextToolSearchContext = toolSearchContext;
+                    if (context.toolSearchService != null && toolSearchContext != null) {
+                        nextToolSearchContext = ToolSearchService.addFoundTools(toolSearchContext, rawToolResults);
+                        nextToolSpecifications = new ArrayList<>(nextToolSearchContext.effectiveTools());
+                    }
+
                     DefaultChatRequestParameters.Builder<?> parametersBuilder = ChatRequestParameters.builder();
-                    parametersBuilder.toolSpecifications(toolSpecifications);
+                    parametersBuilder.toolSpecifications(nextToolSpecifications);
 
                     StreamingChatModel effectiveStreamingChatModel = context.effectiveStreamingChatModel(methodCreateInfo,
                             methodArgs);
@@ -557,8 +573,9 @@ public class QuarkusAiServiceStreamingResponseHandler implements StreamingChatRe
                             errorHandler,
                             temporaryMemory,
                             TokenUsage.sum(tokenUsage, completeResponse.metadata().tokenUsage()),
-                            toolSpecifications,
+                            nextToolSpecifications,
                             toolExecutors,
+                            nextToolSearchContext,
                             mustSwitchToWorkerThread, switchToWorkerForEmission, executionContext, executor, methodCreateInfo,
                             methodArgs,
                             cancelled);

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceTokenStream.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceTokenStream.java
@@ -6,6 +6,7 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static java.util.Collections.emptyList;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -30,6 +31,7 @@ import dev.langchain4j.service.TokenStream;
 import dev.langchain4j.service.tool.BeforeToolExecution;
 import dev.langchain4j.service.tool.ToolExecution;
 import dev.langchain4j.service.tool.ToolExecutor;
+import dev.langchain4j.service.tool.ToolServiceContext;
 import io.vertx.core.Context;
 
 /**
@@ -175,12 +177,30 @@ public class QuarkusAiServiceTokenStream implements TokenStream {
     @Override
     public void start() {
         validateConfiguration();
+
+        // adjust() narrows the upfront catalog to the search tools; the full catalog survives in the returned
+        // context so tools the model later finds can be re-added each round (see addFoundTools in the handler).
+        List<ToolSpecification> effectiveToolSpecifications = toolSpecifications;
+        Map<String, ToolExecutor> effectiveToolExecutors = toolExecutors;
+        ToolServiceContext toolSearchContext = null;
+        if (context.toolSearchService != null) {
+            toolSearchContext = context.toolSearchService.adjust(
+                    new ToolServiceContext.Builder()
+                            .effectiveTools(toolSpecifications)
+                            .availableTools(toolSpecifications)
+                            .toolExecutors(toolExecutors)
+                            .build(),
+                    messages, invocationContext);
+            effectiveToolSpecifications = new ArrayList<>(toolSearchContext.effectiveTools());
+            effectiveToolExecutors = new HashMap<>(toolSearchContext.toolExecutors());
+        }
+
         ChatRequest chatRequest;
         var userParams = AiServiceMethodImplementationSupport
                 .findChatRequestParameters(methodCreateInfo, methodArgs);
         if (userParams.isPresent()) {
             var defaultParams = dev.langchain4j.model.chat.request.ChatRequestParameters.builder()
-                    .toolSpecifications(toolSpecifications)
+                    .toolSpecifications(effectiveToolSpecifications)
                     .build();
             chatRequest = new ChatRequest.Builder()
                     .messages(messages)
@@ -189,7 +209,7 @@ public class QuarkusAiServiceTokenStream implements TokenStream {
         } else {
             chatRequest = new ChatRequest.Builder()
                     .messages(messages)
-                    .toolSpecifications(toolSpecifications)
+                    .toolSpecifications(effectiveToolSpecifications)
                     .build();
         }
 
@@ -209,8 +229,9 @@ public class QuarkusAiServiceTokenStream implements TokenStream {
                 errorHandler,
                 initTemporaryMemory(context, messages),
                 new TokenUsage(),
-                toolSpecifications,
-                toolExecutors,
+                effectiveToolSpecifications,
+                effectiveToolExecutors,
+                toolSearchContext,
                 switchToWorkerThreadForToolExecution,
                 switchToWorkerForEmission,
                 cxtx, methodCreateInfo, methodArgs,

--- a/docs/modules/ROOT/pages/function-calling.adoc
+++ b/docs/modules/ROOT/pages/function-calling.adoc
@@ -297,6 +297,42 @@ public class MyCustomToolProvider implements ToolProvider {
 
 If you prefer more control, you can work directly with `ToolSpecification` and `ToolExecutor` to provide tools.
 
+== Searching Tools Dynamically
+
+When an AI service registers many tools, exposing the full catalog on every request increases token usage and can degrade the model's tool selection. *Tool Search* lets the model discover the relevant tools at inference time through a dedicated search tool, instead of receiving the whole catalog upfront.
+
+Unlike `ToolProvider` (where the application decides which tools to expose before the call), Tool Search is driven by the model itself during the call. The two are complementary.
+
+Configure it with the `toolSearchStrategySupplier` attribute:
+
+[source,java]
+----
+@RegisterAiService(tools = MyTools.class, toolSearchStrategySupplier = MyToolSearchStrategySupplier.class)
+public interface MyAiService {
+// ...
+}
+----
+
+The supplier must be marked as `@ApplicationScoped` and return a LangChain4j `ToolSearchStrategy`:
+
+[source,java]
+----
+@ApplicationScoped
+public class MyToolSearchStrategySupplier implements Supplier<ToolSearchStrategy> {
+
+    @Inject EmbeddingModel embeddingModel;
+
+    public ToolSearchStrategy get() {
+        return new VectorToolSearchStrategy(embeddingModel);
+    }
+}
+----
+
+LangChain4j ships two built-in strategies: `SimpleToolSearchStrategy` (keyword based) and `VectorToolSearchStrategy` (semantic search, requires an `EmbeddingModel`).
+
+Alternatively, if a single `ToolSearchStrategy` CDI bean exists, it is used automatically without setting `toolSearchStrategySupplier` (the default is `BeanIfExistsToolSearchStrategySupplier`). To opt out even when such a bean is present, use `NoToolSearchStrategySupplier`.
+
+The tools the model surfaces through the search tool are added to the conversation and remain available in the following tool-calling rounds. Tool Search works for both blocking and streaming AI service methods.
 
 == How Function Calling Works Internally
 
@@ -501,6 +537,7 @@ Function calling enables the model to take actions and retrieve external informa
 |`@Blocking`, `@NonBlocking`, `@RunOnVirtualThread` | Control how tool execution is scheduled
 |`@UserMessage`, `@SystemMessage` | Provide instructions to guide tool use, depending on the model, the prompt should provide hints.
 |`toolProviderSupplier` | Allows dynamic tool provisioning via ToolProvider
+|`toolSearchStrategySupplier` | Lets the model discover tools dynamically via a search tool (Tool Search)
 |`@ToolInputGuardrails` | Validates tool parameters before execution
 |`@ToolOutputGuardrails` | Validates or transforms tool results after execution
 |===

--- a/integration-tests/tools/src/main/java/org/acme/tools/BookingTool.java
+++ b/integration-tests/tools/src/main/java/org/acme/tools/BookingTool.java
@@ -1,0 +1,14 @@
+package org.acme.tools;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import dev.langchain4j.agent.tool.Tool;
+
+@ApplicationScoped
+public class BookingTool {
+
+    @Tool("Returns booking details")
+    public String getBookingDetails() {
+        return "REAL_TOOL_RESULT";
+    }
+}

--- a/integration-tests/tools/src/main/java/org/acme/tools/FixedToolSearchStrategy.java
+++ b/integration-tests/tools/src/main/java/org/acme/tools/FixedToolSearchStrategy.java
@@ -1,0 +1,31 @@
+package org.acme.tools;
+
+import java.util.List;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.service.tool.search.ToolSearchRequest;
+import dev.langchain4j.service.tool.search.ToolSearchResult;
+import dev.langchain4j.service.tool.search.ToolSearchStrategy;
+
+/**
+ * Deterministic tool search strategy: exposes a single {@code find_tools} tool and always surfaces the booking tool.
+ */
+public class FixedToolSearchStrategy implements ToolSearchStrategy {
+
+    public static final String SEARCH_TOOL_NAME = "find_tools";
+    public static final String FOUND_TOOL_NAME = "getBookingDetails";
+
+    @Override
+    public List<ToolSpecification> getToolSearchTools(InvocationContext invocationContext) {
+        return List.of(ToolSpecification.builder()
+                .name(SEARCH_TOOL_NAME)
+                .description("Search for the tools relevant to the user request")
+                .build());
+    }
+
+    @Override
+    public ToolSearchResult search(ToolSearchRequest toolSearchRequest) {
+        return new ToolSearchResult(List.of(FOUND_TOOL_NAME), "found " + FOUND_TOOL_NAME);
+    }
+}

--- a/integration-tests/tools/src/main/java/org/acme/tools/FixedToolSearchStrategySupplier.java
+++ b/integration-tests/tools/src/main/java/org/acme/tools/FixedToolSearchStrategySupplier.java
@@ -1,0 +1,16 @@
+package org.acme.tools;
+
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import dev.langchain4j.service.tool.search.ToolSearchStrategy;
+
+@ApplicationScoped
+public class FixedToolSearchStrategySupplier implements Supplier<ToolSearchStrategy> {
+
+    @Override
+    public ToolSearchStrategy get() {
+        return new FixedToolSearchStrategy();
+    }
+}

--- a/integration-tests/tools/src/main/java/org/acme/tools/ToolSearchAiService.java
+++ b/integration-tests/tools/src/main/java/org/acme/tools/ToolSearchAiService.java
@@ -1,0 +1,11 @@
+package org.acme.tools;
+
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+
+@RegisterAiService(tools = BookingTool.class, toolSearchStrategySupplier = FixedToolSearchStrategySupplier.class)
+public interface ToolSearchAiService {
+
+    String chat(@UserMessage String message, @MemoryId Object id);
+}

--- a/integration-tests/tools/src/test/java/org/acme/tools/ToolSearchToolsTest.java
+++ b/integration-tests/tools/src/test/java/org/acme/tools/ToolSearchToolsTest.java
@@ -1,0 +1,80 @@
+package org.acme.tools;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * End-to-end check that the {@code toolSearchStrategySupplier} option works in a running application: the catalog is
+ * narrowed to the search tool, and the tool surfaced by the search is added and executed.
+ */
+@QuarkusTest
+public class ToolSearchToolsTest {
+
+    @Inject
+    ToolSearchAiService aiService;
+
+    @InjectMock
+    ChatModel model;
+
+    @Test
+    void searchedToolIsExecuted() {
+        Mockito.when(model.chat(Mockito.any(ChatRequest.class))).thenAnswer(invocation -> {
+            ChatRequest request = invocation.getArgument(0);
+            List<ChatMessage> messages = request.messages();
+            ChatMessage last = messages.get(messages.size() - 1);
+            Set<String> toolNames = request.toolSpecifications() == null ? Set.of()
+                    : request.toolSpecifications().stream().map(ToolSpecification::name).collect(Collectors.toSet());
+
+            if (last instanceof ToolExecutionResultMessage result) {
+                if (result.text().contains("REAL_TOOL_RESULT")) {
+                    return response(AiMessage.from("done"));
+                }
+                // The search tool ran, so the surfaced tool must now be available.
+                assertTrue(toolNames.contains(FixedToolSearchStrategy.FOUND_TOOL_NAME));
+                return response(AiMessage.from(toolCall(FixedToolSearchStrategy.FOUND_TOOL_NAME)));
+            }
+
+            // First request: the catalog must be narrowed to the search tool only.
+            assertFalse(toolNames.contains(FixedToolSearchStrategy.FOUND_TOOL_NAME));
+            assertTrue(toolNames.contains(FixedToolSearchStrategy.SEARCH_TOOL_NAME));
+            return response(AiMessage.from(toolCall(FixedToolSearchStrategy.SEARCH_TOOL_NAME)));
+        });
+
+        assertEquals("done", aiService.chat("get my booking details", 1));
+    }
+
+    private static ToolExecutionRequest toolCall(String name) {
+        return ToolExecutionRequest.builder().id(name).name(name).arguments("{}").build();
+    }
+
+    private static ChatResponse response(AiMessage aiMessage) {
+        return ChatResponse.builder()
+                .aiMessage(aiMessage)
+                .tokenUsage(new TokenUsage(1))
+                .finishReason(aiMessage.hasToolExecutionRequests() ? FinishReason.TOOL_EXECUTION : FinishReason.STOP)
+                .build();
+    }
+}


### PR DESCRIPTION
## Describe your changes

This submission exposes langchain4j's Tool Search (`ToolSearchStrategy`) as a declarative option on `@RegisterAiService`, letting the model discover tools dynamically at inference time instead of receiving the whole tool catalog upfront.

The design follows the established `toolProviderSupplier` pattern. A new `toolSearchStrategySupplier()` attribute defaults to `BeanIfExistsToolSearchStrategySupplier`: if exactly one `ToolSearchStrategy` CDI bean exists it is applied automatically, otherwise no tool search happens. A custom `Supplier<ToolSearchStrategy>` selects a specific instance, and `NoToolSearchStrategySupplier` opts out explicitly even when such a bean is present.

The non-obvious part is the runtime integration. Quarkus drives its own tool-calling loop rather than going through core's `ToolService`, so wiring the strategy into the AI service context is not enough: the loop has to apply the search service itself. The strategy is wrapped in core's `ToolSearchService` and stored on `QuarkusAiServiceContext`, then applied at two points in both the blocking and streaming paths:

- `adjust()` narrows the upfront catalog to the search tools before the first request, so the model only sees the search tool;
- `addFoundTools()` re-adds the tools the model surfaces through the search tool after each round, so they become callable on the next turn.

Blocking support lives in `AiServiceMethodImplementationSupport`; streaming support spans `QuarkusAiServiceTokenStream` and `QuarkusAiServiceStreamingResponseHandler`. The full catalog survives in the returned context across rounds, so discovered tools accumulate as the conversation progresses. The feature works with core's built-in strategies (for example `VectorToolSearchStrategy`) and with custom ones.

## Usage

Declare a `ToolSearchStrategy` as a CDI bean and it is picked up automatically:

```java
@ApplicationScoped
public class MyToolSearchStrategy implements ToolSearchStrategy {
    // returns the search tool(s) and resolves which tools to surface per request
}

@RegisterAiService(tools = BookingTools.class)
public interface BookingAssistant {
    String chat(@UserMessage String message);
}
```

To use a specific instance, point the attribute at a supplier:

```java
@RegisterAiService(tools = BookingTools.class, toolSearchStrategySupplier = MyStrategySupplier.class)
public interface BookingAssistant {
    String chat(@UserMessage String message);
}
```

To opt out when a strategy bean exists:

```java
@RegisterAiService(tools = BookingTools.class, toolSearchStrategySupplier = NoToolSearchStrategySupplier.class)
```

---

- Closes #2533
