### PR TITLE
Add support for watsonx.ai on-demand deployments

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-all-config.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-all-config.adoc
@@ -27733,6 +27733,29 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++ibm/granite-4-h-small+++`
 
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-deployment-id]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-deployment-id[`+++quarkus.langchain4j.watsonx.chat-model.deployment-id+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.deployment-id+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The deployment ID of a model deployed in watsonx.ai.
+
+Use this when targeting a custom model deployment instead of a foundation model. When set, it takes precedence over `modelName`, and neither `projectId` nor `spaceId` is required.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_DEPLOYMENT_ID+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_DEPLOYMENT_ID+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-tool-choice]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-tool-choice[`+++quarkus.langchain4j.watsonx.chat-model.tool-choice+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.tool-choice+++[]
@@ -28217,51 +28240,89 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |
 
-a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-think]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-think[`+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.think+++`]##
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-think-opening]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-think-opening[`+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.think.opening+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.think+++[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.think.opening+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-The XML-like tag enclosing the model’s internal reasoning.
-
-Example: `<think> ... </think>`
+The opening delimiter for the model's internal reasoning section.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_THINK+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_THINK_OPENING+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_THINK+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_THINK_OPENING+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
 |required icon:exclamation-circle[title=Configuration property is required]
 
-a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-response]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-response[`+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.response+++`]##
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-think-closing]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-think-closing[`+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.think.closing+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.response+++[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.think.closing+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-The XML-like tag enclosing the model’s final response.
-
-Optional — if not defined, all text outside the reasoning tag is treated as the response.
+The closing delimiter for the model's internal reasoning section.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_RESPONSE+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_THINK_CLOSING+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_RESPONSE+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_THINK_CLOSING+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|
+|required icon:exclamation-circle[title=Configuration property is required]
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-response-opening]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-response-opening[`+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.response.opening+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.response.opening+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The opening delimiter for the model's final response section.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_RESPONSE_OPENING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_RESPONSE_OPENING+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|required icon:exclamation-circle[title=Configuration property is required]
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-response-closing]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-response-closing[`+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.response.closing+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.response.closing+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The closing delimiter for the model's final response section.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_RESPONSE_CLOSING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_RESPONSE_CLOSING+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|required icon:exclamation-circle[title=Configuration property is required]
 
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-effort]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-effort[`+++quarkus.langchain4j.watsonx.chat-model.thinking.effort+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -29428,6 +29489,29 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++ibm/granite-4-h-small+++`
 
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-deployment-id]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-deployment-id[`+++quarkus.langchain4j.watsonx."model-name".chat-model.deployment-id+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.deployment-id+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The deployment ID of a model deployed in watsonx.ai.
+
+Use this when targeting a custom model deployment instead of a foundation model. When set, it takes precedence over `modelName`, and neither `projectId` nor `spaceId` is required.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_DEPLOYMENT_ID+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_DEPLOYMENT_ID+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-tool-choice]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-tool-choice[`+++quarkus.langchain4j.watsonx."model-name".chat-model.tool-choice+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.tool-choice+++[]
@@ -29912,51 +29996,89 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |
 
-a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-think]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-think[`+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.think+++`]##
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-think-opening]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-think-opening[`+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.think.opening+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.think+++[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.think.opening+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-The XML-like tag enclosing the model’s internal reasoning.
-
-Example: `<think> ... </think>`
+The opening delimiter for the model's internal reasoning section.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_THINK+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_THINK_OPENING+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_THINK+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_THINK_OPENING+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
 |required icon:exclamation-circle[title=Configuration property is required]
 
-a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-response]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-response[`+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.response+++`]##
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-think-closing]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-think-closing[`+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.think.closing+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.response+++[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.think.closing+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-The XML-like tag enclosing the model’s final response.
-
-Optional — if not defined, all text outside the reasoning tag is treated as the response.
+The closing delimiter for the model's internal reasoning section.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_RESPONSE+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_THINK_CLOSING+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_RESPONSE+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_THINK_CLOSING+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|
+|required icon:exclamation-circle[title=Configuration property is required]
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-response-opening]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-response-opening[`+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.response.opening+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.response.opening+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The opening delimiter for the model's final response section.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_RESPONSE_OPENING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_RESPONSE_OPENING+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|required icon:exclamation-circle[title=Configuration property is required]
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-response-closing]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-response-closing[`+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.response.closing+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.response.closing+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The closing delimiter for the model's final response section.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_RESPONSE_CLOSING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_RESPONSE_CLOSING+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|required icon:exclamation-circle[title=Configuration property is required]
 
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-effort]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-effort[`+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.effort+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-watsonx.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-watsonx.adoc
@@ -689,6 +689,29 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++ibm/granite-4-h-small+++`
 
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-deployment-id]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-deployment-id[`+++quarkus.langchain4j.watsonx.chat-model.deployment-id+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.deployment-id+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The deployment ID of a model deployed in watsonx.ai.
+
+Use this when targeting a custom model deployment instead of a foundation model. When set, it takes precedence over `modelName`, and neither `projectId` nor `spaceId` is required.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_DEPLOYMENT_ID+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_DEPLOYMENT_ID+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-tool-choice]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-tool-choice[`+++quarkus.langchain4j.watsonx.chat-model.tool-choice+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.tool-choice+++[]
@@ -1173,51 +1196,89 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |
 
-a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-think]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-think[`+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.think+++`]##
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-think-opening]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-think-opening[`+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.think.opening+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.think+++[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.think.opening+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-The XML-like tag enclosing the model’s internal reasoning.
-
-Example: `<think> ... </think>`
+The opening delimiter for the model's internal reasoning section.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_THINK+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_THINK_OPENING+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_THINK+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_THINK_OPENING+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
 |required icon:exclamation-circle[title=Configuration property is required]
 
-a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-response]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-response[`+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.response+++`]##
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-think-closing]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-think-closing[`+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.think.closing+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.response+++[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.think.closing+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-The XML-like tag enclosing the model’s final response.
-
-Optional — if not defined, all text outside the reasoning tag is treated as the response.
+The closing delimiter for the model's internal reasoning section.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_RESPONSE+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_THINK_CLOSING+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_RESPONSE+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_THINK_CLOSING+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|
+|required icon:exclamation-circle[title=Configuration property is required]
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-response-opening]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-response-opening[`+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.response.opening+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.response.opening+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The opening delimiter for the model's final response section.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_RESPONSE_OPENING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_RESPONSE_OPENING+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|required icon:exclamation-circle[title=Configuration property is required]
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-response-closing]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-response-closing[`+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.response.closing+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.response.closing+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The closing delimiter for the model's final response section.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_RESPONSE_CLOSING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_RESPONSE_CLOSING+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|required icon:exclamation-circle[title=Configuration property is required]
 
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-effort]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-effort[`+++quarkus.langchain4j.watsonx.chat-model.thinking.effort+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -2384,6 +2445,29 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++ibm/granite-4-h-small+++`
 
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-deployment-id]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-deployment-id[`+++quarkus.langchain4j.watsonx."model-name".chat-model.deployment-id+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.deployment-id+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The deployment ID of a model deployed in watsonx.ai.
+
+Use this when targeting a custom model deployment instead of a foundation model. When set, it takes precedence over `modelName`, and neither `projectId` nor `spaceId` is required.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_DEPLOYMENT_ID+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_DEPLOYMENT_ID+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-tool-choice]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-tool-choice[`+++quarkus.langchain4j.watsonx."model-name".chat-model.tool-choice+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.tool-choice+++[]
@@ -2868,51 +2952,89 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |
 
-a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-think]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-think[`+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.think+++`]##
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-think-opening]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-think-opening[`+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.think.opening+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.think+++[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.think.opening+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-The XML-like tag enclosing the model’s internal reasoning.
-
-Example: `<think> ... </think>`
+The opening delimiter for the model's internal reasoning section.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_THINK+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_THINK_OPENING+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_THINK+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_THINK_OPENING+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
 |required icon:exclamation-circle[title=Configuration property is required]
 
-a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-response]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-response[`+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.response+++`]##
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-think-closing]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-think-closing[`+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.think.closing+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.response+++[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.think.closing+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-The XML-like tag enclosing the model’s final response.
-
-Optional — if not defined, all text outside the reasoning tag is treated as the response.
+The closing delimiter for the model's internal reasoning section.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_RESPONSE+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_THINK_CLOSING+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_RESPONSE+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_THINK_CLOSING+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|
+|required icon:exclamation-circle[title=Configuration property is required]
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-response-opening]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-response-opening[`+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.response.opening+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.response.opening+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The opening delimiter for the model's final response section.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_RESPONSE_OPENING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_RESPONSE_OPENING+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|required icon:exclamation-circle[title=Configuration property is required]
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-response-closing]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-response-closing[`+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.response.closing+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.response.closing+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The closing delimiter for the model's final response section.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_RESPONSE_CLOSING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_RESPONSE_CLOSING+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|required icon:exclamation-circle[title=Configuration property is required]
 
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-effort]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-effort[`+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.effort+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-watsonx_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-watsonx_quarkus.langchain4j.adoc
@@ -689,6 +689,29 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++ibm/granite-4-h-small+++`
 
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-deployment-id]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-deployment-id[`+++quarkus.langchain4j.watsonx.chat-model.deployment-id+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.deployment-id+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The deployment ID of a model deployed in watsonx.ai.
+
+Use this when targeting a custom model deployment instead of a foundation model. When set, it takes precedence over `modelName`, and neither `projectId` nor `spaceId` is required.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_DEPLOYMENT_ID+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_DEPLOYMENT_ID+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-tool-choice]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-tool-choice[`+++quarkus.langchain4j.watsonx.chat-model.tool-choice+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.tool-choice+++[]
@@ -1173,51 +1196,89 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |
 
-a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-think]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-think[`+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.think+++`]##
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-think-opening]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-think-opening[`+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.think.opening+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.think+++[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.think.opening+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-The XML-like tag enclosing the model’s internal reasoning.
-
-Example: `<think> ... </think>`
+The opening delimiter for the model's internal reasoning section.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_THINK+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_THINK_OPENING+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_THINK+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_THINK_OPENING+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
 |required icon:exclamation-circle[title=Configuration property is required]
 
-a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-response]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-response[`+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.response+++`]##
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-think-closing]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-think-closing[`+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.think.closing+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.response+++[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.think.closing+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-The XML-like tag enclosing the model’s final response.
-
-Optional — if not defined, all text outside the reasoning tag is treated as the response.
+The closing delimiter for the model's internal reasoning section.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_RESPONSE+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_THINK_CLOSING+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_RESPONSE+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_THINK_CLOSING+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|
+|required icon:exclamation-circle[title=Configuration property is required]
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-response-opening]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-response-opening[`+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.response.opening+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.response.opening+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The opening delimiter for the model's final response section.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_RESPONSE_OPENING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_RESPONSE_OPENING+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|required icon:exclamation-circle[title=Configuration property is required]
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-response-closing]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-tags-response-closing[`+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.response.closing+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.thinking.tags.response.closing+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The closing delimiter for the model's final response section.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_RESPONSE_CLOSING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_THINKING_TAGS_RESPONSE_CLOSING+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|required icon:exclamation-circle[title=Configuration property is required]
 
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-effort]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-thinking-effort[`+++quarkus.langchain4j.watsonx.chat-model.thinking.effort+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -2384,6 +2445,29 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++ibm/granite-4-h-small+++`
 
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-deployment-id]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-deployment-id[`+++quarkus.langchain4j.watsonx."model-name".chat-model.deployment-id+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.deployment-id+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The deployment ID of a model deployed in watsonx.ai.
+
+Use this when targeting a custom model deployment instead of a foundation model. When set, it takes precedence over `modelName`, and neither `projectId` nor `spaceId` is required.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_DEPLOYMENT_ID+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_DEPLOYMENT_ID+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-tool-choice]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-tool-choice[`+++quarkus.langchain4j.watsonx."model-name".chat-model.tool-choice+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.tool-choice+++[]
@@ -2868,51 +2952,89 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |
 
-a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-think]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-think[`+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.think+++`]##
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-think-opening]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-think-opening[`+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.think.opening+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.think+++[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.think.opening+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-The XML-like tag enclosing the model’s internal reasoning.
-
-Example: `<think> ... </think>`
+The opening delimiter for the model's internal reasoning section.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_THINK+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_THINK_OPENING+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_THINK+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_THINK_OPENING+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
 |required icon:exclamation-circle[title=Configuration property is required]
 
-a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-response]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-response[`+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.response+++`]##
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-think-closing]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-think-closing[`+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.think.closing+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.response+++[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.think.closing+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-The XML-like tag enclosing the model’s final response.
-
-Optional — if not defined, all text outside the reasoning tag is treated as the response.
+The closing delimiter for the model's internal reasoning section.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_RESPONSE+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_THINK_CLOSING+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_RESPONSE+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_THINK_CLOSING+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|
+|required icon:exclamation-circle[title=Configuration property is required]
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-response-opening]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-response-opening[`+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.response.opening+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.response.opening+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The opening delimiter for the model's final response section.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_RESPONSE_OPENING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_RESPONSE_OPENING+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|required icon:exclamation-circle[title=Configuration property is required]
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-response-closing]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-tags-response-closing[`+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.response.closing+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.tags.response.closing+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The closing delimiter for the model's final response section.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_RESPONSE_CLOSING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_THINKING_TAGS_RESPONSE_CLOSING+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|required icon:exclamation-circle[title=Configuration property is required]
 
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-effort]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-thinking-effort[`+++quarkus.langchain4j.watsonx."model-name".chat-model.thinking.effort+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/watsonx-chat-model.adoc
+++ b/docs/modules/ROOT/pages/watsonx-chat-model.adoc
@@ -108,6 +108,19 @@ quarkus.langchain4j.watsonx.chat-model.temperature=0.2
 
 If a chat model is configured, Quarkus automatically registers a `ChatModel` / `StreamingChatModel` bean.
 
+=== Using a Deployment
+
+As an alternative to `model-name`, you can target a model deployed in watsonx.ai by specifying its `deployment-id`. When set, the deployment ID takes precedence over `model-name`, and neither `project-id` nor `space-id` is required.
+
+[source,properties]
+----
+quarkus.langchain4j.watsonx.base-url=${BASE_URL}
+quarkus.langchain4j.watsonx.api-key=${API_KEY}
+
+# Use a deployed model instead of a foundation model
+quarkus.langchain4j.watsonx.chat-model.deployment-id=${DEPLOYMENT_ID}
+----
+
 === Injection
 
 [source,java]
@@ -130,20 +143,32 @@ This ensures that LangChain4j can automatically extract the reasoning and respon
 === Models that return reasoning and response together
 
 Use **`ExtractionTags`** when the model outputs reasoning and response in the same text string.  
-The tags define XML-like markers used to separate the reasoning from the final response.
+Configure the exact opening and closing delimiters used by the model.
+
+==== Example for **ibm/granite-3-3-8b-instruct**
 
 [source,properties]
 ----
-# Example configuration for ibm/granite-3-3-8b-instruct
 quarkus.langchain4j.watsonx.chat-model.model-name=ibm/granite-3-3-8b-instruct
-quarkus.langchain4j.watsonx.chat-model.thinking.tags.think=think
-quarkus.langchain4j.watsonx.chat-model.thinking.tags.response=response
+quarkus.langchain4j.watsonx.chat-model.thinking.tags.think.opening=<think>
+quarkus.langchain4j.watsonx.chat-model.thinking.tags.think.closing=</think>
+quarkus.langchain4j.watsonx.chat-model.thinking.tags.response.opening=<response>
+quarkus.langchain4j.watsonx.chat-model.thinking.tags.response.closing=</response>
+----
+
+==== Example for **google/gemma-4-31b-it**
+
+[source,properties]
+----
+quarkus.langchain4j.watsonx.chat-model.model-name=google/gemma-4-31b-it
+quarkus.langchain4j.watsonx.chat-model.thinking.tags.think.opening=<|channel>thought\n
+quarkus.langchain4j.watsonx.chat-model.thinking.tags.think.closing=<channel|>
 ----
 
 ==== Behavior
 
-- If **both tags** are specified, they are used directly to extract reasoning and response segments.  
-- If **only the reasoning tag** is specified, everything outside that tag is considered the response.
+- If **both `think` and `response`** delimiters are specified, they are used to extract reasoning and response segments respectively.
+- If **only `think`** delimiters are specified, everything outside that delimiter pair is treated as the response.
 
 [source,java]
 ----
@@ -206,7 +231,7 @@ streamingChatModel.chat(chatRequest, new StreamingChatResponseHandler() {
 [NOTE]
 ====
 - Ensure that the selected model supports reasoning output.  
-- Use `thinking.tags` for models that embed reasoning and response in a single text string.  
+- Use `thinking.tags` for models that embed reasoning and response in a single text string, specifying the full opening and closing delimiters explicitly.  
 - Use `thinking.effort` or `thinking=true` for models that already separate reasoning and response automatically.
 ====
 

--- a/docs/modules/ROOT/pages/watsonx-embedding-model.adoc
+++ b/docs/modules/ROOT/pages/watsonx-embedding-model.adoc
@@ -93,6 +93,19 @@ quarkus.langchain4j.watsonx.chat-model.temperature=0.2
 
 If a chat model is configured, Quarkus automatically registers a `ChatModel` / `StreamingChatModel` bean.
 
+=== Using a Deployment
+
+As an alternative to `model-name`, you can target a model deployed in watsonx.ai by specifying its `deployment-id`. When set, the deployment ID takes precedence over `model-name`, and neither `project-id` nor `space-id` is required.
+
+[source,properties]
+----
+quarkus.langchain4j.watsonx.base-url=${BASE_URL}
+quarkus.langchain4j.watsonx.api-key=${API_KEY}
+
+# Use a deployed model instead of a foundation model
+quarkus.langchain4j.watsonx.chat-model.deployment-id=${DEPLOYMENT_ID}
+----
+
 === Injection
 
 [source,java]
@@ -115,20 +128,32 @@ This ensures that LangChain4j can automatically extract the reasoning and respon
 === Models that return reasoning and response together
 
 Use **`ExtractionTags`** when the model outputs reasoning and response in the same text string.  
-The tags define XML-like markers used to separate the reasoning from the final response.
+Configure the exact opening and closing delimiters used by the model.
+
+==== Example for **ibm/granite-3-3-8b-instruct**
 
 [source,properties]
 ----
-# Example configuration for ibm/granite-3-3-8b-instruct
 quarkus.langchain4j.watsonx.chat-model.model-name=ibm/granite-3-3-8b-instruct
-quarkus.langchain4j.watsonx.chat-model.thinking.tags.think=think
-quarkus.langchain4j.watsonx.chat-model.thinking.tags.response=response
+quarkus.langchain4j.watsonx.chat-model.thinking.tags.think.opening=<think>
+quarkus.langchain4j.watsonx.chat-model.thinking.tags.think.closing=</think>
+quarkus.langchain4j.watsonx.chat-model.thinking.tags.response.opening=<response>
+quarkus.langchain4j.watsonx.chat-model.thinking.tags.response.closing=</response>
+----
+
+==== Example for **google/gemma-4-31b-it**
+
+[source,properties]
+----
+quarkus.langchain4j.watsonx.chat-model.model-name=google/gemma-4-31b-it
+quarkus.langchain4j.watsonx.chat-model.thinking.tags.think.opening=<|channel>thought\n
+quarkus.langchain4j.watsonx.chat-model.thinking.tags.think.closing=<channel|>
 ----
 
 ==== Behavior
 
-- If **both tags** are specified, they are used directly to extract reasoning and response segments.  
-- If **only the reasoning tag** is specified, everything outside that tag is considered the response.
+- If **both `think` and `response`** delimiters are specified, they are used to extract reasoning and response segments respectively.
+- If **only `think`** delimiters are specified, everything outside that delimiter pair is treated as the response.
 
 [source,java]
 ----
@@ -191,7 +216,7 @@ streamingChatModel.chat(chatRequest, new StreamingChatResponseHandler() {
 [NOTE]
 ====
 - Ensure that the selected model supports reasoning output.  
-- Use `thinking.tags` for models that embed reasoning and response in a single text string.  
+- Use `thinking.tags` for models that embed reasoning and response in a single text string, specifying the full opening and closing delimiters explicitly.  
 - Use `thinking.effort` or `thinking=true` for models that already separate reasoning and response automatically.
 ====
 

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ChatAllPropertiesTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ChatAllPropertiesTest.java
@@ -77,8 +77,10 @@ public class ChatAllPropertiesTest extends WireMockAbstract {
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.repetition-penalty", "1.1")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.length-penalty", "1.2")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.thinking.enabled", "true")
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.thinking.tags.think", "think")
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.thinking.tags.response", "response")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.thinking.tags.think.opening", "<think>")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.thinking.tags.think.closing", "</think>")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.thinking.tags.response.opening", "<response>")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.thinking.tags.response.closing", "</response>")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.thinking.effort", "low")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.thinking.include-reasoning", "true")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
@@ -182,8 +184,10 @@ public class ChatAllPropertiesTest extends WireMockAbstract {
         assertTrue(thinking.enabled().orElse(false));
         assertTrue(thinking.includeReasoning().orElse(false));
         assertNotNull(thinking.tags().orElse(null));
-        assertEquals("think", thinking.tags().get().think());
-        assertEquals("response", thinking.tags().get().response().orElse(null));
+        assertEquals("<think>", thinking.tags().get().think().opening());
+        assertEquals("</think>", thinking.tags().get().think().closing());
+        assertEquals("<response>", thinking.tags().get().response().map(r -> r.opening()).orElse(null));
+        assertEquals("</response>", thinking.tags().get().response().map(r -> r.closing()).orElse(null));
         assertEquals(1.1, runtimeConfig.chatModel().repetitionPenalty().orElse(null));
         assertEquals(1.2, runtimeConfig.chatModel().lengthPenalty().orElse(null));
         assertEquals(new TreeSet<>(Set.of("1")), runtimeConfig.chatModel().guidedChoice().orElse(null));

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/it/ChatModelITTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/it/ChatModelITTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.ibm.watsonx.ai.chat.model.ExtractionTags;
 import com.ibm.watsonx.ai.core.Json;
 
 import dev.langchain4j.agent.tool.ToolSpecification;
@@ -31,7 +30,6 @@ import dev.langchain4j.model.chat.request.ResponseFormatType;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
-import dev.langchain4j.model.watsonx.WatsonxChatRequestParameters;
 import io.quarkiverse.langchain4j.ModelName;
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -43,6 +41,8 @@ public class ChatModelITTest {
     static final String API_KEY = System.getenv("WATSONX_API_KEY");
     static final String PROJECT_ID = System.getenv("WATSONX_PROJECT_ID");
     static final String URL = System.getenv("WATSONX_URL");
+    static final String DEPLOYMENT_ID = System.getenv("WATSONX_DEPLOYMENT_ID");
+    static final String GRANITE_3_3_DEPLOYMENT_ID = System.getenv("WATSONX_GRANITE_3_3_DEPLOYMENT_ID");
 
     @RegisterExtension
     static QuarkusUnitTest unitTest = new QuarkusUnitTest()
@@ -51,11 +51,17 @@ public class ChatModelITTest {
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", PROJECT_ID)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.timeout", "30s")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"wrong-key\".api-key", "wrong-key")
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"think-model\".chat-model.model-name",
-                    "ibm/granite-3-3-8b-instruct")
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"think-model\".chat-model.thinking.tags.think", "think")
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"think-model\".chat-model.thinking.tags.response",
-                    "response")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"think-model\".chat-model.deployment-id",
+                    GRANITE_3_3_DEPLOYMENT_ID)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"think-model\".chat-model.thinking.tags.think.opening",
+                    "<think>")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"think-model\".chat-model.thinking.tags.think.closing",
+                    "</think>")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"think-model\".chat-model.thinking.tags.response.opening",
+                    "<response>")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"think-model\".chat-model.thinking.tags.response.closing",
+                    "</response>")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"deployment\".chat-model.deployment-id", DEPLOYMENT_ID)
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
 
     @Inject
