### PR TITLE
Allow the system message to depend on the model in use

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ModelAwareSystemMessageProviderModelNameTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ModelAwareSystemMessageProviderModelNameTest.java
@@ -1,0 +1,138 @@
+package io.quarkiverse.langchain4j.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.ModelName;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.runtime.aiservice.SystemMessageProviderWithContext;
+import io.quarkus.arc.Unremovable;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ModelAwareSystemMessageProviderModelNameTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(
+                            Assistant.class,
+                            ModelAwareProvider.class,
+                            DefaultModelSupplier.class,
+                            NamedModelProducer.class,
+                            EchoModel.class));
+
+    @Inject
+    Assistant assistant;
+
+    @Test
+    @ActivateRequestContext
+    public void promptReflectsPerCallModel() {
+        assertThat(assistant.chat("Hello", "claude")).isEqualTo("provider=ANTHROPIC model=claude-opus-4-8");
+        assertThat(assistant.chat("Hello", "gpt")).isEqualTo("provider=OPEN_AI model=gpt-4o");
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = DefaultModelSupplier.class, chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class, systemMessageProviderSupplier = ModelAwareProvider.class)
+    public interface Assistant {
+        String chat(@UserMessage String userMessage, @ModelName String model);
+    }
+
+    @ApplicationScoped
+    public static class ModelAwareProvider implements SystemMessageProviderWithContext {
+
+        @Override
+        public Optional<String> getSystemMessage(InvocationContext context) {
+            return Optional.of("provider=" + context.modelProvider()
+                    + " model=" + context.defaultRequestParameters().modelName());
+        }
+    }
+
+    @Singleton
+    public static class DefaultModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new EchoModel(ModelProvider.MISTRAL_AI, "default-model");
+        }
+    }
+
+    @Singleton
+    public static class NamedModelProducer {
+
+        // @Unremovable: these beans are only resolved at runtime via @ModelName lookup, so Arc would otherwise remove them
+        @Produces
+        @Singleton
+        @Unremovable
+        @ModelName("claude")
+        public ChatModel claude() {
+            return new EchoModel(ModelProvider.ANTHROPIC, "claude-opus-4-8");
+        }
+
+        @Produces
+        @Singleton
+        @Unremovable
+        @ModelName("gpt")
+        public ChatModel gpt() {
+            return new EchoModel(ModelProvider.OPEN_AI, "gpt-4o");
+        }
+    }
+
+    public static class EchoModel implements ChatModel {
+
+        private final ModelProvider provider;
+        private final String modelName;
+
+        public EchoModel(ModelProvider provider, String modelName) {
+            this.provider = provider;
+            this.modelName = modelName;
+        }
+
+        @Override
+        public ModelProvider provider() {
+            return provider;
+        }
+
+        @Override
+        public ChatRequestParameters defaultRequestParameters() {
+            return ChatRequestParameters.builder().modelName(modelName).build();
+        }
+
+        @Override
+        public ChatResponse chat(List<ChatMessage> messages) {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            SystemMessage systemMessage = chatRequest.messages().stream()
+                    .filter(SystemMessage.class::isInstance)
+                    .map(SystemMessage.class::cast)
+                    .findFirst()
+                    .orElse(null);
+            String responseText = systemMessage != null ? systemMessage.text() : "No system message";
+            return ChatResponse.builder().aiMessage(new AiMessage(responseText)).build();
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ModelAwareSystemMessageProviderStreamingTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ModelAwareSystemMessageProviderStreamingTest.java
@@ -1,0 +1,117 @@
+package io.quarkiverse.langchain4j.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.runtime.aiservice.SystemMessageProviderWithContext;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+
+/**
+ * Streaming counterpart of {@link ModelAwareSystemMessageProviderTest}: verifies that the
+ * {@link InvocationContext} is populated from the streaming chat model (provider and default
+ * request parameters) when no blocking chat model is present.
+ */
+public class ModelAwareSystemMessageProviderStreamingTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(
+                            Assistant.class,
+                            ModelAwareProvider.class,
+                            ClaudeStreamingModelSupplier.class,
+                            FakeClaudeStreamingModel.class));
+
+    @Inject
+    Assistant assistant;
+
+    @Test
+    @ActivateRequestContext
+    public void providerReceivesModelInformationFromStreamingContext() {
+        String response = String.join("",
+                assistant.chat("user1", "Hello").collect().asList().await().indefinitely());
+        assertThat(response).isEqualTo("provider=ANTHROPIC model=claude-opus-4-8");
+    }
+
+    @RegisterAiService(streamingChatLanguageModelSupplier = ClaudeStreamingModelSupplier.class, chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class, systemMessageProviderSupplier = ModelAwareProvider.class)
+    public interface Assistant {
+        Multi<String> chat(@MemoryId String memoryId, @UserMessage String userMessage);
+    }
+
+    @ApplicationScoped
+    public static class ModelAwareProvider implements SystemMessageProviderWithContext {
+
+        @Override
+        public Optional<String> getSystemMessage(InvocationContext context) {
+            return Optional.of("provider=" + context.modelProvider()
+                    + " model=" + context.defaultRequestParameters().modelName());
+        }
+    }
+
+    @Singleton
+    public static class ClaudeStreamingModelSupplier implements Supplier<StreamingChatModel> {
+
+        private FakeClaudeStreamingModel model;
+
+        @PostConstruct
+        public void init() {
+            model = new FakeClaudeStreamingModel();
+        }
+
+        @Override
+        public StreamingChatModel get() {
+            return model;
+        }
+    }
+
+    public static class FakeClaudeStreamingModel implements StreamingChatModel {
+
+        @Override
+        public ModelProvider provider() {
+            return ModelProvider.ANTHROPIC;
+        }
+
+        @Override
+        public ChatRequestParameters defaultRequestParameters() {
+            return ChatRequestParameters.builder().modelName("claude-opus-4-8").build();
+        }
+
+        @Override
+        public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+            SystemMessage systemMessage = chatRequest.messages().stream()
+                    .filter(SystemMessage.class::isInstance)
+                    .map(SystemMessage.class::cast)
+                    .findFirst()
+                    .orElse(null);
+            String responseText = systemMessage != null ? systemMessage.text() : "No system message";
+            handler.onPartialResponse(responseText);
+            handler.onCompleteResponse(ChatResponse.builder().aiMessage(new AiMessage("")).build());
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ModelAwareSystemMessageProviderTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ModelAwareSystemMessageProviderTest.java
@@ -1,0 +1,120 @@
+package io.quarkiverse.langchain4j.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.runtime.aiservice.SystemMessageProviderWithContext;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests that a {@link SystemMessageProvider} can produce a system message based on the
+ * model in use, by inspecting the {@link InvocationContext} (model provider and default
+ * request parameters such as the model name).
+ */
+public class ModelAwareSystemMessageProviderTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(
+                            Assistant.class,
+                            ModelAwareProvider.class,
+                            ClaudeModelSupplier.class,
+                            FakeClaudeModel.class));
+
+    @Inject
+    Assistant assistant;
+
+    @Test
+    @ActivateRequestContext
+    public void providerReceivesModelInformationFromContext() {
+        String response = assistant.chat("user1", "Hello");
+        assertThat(response).isEqualTo("provider=ANTHROPIC model=claude-opus-4-8");
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = ClaudeModelSupplier.class, chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class, systemMessageProviderSupplier = ModelAwareProvider.class)
+    public interface Assistant {
+        String chat(@MemoryId String memoryId, @UserMessage String userMessage);
+    }
+
+    @ApplicationScoped
+    public static class ModelAwareProvider implements SystemMessageProviderWithContext {
+
+        @Override
+        public Optional<String> getSystemMessage(InvocationContext context) {
+            return Optional.of("provider=" + context.modelProvider()
+                    + " model=" + context.defaultRequestParameters().modelName());
+        }
+    }
+
+    @Singleton
+    public static class ClaudeModelSupplier implements Supplier<ChatModel> {
+
+        private FakeClaudeModel model;
+
+        @PostConstruct
+        public void init() {
+            model = new FakeClaudeModel();
+        }
+
+        @Override
+        public ChatModel get() {
+            return model;
+        }
+    }
+
+    public static class FakeClaudeModel implements ChatModel {
+
+        @Override
+        public ModelProvider provider() {
+            return ModelProvider.ANTHROPIC;
+        }
+
+        @Override
+        public ChatRequestParameters defaultRequestParameters() {
+            return ChatRequestParameters.builder().modelName("claude-opus-4-8").build();
+        }
+
+        @Override
+        public ChatResponse chat(List<ChatMessage> messages) {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            SystemMessage systemMessage = chatRequest.messages().stream()
+                    .filter(SystemMessage.class::isInstance)
+                    .map(SystemMessage.class::cast)
+                    .findFirst()
+                    .orElse(null);
+            String responseText = systemMessage != null ? systemMessage.text() : "No system message";
+            return ChatResponse.builder().aiMessage(new AiMessage(responseText)).build();
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/SystemMessageAnnotationPrecedenceTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/SystemMessageAnnotationPrecedenceTest.java
@@ -1,0 +1,104 @@
+package io.quarkiverse.langchain4j.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.runtime.aiservice.SystemMessageProviderWithContext;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SystemMessageAnnotationPrecedenceTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(
+                            Assistant.class,
+                            ProviderShouldNotWin.class,
+                            ModelSupplier.class,
+                            EchoModel.class));
+
+    @Inject
+    Assistant assistant;
+
+    @Test
+    @ActivateRequestContext
+    public void annotationWinsOverProvider() {
+        assertThat(assistant.chat("Hello")).isEqualTo("from annotation");
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = ModelSupplier.class, chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class, systemMessageProviderSupplier = ProviderShouldNotWin.class)
+    public interface Assistant {
+        @dev.langchain4j.service.SystemMessage("from annotation")
+        String chat(@UserMessage String userMessage);
+    }
+
+    @ApplicationScoped
+    public static class ProviderShouldNotWin implements SystemMessageProviderWithContext {
+
+        @Override
+        public Optional<String> getSystemMessage(InvocationContext context) {
+            return Optional.of("from provider (with context)");
+        }
+    }
+
+    @Singleton
+    public static class ModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new EchoModel();
+        }
+    }
+
+    public static class EchoModel implements ChatModel {
+
+        @Override
+        public ModelProvider provider() {
+            return ModelProvider.ANTHROPIC;
+        }
+
+        @Override
+        public ChatRequestParameters defaultRequestParameters() {
+            return ChatRequestParameters.builder().modelName("claude-opus-4-8").build();
+        }
+
+        @Override
+        public ChatResponse chat(List<ChatMessage> messages) {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            SystemMessage systemMessage = chatRequest.messages().stream()
+                    .filter(SystemMessage.class::isInstance)
+                    .map(SystemMessage.class::cast)
+                    .findFirst()
+                    .orElse(null);
+            String responseText = systemMessage != null ? systemMessage.text() : "No system message";
+            return ChatResponse.builder().aiMessage(new AiMessage(responseText)).build();
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/QuarkusAiServicesFactory.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/QuarkusAiServicesFactory.java
@@ -19,6 +19,7 @@ import io.quarkiverse.langchain4j.runtime.aiservice.ChatMemoryFlushStrategy;
 import io.quarkiverse.langchain4j.runtime.aiservice.ChatMemorySeeder;
 import io.quarkiverse.langchain4j.runtime.aiservice.QuarkusAiServiceContext;
 import io.quarkiverse.langchain4j.runtime.aiservice.SystemMessageProvider;
+import io.quarkiverse.langchain4j.runtime.aiservice.SystemMessageProviderWithContext;
 import io.quarkiverse.langchain4j.runtime.aiservice.ThinkingHandler;
 
 public class QuarkusAiServicesFactory implements AiServicesFactory {
@@ -68,6 +69,12 @@ public class QuarkusAiServicesFactory implements AiServicesFactory {
 
         public AiServices<T> systemMessageProvider(SystemMessageProvider systemMessageProvider) {
             context.systemMessageProvider = memoryId -> systemMessageProvider.getSystemMessage(memoryId);
+            return this;
+        }
+
+        public AiServices<T> systemMessageProvider(SystemMessageProviderWithContext systemMessageProvider) {
+            context.systemMessageProviderWithContext = invocationContext -> systemMessageProvider
+                    .getSystemMessage(invocationContext).orElse(null);
             return this;
         }
 

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/RegisterAiService.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/RegisterAiService.java
@@ -28,8 +28,10 @@ import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.service.tool.search.ToolSearchStrategy;
 import dev.langchain4j.store.memory.chat.ChatMemoryStore;
 import dev.langchain4j.store.memory.chat.InMemoryChatMemoryStore;
+import io.quarkiverse.langchain4j.runtime.aiservice.BaseSystemMessageProvider;
 import io.quarkiverse.langchain4j.runtime.aiservice.ChatMemoryFlushStrategy;
 import io.quarkiverse.langchain4j.runtime.aiservice.SystemMessageProvider;
+import io.quarkiverse.langchain4j.runtime.aiservice.SystemMessageProviderWithContext;
 
 /**
  * Used to create LangChain4j's {@link AiServices} in a declarative manner that the application can then use simply by
@@ -218,9 +220,9 @@ public @interface RegisterAiService {
     boolean allowContinuousForcedToolCalling() default false;
 
     /**
-     * Configures a {@link SystemMessageProvider} to dynamically supply a system message based on the memory ID.
-     * This is useful when the system message needs to be determined at runtime, for example based on user context
-     * or other dynamic factors.
+     * Configures a system message provider to dynamically supply a system message at runtime.
+     * Provide either a {@link SystemMessageProvider} (based on the memory ID) or a
+     * {@link SystemMessageProviderWithContext} (based on the invocation context, so the system message can vary by model).
      * <p>
      * If not configured (left at the default), no dynamic system message provider is used. In that case,
      * the system message can still be provided via the {@link dev.langchain4j.service.SystemMessage} annotation
@@ -229,7 +231,7 @@ public @interface RegisterAiService {
      * @see <a href="https://docs.langchain4j.dev/tutorials/ai-services#system-message-provider">LangChain4j System Message
      *      Provider</a>
      */
-    Class<? extends SystemMessageProvider> systemMessageProviderSupplier() default NoSystemMessageProviderSupplier.class;
+    Class<? extends BaseSystemMessageProvider> systemMessageProviderSupplier() default NoSystemMessageProviderSupplier.class;
 
     /**
      * Indicates whether exceptions thrown during

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/AiServicesRecorder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/AiServicesRecorder.java
@@ -36,6 +36,7 @@ import io.quarkiverse.langchain4j.runtime.aiservice.ChatMemorySeeder;
 import io.quarkiverse.langchain4j.runtime.aiservice.DeclarativeAiServiceCreateInfo;
 import io.quarkiverse.langchain4j.runtime.aiservice.QuarkusAiServiceContext;
 import io.quarkiverse.langchain4j.runtime.aiservice.SystemMessageProvider;
+import io.quarkiverse.langchain4j.runtime.aiservice.SystemMessageProviderWithContext;
 import io.quarkiverse.langchain4j.runtime.aiservice.ThinkingHandler;
 import io.quarkiverse.langchain4j.spi.DefaultMemoryIdProvider;
 import io.quarkus.arc.Arc;
@@ -355,9 +356,13 @@ public class AiServicesRecorder {
                     }
 
                     if (info.systemMessageProviderClassName() != null) {
-                        quarkusAiServices.systemMessageProvider((SystemMessageProvider) loadClass(
-                                info.systemMessageProviderClassName())
-                                .getConstructor().newInstance());
+                        Object provider = loadClass(info.systemMessageProviderClassName())
+                                .getConstructor().newInstance();
+                        if (provider instanceof SystemMessageProviderWithContext withContext) {
+                            quarkusAiServices.systemMessageProvider(withContext);
+                        } else if (provider instanceof SystemMessageProvider memoryIdProvider) {
+                            quarkusAiServices.systemMessageProvider(memoryIdProvider);
+                        }
                     }
 
                     if (info.maxToolCallingRoundTrips() != null && info.maxToolCallingRoundTrips() > 0) {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
@@ -65,6 +65,7 @@ import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.invocation.InvocationParameters;
 import dev.langchain4j.invocation.LangChain4jManaged;
 import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
@@ -172,15 +173,29 @@ public class AiServiceMethodImplementationSupport {
         QuarkusAiServiceContext context = input.context;
         AiServiceMethodCreateInfo createInfo = input.createInfo;
         Object[] methodArgs = input.methodArgs;
+        ModelProvider modelProvider;
+        ChatRequestParameters defaultRequestParameters;
+
+        if (context.chatModel != null) {
+            var chatModel = context.effectiveChatModel(createInfo, methodArgs);
+            modelProvider = chatModel.provider();
+            defaultRequestParameters = chatModel.defaultRequestParameters();
+        } else {
+            var streamingChatModel = context.effectiveStreamingChatModel(createInfo, methodArgs);
+            modelProvider = streamingChatModel.provider();
+            defaultRequestParameters = streamingChatModel.defaultRequestParameters();
+        }
 
         InvocationContext invocationContext = InvocationContext.builder()
                 .invocationId(UUID.randomUUID())
                 .interfaceName(context.aiServiceClass.getName())
                 .methodName(createInfo.getMethodName())
+                .modelProvider(modelProvider)
                 .methodArguments((methodArgs != null) ? Arrays.asList(methodArgs) : List.of())
                 .chatMemoryId(memoryId(createInfo, methodArgs, context.hasChatMemory(), context.defaultMemoryIdProvider))
                 .invocationParameters(findInvocationParams(methodArgs))
                 .managedParameters(LangChain4jManaged.current())
+                .defaultRequestParameters(defaultRequestParameters)
                 .timestampNow()
                 .build();
 
@@ -226,7 +241,7 @@ public class AiServiceMethodImplementationSupport {
                 context.chatMemoryFlushStrategy);
 
         Optional<SystemMessage> systemMessage = prepareSystemMessage(methodCreateInfo, methodArgs, context, memoryId,
-                committableChatMemory);
+                committableChatMemory, invocationContext);
 
         boolean supportsJsonSchema = supportsJsonSchema(context, methodCreateInfo, methodArgs);
 
@@ -1026,10 +1041,15 @@ public class AiServiceMethodImplementationSupport {
             Object[] methodArgs,
             QuarkusAiServiceContext context,
             Object memoryId,
-            CommittableChatMemory committableChatMemory) {
+            CommittableChatMemory committableChatMemory,
+            InvocationContext invocationContext) {
         List<ChatMessage> previousChatMessages = committableChatMemory.messages();
 
         if (createInfo.getSystemMessageInfo().isEmpty()) {
+            if (context.systemMessageProviderWithContext != null) {
+                return Optional.ofNullable(context.systemMessageProviderWithContext.apply(invocationContext))
+                        .map(SystemMessage::new);
+            }
             return context.systemMessageProvider.apply(memoryId).map(SystemMessage::new);
         }
         AiServiceMethodCreateInfo.TemplateInfo systemMessageInfo = createInfo.getSystemMessageInfo().get();

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/BaseSystemMessageProvider.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/BaseSystemMessageProvider.java
@@ -1,0 +1,10 @@
+package io.quarkiverse.langchain4j.runtime.aiservice;
+
+/**
+ * Common super-type for the system message providers, so a single {@code @RegisterAiService}
+ * attribute can accept either a {@link SystemMessageProvider} or a {@link SystemMessageProviderWithContext}.
+ * <p>
+ * Implement one of the sub-interfaces, not this one directly.
+ */
+public interface BaseSystemMessageProvider {
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/SystemMessageProvider.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/SystemMessageProvider.java
@@ -7,12 +7,14 @@ import java.util.Optional;
  * This is useful when the system message needs to be determined at runtime, for example based on user context
  * or other dynamic factors.
  * <p>
+ * If the system message needs to vary by the model in use, implement {@link SystemMessageProviderWithContext} instead.
+ * <p>
  * This corresponds to LangChain4j's {@code systemMessageProvider} functionality.
  *
  * @see <a href="https://docs.langchain4j.dev/tutorials/ai-services#system-message-provider">LangChain4j System Message
  *      Provider</a>
  */
-public interface SystemMessageProvider {
+public interface SystemMessageProvider extends BaseSystemMessageProvider {
 
     /**
      * Provides a system message for the given memory ID.

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/SystemMessageProviderWithContext.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/SystemMessageProviderWithContext.java
@@ -1,0 +1,25 @@
+package io.quarkiverse.langchain4j.runtime.aiservice;
+
+import java.util.Optional;
+
+import dev.langchain4j.invocation.InvocationContext;
+
+/**
+ * Provides a way for an AiService to dynamically supply a system message based on the invocation context,
+ * which exposes the model in use (provider and default request parameters such as the model name).
+ * This allows the system message to vary by model.
+ * <p>
+ * If the system message only depends on the memory ID, implement {@link SystemMessageProvider} instead.
+ * <p>
+ * This corresponds to LangChain4j's {@code systemMessageProviderWithContext} functionality.
+ */
+public interface SystemMessageProviderWithContext extends BaseSystemMessageProvider {
+
+    /**
+     * Provides a system message based on the invocation context.
+     *
+     * @param context the invocation context
+     * @return an optional containing the system message, or empty if no system message should be used
+     */
+    Optional<String> getSystemMessage(InvocationContext context);
+}

--- a/docs/modules/ROOT/pages/ai-services.adoc
+++ b/docs/modules/ROOT/pages/ai-services.adoc
@@ -129,6 +129,29 @@ The system message can be set on the AI Service interface itself or on individua
 - `delimiter`: line delimiter for multi-line templates (`"\n"` by default).
 - `fromResource`: load message from a resource file.
 
+When the system message needs to be computed at runtime, implement a provider and reference it from `@RegisterAiService(systemMessageProviderSupplier = ...)`.
+Implement `SystemMessageProvider` when the message only depends on the memory ID, or `SystemMessageProviderWithContext` when it needs to inspect the model in use (provider and model name).
+
+To customize the system message for a specific model while keeping a default for all others, return the model-specific message in the matching branch and the default at the end (the fallback):
+
+[source,java]
+----
+public class ModelAwareSystemMessageProvider implements SystemMessageProviderWithContext {
+
+    @Override
+    public Optional<String> getSystemMessage(InvocationContext context) {
+        if (context.modelProvider() == ModelProvider.OPEN_AI) {
+            return Optional.of("You are a helpful assistant. Be concise.");
+        }
+        return Optional.of("You are a helpful assistant."); // fallback for every other model
+    }
+}
+----
+
+`InvocationContext` also exposes `chatMemoryId()`, so `SystemMessageProviderWithContext` can combine the model with the memory ID; `SystemMessageProvider` is the simpler option when only the memory ID matters.
+
+An explicit `@SystemMessage` on the method takes precedence over the provider.
+
 === @UserMessage
 
 The `@UserMessage` annotation defines user instructions or prompts sent to the LLM.


### PR DESCRIPTION
## Describe your changes

Introduces `SystemMessageProviderWithContext`, a system message provider that receives the `InvocationContext` and can inspect the model serving each call (`modelProvider()` and `defaultRequestParameters()`), so the system message can be chosen per model. It works for both blocking and streaming services and honors per-call `@ModelName` selection, since the context is built from the effective model.

It is a separate interface rather than a second method on `SystemMessageProvider`, so an implementation only writes the method it needs. Both interfaces extend the `BaseSystemMessageProvider` marker so the single `systemMessageProviderSupplier` attribute accepts either. `InvocationContext` also exposes `chatMemoryId()`, so the context-aware provider can do everything the memory-id one does, plus inspect the model.

Resolution precedence is `@SystemMessage` annotation > provider. Backward compatible: the existing `SystemMessageProvider`, with its single `getSystemMessage(Object)` method, is unchanged.

---

- Closes #2466