### PR TITLE
Marshal AgenticScope through the managed ObjectMapper

### DIFF
--- a/agentic/deployment/src/main/java/io/quarkiverse/langchain4j/agentic/deployment/AgenticProcessor.java
+++ b/agentic/deployment/src/main/java/io/quarkiverse/langchain4j/agentic/deployment/AgenticProcessor.java
@@ -65,6 +65,7 @@ import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageProxyDefinitionBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 
 public class AgenticProcessor {
 
@@ -73,6 +74,34 @@ public class AgenticProcessor {
     @BuildStep
     void indexDependencies(BuildProducer<IndexDependencyBuildItem> producer) {
         producer.produce(new IndexDependencyBuildItem("dev.langchain4j", "langchain4j-agentic"));
+    }
+
+    /**
+     * Registers the classes that langchain4j's {@code AgenticScopeSerializer} marshals via reflection so the
+     * managed ObjectMapper can (de)serialize an {@code AgenticScope} in native mode.
+     * The serializer uses Jackson default typing, which embeds concrete container class names that must also
+     * be reflectively instantiable on read.
+     */
+    @BuildStep
+    void registerAgenticScopeSerialization(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses) {
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(
+                "dev.langchain4j.agentic.scope.DefaultAgenticScope",
+                "dev.langchain4j.agentic.scope.DefaultAgenticScope$Kind",
+                "dev.langchain4j.agentic.scope.DefaultAgenticScope$AgentMessage",
+                "dev.langchain4j.agentic.scope.AgentInvocation",
+                "dev.langchain4j.agentic.scope.AgenticScopeJsonCodec",
+                "dev.langchain4j.agentic.scope.JacksonAgenticScopeJsonCodec",
+                "dev.langchain4j.agentic.scope.JacksonAgenticScopeJsonCodec$AgenticScopeMixin",
+                "dev.langchain4j.agentic.scope.JacksonAgenticScopeJsonCodec$AgentMessageMixin",
+                "dev.langchain4j.agentic.scope.JacksonAgenticScopeJsonCodec$AgentInvocationMixin")
+                .methods().fields().constructors().build());
+
+        reflectiveClasses.produce(ReflectiveClassBuildItem.builder(
+                "java.util.concurrent.ConcurrentHashMap",
+                "java.util.Collections$SynchronizedList",
+                "java.util.Collections$SynchronizedRandomAccessList",
+                "java.util.Collections$SynchronizedCollection")
+                .constructors().build());
     }
 
     @BuildStep

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgenticScopeObjectMapperTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgenticScopeObjectMapperTest.java
@@ -1,0 +1,72 @@
+package io.quarkiverse.langchain4j.agentic.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.agentic.scope.DefaultAgenticScope;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verifies that an {@link AgenticScope} can be serialized through the application's managed
+ * {@link ObjectMapper} and round-tripped.
+ * <p>
+ * The companion unit test {@code AgenticScopeSerializationTest} (agentic/runtime) evidences why this is
+ * needed: a vanilla ObjectMapper without our customizer throws {@code InvalidDefinitionException}. Here we
+ * assert the managed mapper, customized by {@code AgenticScopeObjectMapperCustomizer}, marshals it correctly.
+ */
+public class AgenticScopeObjectMapperTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "whatever");
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    private DefaultAgenticScope newScope() {
+        DefaultAgenticScope scope = DefaultAgenticScope.ephemeralAgenticScope();
+        scope.writeState("topic", "dragons and wizards");
+        scope.writeState("style", "fantasy");
+        scope.writeState("score", 0.9);
+        return scope;
+    }
+
+    @Test
+    void managedObjectMapperRoundTripsAgenticScope() throws Exception {
+        String json = objectMapper.writeValueAsString(newScope());
+
+        DefaultAgenticScope restored = objectMapper.readValue(json, DefaultAgenticScope.class);
+
+        assertThat(restored.readState("topic")).isEqualTo("dragons and wizards");
+        assertThat(restored.readState("style")).isEqualTo("fantasy");
+        assertThat(restored.<Double> readState("score", 0.0)).isEqualTo(0.9);
+    }
+
+    @Test
+    void managedObjectMapperSerializesAgenticScopeNestedInAnotherObject() throws Exception {
+        Wrapper wrapper = new Wrapper();
+        wrapper.name = "story-creator";
+        wrapper.scope = newScope();
+
+        String json = objectMapper.writeValueAsString(wrapper);
+        Wrapper restored = objectMapper.readValue(json, Wrapper.class);
+
+        assertThat(restored.name).isEqualTo("story-creator");
+        assertThat(restored.scope.readState("topic")).isEqualTo("dragons and wizards");
+    }
+
+    public static class Wrapper {
+        public String name;
+        public AgenticScope scope;
+    }
+}

