### PR TITLE
Add default ToolExecutionErrorHandler and way to override it.

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
@@ -18,6 +18,7 @@ import static io.quarkiverse.langchain4j.deployment.MethodParameterAsTemplateVar
 import static io.quarkiverse.langchain4j.deployment.ObjectSubstitutionUtil.registerJsonSchema;
 import static io.quarkiverse.langchain4j.runtime.types.TypeUtil.isMulti;
 import static io.quarkus.arc.processor.DotNames.NAMED;
+import static io.quarkus.arc.processor.DotNames.SINGLETON;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -1516,6 +1517,23 @@ public class AiServicesProcessor {
                 }
             }
         }
+    }
+
+    @BuildStep
+    public void defaultToolExecutionErrorHandler(CombinedIndexBuildItem indexBuildItem,
+            BuildProducer<AdditionalBeanBuildItem> additionalBeanProducer) {
+        IndexView index = indexBuildItem.getIndex();
+        List<AnnotationInstance> instances = new ArrayList<>();
+        instances.addAll(index.getAnnotations(LangChain4jDotNames.DEFAULT_TOOL_EXECUTION_ERROR_HANDLER));
+        if (instances.isEmpty()) {
+            return;
+        } else if (instances.size() > 1) {
+            throw new IllegalStateException(
+                    "Multiple @DefaultToolExecutionErrorHandler annotations found.  Only one is allowed.");
+        }
+        String className = instances.get(0).target().asClass().name().toString();
+        additionalBeanProducer.produce(
+                AdditionalBeanBuildItem.builder().addBeanClass(className).setDefaultScope(SINGLETON).setUnremovable().build());
     }
 
     @BuildStep

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/LangChain4jDotNames.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/LangChain4jDotNames.java
@@ -40,6 +40,7 @@ import dev.langchain4j.web.search.WebSearchEngine;
 import dev.langchain4j.web.search.WebSearchTool;
 import io.quarkiverse.langchain4j.AudioUrl;
 import io.quarkiverse.langchain4j.CreatedAware;
+import io.quarkiverse.langchain4j.DefaultToolExecutionErrorHandler;
 import io.quarkiverse.langchain4j.HandleToolArgumentError;
 import io.quarkiverse.langchain4j.HandleToolExecutionError;
 import io.quarkiverse.langchain4j.ImageUrl;
