### PR TITLE
Fix/mistral streaming tool call implementation

### DIFF
--- a/model-providers/mistral/deployment/src/test/java/io/quarkiverse/langchain4j/mistralai/deployment/MistralAiStreamingChatLanguageModelSmokeTest.java
+++ b/model-providers/mistral/deployment/src/test/java/io/quarkiverse/langchain4j/mistralai/deployment/MistralAiStreamingChatLanguageModelSmokeTest.java
@@ -3,31 +3,42 @@ package io.quarkiverse.langchain4j.mistralai.deployment;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.okForContentType;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.core.MediaType;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 
+import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.mistralai.MistralAiStreamingChatModel;
+import io.quarkiverse.langchain4j.RegisterAiService;
 import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
 import io.quarkus.arc.ClientProxy;
 import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
 
 class MistralAiStreamingChatLanguageModelSmokeTest extends WiremockAware {
 
@@ -36,23 +47,60 @@ class MistralAiStreamingChatLanguageModelSmokeTest extends WiremockAware {
 
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(WeatherAssistant.class, WeatherTools.class))
             .overrideRuntimeConfigKey("quarkus.langchain4j.mistralai.api-key", API_KEY)
             .overrideRuntimeConfigKey("quarkus.langchain4j.mistralai.log-requests", "true")
             .overrideRuntimeConfigKey("quarkus.langchain4j.mistralai.base-url",
                     WiremockAware.wiremockUrlForConfig("/v1"));
 
+    @Singleton
+    @RegisterAiService(tools = WeatherTools.class)
+    interface WeatherAssistant {
+        Multi<String> chat(String message);
+    }
+
+    @ApplicationScoped
+    public static class WeatherTools {
+
+        static final List<String> invocations = new CopyOnWriteArrayList<>();
+
+        @Tool
+        public String getWeather(String name) {
+            invocations.add("getWeather(" + name + ")");
+            return "The weather in " + name + " is sunny";
+        }
+
+        @Tool
+        public String getTime(String zone) {
+            invocations.add("getTime(" + zone + ")");
+            return "The time in " + zone + " is 12:00";
+        }
+    }
+
     @Inject
     StreamingChatModel streamingChatModel;
+
+    @Inject
+    WeatherAssistant assistant;
+
+    @BeforeEach
+    void setup() {
+        WeatherTools.invocations.clear();
+        resetRequests();
+    }
 
     @Test
     void streaming() throws InterruptedException {
         assertThat(ClientProxy.unwrap(streamingChatModel))
                 .isInstanceOf(MistralAiStreamingChatModel.class);
 
-        // Mistral emits a tool-call delta with "content": null. Before the null-guard fix,
-        // QuarkusMistralAiClient iterated getDelta().getContent() and threw a NullPointerException,
-        // breaking streaming + function calling. This stream reproduces that exact shape.
+        // Mistral emits a tool-call delta with "content": null. Before the null-guard
+        // fix,
+        // QuarkusMistralAiClient iterated getDelta().getContent() and threw a
+        // NullPointerException,
+        // breaking streaming + function calling. This stream reproduces that exact
+        // shape.
         String eventStream = """
                 data: {"id":"cmpl-1","object":"chat.completion.chunk","created":1711442725,"model":"mistral-tiny","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":19,"total_tokens":27,"completion_tokens":8}}
 
@@ -96,7 +144,8 @@ class MistralAiStreamingChatLanguageModelSmokeTest extends WiremockAware {
             fail("streaming failed: %s".formatted(error.get().getMessage()), error.get());
         }
 
-        // The stream completed without onError -> the null-content delta no longer NPEs.
+        // The stream completed without onError -> the null-content delta no longer
+        // NPEs.
         assertThat(response.get()).isNotNull();
         assertThat(response.get().aiMessage()).isNotNull();
 
@@ -104,5 +153,80 @@ class MistralAiStreamingChatLanguageModelSmokeTest extends WiremockAware {
         assertThat(loggedRequest.getHeader("User-Agent")).isEqualTo("Quarkus REST Client");
         String requestBody = new String(loggedRequest.getBody());
         assertThat(requestBody).contains(CHAT_MODEL_ID).contains("stream");
+    }
+
+    @Test
+    void streamingToolCalling() {
+        // Step 1: the model answers with two tool calls. getWeather's arguments are
+        // split across
+        // two chunks (the second delta has no tool-call id) to exercise the
+        // ToolCallBuilder
+        // argument aggregation in QuarkusMistralAiClient. All deltas carry "content":
+        // null,
+        // which also covers the original NPE regression.
+        String toolCallStream = """
+                data: {"id":"cmpl-1","object":"chat.completion.chunk","created":1711442725,"model":"mistral-tiny","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"getWeather","arguments":"{\\"name\\": \\"Pa"}}]},"finish_reason":null}]}
+
+                data: {"id":"cmpl-1","object":"chat.completion.chunk","created":1711442725,"model":"mistral-tiny","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"function":{"arguments":"ris\\"}"}}]},"finish_reason":null}]}
+
+                data: {"id":"cmpl-1","object":"chat.completion.chunk","created":1711442725,"model":"mistral-tiny","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"id":"call_2","type":"function","function":{"name":"getTime","arguments":"{\\"zone\\": \\"Europe/Paris\\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":19,"total_tokens":27,"completion_tokens":8}}
+
+                data: [DONE]
+
+                """;
+
+        // Step 2: after the tools have been executed, the model streams the final
+        // answer.
+        String finalAnswerStream = """
+                data: {"id":"cmpl-2","object":"chat.completion.chunk","created":1711442726,"model":"mistral-tiny","choices":[{"index":0,"delta":{"role":"assistant","content":"The weather in Paris is sunny"},"finish_reason":null}]}
+
+                data: {"id":"cmpl-2","object":"chat.completion.chunk","created":1711442726,"model":"mistral-tiny","choices":[{"index":0,"delta":{"content":" and it is 12:00."},"finish_reason":"stop"}],"usage":{"prompt_tokens":40,"total_tokens":60,"completion_tokens":20}}
+
+                data: [DONE]
+
+                """;
+
+        wiremock().register(
+                post(urlEqualTo("/v1/chat/completions"))
+                        .inScenario("tool-calling")
+                        .whenScenarioStateIs(Scenario.STARTED)
+                        .willSetStateTo("tools-executed")
+                        .withHeader("Authorization", equalTo("Bearer " + API_KEY))
+                        .willReturn(okForContentType(MediaType.SERVER_SENT_EVENTS, toolCallStream)));
+        wiremock().register(
+                post(urlEqualTo("/v1/chat/completions"))
+                        .inScenario("tool-calling")
+                        .whenScenarioStateIs("tools-executed")
+                        .withHeader("Authorization", equalTo("Bearer " + API_KEY))
+                        .willReturn(okForContentType(MediaType.SERVER_SENT_EVENTS, finalAnswerStream)));
+
+        List<String> tokens = assistant.chat("What is the weather and time in Paris?")
+                .collect().asList()
+                .await().atMost(Duration.ofSeconds(30));
+
+        // the streamed answer is the one from the second (post-tools) response
+        assertThat(String.join("", tokens)).isEqualTo("The weather in Paris is sunny and it is 12:00.");
+
+        // both tools were actually executed, with the arguments parsed from the stream
+        assertThat(WeatherTools.invocations)
+                .containsExactlyInAnyOrder("getWeather(Paris)", "getTime(Europe/Paris)");
+
+        List<LoggedRequest> requests = wiremock().find(postRequestedFor(urlEqualTo("/v1/chat/completions")));
+        assertThat(requests).hasSize(2);
+        List<String> bodies = requests.stream().map(r -> new String(r.getBody())).toList();
+
+        // the tools were declared to the model on the initial streaming request
+        assertThat(bodies).anySatisfy(body -> assertThat(body)
+                .contains("\"tools\"")
+                .contains("getWeather")
+                .contains("getTime")
+                .doesNotContain("call_1"));
+
+        // the follow-up request carried the tool execution results back to the model
+        assertThat(bodies).anySatisfy(body -> assertThat(body)
+                .contains("call_1")
+                .contains("call_2")
+                .contains("The weather in Paris is sunny")
+                .contains("The time in Europe/Paris is 12:00"));
     }
 }

--- a/model-providers/mistral/runtime/src/main/java/io/quarkiverse/langchain4j/mistralai/QuarkusMistralAiClient.java
+++ b/model-providers/mistral/runtime/src/main/java/io/quarkiverse/langchain4j/mistralai/QuarkusMistralAiClient.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.langchain4j.mistralai;
 
+import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
 import static dev.langchain4j.model.mistralai.internal.mapper.MistralAiMapper.finishReasonFrom;
 import static dev.langchain4j.model.mistralai.internal.mapper.MistralAiMapper.tokenUsageFrom;
 import static java.util.stream.Collectors.joining;
@@ -18,7 +19,9 @@ import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.client.api.ClientLogger;
 import org.jboss.resteasy.reactive.client.api.LoggingScope;
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.internal.ToolCallBuilder;
 import dev.langchain4j.model.StreamingResponseHandler;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
@@ -33,6 +36,7 @@ import dev.langchain4j.model.mistralai.internal.api.MistralAiModelResponse;
 import dev.langchain4j.model.mistralai.internal.api.MistralAiModerationRequest;
 import dev.langchain4j.model.mistralai.internal.api.MistralAiModerationResponse;
 import dev.langchain4j.model.mistralai.internal.api.MistralAiTextContent;
+import dev.langchain4j.model.mistralai.internal.api.MistralAiToolCall;
 import dev.langchain4j.model.mistralai.internal.api.MistralAiUsage;
 import dev.langchain4j.model.mistralai.internal.client.MistralAiClient;
 import dev.langchain4j.model.mistralai.internal.client.MistralAiClientBuilderFactory;
@@ -81,6 +85,9 @@ public class QuarkusMistralAiClient extends MistralAiClient {
         AtomicReference<StringBuffer> contentBuilder = new AtomicReference<>(new StringBuffer());
         AtomicReference<TokenUsage> tokenUsage = new AtomicReference<>();
         AtomicReference<FinishReason> finishReason = new AtomicReference<>();
+
+        ToolCallBuilder toolCallBuilder = new ToolCallBuilder(-1);
+
         restApi.streamingChatCompletion(request, apiKey).subscribe().with(new Consumer<>() {
             @Override
             public void accept(MistralAiChatCompletionResponse response) {
@@ -102,6 +109,21 @@ public class QuarkusMistralAiClient extends MistralAiClient {
                     handler.onPartialResponse(chunk);
                 }
 
+                List<MistralAiToolCall> toolCalls = choice.getDelta().getToolCalls();
+                if (toolCalls != null) {
+                    for (MistralAiToolCall toolCall : toolCalls) {
+                        if (isNotNullOrBlank(toolCall.getId())) {
+                            if (toolCallBuilder.name() != null) {
+                                toolCallBuilder.buildAndReset();
+                            }
+                            toolCallBuilder.updateIndex(toolCallBuilder.index() + 1);
+                            toolCallBuilder.updateId(toolCall.getId());
+                            toolCallBuilder.updateName(toolCall.getFunction().getName());
+                        }
+                        toolCallBuilder.appendArguments(toolCall.getFunction().getArguments());
+                    }
+                }
+
                 MistralAiUsage usageInfo = response.getUsage();
                 if (usageInfo != null) {
                     tokenUsage.set(tokenUsageFrom(usageInfo));
@@ -120,8 +142,20 @@ public class QuarkusMistralAiClient extends MistralAiClient {
         }, new Runnable() {
             @Override
             public void run() {
+                if (toolCallBuilder.name() != null) {
+                    toolCallBuilder.buildAndReset();
+                }
+                List<ToolExecutionRequest> toolExecutionRequests = List.of();
+                if (toolCallBuilder.hasRequests()) {
+                    toolExecutionRequests = toolCallBuilder.allRequests();
+                }
+
+                AiMessage aiMessage = AiMessage.builder()
+                        .text(contentBuilder.get().toString())
+                        .toolExecutionRequests(toolExecutionRequests)
+                        .build();
                 ChatResponse response = ChatResponse.builder()
-                        .aiMessage(AiMessage.from(contentBuilder.get().toString()))
+                        .aiMessage(aiMessage)
                         .tokenUsage(tokenUsage.get())
                         .finishReason(finishReason.get())
                         .build();
@@ -190,7 +224,8 @@ public class QuarkusMistralAiClient extends MistralAiClient {
     }
 
     /**
-     * Introduce a custom logger as the stock one logs at the DEBUG level by default...
+     * Introduce a custom logger as the stock one logs at the DEBUG level by
+     * default...
      */
     static class MistralAiClientLogger implements ClientLogger {
         private static final Logger log = Logger.getLogger(MistralAiClientLogger.class);


### PR DESCRIPTION
## Problem
With `MistralAI` as a provider, tool/function calling does not work when the response is streamed. The model returned the tool call, but the tool was never executed.

## Root Cause
`QuarkusMistralAiClient#streamingChatCompletion` only accumulated text content from each delta and used it to build `AiMessage`. The `tool_calls` deltas were ignored, which resulted in `AiMessage` containing no `ToolExecutionRequests`.

## Fix
Gathered streamed `tool_calls` using `ToolCallBuilder`.

## Related
Builds on the streaming null-content NPE fix (#2553 ).