--- a/agentic/runtime/src/main/java/io/quarkiverse/langchain4j/agentic/runtime/jackson/AgenticScopeJacksonModule.java
+++ b/agentic/runtime/src/main/java/io/quarkiverse/langchain4j/agentic/runtime/jackson/AgenticScopeJacksonModule.java
@@ -1,0 +1,37 @@
+package io.quarkiverse.langchain4j.agentic.runtime.jackson;
+
+import com.fasterxml.jackson.databind.module.SimpleDeserializers;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.module.SimpleSerializers;
+
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.agentic.scope.DefaultAgenticScope;
+
+/**
+ * Jackson module that teaches an {@link com.fasterxml.jackson.databind.ObjectMapper} how to (de)serialize a
+ * langchain4j {@link AgenticScope} by delegating to {@link dev.langchain4j.agentic.scope.AgenticScopeSerializer}.
+ * <p>
+ * Follows the same {@code SimpleModule} convention as the core {@code QuarkusLangChain4jModule}.
+ */
+public class AgenticScopeJacksonModule extends SimpleModule {
+
+    public static final AgenticScopeJacksonModule INSTANCE = new AgenticScopeJacksonModule();
+
+    @Override
+    public String getModuleName() {
+        return "QuarkusLangChain4jAgenticScopeModule";
+    }
+
+    @Override
+    public void setupModule(SetupContext context) {
+        SimpleSerializers serializers = new SimpleSerializers();
+        serializers.addSerializer(AgenticScope.class, new AgenticScopeJsonSerializer());
+        context.addSerializers(serializers);
+
+        AgenticScopeJsonDeserializer deserializer = new AgenticScopeJsonDeserializer();
+        SimpleDeserializers deserializers = new SimpleDeserializers();
+        deserializers.addDeserializer(AgenticScope.class, deserializer);
+        deserializers.addDeserializer(DefaultAgenticScope.class, deserializer);
+        context.addDeserializers(deserializers);
+    }
+}

--- a/agentic/runtime/src/main/java/io/quarkiverse/langchain4j/agentic/runtime/jackson/AgenticScopeJsonDeserializer.java
+++ b/agentic/runtime/src/main/java/io/quarkiverse/langchain4j/agentic/runtime/jackson/AgenticScopeJsonDeserializer.java
@@ -1,0 +1,24 @@
+package io.quarkiverse.langchain4j.agentic.runtime.jackson;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import dev.langchain4j.agentic.scope.AgenticScopeSerializer;
+import dev.langchain4j.agentic.scope.DefaultAgenticScope;
+
+/**
+ * Mirror of {@link AgenticScopeJsonSerializer}: reconstructs a {@link DefaultAgenticScope} from JSON by
+ * delegating to langchain4j's {@link AgenticScopeSerializer}.
+ */
+public class AgenticScopeJsonDeserializer extends JsonDeserializer<DefaultAgenticScope> {
+
+    @Override
+    public DefaultAgenticScope deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+        JsonNode node = parser.readValueAsTree();
+        return AgenticScopeSerializer.fromJson(node.toString());
+    }
+}