@@ -90,6 +91,7 @@ public class LangChain4jDotNames {
     static final DotName DESCRIPTION = DotName.createSimple(Description.class);
     static final DotName STRUCTURED_PROMPT = DotName.createSimple(StructuredPrompt.class);
     static final DotName STRUCTURED_PROMPT_PROCESSOR = DotName.createSimple(StructuredPromptProcessor.class);
+    static final DotName DEFAULT_TOOL_EXECUTION_ERROR_HANDLER = DotName.createSimple(DefaultToolExecutionErrorHandler.class);
     public static final DotName V = DotName.createSimple(dev.langchain4j.service.V.class);
 
     public static final DotName MODEL_NAME = DotName.createSimple(ModelName.class);

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolresolution/DefaultToolExecutionErrorHandlerTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolresolution/DefaultToolExecutionErrorHandlerTest.java
@@ -1,0 +1,106 @@
+package io.quarkiverse.langchain4j.test.toolresolution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.mock.ChatModelMock;
+import dev.langchain4j.service.tool.ToolErrorContext;
+import dev.langchain4j.service.tool.ToolErrorHandlerResult;
+import dev.langchain4j.service.tool.ToolExecutionErrorHandler;
+import io.quarkiverse.langchain4j.DefaultToolExecutionErrorHandler;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.ToolBox;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DefaultToolExecutionErrorHandlerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(Assistant.class, Tools.class, TestChatModelSupplier.class, MyErrorHandler.class));
+
+    @Inject
+    Assistant assistant;
+
+    @Test
+    @ActivateRequestContext
+    void assistant() {
+        int initialToolInvocationCount = Tools.INVOCATION_COUNTER.get();
+
+        try {
+            String hello = assistant.chat("hello");
+            Assertions.fail("Expected DummyException");
+        } catch (DummyException e) {
+            // good!
+        }
+        int latestToolInvocationCount = Tools.INVOCATION_COUNTER.get();
+        assertThat(latestToolInvocationCount).isEqualTo(initialToolInvocationCount + 1);
+
+    }
+
+    @DefaultToolExecutionErrorHandler
+    public static class MyErrorHandler implements ToolExecutionErrorHandler {
+        @Override
+        public ToolErrorHandlerResult handle(Throwable error, ToolErrorContext context) {
+            if (error instanceof DummyException) {
+                throw (DummyException) error;
+            }
+            throw new RuntimeException(error);
+        }
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = TestChatModelSupplier.class)
+    interface Assistant {
+
+        @ToolBox(Tools.class)
+        String chat(String userMessage);
+
+    }
+
+    @ApplicationScoped
+    public static final class Tools {
+
+        public static final AtomicInteger INVOCATION_COUNTER = new AtomicInteger(0);
+
+        @Tool
+        String getWeather(String ignored) {
+            INVOCATION_COUNTER.incrementAndGet();
+            throw new DummyException();
+        }
+    }
+
+    public static class DummyException extends RuntimeException {
+
+    }
+
+    @ApplicationScoped
+    public static class TestChatModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            ToolExecutionRequest toolExecutionRequest = ToolExecutionRequest.builder()
+                    .name("getWeather")
+                    .arguments("{\"arg0\":\"Munich\"}")
+                    .build();
+
+            return ChatModelMock.thatAlwaysResponds(
+                    AiMessage.from(toolExecutionRequest),
+                    AiMessage.from("I was not able to get the weather"));
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/DefaultToolExecutionErrorHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/DefaultToolExecutionErrorHandler.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.langchain4j;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+
+/**
+ * Specifies the default error handler for tool execution for the entire project for all AI Services.
+ * This handler will be a CDI bean with the default scope of {@link jakarta.inject.Singleton}.
+ *
+ * If more than one class is annotated with this qualifier, then you will get a deployment error.
+ */
+@Qualifier
+@Retention(RUNTIME)
+@Target(ElementType.TYPE)
+public @interface DefaultToolExecutionErrorHandler {
+
+    class Literal extends AnnotationLiteral<DefaultToolExecutionErrorHandler> implements DefaultToolExecutionErrorHandler {
+        public static final Literal INSTANCE = new Literal();
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/AiServicesRecorder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/AiServicesRecorder.java
@@ -26,6 +26,7 @@ import dev.langchain4j.service.tool.ToolExecutionErrorHandler;
 import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.service.tool.search.ToolSearchService;
 import dev.langchain4j.service.tool.search.ToolSearchStrategy;
+import io.quarkiverse.langchain4j.DefaultToolExecutionErrorHandler;
 import io.quarkiverse.langchain4j.ModelName;
 import io.quarkiverse.langchain4j.RegisterAiService;
 import io.quarkiverse.langchain4j.observability.AiServiceEvents;
@@ -37,6 +38,7 @@ import io.quarkiverse.langchain4j.runtime.aiservice.DeclarativeAiServiceCreateIn
 import io.quarkiverse.langchain4j.runtime.aiservice.QuarkusAiServiceContext;
 import io.quarkiverse.langchain4j.runtime.aiservice.SystemMessageProvider;
 import io.quarkiverse.langchain4j.runtime.aiservice.ThinkingHandler;
+import io.quarkiverse.langchain4j.runtime.tool.LoggingToolExecutionErrorHandler;
 import io.quarkiverse.langchain4j.spi.DefaultMemoryIdProvider;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InstanceHandle;
@@ -227,6 +229,14 @@ public class AiServicesRecorder {
                                 .getInjectedReference(
                                         loadClass(info.toolExecutionErrorHandlerClassName()));
                         quarkusAiServices.toolExecutionErrorHandler(toolArgumentsErrorHandler);
+                    } else {
+                        InstanceHandle<ToolExecutionErrorHandler> instance = Arc.container()
+                                .instance(ToolExecutionErrorHandler.class, DefaultToolExecutionErrorHandler.Literal.INSTANCE);
+                        if (instance.isAvailable()) {
+                            quarkusAiServices.toolExecutionErrorHandler(instance.get());
+                        } else {
+                            quarkusAiServices.toolExecutionErrorHandler(new LoggingToolExecutionErrorHandler());
+                        }
                     }
 
                     // if no explicit tools are provided, check if we should use a tool provider

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/LoggingToolExecutionErrorHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/LoggingToolExecutionErrorHandler.java
@@ -1,0 +1,19 @@
+package io.quarkiverse.langchain4j.runtime.tool;
+
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+
+import org.jboss.logging.Logger;
+
+import dev.langchain4j.service.tool.ToolErrorContext;
+import dev.langchain4j.service.tool.ToolErrorHandlerResult;
+import dev.langchain4j.service.tool.ToolExecutionErrorHandler;
+
+public class LoggingToolExecutionErrorHandler implements ToolExecutionErrorHandler {
+    private static final Logger log = Logger.getLogger("Tool Error");
+
+    @Override
+    public ToolErrorHandlerResult handle(Throwable error, ToolErrorContext context) {
+        log.error(error);
+        return ToolErrorHandlerResult.text(isNullOrBlank(error.getMessage()) ? error.getClass().getName() : error.getMessage());
+    }
+}

--- a/docs/modules/ROOT/pages/ai-services.adoc
+++ b/docs/modules/ROOT/pages/ai-services.adoc
@@ -334,7 +334,6 @@ String response = myAiService.chat("Hello!", params);
 
 Only the fields you set on the `ChatRequestParameters` object override the defaults — all other parameters keep their configured values.
 Passing `null` is also safe and behaves the same as calling the method without the parameter.
-----
 
 == Tools Integration
 
@@ -408,6 +407,28 @@ public interface MyAiService {
     }
 }
 ----
+
+==== @DefaultToolExecutionErrorHandler
+
+If no error handler is provided, Quarkus will log the exception and return a text response to the LLM (same as LC4J default).
+If you want to define a default error handler for your entire deployment, then use the `@DefaultToolExecutionErrorHandler`.
+Only one can be provided per deployment.
+
+[source,java]
+----
+import io.quarkiverse.langchain4j.DefaultToolExecutionErrorHandler;
+import dev.langchain4j.service.tool.ToolExecutionErrorHandler;
+
+@DefaultToolExecutionErrorHandler
+public class MyHandler implements ToolExecutionErrorHandler {
+    @Override
+    public ToolErrorHandlerResult handle(Throwable error, ToolErrorContext context) {
+       // ... your implementation ...
+    }
+}
+----
+
+This class is a CDI bean defaulting to `@Singleton` scope.
 
 **Method requirements:**
 


### PR DESCRIPTION
This PR does two things:

* The default tool execution error handling eats the exception and doesn't even log the exception.  It is impossible to diagnosis problems thrown from a tool method.  So, I added a simple OOTB default to log the exception and to then perform the default behavior LC4J does.

* If devs want to override the default behavior they annotation a class with `@DefaultToolExecutionErrorHandler`

```java
@DefaulToolExecutionErrorHandler
public class MyHandler implements ToolExecutionErrorHandler {
...
}
```

See docs in PR for more information.