@@ -69,11 +75,16 @@ public class ChatModelITTest {
     @ModelName("think-model")
     ChatModel thinkingChatModel;
 
+    @Inject
+    @ModelName("deployment")
+    ChatModel deploymentChatModel;
+
     @Test
     void test_chat() {
 
         ChatRequest chatRequest = ChatRequest.builder()
                 .messages(UserMessage.from("Hello"))
+                .parameters(ChatRequestParameters.builder().modelName("openai/gpt-oss-120b").build())
                 .build();
         var chatResponse = assertDoesNotThrow(() -> chatModel.chat(chatRequest));
         var text = chatResponse.aiMessage().text();
@@ -176,33 +187,6 @@ public class ChatModelITTest {
     }
 
     @Test
-    void test_chat_thinking_with_parameters() {
-
-        WatsonxChatRequestParameters parameters = WatsonxChatRequestParameters.builder()
-                .modelName("ibm/granite-3-3-8b-instruct")
-                .thinking(new ExtractionTags("think", "response"))
-                .build();
-
-        ChatRequest request = ChatRequest.builder()
-                .messages(UserMessage.from("Why the sky is blue?"))
-                .parameters(parameters)
-                .build();
-
-        var chatResponse = assertDoesNotThrow(() -> chatModel.chat(request));
-        var text = chatResponse.aiMessage().text();
-
-        assertNotNull(chatResponse);
-        assertNotNull(text);
-        assertFalse(text.isBlank());
-        assertFalse(text.contains("<think>") && text.contains("</think>"));
-        assertFalse(text.contains("<response>") && text.contains("</response>"));
-
-        var thinkingMessage = chatResponse.aiMessage().thinking();
-        assertNotNull(thinkingMessage);
-        assertFalse(thinkingMessage.isBlank());
-    }
-
-    @Test
     void test_chat_tool_without_params() {
 
         ChatRequest request = ChatRequest.builder()
@@ -264,5 +248,18 @@ public class ChatModelITTest {
 
         var ex = assertThrows(LangChain4jException.class, () -> wrongKeyChatModel.chat(request));
         assertTrue(ex.getMessage().contains("Provided API key could not be found."));
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "WATSONX_DEPLOYMENT_ID", matches = ".+")
+    void test_chat_with_deployment_id() {
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("Hello!"))
+                .build();
+
+        var chatResponse = assertDoesNotThrow(() -> deploymentChatModel.chat(request));
+        var assistantMessage = chatResponse.aiMessage();
+        assertTrue(!assistantMessage.text().isBlank());
     }
 }

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/it/StreamingChatModelITTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/it/StreamingChatModelITTest.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.ibm.watsonx.ai.chat.model.ExtractionTags;
+import com.ibm.watsonx.ai.chat.model.ExtractionTags.Response;
+import com.ibm.watsonx.ai.chat.model.ExtractionTags.Think;
 import com.ibm.watsonx.ai.core.Json;
 
 import dev.langchain4j.agent.tool.ToolSpecification;
@@ -49,22 +51,28 @@ public class StreamingChatModelITTest {
     static final String API_KEY = System.getenv("WATSONX_API_KEY");
     static final String PROJECT_ID = System.getenv("WATSONX_PROJECT_ID");
     static final String URL = System.getenv("WATSONX_URL");
+    static final String DEPLOYMENT_ID = System.getenv("WATSONX_DEPLOYMENT_ID");
+    static final String GRANITE_3_3_DEPLOYMENT_ID = System.getenv("WATSONX_GRANITE_3_3_DEPLOYMENT_ID");
 
     @RegisterExtension
     static QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", URL)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", API_KEY)
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", PROJECT_ID)
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.log-requests", "true")
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.log-responses", "true")
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.timeout", "30s")
 
             .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"wrong-key\".api-key", "wrong-key")
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"think-model\".chat-model.model-name",
-                    "ibm/granite-3-3-8b-instruct")
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"think-model\".chat-model.thinking.tags.think", "think")
-            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"think-model\".chat-model.thinking.tags.response",
-                    "response")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"think-model\".chat-model.deployment-id",
+                    GRANITE_3_3_DEPLOYMENT_ID)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"think-model\".chat-model.thinking.tags.think.opening",
+                    "<think>")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"think-model\".chat-model.thinking.tags.think.closing",
+                    "</think>")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"think-model\".chat-model.thinking.tags.response.opening",
+                    "<response>")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"think-model\".chat-model.thinking.tags.response.closing",
+                    "</response>")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"deployment\".chat-model.deployment-id", DEPLOYMENT_ID)
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
 
     @Inject