--- a/agentic/runtime/src/main/java/io/quarkiverse/langchain4j/agentic/runtime/jackson/AgenticScopeJsonSerializer.java
+++ b/agentic/runtime/src/main/java/io/quarkiverse/langchain4j/agentic/runtime/jackson/AgenticScopeJsonSerializer.java
@@ -1,0 +1,31 @@
+package io.quarkiverse.langchain4j.agentic.runtime.jackson;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.agentic.scope.AgenticScopeSerializer;
+import dev.langchain4j.agentic.scope.DefaultAgenticScope;
+
+/**
+ * Serializes an {@link AgenticScope} by delegating to langchain4j's own {@link AgenticScopeSerializer}.
+ * <p>
+ * A vanilla Jackson {@code ObjectMapper} cannot serialize {@link DefaultAgenticScope}: its state is held
+ * in private fields with no discoverable bean properties (plus {@code transient} fields such as a lock),
+ * so serialization fails with {@code InvalidDefinitionException}. langchain4j ships a dedicated codec with
+ * the required mixins and type information; this serializer routes through it so the managed ObjectMapper
+ * produces the same correct JSON.
+ */
+public class AgenticScopeJsonSerializer extends JsonSerializer<AgenticScope> {
+
+    @Override
+    public void serialize(AgenticScope value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        if (!(value instanceof DefaultAgenticScope defaultScope)) {
+            throw new IOException("Unsupported AgenticScope implementation: " + value.getClass().getName());
+        }
+        gen.writeRawValue(AgenticScopeSerializer.toJson(defaultScope));
+    }
+}

--- a/agentic/runtime/src/main/java/io/quarkiverse/langchain4j/agentic/runtime/jackson/AgenticScopeObjectMapperCustomizer.java
+++ b/agentic/runtime/src/main/java/io/quarkiverse/langchain4j/agentic/runtime/jackson/AgenticScopeObjectMapperCustomizer.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.langchain4j.agentic.runtime.jackson;
+
+import jakarta.inject.Singleton;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.agentic.scope.DefaultAgenticScope;
+import io.quarkus.jackson.ObjectMapperCustomizer;
+
+/**
+ * Registers {@link AgenticScopeJacksonModule} on the application's managed {@link ObjectMapper} so agentic
+ * state can be marshalled transparently — for instance when a workflow engine persists it.
+ * <p>
+ * Without this, any code using the Quarkus-managed ObjectMapper to serialize an {@link AgenticScope}
+ * (directly or nested in another object) fails, because {@link DefaultAgenticScope} exposes no
+ * Jackson-discoverable properties.
+ */
+@Singleton
+public class AgenticScopeObjectMapperCustomizer implements ObjectMapperCustomizer {
+
+    @Override
+    public void customize(ObjectMapper objectMapper) {
+        objectMapper.registerModule(AgenticScopeJacksonModule.INSTANCE);
+    }
+}

