### PR TITLE
feat(agentic): CDI wiring and guardrails for agent interfaces

### DIFF
--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgentGuardrailClassLevelTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgentGuardrailClassLevelTest.java
@@ -1,0 +1,100 @@
+package io.quarkiverse.langchain4j.agentic.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.guardrail.InputGuardrail;
+import dev.langchain4j.guardrail.InputGuardrailResult;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import dev.langchain4j.service.guardrail.InputGuardrails;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verifies method-level @InputGuardrails takes precedence over class-level.
+ * The agent has ClassLevelGuardrail on the interface and MethodLevelGuardrail on the method.
+ * Only MethodLevelGuardrail should fire.
+ */
+@SuppressWarnings("CdiInjectionPointsInspection")
+public class AgentGuardrailClassLevelTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(PrecedenceAgent.class,
+                                    ClassLevelGuardrail.class, MethodLevelGuardrail.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "whatever")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    PrecedenceAgent agent;
+
+    @Inject
+    ClassLevelGuardrail classGuardrail;
+
+    @Inject
+    MethodLevelGuardrail methodGuardrail;
+
+    @Test
+    @ActivateRequestContext
+    void methodLevelGuardrailTakesPrecedenceOverClassLevel() {
+        agent.process("test");
+
+        assertThat(methodGuardrail.invocationCount()).isEqualTo(1);
+        assertThat(classGuardrail.invocationCount()).isEqualTo(0);
+    }
+
+    @InputGuardrails(ClassLevelGuardrail.class)
+    public interface PrecedenceAgent {
+
+        @Agent
+        @InputGuardrails(MethodLevelGuardrail.class)
+        @UserMessage("Process: {{request}}")
+        String process(@V("request") String request);
+    }
+
+    @ApplicationScoped
+    public static class ClassLevelGuardrail implements InputGuardrail {
+        private final AtomicInteger count = new AtomicInteger(0);
+
+        @Override
+        public InputGuardrailResult validate(dev.langchain4j.data.message.UserMessage userMessage) {
+            count.incrementAndGet();
+            return success();
+        }
+
+        public int invocationCount() {
+            return count.get();
+        }
+    }
+
+    @ApplicationScoped
+    public static class MethodLevelGuardrail implements InputGuardrail {
+        private final AtomicInteger count = new AtomicInteger(0);
+
+        @Override
+        public InputGuardrailResult validate(dev.langchain4j.data.message.UserMessage userMessage) {
+            count.incrementAndGet();
+            return success();
+        }
+
+        public int invocationCount() {
+            return count.get();
+        }
+    }
+}

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgentGuardrailMaxRetriesTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgentGuardrailMaxRetriesTest.java
@@ -1,0 +1,101 @@
+package io.quarkiverse.langchain4j.agentic.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.ChatModelSupplier;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.guardrail.OutputGuardrail;
+import dev.langchain4j.guardrail.OutputGuardrailResult;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import dev.langchain4j.service.guardrail.OutputGuardrails;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verifies that the maxRetries annotation attribute is respected on agent methods.
+ * The guardrail always rejects, so the LLM is called maxRetries times total
+ * (upstream treats maxRetries as total attempts, not retries-after-first).
+ */
+@SuppressWarnings("CdiInjectionPointsInspection")
+public class AgentGuardrailMaxRetriesTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(MaxRetriesAgent.class, AlwaysRejectGuardrail.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "whatever")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    MaxRetriesAgent agent;
+
+    @Inject
+    AlwaysRejectGuardrail guardrail;
+
+    @Test
+    @ActivateRequestContext
+    void maxRetriesFromAnnotationIsRespected() {
+        assertThatThrownBy(() -> agent.process("hello"))
+                .hasRootCauseInstanceOf(dev.langchain4j.guardrail.OutputGuardrailException.class)
+                .rootCause()
+                .hasMessageContaining("maximum number of retries");
+
+        // maxRetries=2: upstream counts total attempts, so 2 validations total
+        assertThat(guardrail.validationCount()).isEqualTo(2);
+    }
+
+    public interface MaxRetriesAgent {
+
+        @ChatModelSupplier
+        static ChatModel chatModel() {
+            return new FixedChatModel();
+        }
+
+        @Agent
+        @OutputGuardrails(value = AlwaysRejectGuardrail.class, maxRetries = 2)
+        @UserMessage("Process: {{request}}")
+        String process(@V("request") String request);
+    }
+
+    public static class FixedChatModel implements ChatModel {
+        @Override
+        public ChatResponse doChat(ChatRequest request) {
+            return ChatResponse.builder().aiMessage(new AiMessage("bad content")).build();
+        }
+    }
+
+    @ApplicationScoped
+    public static class AlwaysRejectGuardrail implements OutputGuardrail {
+        private final AtomicInteger count = new AtomicInteger(0);
+
+        @Override
+        public OutputGuardrailResult validate(AiMessage responseFromLLM) {
+            count.incrementAndGet();
+            return retry("Content always rejected");
+        }
+
+        public int validationCount() {
+            return count.get();
+        }
+    }
+}

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgentGuardrailMissingBeanTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgentGuardrailMissingBeanTest.java
@@ -1,0 +1,54 @@
+package io.quarkiverse.langchain4j.agentic.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.enterprise.inject.spi.DeploymentException;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.guardrail.InputGuardrail;
+import dev.langchain4j.guardrail.InputGuardrailResult;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.guardrail.InputGuardrails;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class AgentGuardrailMissingBeanTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(AgentWithMissingGuardrail.class, NotACdiBean.class))
+            .assertException(t -> {
+                assertThat(t).isInstanceOf(DeploymentException.class);
+                assertThat(t).hasMessageContaining(
+                        "io.quarkiverse.langchain4j.agentic.deployment.AgentGuardrailMissingBeanTest$NotACdiBean");
+            });
+
+    @Test
+    @ActivateRequestContext
+    void buildShouldFailWithMissingGuardrailBean() {
+        fail("Should not be called — build should fail");
+    }
+
+    public interface AgentWithMissingGuardrail {
+
+        @Agent
+        @InputGuardrails(NotACdiBean.class)
+        @UserMessage("Process this")
+        String process();
+    }
+
+    public static class NotACdiBean implements InputGuardrail {
+        @Override
+        public InputGuardrailResult validate(dev.langchain4j.data.message.UserMessage userMessage) {
+            return success();
+        }
+    }
+}

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgentGuardrailOrderingTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgentGuardrailOrderingTest.java
@@ -1,0 +1,110 @@
+package io.quarkiverse.langchain4j.agentic.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.guardrail.InputGuardrail;
+import dev.langchain4j.guardrail.InputGuardrailResult;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import dev.langchain4j.service.guardrail.InputGuardrails;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+@SuppressWarnings("CdiInjectionPointsInspection")
+public class AgentGuardrailOrderingTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(OrderedGuardedAgent.class,
+                                    FirstGuardrail.class, SecondGuardrail.class, ExecutionLog.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "whatever")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    OrderedGuardedAgent agent;
+
+    @Inject
+    ExecutionLog log;
+
+    @BeforeEach
+    void clearLog() {
+        log.clear();
+    }
+
+    @Test
+    @ActivateRequestContext
+    void guardrailsExecuteInDeclarationOrder() {
+        agent.process("test");
+
+        assertThat(log.entries()).containsExactly("First", "Second");
+    }
+
+    public interface OrderedGuardedAgent {
+
+        @Agent
+        @InputGuardrails({ FirstGuardrail.class, SecondGuardrail.class })
+        @UserMessage("Process: {{request}}")
+        String process(@V("request") String request);
+    }
+
+    @ApplicationScoped
+    public static class ExecutionLog {
+        private final List<String> entries = new ArrayList<>();
+
+        public synchronized void add(String entry) {
+            entries.add(entry);
+        }
+
+        public synchronized List<String> entries() {
+            return new ArrayList<>(entries);
+        }
+
+        public synchronized void clear() {
+            entries.clear();
+        }
+    }
+
+    @ApplicationScoped
+    public static class FirstGuardrail implements InputGuardrail {
+
+        @Inject
+        ExecutionLog log;
+
+        @Override
+        public InputGuardrailResult validate(dev.langchain4j.data.message.UserMessage userMessage) {
+            log.add("First");
+            return success();
+        }
+    }
+
+    @ApplicationScoped
+    public static class SecondGuardrail implements InputGuardrail {
+
+        @Inject
+        ExecutionLog log;
+
+        @Override
+        public InputGuardrailResult validate(dev.langchain4j.data.message.UserMessage userMessage) {
+            log.add("Second");
+            return success();
+        }
+    }
+}

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgentGuardrailUnremovableTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgentGuardrailUnremovableTest.java
@@ -1,0 +1,78 @@
+package io.quarkiverse.langchain4j.agentic.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.guardrail.InputGuardrail;
+import dev.langchain4j.guardrail.InputGuardrailResult;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import dev.langchain4j.service.guardrail.InputGuardrails;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verifies that a guardrail bean referenced ONLY from an agent interface
+ * (not injected anywhere else) survives Arc's dead-code elimination.
+ */
+@SuppressWarnings("CdiInjectionPointsInspection")
+public class AgentGuardrailUnremovableTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(AgentWithGuardrail.class, OnlyAgentReferencedGuardrail.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "whatever")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    AgentWithGuardrail agent;
+
+    @BeforeEach
+    void resetStaticState() {
+        OnlyAgentReferencedGuardrail.invoked.set(false);
+    }
+
+    @Test
+    @ActivateRequestContext
+    void guardrailBeanSurvivesArcDeadCodeElimination() {
+        assertThat(OnlyAgentReferencedGuardrail.invoked.get()).isFalse();
+        agent.process("test");
+        assertThat(OnlyAgentReferencedGuardrail.invoked.get()).isTrue();
+    }
+
+    public interface AgentWithGuardrail {
+
+        @Agent
+        @InputGuardrails(OnlyAgentReferencedGuardrail.class)
+        @UserMessage("Process: {{request}}")
+        String process(@V("request") String request);
+    }
+
+    @ApplicationScoped
+    public static class OnlyAgentReferencedGuardrail implements InputGuardrail {
+
+        static final AtomicBoolean invoked = new AtomicBoolean(false);
+
+        @Override
+        public InputGuardrailResult validate(dev.langchain4j.data.message.UserMessage userMessage) {
+            invoked.set(true);
+            return success();
+        }
+    }
+}

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgentInputGuardrailTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgentInputGuardrailTest.java
@@ -1,0 +1,76 @@
+package io.quarkiverse.langchain4j.agentic.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.guardrail.InputGuardrail;
+import dev.langchain4j.guardrail.InputGuardrailResult;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import dev.langchain4j.service.guardrail.InputGuardrails;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+@SuppressWarnings("CdiInjectionPointsInspection")
+public class AgentInputGuardrailTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(GuardedAgent.class, SpyInputGuardrail.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "whatever")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    GuardedAgent agent;
+
+    @Inject
+    SpyInputGuardrail guardrail;
+
+    @Test
+    @ActivateRequestContext
+    void inputGuardrailFiresOnAgentInvocation() {
+        assertThat(guardrail.invocationCount()).isEqualTo(0);
+        agent.process("hello");
+        assertThat(guardrail.invocationCount()).isEqualTo(1);
+    }
+
+    public interface GuardedAgent {
+
+        @Agent
+        @InputGuardrails(SpyInputGuardrail.class)
+        @UserMessage("Process: {{request}}")
+        String process(@V("request") String request);
+    }
+
+    @ApplicationScoped
+    public static class SpyInputGuardrail implements InputGuardrail {
+
+        private final AtomicInteger count = new AtomicInteger(0);
+
+        @Override
+        public InputGuardrailResult validate(dev.langchain4j.data.message.UserMessage userMessage) {
+            count.incrementAndGet();
+            return success();
+        }
+
+        public int invocationCount() {
+            return count.get();
+        }
+    }
+
+}

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgentOutputGuardrailRepromptTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgentOutputGuardrailRepromptTest.java
@@ -1,0 +1,104 @@
+package io.quarkiverse.langchain4j.agentic.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.ChatModelSupplier;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.guardrail.OutputGuardrail;
+import dev.langchain4j.guardrail.OutputGuardrailResult;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import dev.langchain4j.service.guardrail.OutputGuardrails;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verifies that output guardrail reprompting works through the AgentBuilder inner AiServices path.
+ * The guardrail rejects the first response and reprompts; the second response is accepted.
+ */
+@SuppressWarnings("CdiInjectionPointsInspection")
+public class AgentOutputGuardrailRepromptTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(RepromptAgent.class, RejectFirstGuardrail.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "whatever")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    RepromptAgent agent;
+
+    @Inject
+    RejectFirstGuardrail guardrail;
+
+    @Test
+    @ActivateRequestContext
+    void outputGuardrailRepromptTriggersRetry() {
+        String result = agent.process("hello");
+
+        assertThat(guardrail.validationCount()).isEqualTo(2);
+        assertThat(result).isEqualTo("ACCEPTED");
+    }
+
+    public interface RepromptAgent {
+
+        @ChatModelSupplier
+        static ChatModel chatModel() {
+            return new RetryAwareChatModel();
+        }
+
+        @Agent
+        @OutputGuardrails(RejectFirstGuardrail.class)
+        @UserMessage("Process: {{request}}")
+        String process(@V("request") String request);
+    }
+
+    public static class RetryAwareChatModel implements ChatModel {
+        private final AtomicInteger callCount = new AtomicInteger(0);
+
+        @Override
+        public ChatResponse doChat(ChatRequest request) {
+            int call = callCount.incrementAndGet();
+            String response = call == 1 ? "REJECTED_CONTENT" : "ACCEPTED";
+            return ChatResponse.builder().aiMessage(new AiMessage(response)).build();
+        }
+    }
+
+    @ApplicationScoped
+    public static class RejectFirstGuardrail implements OutputGuardrail {
+        private final AtomicInteger count = new AtomicInteger(0);
+
+        @Override
+        public OutputGuardrailResult validate(AiMessage responseFromLLM) {
+            int attempt = count.incrementAndGet();
+            if (responseFromLLM.text().equals("REJECTED_CONTENT")) {
+                return reprompt("Content rejected, please try again",
+                        "Please respond with ACCEPTED instead");
+            }
+            return success();
+        }
+
+        public int validationCount() {
+            return count.get();
+        }
+    }
+}

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgentOutputGuardrailTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgentOutputGuardrailTest.java
@@ -1,0 +1,87 @@
+package io.quarkiverse.langchain4j.agentic.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.guardrail.OutputGuardrail;
+import dev.langchain4j.guardrail.OutputGuardrailResult;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import dev.langchain4j.service.guardrail.OutputGuardrails;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+@SuppressWarnings("CdiInjectionPointsInspection")
+public class AgentOutputGuardrailTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(OutputGuardedAgent.class, SpyOutputGuardrail.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "whatever")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    OutputGuardedAgent agent;
+
+    @Inject
+    SpyOutputGuardrail guardrail;
+
+    @Test
+    @ActivateRequestContext
+    void outputGuardrailFiresAfterLlmCall() {
+        assertThat(guardrail.invocationCount()).isEqualTo(0);
+        assertThat(guardrail.lastMessage()).isNull();
+
+        agent.process("hello");
+
+        assertThat(guardrail.invocationCount()).isEqualTo(1);
+        assertThat(guardrail.lastMessage()).isNotNull();
+    }
+
+    public interface OutputGuardedAgent {
+
+        @Agent
+        @OutputGuardrails(SpyOutputGuardrail.class)
+        @UserMessage("Process: {{request}}")
+        String process(@V("request") String request);
+    }
+
+    @ApplicationScoped
+    public static class SpyOutputGuardrail implements OutputGuardrail {
+
+        private final AtomicInteger count = new AtomicInteger(0);
+        private final AtomicReference<AiMessage> lastMessage = new AtomicReference<>();
+
+        @Override
+        public OutputGuardrailResult validate(AiMessage responseFromLLM) {
+            count.incrementAndGet();
+            lastMessage.set(responseFromLLM);
+            return success();
+        }
+
+        public int invocationCount() {
+            return count.get();
+        }
+
+        public AiMessage lastMessage() {
+            return lastMessage.get();
+        }
+    }
+}

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/CdiChatSupplierParameterResolverTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/CdiChatSupplierParameterResolverTest.java
@@ -33,6 +33,7 @@ public class CdiChatSupplierParameterResolverTest extends OpenAiBaseTest {
                                     ModelSelector.class,
                                     EchoAgent.class, ModelSelectingAgent.class, SequenceWrapper.class,
                                     MixedParamsAgent.class, MixedParamsSequenceWrapper.class,
+                                    QualifiedModelAgent.class, QualifiedSequenceWrapper.class,
                                     Agents.FixedResponseChatModel.class, Agents.EchoResponseChatModel.class))
             .overrideRuntimeConfigKey("quarkus.langchain4j.openai.echo.api-key", "echo")
             .overrideRuntimeConfigKey("quarkus.langchain4j.openai.fixed.api-key", "fixed")
