### PR TITLE
Register ImageUsage classes for reflection in native image

### DIFF
--- a/model-providers/openai/openai-common/deployment/src/main/java/io/quarkiverse/langchain4j/openai/common/OpenAiCommonProcessor.java
+++ b/model-providers/openai/openai-common/deployment/src/main/java/io/quarkiverse/langchain4j/openai/common/OpenAiCommonProcessor.java
@@ -21,6 +21,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.resteasy.reactive.spi.MessageBodyReaderOverrideBuildItem;
 import io.quarkus.resteasy.reactive.spi.MessageBodyWriterOverrideBuildItem;
 import io.smallrye.config.Priorities;
@@ -33,8 +34,18 @@ public class OpenAiCommonProcessor {
     }
 
     @BuildStep
-    void nativeImageSupport(BuildProducer<NativeImageResourceBuildItem> resourcesProducer) {
+    void nativeImageSupport(BuildProducer<NativeImageResourceBuildItem> resourcesProducer,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClassProducer) {
         registerJtokkitResources(resourcesProducer);
+
+        // Workaround for https://github.com/langchain4j/langchain4j/pull/5409
+        // ImageUsage and its inner classes are missing from langchain4j-open-ai's reflect-config.json
+        reflectiveClassProducer.produce(ReflectiveClassBuildItem.builder(
+                "dev.langchain4j.model.openai.internal.image.ImageUsage",
+                "dev.langchain4j.model.openai.internal.image.ImageUsage$Builder",
+                "dev.langchain4j.model.openai.internal.image.ImageUsage$TokensDetails",
+                "dev.langchain4j.model.openai.internal.image.ImageUsage$TokensDetails$TokensDetailsBuilder")
+                .methods().fields().constructors().build());
     }
 
     private void registerJtokkitResources(BuildProducer<NativeImageResourceBuildItem> resourcesProducer) {


### PR DESCRIPTION
## Summary

- Register `ImageUsage` and its inner classes (`Builder`, `TokensDetails`, `TokensDetailsBuilder`) for GraalVM native image reflection
- These classes were added in langchain4j 1.16.1 as part of gpt-image-1 API support but are missing from langchain4j-open-ai's `reflect-config.json`, causing Jackson deserialization failures in native mode:
  ```
  com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Builder class
  `dev.langchain4j.model.openai.internal.image.ImageUsage$Builder` does not have
  build method (name: 'build')
  ```
- The fix is in `OpenAiCommonProcessor` (shared by both vanilla and Azure OpenAI providers)

Follow-up to #2541

Upstream fix: https://github.com/langchain4j/langchain4j/pull/5409