--- a/agentic/runtime/src/test/java/io/quarkiverse/langchain4j/agentic/runtime/AgenticScopeSerializationTest.java
+++ b/agentic/runtime/src/test/java/io/quarkiverse/langchain4j/agentic/runtime/AgenticScopeSerializationTest.java
@@ -1,0 +1,50 @@
+package io.quarkiverse.langchain4j.agentic.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import dev.langchain4j.agentic.scope.AgenticScopeSerializer;
+import dev.langchain4j.agentic.scope.DefaultAgenticScope;
+
+/**
+ * Guards the serialization contract that downstream persistence integrations (e.g. quarkus-flow) rely on:
+ * a {@link DefaultAgenticScope} cannot be marshalled with a vanilla Jackson {@link ObjectMapper}, it must
+ * go through langchain4j's {@link AgenticScopeSerializer}, which configures the required mixins and typing.
+ *
+ * <p>
+ * Marshalling with a raw ObjectMapper fails because {@code DefaultAgenticScope} exposes no
+ * Jackson-discoverable properties.
+ */
+class AgenticScopeSerializationTest {
+
+    private DefaultAgenticScope newScope() {
+        DefaultAgenticScope scope = DefaultAgenticScope.ephemeralAgenticScope();
+        scope.writeState("topic", "dragons and wizards");
+        scope.writeState("style", "fantasy");
+        scope.writeState("score", 0.9);
+        return scope;
+    }
+
+    @Test
+    void rawObjectMapperCannotSerializeAgenticScope() {
+        assertThrows(JsonMappingException.class,
+                () -> new ObjectMapper().writeValueAsString(newScope()));
+    }
+
+    @Test
+    void agenticScopeSerializerRoundTripsState() throws Exception {
+        DefaultAgenticScope scope = newScope();
+
+        String json = AgenticScopeSerializer.toJson(scope);
+        DefaultAgenticScope restored = AgenticScopeSerializer.fromJson(json);
+
+        assertEquals("dragons and wizards", restored.readState("topic"));
+        assertEquals("fantasy", restored.readState("style"));
+        assertEquals(0.9, restored.readState("score", 0.0));
+    }
+}

--- a/docs/modules/ROOT/pages/agentic.adoc
+++ b/docs/modules/ROOT/pages/agentic.adoc
@@ -535,6 +535,21 @@ public interface MedicalExpertWithMemory {
 }
 ----
 
+=== Serialization
+
+An `AgenticScope` can be serialized to JSON through the application's managed `ObjectMapper`. This is what lets a persistence layer (for example a workflow engine) store and restore agentic state:
+
+[source,java]
+----
+@Inject
+ObjectMapper objectMapper;
+
+String json = objectMapper.writeValueAsString(scope);
+AgenticScope restored = objectMapper.readValue(json, AgenticScope.class);
+----
+
+The extension registers the Jackson support required to (de)serialize the scope, including in native mode; no manual configuration is needed.
+
 == Error Handling
 
 Define error recovery strategies on workflow agents using `@ErrorHandler`:


### PR DESCRIPTION
## Describe your changes

A langchain4j `DefaultAgenticScope` can't be serialized by the Quarkus-managed Jackson `ObjectMapper` (it exposes no discoverable bean properties), so `writeValueAsString` throws `InvalidDefinitionException`. langchain4j already serializes it correctly through its own `AgenticScopeSerializer`; it just isn't wired into the application's `ObjectMapper`.

This adds an `ObjectMapperCustomizer` that registers a `SimpleModule` delegating `AgenticScope` (de)serialization to `AgenticScopeSerializer`, plus a build step registering the classes the codec marshals reflectively for native image (it uses Jackson default typing, which embeds concrete class names). A consumer like `quarkus-flow` reaches this because it injects the managed `ObjectMapper` bean into the serverlessworkflow SDK.

On where this belongs: langchain4j keeps its Jackson codec `@Internal` and exposes only the String-based `AgenticScopeSerializer` as public API, so bridging it into a framework-managed `ObjectMapper` is by design the integrator's job, which is what this PR does. (I can ask upstream whether they'd consider a public Jackson `Module`, which would shrink the serializer here to a one-line registration, but the `ObjectMapperCustomizer` wiring stays regardless.)

Two regression tests: `AgenticScopeSerializationTest` (runtime) pins the contract (vanilla mapper throws, `AgenticScopeSerializer` round-trips), and `AgenticScopeObjectMapperTest` (deployment) checks the managed mapper round-trips a scope, including when nested.

Tested locally at module level (runtime + deployment); relying on CI for the full and native builds.

---

- Relates to quarkiverse/quarkus-flow#613 , quarkiverse/quarkus-flow#614 

(the Quarkus LangChain4j side of it; the flow workflow model still needs to stop swallowing the failure).