@@ -122,11 +123,32 @@ public class CdiChatSupplierParameterResolverTest extends OpenAiBaseTest {
         String run(String text);
     }
 
+    public interface QualifiedModelAgent {
+
+        @UserMessage("Answer: {{text}}")
+        @Agent(description = "An agent using a qualified CDI model", outputKey = "answer")
+        String answer(String text);
+
+        @ChatModelSupplier
+        static ChatModel chatModel(@CdiBean @ModelName("fixed") ChatModel model) {
+            return model;
+        }
+    }
+
+    public interface QualifiedSequenceWrapper {
+
+        @SequenceAgent(outputKey = "answer", subAgents = { EchoAgent.class, QualifiedModelAgent.class })
+        String run(String text);
+    }
+
     @Inject
     SequenceWrapper sequenceWrapper;
 
     @Inject
     MixedParamsSequenceWrapper mixedParamsSequenceWrapper;
+
+    @Inject
+    QualifiedSequenceWrapper qualifiedSequenceWrapper;
 
     @Test
     void cdiResolvedBeanIsUsedInChatModelSupplier() {
@@ -143,6 +165,12 @@ public class CdiChatSupplierParameterResolverTest extends OpenAiBaseTest {
     @Test
     void mixedScopeAndCdiParamsWork() {
         String result = mixedParamsSequenceWrapper.run("cat");
+        assertThat(result).isEqualTo(SELECTED_RESPONSE);
+    }
+
+    @Test
+    void qualifierAnnotationSelectsCorrectBean() {
+        String result = qualifiedSequenceWrapper.run("dog");
         assertThat(result).isEqualTo(SELECTED_RESPONSE);
     }
 }

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/CdiScopeValidationAgentListenerTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/CdiScopeValidationAgentListenerTest.java
@@ -1,0 +1,55 @@
+package io.quarkiverse.langchain4j.agentic.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.RequestScoped;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.ChatModelSupplier;
+import dev.langchain4j.agentic.observability.AgentListener;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.service.UserMessage;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CdiScopeValidationAgentListenerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(RequestScopedAgentListener.class,
+                                    SimpleAgent.class,
+                                    Agents.FixedResponseChatModel.class))
+            .assertException(t -> assertThat(t.getMessage())
+                    .contains("@RequestScoped")
+                    .contains("cannot be auto-wired"));
+
+    @RequestScoped
+    public static class RequestScopedAgentListener implements AgentListener {
+        // No methods need to be implemented - just the marker interface
+    }
+
+    public interface SimpleAgent {
+
+        @UserMessage("test")
+        @Agent(description = "Agent", outputKey = "answer")
+        String ask();
+
+        @ChatModelSupplier
+        static ChatModel chatModel() {
+            return new Agents.FixedResponseChatModel("response");
+        }
+    }
+
+    @Test
+    void requestScopedAgentListenerRejectedAtBuildTime() {
+        // Verification is done via assertException on the @RegisterExtension above:
+        // QuarkusUnitTest fails deployment and asserts the exception message contains
+        // "@RequestScoped" and "cannot be auto-wired". No runtime assertions needed.
+    }
+}

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/CdiWiringTier1StaticSuppliersTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/CdiWiringTier1StaticSuppliersTest.java
@@ -1,0 +1,111 @@
+package io.quarkiverse.langchain4j.agentic.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.ChatMemorySupplier;
+import dev.langchain4j.agentic.declarative.ChatModelSupplier;
+import dev.langchain4j.agentic.declarative.ContentRetrieverSupplier;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.rag.content.retriever.ContentRetriever;
+import dev.langchain4j.rag.query.Query;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tier 1: @Agent with static suppliers only — no CDI wiring.
+ * <p>
+ * All dependencies are declared via static supplier methods on the agent interface.
+ * This is the most portable mode — the interface works identically in plain
+ * langchain4j, langchain4j-cdi, and Quarkus.
+ */
+public class CdiWiringTier1StaticSuppliersTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ResearchAgent.class, InlineRetriever.class, InlineMemory.class,
+                            Agents.FixedResponseChatModel.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "test-key")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    public static class InlineRetriever implements ContentRetriever {
+        @Override
+        public List<Content> retrieve(Query query) {
+            return List.of(Content.from(TextSegment.from("static-retriever-result")));
+        }
+    }
+
+    public static class InlineMemory implements ChatMemory {
+        private final List<ChatMessage> messages = new ArrayList<>();
+
+        @Override
+        public Object id() {
+            return "static";
+        }
+
+        @Override
+        public void add(ChatMessage message) {
+            messages.add(message);
+        }
+
+        @Override
+        public List<ChatMessage> messages() {
+            return new ArrayList<>(messages);
+        }
+
+        @Override
+        public void clear() {
+            messages.clear();
+        }
+    }
+
+    public interface ResearchAgent {
+
+        @UserMessage("Research: {{topic}}")
+        @Agent(description = "Static-only agent", outputKey = "findings")
+        String research(@V("topic") String topic);
+
+        @ChatModelSupplier
+        static ChatModel chatModel() {
+            return new Agents.FixedResponseChatModel("static-findings");
+        }
+
+        @ContentRetrieverSupplier
+        static ContentRetriever retriever() {
+            return new InlineRetriever();
+        }
+
+        @ChatMemorySupplier
+        static ChatMemory memory() {
+            return new InlineMemory();
+        }
+    }
+
+    @Inject
+    ResearchAgent agent;
+
+    @Test
+    void agentBootsAndRespondsWithStaticSuppliersOnly() {
+        assertThat(agent).isNotNull();
+        assertThat(agent.research("quantum computing")).isEqualTo("static-findings");
+    }
+}

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/CdiWiringTier2CdiBeanTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/CdiWiringTier2CdiBeanTest.java
@@ -1,0 +1,91 @@
+package io.quarkiverse.langchain4j.agentic.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.ChatModelSupplier;
+import dev.langchain4j.agentic.declarative.SequenceAgent;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.agentic.runtime.CdiBean;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tier 2: @Agent with @CdiBean on @ChatModelSupplier parameters.
+ * <p>
+ * The supplier method is the declaration site (portable), and @CdiBean
+ * tells Quarkus to resolve the parameter from CDI at build time.
+ * <p>
+ * Currently @CdiBean parameters are supported on @ChatModelSupplier only —
+ * upstream issue #5377 tracks generalising the parameter resolver SPI to
+ * all supplier types.
+ * <p>
+ * See {@link CdiChatSupplierParameterResolverTest} for the full gallery
+ * of @CdiBean scenarios (mixed params, qualifiers, scope resolution).
+ */
+public class CdiWiringTier2CdiBeanTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ModelSelector.class, EchoAgent.class,
+                            CdiModelAgent.class, Wrapper.class,
+                            Agents.FixedResponseChatModel.class,
+                            Agents.EchoResponseChatModel.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "test-key")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Singleton
+    public static class ModelSelector {
+        public ChatModel select() {
+            return new Agents.FixedResponseChatModel("cdi-selected");
+        }
+    }
+
+    public interface EchoAgent {
+        @UserMessage("{{text}}")
+        @Agent(description = "Echo agent", outputKey = "echo")
+        String echo(String text);
+
+        @ChatModelSupplier
+        static ChatModel chatModel() {
+            return new Agents.EchoResponseChatModel();
+        }
+    }
+
+    public interface CdiModelAgent {
+        @UserMessage("Answer: {{text}}")
+        @Agent(description = "Agent with CDI-selected model", outputKey = "answer")
+        String answer(String text);
+
+        @ChatModelSupplier
+        static ChatModel chatModel(@CdiBean ModelSelector selector) {
+            return selector.select();
+        }
+    }
+
+    public interface Wrapper {
+        @SequenceAgent(outputKey = "answer", subAgents = { EchoAgent.class, CdiModelAgent.class })
+        String run(String text);
+    }
+
+    @Inject
+    Wrapper wrapper;
+
+    @Test
+    void cdiBeanParameterResolvesModelFromCdi() {
+        String result = wrapper.run("test-input");
+        assertThat(result).isEqualTo("cdi-selected");
+    }
+}

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/CdiWiringTier3RegisterAiServiceTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/CdiWiringTier3RegisterAiServiceTest.java
@@ -1,0 +1,105 @@
+package io.quarkiverse.langchain4j.agentic.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.ChatModelSupplier;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.rag.AugmentationResult;
+import dev.langchain4j.rag.RetrievalAugmentor;
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tier 3: @Agent with @RegisterAiService — opt-in CDI auto-wiring.
+ * <p>
+ * Adding @RegisterAiService to an agent interface opts into the Quarkus
+ * CDI auto-wiring model. Properties on @RegisterAiService explicitly
+ * control which suppliers are wired, with opt-out via NoXxxSupplier classes.
+ * <p>
+ * This test verifies two agents in the same deployment:
+ * <ul>
+ * <li>ResearchAgent uses @RegisterAiService — gets the RetrievalAugmentor bean</li>
+ * <li>PlainAgent has no @RegisterAiService — does NOT get the augmentor (no cross-contamination)</li>
+ * </ul>
+ */
+public class CdiWiringTier3RegisterAiServiceTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyAugmentorSupplier.class, ResearchAgent.class, PlainAgent.class,
+                            Agents.FixedResponseChatModel.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "test-key")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @ApplicationScoped
+    public static class MyAugmentorSupplier implements Supplier<RetrievalAugmentor> {
+        @Override
+        public RetrievalAugmentor get() {
+            return request -> new AugmentationResult(request.chatMessage(),
+                    List.of(Content.from(TextSegment.from("augmented-context"))));
+        }
+    }
+
+    @RegisterAiService(retrievalAugmentor = MyAugmentorSupplier.class)
+    public interface ResearchAgent {
+
+        @UserMessage("Research: {{topic}}")
+        @Agent(description = "Agent with @RegisterAiService opt-in", outputKey = "findings")
+        String research(@V("topic") String topic);
+
+        @ChatModelSupplier
+        static ChatModel chatModel() {
+            return new Agents.FixedResponseChatModel("registered-findings");
+        }
+    }
+
+    public interface PlainAgent {
+
+        @UserMessage("{{input}}")
+        @Agent(description = "Agent without @RegisterAiService")
+        String process(String input);
+
+        @ChatModelSupplier
+        static ChatModel chatModel() {
+            return new Agents.FixedResponseChatModel("plain-response");
+        }
+    }
+
+    @Inject
+    ResearchAgent researchAgent;
+
+    @Inject
+    PlainAgent plainAgent;
+
+    @Test
+    void registeredAgentGetsAugmentor() {
+        assertThat(researchAgent).isNotNull();
+        assertThat(researchAgent.research("quantum computing")).isEqualTo("registered-findings");
+    }
+
+    @Test
+    void plainAgentDoesNotGetAugmentor() {
+        assertThat(plainAgent).isNotNull();
+        assertThat(plainAgent.process("hello")).isEqualTo("plain-response");
+    }
+}


### PR DESCRIPTION
## PR Chain — Agentic module Quarkus integration

| PR | Status | Description |
|----|--------|-------------|
| ~~#2526~~ | ~~✅ merged~~ | ~~fix(agentic): invokeAgent allowlist~~ |
| #2534 | 🔵 open | feat(agentic): build-time safety checks and CDI foundation |
| **#2555** | **🔵 this PR** | **feat(agentic): CDI wiring tiers and guardrails ← depends on #2534** |
| #2544 | 🔵 open (draft) | fix(agentic): parallel context propagation ← depends on #2555 |
| #2550 | 🔵 open (draft) | feat(agentic): OTel, metrics, CDI events, health checks ← depends on #2534 |
| #2591 | 🔵 open (draft) | feat(#2578): replace supplier-class attributes with direct bean-class references ← independent |

```
main
 ├── #2534
 │    ├── #2555 (this PR) → #2544
 │    └── #2550
 └── #2591
```

> Depends on #2534. Merge #2534 first.

---

## Summary

CDI wiring tiers and guardrails for agent interfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)