@@ -77,6 +85,10 @@ public class StreamingChatModelITTest {
     @Inject
     @ModelName("think-model")
     StreamingChatModel thinkingChatModel;
+
+    @Inject
+    @ModelName("deployment")
+    StreamingChatModel deploymentChatModel;
 
     @Test
     void test_chat() {
@@ -284,11 +296,12 @@ public class StreamingChatModelITTest {
     }
 
     @Test
+    @EnabledIfEnvironmentVariable(named = "WATSONX_GRANITE_3_3_DEPLOYMENT_ID", matches = ".*")
     void test_chat_thinking_with_parameters() {
 
         WatsonxChatRequestParameters parameters = WatsonxChatRequestParameters.builder()
                 .modelName("ibm/granite-3-3-8b-instruct")
-                .thinking(new ExtractionTags("think", "response"))
+                .thinking(ExtractionTags.of(new Think("<think>", "</think>"), new Response("<response>", "</response>")))
                 .build();
 
         ChatRequest chatRequest = ChatRequest.builder()
@@ -499,5 +512,36 @@ public class StreamingChatModelITTest {
 
         assertDoesNotThrow(() -> latch.await(3, TimeUnit.SECONDS));
         assertTrue(throwable.get().getMessage().contains("Provided API key could not be found."));
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "WATSONX_DEPLOYMENT_ID", matches = ".+")
+    void test_chat_with_deployment_id() {
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("Hello!"))
+                .build();
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<ChatResponse> chatResponse = new AtomicReference<>();
+
+        deploymentChatModel.chat(request, new StreamingChatResponseHandler() {
+            @Override
+            public void onPartialResponse(String partialResponse) {
+            }
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {
+                chatResponse.set(completeResponse);
+                latch.countDown();
+            }
+
+            @Override
+            public void onError(Throwable error) {
+            }
+        });
+
+        assertDoesNotThrow(() -> latch.await(5, TimeUnit.SECONDS));
+        assertTrue(!chatResponse.get().aiMessage().text().isBlank());
     }
 }

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/WatsonxRecorder.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/WatsonxRecorder.java
@@ -2,6 +2,7 @@ package io.quarkiverse.langchain4j.watsonx.runtime;
 
 import static io.quarkiverse.langchain4j.runtime.OptionalUtil.firstOrDefault;
 import static io.quarkiverse.langchain4j.watsonx.runtime.AuthenticatorCache.getOrCreateTokenGenerator;
+import static java.util.Objects.nonNull;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -13,6 +14,8 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.util.TypeLiteral;
 
 import com.ibm.watsonx.ai.chat.model.ExtractionTags;
+import com.ibm.watsonx.ai.chat.model.ExtractionTags.Response;
+import com.ibm.watsonx.ai.chat.model.ExtractionTags.Think;
 import com.ibm.watsonx.ai.chat.model.Thinking;
 import com.ibm.watsonx.ai.detection.detector.BaseDetector;
 import com.ibm.watsonx.ai.detection.detector.GraniteGuardian;
@@ -103,10 +106,21 @@ public class WatsonxRecorder {
                     .map(URI::create)
                     .orElseThrow();
 
+            String deploymentId = chatModelConfig.deploymentId().orElse(null);
+            String modelName = specificConfig.chatModel().modelName();
+            String projectId = firstOrDefault(defaultConfig.projectId().orElse(null), specificConfig.projectId());
+            String spaceId = firstOrDefault(defaultConfig.spaceId().orElse(null), specificConfig.spaceId());
+
+            if (nonNull(deploymentId)) {
+                modelName = null;
+                projectId = null;
+                spaceId = null;
+            }
+
             WatsonxChatModel.Builder builder = WatsonxChatModel.builder()
                     .baseUrl(url)
                     .version(specificConfig.version().orElse(null))
-                    .modelName(specificConfig.chatModel().modelName())
+                    .modelName(modelName)
                     .frequencyPenalty(chatModelConfig.frequencyPenalty())
                     .logprobs(chatModelConfig.logprobs())
                     .topLogprobs(chatModelConfig.topLogprobs().orElse(null))
@@ -121,7 +135,8 @@ public class WatsonxRecorder {
                     .guidedGrammar(chatModelConfig.guidedGrammar().orElse(null))
                     .guidedRegex(chatModelConfig.guidedRegex().orElse(null))
                     .lengthPenalty(chatModelConfig.lengthPenalty().orElse(null))
-                    .repetitionPenalty(chatModelConfig.repetitionPenalty().orElse(null));
+                    .repetitionPenalty(chatModelConfig.repetitionPenalty().orElse(null))
+                    .deploymentId(deploymentId);
 
             if (chatModelConfig.guidedChoice().isPresent())
                 builder.guidedChoice(chatModelConfig.guidedChoice().orElseThrow());
@@ -143,8 +158,11 @@ public class WatsonxRecorder {
                         .map(new Function<ExtractionTagsConfig, ExtractionTags>() {
                             @Override
                             public ExtractionTags apply(ExtractionTagsConfig extractionTagsConfig) {
-                                return new ExtractionTags(extractionTagsConfig.think(),
-                                        extractionTagsConfig.response().orElse(null));
+                                Think think = new Think(extractionTagsConfig.think().opening(),
+                                        extractionTagsConfig.think().closing());
+                                Response response = extractionTagsConfig.response()
+                                        .map(r -> new Response(r.opening(), r.closing())).orElse(null);
+                                return new ExtractionTags(think, response);
                             }
                         }).orElse(null);
 
@@ -176,15 +194,8 @@ public class WatsonxRecorder {
                             chatModelConfig.logResponses(),
                             specificConfig.logResponses()));
 
-            builder.spaceId(
-                    firstOrDefault(
-                            defaultConfig.spaceId().orElse(null),
-                            specificConfig.spaceId()));
-
-            builder.projectId(
-                    firstOrDefault(
-                            defaultConfig.projectId().orElse(null),
-                            specificConfig.projectId()));
+            builder.spaceId(spaceId);
+            builder.projectId(projectId);
 
             String apiKey = firstOrDefault(runtimeConfig.getValue().defaultConfig().apiKey().orElse(null),
                     watsonxConfig.apiKey());
@@ -238,10 +249,21 @@ public class WatsonxRecorder {
                     .map(URI::create)
                     .orElseThrow();
 
+            String deploymentId = chatModelConfig.deploymentId().orElse(null);
+            String modelName = specificConfig.chatModel().modelName();
+            String projectId = firstOrDefault(defaultConfig.projectId().orElse(null), specificConfig.projectId());
+            String spaceId = firstOrDefault(defaultConfig.spaceId().orElse(null), specificConfig.spaceId());
+
+            if (nonNull(deploymentId)) {
+                modelName = null;
+                projectId = null;
+                spaceId = null;
+            }
+
             WatsonxStreamingChatModel.Builder builder = WatsonxStreamingChatModel.builder()
                     .baseUrl(url)
                     .version(specificConfig.version().orElse(null))
-                    .modelName(specificConfig.chatModel().modelName())
+                    .modelName(modelName)
                     .frequencyPenalty(chatModelConfig.frequencyPenalty())
                     .logprobs(chatModelConfig.logprobs())
                     .topLogprobs(chatModelConfig.topLogprobs().orElse(null))
@@ -256,7 +278,8 @@ public class WatsonxRecorder {
                     .guidedGrammar(chatModelConfig.guidedGrammar().orElse(null))
                     .guidedRegex(chatModelConfig.guidedRegex().orElse(null))
                     .lengthPenalty(chatModelConfig.lengthPenalty().orElse(null))
-                    .repetitionPenalty(chatModelConfig.repetitionPenalty().orElse(null));
+                    .repetitionPenalty(chatModelConfig.repetitionPenalty().orElse(null))
+                    .deploymentId(deploymentId);
 
             if (chatModelConfig.guidedChoice().isPresent())
                 builder.guidedChoice(chatModelConfig.guidedChoice().orElseThrow());
@@ -278,8 +301,11 @@ public class WatsonxRecorder {
                         .map(new Function<ExtractionTagsConfig, ExtractionTags>() {
                             @Override
                             public ExtractionTags apply(ExtractionTagsConfig extractionTagsConfig) {
-                                return new ExtractionTags(extractionTagsConfig.think(),
-                                        extractionTagsConfig.response().orElse(null));
+                                Think think = new Think(extractionTagsConfig.think().opening(),
+                                        extractionTagsConfig.think().closing());
+                                Response response = extractionTagsConfig.response()
+                                        .map(r -> new Response(r.opening(), r.closing())).orElse(null);
+                                return new ExtractionTags(think, response);
                             }
                         }).orElse(null);
 
@@ -311,15 +337,8 @@ public class WatsonxRecorder {
                             chatModelConfig.logResponses(),
                             specificConfig.logResponses()));
 
-            builder.spaceId(
-                    firstOrDefault(
-                            defaultConfig.spaceId().orElse(null),
-                            specificConfig.spaceId()));
-
-            builder.projectId(
-                    firstOrDefault(
-                            defaultConfig.projectId().orElse(null),
-                            specificConfig.projectId()));
+            builder.spaceId(spaceId);
+            builder.projectId(projectId);
 
             String apiKey = firstOrDefault(runtimeConfig.getValue().defaultConfig().apiKey().orElse(null),
                     watsonxConfig.apiKey());

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/ChatModelConfig.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/ChatModelConfig.java
@@ -28,6 +28,15 @@ public interface ChatModelConfig {
     String modelName();
 
     /**
+     * The deployment ID of a model deployed in watsonx.ai.
+     * <p>
+     * Use this when targeting a custom model deployment instead of a foundation model. When set, it takes precedence over
+     * {@code modelName}, and
+     * neither {@code projectId} nor {@code spaceId} is required.
+     */
+    Optional<String> deploymentId();
+
+    /**
      * Specifies how the model should choose which tool to call during a request.
      * <p>
      * This value can be:
@@ -263,13 +272,42 @@ public interface ChatModelConfig {
          * <p>
          * Example: {@code <think> ... </think>}
          */
-        String think();
+        Think think();
 
         /**
          * The XML-like tag enclosing the model’s final response.
          * <p>
          * Optional — if not defined, all text outside the reasoning tag is treated as the response.
          */
-        Optional<String> response();
+        Optional<Response> response();
     }
+
+    @ConfigGroup
+    public interface Think {
+
+        /**
+         * The opening delimiter for the model's internal reasoning section.
+         */
+        String opening();
+
+        /**
+         * The closing delimiter for the model's internal reasoning section.
+         */
+        String closing();
+    }
+
+    @ConfigGroup
+    public interface Response {
+
+        /**
+         * The opening delimiter for the model's final response section.
+         */
+        String opening();
+
+        /**
+         * The closing delimiter for the model's final response section.
+         */
+        String closing();
+    }
+
 }


### PR DESCRIPTION
This PR adds support for using **on-demand deployments** in IBM watsonx.ai through the new `deployment-id` configuration property, and updates the `ExtractionTags` configuration to use explicit opening/closing delimiters instead of simple tag names.

This is a **draft PR** because it depends on `langchain4j-1.17.0`, which includes the upstream changes from [langchain4j#5344](https://github.com/langchain4j/langchain4j/pull/5344) (not yet released). It will be marked ready for review once a stable langchain4j release including these changes is available.