### PR TITLE
Tool-calling support for GPULlama3

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-all-config.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-all-config.adoc
@@ -13593,6 +13593,96 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++512+++`
 
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-prefill-decode]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-prefill-decode[`+++quarkus.langchain4j.gpu-llama3.chat-model.prefill-decode+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.chat-model.prefill-decode+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to use the prefill/decode inference path, which processes the prompt in a dedicated prefill phase before single-token decoding. Combined with a `prefill-batch-size()` greater than 1 this enables the batched prefill path, which significantly speeds up prompt processing on the GPU.
+
+Note: this maps to the JVM-global engine flags `llama.withPrefillDecode` / `llama.prefillBatchSize`, so when multiple models are configured the first one to initialize wins.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_PREFILL_DECODE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_PREFILL_DECODE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-prefill-batch-size]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-prefill-batch-size[`+++quarkus.langchain4j.gpu-llama3.chat-model.prefill-batch-size+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.chat-model.prefill-batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Number of prompt tokens processed per batch during the prefill phase. Only used when `prefill-decode()` is `true`: a value greater than 1 enables the batched prefill path, while 1 falls back to sequential prefill/decode.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_PREFILL_BATCH_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_PREFILL_BATCH_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++32+++`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-enable-thinking]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-enable-thinking[`+++quarkus.langchain4j.gpu-llama3.chat-model.enable-thinking+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.chat-model.enable-thinking+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to enable the model's thinking/reasoning phase. Only models with a thinking mode (e.g. Qwen3) honor this; for other models it has no effect.
+
+When `true`, the model reasons inside `<think>…</think>` before answering, which tends to improve tool-calling decisions. Set to `false` for faster responses by skipping the reasoning phase.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_ENABLE_THINKING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_ENABLE_THINKING+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-device-memory]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-device-memory[`+++quarkus.langchain4j.gpu-llama3.chat-model.device-memory+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.chat-model.device-memory+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Amount of GPU memory TornadoVM is allowed to allocate e.g. `"7GB"`, `"512MB"`.
+
+Note: this maps to the JVM-global engine flag `tornado.device.memory`, so when multiple models are configured the first one to initialize wins.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_DEVICE_MEMORY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_DEVICE_MEMORY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++4GB+++`
+
 a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-enable-integration]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-enable-integration[`+++quarkus.langchain4j.gpu-llama3.enable-integration+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.enable-integration+++[]
@@ -13785,6 +13875,96 @@ endif::add-copy-button-to-env-var[]
 --
 |int
 |`+++512+++`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-prefill-decode]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-prefill-decode[`+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.prefill-decode+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.prefill-decode+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to use the prefill/decode inference path, which processes the prompt in a dedicated prefill phase before single-token decoding. Combined with a `prefill-batch-size()` greater than 1 this enables the batched prefill path, which significantly speeds up prompt processing on the GPU.
+
+Note: this maps to the JVM-global engine flags `llama.withPrefillDecode` / `llama.prefillBatchSize`, so when multiple models are configured the first one to initialize wins.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_PREFILL_DECODE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_PREFILL_DECODE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-prefill-batch-size]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-prefill-batch-size[`+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.prefill-batch-size+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.prefill-batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Number of prompt tokens processed per batch during the prefill phase. Only used when `prefill-decode()` is `true`: a value greater than 1 enables the batched prefill path, while 1 falls back to sequential prefill/decode.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_PREFILL_BATCH_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_PREFILL_BATCH_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++32+++`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-enable-thinking]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-enable-thinking[`+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.enable-thinking+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.enable-thinking+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to enable the model's thinking/reasoning phase. Only models with a thinking mode (e.g. Qwen3) honor this; for other models it has no effect.
+
+When `true`, the model reasons inside `<think>…</think>` before answering, which tends to improve tool-calling decisions. Set to `false` for faster responses by skipping the reasoning phase.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_ENABLE_THINKING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_ENABLE_THINKING+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-device-memory]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-device-memory[`+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.device-memory+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.device-memory+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Amount of GPU memory TornadoVM is allowed to allocate e.g. `"7GB"`, `"512MB"`.
+
+Note: this maps to the JVM-global engine flag `tornado.device.memory`, so when multiple models are configured the first one to initialize wins.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_DEVICE_MEMORY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_DEVICE_MEMORY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++4GB+++`
 
 a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-enable-integration]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-enable-integration[`+++quarkus.langchain4j.gpu-llama3."model-name".enable-integration+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-gpu-llama3.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-gpu-llama3.adoc
@@ -196,6 +196,96 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++512+++`
 
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-prefill-decode]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-prefill-decode[`+++quarkus.langchain4j.gpu-llama3.chat-model.prefill-decode+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.chat-model.prefill-decode+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to use the prefill/decode inference path, which processes the prompt in a dedicated prefill phase before single-token decoding. Combined with a `prefill-batch-size()` greater than 1 this enables the batched prefill path, which significantly speeds up prompt processing on the GPU.
+
+Note: this maps to the JVM-global engine flags `llama.withPrefillDecode` / `llama.prefillBatchSize`, so when multiple models are configured the first one to initialize wins.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_PREFILL_DECODE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_PREFILL_DECODE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-prefill-batch-size]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-prefill-batch-size[`+++quarkus.langchain4j.gpu-llama3.chat-model.prefill-batch-size+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.chat-model.prefill-batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Number of prompt tokens processed per batch during the prefill phase. Only used when `prefill-decode()` is `true`: a value greater than 1 enables the batched prefill path, while 1 falls back to sequential prefill/decode.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_PREFILL_BATCH_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_PREFILL_BATCH_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++32+++`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-enable-thinking]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-enable-thinking[`+++quarkus.langchain4j.gpu-llama3.chat-model.enable-thinking+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.chat-model.enable-thinking+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to enable the model's thinking/reasoning phase. Only models with a thinking mode (e.g. Qwen3) honor this; for other models it has no effect.
+
+When `true`, the model reasons inside `<think>…</think>` before answering, which tends to improve tool-calling decisions. Set to `false` for faster responses by skipping the reasoning phase.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_ENABLE_THINKING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_ENABLE_THINKING+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-device-memory]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-device-memory[`+++quarkus.langchain4j.gpu-llama3.chat-model.device-memory+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.chat-model.device-memory+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Amount of GPU memory TornadoVM is allowed to allocate e.g. `"7GB"`, `"512MB"`.
+
+Note: this maps to the JVM-global engine flag `tornado.device.memory`, so when multiple models are configured the first one to initialize wins.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_DEVICE_MEMORY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_DEVICE_MEMORY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++4GB+++`
+
 a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-enable-integration]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-enable-integration[`+++quarkus.langchain4j.gpu-llama3.enable-integration+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.enable-integration+++[]
@@ -388,6 +478,96 @@ endif::add-copy-button-to-env-var[]
 --
 |int
 |`+++512+++`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-prefill-decode]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-prefill-decode[`+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.prefill-decode+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.prefill-decode+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to use the prefill/decode inference path, which processes the prompt in a dedicated prefill phase before single-token decoding. Combined with a `prefill-batch-size()` greater than 1 this enables the batched prefill path, which significantly speeds up prompt processing on the GPU.
+
+Note: this maps to the JVM-global engine flags `llama.withPrefillDecode` / `llama.prefillBatchSize`, so when multiple models are configured the first one to initialize wins.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_PREFILL_DECODE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_PREFILL_DECODE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-prefill-batch-size]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-prefill-batch-size[`+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.prefill-batch-size+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.prefill-batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Number of prompt tokens processed per batch during the prefill phase. Only used when `prefill-decode()` is `true`: a value greater than 1 enables the batched prefill path, while 1 falls back to sequential prefill/decode.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_PREFILL_BATCH_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_PREFILL_BATCH_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++32+++`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-enable-thinking]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-enable-thinking[`+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.enable-thinking+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.enable-thinking+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to enable the model's thinking/reasoning phase. Only models with a thinking mode (e.g. Qwen3) honor this; for other models it has no effect.
+
+When `true`, the model reasons inside `<think>…</think>` before answering, which tends to improve tool-calling decisions. Set to `false` for faster responses by skipping the reasoning phase.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_ENABLE_THINKING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_ENABLE_THINKING+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-device-memory]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-device-memory[`+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.device-memory+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.device-memory+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Amount of GPU memory TornadoVM is allowed to allocate e.g. `"7GB"`, `"512MB"`.
+
+Note: this maps to the JVM-global engine flag `tornado.device.memory`, so when multiple models are configured the first one to initialize wins.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_DEVICE_MEMORY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_DEVICE_MEMORY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++4GB+++`
 
 a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-enable-integration]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-enable-integration[`+++quarkus.langchain4j.gpu-llama3."model-name".enable-integration+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-gpu-llama3_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-gpu-llama3_quarkus.langchain4j.adoc
@@ -196,6 +196,96 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++512+++`
 
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-prefill-decode]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-prefill-decode[`+++quarkus.langchain4j.gpu-llama3.chat-model.prefill-decode+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.chat-model.prefill-decode+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to use the prefill/decode inference path, which processes the prompt in a dedicated prefill phase before single-token decoding. Combined with a `prefill-batch-size()` greater than 1 this enables the batched prefill path, which significantly speeds up prompt processing on the GPU.
+
+Note: this maps to the JVM-global engine flags `llama.withPrefillDecode` / `llama.prefillBatchSize`, so when multiple models are configured the first one to initialize wins.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_PREFILL_DECODE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_PREFILL_DECODE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-prefill-batch-size]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-prefill-batch-size[`+++quarkus.langchain4j.gpu-llama3.chat-model.prefill-batch-size+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.chat-model.prefill-batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Number of prompt tokens processed per batch during the prefill phase. Only used when `prefill-decode()` is `true`: a value greater than 1 enables the batched prefill path, while 1 falls back to sequential prefill/decode.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_PREFILL_BATCH_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_PREFILL_BATCH_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++32+++`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-enable-thinking]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-enable-thinking[`+++quarkus.langchain4j.gpu-llama3.chat-model.enable-thinking+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.chat-model.enable-thinking+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to enable the model's thinking/reasoning phase. Only models with a thinking mode (e.g. Qwen3) honor this; for other models it has no effect.
+
+When `true`, the model reasons inside `<think>…</think>` before answering, which tends to improve tool-calling decisions. Set to `false` for faster responses by skipping the reasoning phase.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_ENABLE_THINKING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_ENABLE_THINKING+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-device-memory]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-chat-model-device-memory[`+++quarkus.langchain4j.gpu-llama3.chat-model.device-memory+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.chat-model.device-memory+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Amount of GPU memory TornadoVM is allowed to allocate e.g. `"7GB"`, `"512MB"`.
+
+Note: this maps to the JVM-global engine flag `tornado.device.memory`, so when multiple models are configured the first one to initialize wins.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_DEVICE_MEMORY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3_CHAT_MODEL_DEVICE_MEMORY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++4GB+++`
+
 a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-enable-integration]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-enable-integration[`+++quarkus.langchain4j.gpu-llama3.enable-integration+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.gpu-llama3.enable-integration+++[]
@@ -388,6 +478,96 @@ endif::add-copy-button-to-env-var[]
 --
 |int
 |`+++512+++`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-prefill-decode]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-prefill-decode[`+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.prefill-decode+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.prefill-decode+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to use the prefill/decode inference path, which processes the prompt in a dedicated prefill phase before single-token decoding. Combined with a `prefill-batch-size()` greater than 1 this enables the batched prefill path, which significantly speeds up prompt processing on the GPU.
+
+Note: this maps to the JVM-global engine flags `llama.withPrefillDecode` / `llama.prefillBatchSize`, so when multiple models are configured the first one to initialize wins.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_PREFILL_DECODE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_PREFILL_DECODE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-prefill-batch-size]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-prefill-batch-size[`+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.prefill-batch-size+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.prefill-batch-size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Number of prompt tokens processed per batch during the prefill phase. Only used when `prefill-decode()` is `true`: a value greater than 1 enables the batched prefill path, while 1 falls back to sequential prefill/decode.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_PREFILL_BATCH_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_PREFILL_BATCH_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++32+++`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-enable-thinking]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-enable-thinking[`+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.enable-thinking+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.enable-thinking+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to enable the model's thinking/reasoning phase. Only models with a thinking mode (e.g. Qwen3) honor this; for other models it has no effect.
+
+When `true`, the model reasons inside `<think>…</think>` before answering, which tends to improve tool-calling decisions. Set to `false` for faster responses by skipping the reasoning phase.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_ENABLE_THINKING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_ENABLE_THINKING+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-device-memory]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-chat-model-device-memory[`+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.device-memory+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.gpu-llama3."model-name".chat-model.device-memory+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Amount of GPU memory TornadoVM is allowed to allocate e.g. `"7GB"`, `"512MB"`.
+
+Note: this maps to the JVM-global engine flag `tornado.device.memory`, so when multiple models are configured the first one to initialize wins.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_DEVICE_MEMORY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_GPU_LLAMA3__MODEL_NAME__CHAT_MODEL_DEVICE_MEMORY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++4GB+++`
 
 a| [[quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-enable-integration]] [.property-path]##link:#quarkus-langchain4j-gpu-llama3_quarkus-langchain4j-gpu-llama3-model-name-enable-integration[`+++quarkus.langchain4j.gpu-llama3."model-name".enable-integration+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/model-providers/gpu-llama3/runtime/src/main/java/io/quarkiverse/langchain4j/gpullama3/GPULlama3BaseModel.java
+++ b/model-providers/gpu-llama3/runtime/src/main/java/io/quarkiverse/langchain4j/gpullama3/GPULlama3BaseModel.java
@@ -1,21 +1,39 @@
 package io.quarkiverse.langchain4j.gpullama3;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.IntConsumer;
+import java.util.stream.Collectors;
 
 import org.beehive.gpullama3.inference.sampler.Sampler;
 import org.beehive.gpullama3.model.Model;
 import org.beehive.gpullama3.model.format.ChatFormat;
+import org.beehive.gpullama3.model.format.ToolCallExtract;
+import org.jboss.logging.Logger;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.internal.Json;
+import dev.langchain4j.internal.JsonSchemaElementUtils;
 import dev.langchain4j.model.chat.request.ChatRequest;
 
 abstract class GPULlama3BaseModel {
+
+    private static final Logger LOG = Logger.getLogger(GPULlama3BaseModel.class);
 
     /**
      * Centralized holder of the actual model instance.
@@ -32,7 +50,15 @@ abstract class GPULlama3BaseModel {
         return holder.sampler;
     }
 
-    // @formatter:off
+    /**
+     * Runs inference for the given {@link ChatRequest} and returns the raw decoded response text.
+     *
+     * When the request contains tool specifications, the tool definitions are injected into the
+     * system message and tool-aware stop tokens are used so the model can signal a tool call.
+     * The caller ({@link GPULlama3ChatModel} / {@link GPULlama3StreamingChatModel}) is responsible
+     * for inspecting the raw text and deciding whether to return a tool execution request or a
+     * plain text response.
+     */
     public String modelResponse(ChatRequest request, IntConsumer tokenConsumer) {
         List<Integer> promptTokens = new ArrayList<>();
 
@@ -40,9 +66,51 @@ abstract class GPULlama3BaseModel {
             promptTokens.add(holder.chatFormat.getBeginOfText());
         }
 
-        processPromptMessages(request.messages(), promptTokens);
+        // Build tools JSON if the request carries tool definitions
+        List<ToolSpecification> tools = request.toolSpecifications();
+        String toolsJson = (tools != null && !tools.isEmpty()) ? buildToolsJson(tools) : null;
 
-        Set<Integer> stopTokens = holder.chatFormat.getStopTokens();
+        if (toolsJson != null && !holder.chatFormat.supportsToolCalling()) {
+            throw new UnsupportedOperationException(
+                    "Tool calling is not supported for model format: " + holder.chatFormat.getClass().getSimpleName());
+        }
+
+        processPromptMessages(request.messages(), promptTokens, toolsJson);
+
+        if (toolsJson != null) {
+            boolean hasPriorToolResult = request.messages().stream()
+                    .anyMatch(m -> m.type() == dev.langchain4j.data.message.ChatMessageType.TOOL_EXECUTION_RESULT);
+            String toolNames = tools.stream()
+                    .map(ToolSpecification::name)
+                    .collect(Collectors.joining(", "));
+            long priorResultCount = request.messages().stream()
+                    .filter(m -> m.type() == dev.langchain4j.data.message.ChatMessageType.TOOL_EXECUTION_RESULT)
+                    .count();
+            if (hasPriorToolResult) {
+                LOG.infof("[Tool turn] %d tool(s) available: %s  (after %d result(s))",
+                        tools.size(), toolNames, priorResultCount);
+            } else {
+                LOG.infof("[Tool turn] %d tool(s) available: %s", tools.size(), toolNames);
+            }
+        }
+
+        // Full decoded prompt the model is about to see this turn: includes the thinking-control
+        // primer, injected tool definitions, re-encoded prior assistant tool-call turns, and the
+        // <tool_response>-wrapped tool results. This is the precise view for debugging tool calls
+        // and tool responses. Enable with:
+        //   quarkus.log.category."io.quarkiverse.langchain4j.gpullama3".level=DEBUG
+        if (LOG.isDebugEnabled()) {
+            LOG.debugf("[Prompt: %d tokens]%n>>>%n%s%n<<<",
+                    promptTokens.size(), holder.model.tokenizer().decode(promptTokens));
+        }
+
+        // Use tool-aware stop tokens whenever tools are present so the model can signal a tool
+        // call (eom_id on LLaMA 3.1) or a regular response (eot_id) on every turn — including
+        // turns that already contain prior tool results.
+        Set<Integer> stopTokens = (toolsJson != null)
+                ? holder.chatFormat.getToolAwareStopTokens()
+                : holder.chatFormat.getStopTokens();
+
         List<Integer> responseTokens;
 
         if (holder.onGPU) {
@@ -76,13 +144,16 @@ abstract class GPULlama3BaseModel {
 
         String responseText = holder.model.tokenizer().decode(responseTokens);
 
-        // Add the response content tokens to conversation history
+        // Append to conversation history
         promptTokens.addAll(responseTokens);
 
         // Add the stop token to complete the message
         if (stopToken != null) {
             promptTokens.add(stopToken);
         }
+
+        LOG.debug("stopToken=" + stopToken + "  responseTokens=" + responseTokens.size()
+                + "  raw response: >>>" + responseText + "<<<");
 
         if (stopToken == null) {
             return "Ran out of context length...\n Increase context length with by passing to llama-tornado --max-tokens XXX";
@@ -92,21 +163,230 @@ abstract class GPULlama3BaseModel {
     }
     // @formatter:on
 
-    private void processPromptMessages(List<ChatMessage> messageList, List<Integer> promptTokens) {
+    /**
+     * Encodes all conversation messages into {@code promptTokens} using the <b>native Llama 3.2
+     * chat template</b> extracted from the GGUF metadata.
+     *
+     * <p>
+     * Key template behaviours reproduced here:
+     * <ul>
+     * <li>System message gets an {@code "Environment: ipython\n"} prefix when tools are active.</li>
+     * <li>Tool definitions are injected into the <em>first</em> user message
+     * ({@code tools_in_user_message = true} is the default in the template).</li>
+     * <li>Assistant tool-call turns are encoded as native JSON:
+     * {@code {"name":"…","parameters":{…}}} — not {@code <tool_call>} XML.</li>
+     * <li>Tool results use the {@code ipython} role (handled by
+     * {@link ChatFormat#encodeToolResultTurn}).</li>
+     * </ul>
+     */
+    private void processPromptMessages(List<ChatMessage> messageList, List<Integer> promptTokens, String toolsJson) {
+        boolean toolsInjected = false;
+
+        // Tool definitions are injected on every turn so the model always knows which tools
+        // are available — matching Ollama's behaviour of sending the tools array with every
+        // request. Models correctly decide when to call a tool vs. synthesise a final answer
+        // based on whether they already have enough information from prior tool results.
+        boolean hasPriorToolResult = messageList.stream()
+                .anyMatch(m -> m.type() == dev.langchain4j.data.message.ChatMessageType.TOOL_EXECUTION_RESULT);
+        boolean injectTools = toolsJson != null;
+        boolean userMessageInjection = injectTools && holder.chatFormat.injectsToolsInUserMessage();
+
+        LOG.debug("processPromptMessages: msgs=" + messageList.size()
+                + "  injectTools=" + injectTools + "  userMsgInjection=" + userMessageInjection);
+
         for (ChatMessage msg : messageList) {
-            if (msg instanceof UserMessage userMessage) {
-                promptTokens.addAll(holder.chatFormat.encodeMessage(
-                        new ChatFormat.Message(ChatFormat.Role.USER, userMessage.singleText())));
-            } else if (msg instanceof SystemMessage systemMessage && holder.model.shouldAddSystemPrompt()) {
-                promptTokens.addAll(
-                        holder.chatFormat.encodeMessage(new ChatFormat.Message(ChatFormat.Role.SYSTEM, systemMessage.text())));
-            } else if (msg instanceof AiMessage aiMessage) {
-                promptTokens.addAll(
-                        holder.chatFormat.encodeMessage(new ChatFormat.Message(ChatFormat.Role.ASSISTANT, aiMessage.text())));
+            switch (msg.type()) {
+                case SYSTEM -> {
+                    SystemMessage systemMessage = (SystemMessage) msg;
+                    if (holder.model.shouldAddSystemPrompt()) {
+                        String content = systemMessage.text();
+                        if (injectTools) {
+                            if (userMessageInjection) {
+                                String prefix = holder.chatFormat.toolSystemMessagePrefix();
+                                if (!prefix.isEmpty())
+                                    content = prefix + content;
+                            } else {
+                                content = content + holder.chatFormat.toolSystemPromptSuffix(toolsJson);
+                                toolsInjected = true;
+                            }
+                        }
+                        LOG.debugf("SYSTEM (first 300): %s",
+                                content.substring(0, Math.min(300, content.length())));
+                        promptTokens.addAll(
+                                holder.chatFormat.encodeMessage(new ChatFormat.Message(ChatFormat.Role.SYSTEM, content)));
+                    }
+                }
+                case USER -> {
+                    UserMessage userMessage = (UserMessage) msg;
+                    String userText = userMessage.singleText();
+                    if (injectTools && !toolsInjected && userMessageInjection) {
+                        userText = holder.chatFormat.toolFirstUserMessagePrefix(toolsJson) + userText;
+                        toolsInjected = true;
+                    }
+                    LOG.debugf("USER (first 200): %s", userText.substring(0, Math.min(200, userText.length())));
+                    promptTokens.addAll(holder.chatFormat.encodeMessage(
+                            new ChatFormat.Message(ChatFormat.Role.USER, userText)));
+                }
+                case AI -> {
+                    AiMessage aiMessage = (AiMessage) msg;
+                    if (aiMessage.hasToolExecutionRequests()) {
+                        List<ToolCallExtract> toolCalls = aiMessage.toolExecutionRequests().stream()
+                                .map(req -> new ToolCallExtract(req.name(), req.arguments()))
+                                .collect(Collectors.toList());
+                        promptTokens.addAll(holder.chatFormat.encodeToolCallAssistantTurn(toolCalls));
+                    } else if (aiMessage.text() != null) {
+                        promptTokens.addAll(
+                                holder.chatFormat.encodeMessage(
+                                        new ChatFormat.Message(ChatFormat.Role.ASSISTANT, aiMessage.text())));
+                    }
+                }
+                case TOOL_EXECUTION_RESULT -> {
+                    ToolExecutionResultMessage toolMessage = (ToolExecutionResultMessage) msg;
+                    String resultText = unwrapToolResult(toolMessage.text());
+                    LOG.infof("[Tool result] ← %s:\n%s", toolMessage.toolName(), resultText);
+                    promptTokens.addAll(holder.chatFormat.encodeToolResultTurn(
+                            toolMessage.id(), toolMessage.toolName(), resultText));
+                }
+                default -> {
+                    // Unsupported message types are silently skipped
+                }
             }
         }
 
-        // EncodeHeader to prime the model to start generating a new assistant response.
+        // Fallback: no system or user message encountered — inject tools at the start
+        if (injectTools && !toolsInjected && !userMessageInjection && holder.model.shouldAddSystemPrompt()) {
+            String toolsOnlySystem = holder.chatFormat.toolSystemPromptSuffix(toolsJson).stripLeading();
+            promptTokens.addAll(0,
+                    holder.chatFormat.encodeMessage(new ChatFormat.Message(ChatFormat.Role.SYSTEM, toolsOnlySystem)));
+        }
+
+        // Prime the model to start generating an assistant response
         promptTokens.addAll(holder.chatFormat.encodeHeader(new ChatFormat.Message(ChatFormat.Role.ASSISTANT, "")));
+
+        // Control the reasoning phase: when thinking is disabled, formats that support it
+        // (e.g. Qwen3) prime a pre-closed thinking block so the model skips reasoning. No-op
+        // for formats without a thinking mode.
+        promptTokens.addAll(holder.chatFormat.encodeThinkingControl(holder.enableThinking));
+    }
+
+    private static final String CALL_ID_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789";
+
+    /** Generates an Ollama-style tool call ID: {@code call_} + 8 random alphanumeric chars. */
+    protected static String generateCallId() {
+        ThreadLocalRandom rng = ThreadLocalRandom.current();
+        StringBuilder sb = new StringBuilder("call_");
+        for (int i = 0; i < 8; i++) {
+            sb.append(CALL_ID_CHARS.charAt(rng.nextInt(CALL_ID_CHARS.length())));
+        }
+        return sb.toString();
+    }
+
+    private static final ObjectMapper TOOL_MAPPER = new ObjectMapper();
+    /** Compact single-line JSON writer — Qwen3 ChatML tool list. */
+    private static final ObjectWriter COMPACT_TOOL_WRITER = TOOL_MAPPER.writer();
+    /** 4-space pretty JSON writer — Llama Instruct tool list (matches the template's {@code tojson(indent=4)}). */
+    private static final ObjectWriter PRETTY_TOOL_WRITER = TOOL_MAPPER.writer(
+            new DefaultPrettyPrinter()
+                    .withObjectIndenter(new DefaultIndenter("    ", "\n"))
+                    .withArrayIndenter(new DefaultIndenter("    ", "\n")));
+
+    /**
+     * Builds the {@code <tools>} JSON for the model family, dispatching on
+     * {@link Model#getModelType()}. Each family expects a different serialization (see the
+     * dedicated builders). Only Llama and Qwen3/ChatML formats currently reach this method —
+     * tool calling is gated upstream by {@code chatFormat.supportsToolCalling()}.
+     */
+    private String buildToolsJson(List<ToolSpecification> tools) {
+        return switch (holder.model.getModelType()) {
+            case LLAMA_3 -> buildToolsJsonLlama(tools);
+            case QWEN_3, DEEPSEEK_R1_DISTILL_QWEN -> buildToolsJsonQwen3(tools);
+            // Llama 3.1 and 3.2 both report LLAMA_3 and share the same tool template, so no
+            // per-version split is needed. Any other ChatML-based format that opts into tool
+            // calling later falls back to the Qwen3 layout.
+            default -> buildToolsJsonQwen3(tools);
+        };
+    }
+
+    /**
+     * Qwen3 tool list: each tool object as <em>compact</em> single-line JSON, one per line, with
+     * no enclosing array — matching the official Qwen3 chat template, which renders the section as
+     * {@code <tools>\n{tool|tojson}\n…\n</tools>}. Compact output keeps the per-turn token cost low.
+     */
+    static String buildToolsJsonQwen3(List<ToolSpecification> tools) {
+        return buildToolMaps(tools).stream()
+                .map(m -> writeJson(COMPACT_TOOL_WRITER, m))
+                .collect(Collectors.joining("\n"));
+    }
+
+    /**
+     * Llama 3.1/3.2 tool list: each tool object <em>pretty-printed with 4-space indentation</em>,
+     * separated by blank lines, with no enclosing array — matching the Llama Instruct template,
+     * which renders each tool via {@code t | tojson(indent=4)} in the first user message.
+     */
+    static String buildToolsJsonLlama(List<ToolSpecification> tools) {
+        return buildToolMaps(tools).stream()
+                .map(m -> writeJson(PRETTY_TOOL_WRITER, m))
+                .collect(Collectors.joining("\n\n"));
+    }
+
+    /** Builds the shared OpenAI-style tool maps ({@code {"type":"function","function":{…}}}). */
+    private static List<Map<String, Object>> buildToolMaps(List<ToolSpecification> tools) {
+        List<Map<String, Object>> toolArray = new ArrayList<>();
+        for (ToolSpecification tool : tools) {
+            Map<String, Object> funcMap = new LinkedHashMap<>();
+            funcMap.put("name", tool.name());
+            if (tool.description() != null) {
+                funcMap.put("description", tool.description());
+            }
+            funcMap.put("parameters", buildParametersMap(tool));
+
+            Map<String, Object> toolMap = new LinkedHashMap<>();
+            toolMap.put("type", "function");
+            toolMap.put("function", funcMap);
+            toolArray.add(toolMap);
+        }
+        return toolArray;
+    }
+
+    private static String writeJson(ObjectWriter writer, Object value) {
+        try {
+            return writer.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize tool definition JSON", e);
+        }
+    }
+
+    private static Map<String, Object> buildParametersMap(ToolSpecification tool) {
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("type", "object");
+        Map<String, Object> props = new LinkedHashMap<>();
+        if (tool.parameters() != null) {
+            for (var entry : tool.parameters().properties().entrySet()) {
+                props.put(entry.getKey(), JsonSchemaElementUtils.toMap(entry.getValue()));
+            }
+            List<String> required = tool.parameters().required();
+            if (required != null && !required.isEmpty()) {
+                params.put("required", required);
+            }
+        }
+        params.put("properties", props);
+        return params;
+    }
+
+    /**
+     * LangChain4j serializes {@code String} tool results via {@code Json.toJson()}, which wraps
+     * them in a JSON string literal: {@code "hello\nworld"} becomes {@code "\"hello\\nworld\""}.
+     * Unwrap the JSON quoting so the model receives plain readable text with real newlines.
+     */
+    private static String unwrapToolResult(String text) {
+        if (text == null)
+            return "";
+        if (text.startsWith("\"")) {
+            try {
+                return Json.fromJson(text, String.class);
+            } catch (Exception ignored) {
+            }
+        }
+        return text;
     }
 }

--- a/model-providers/gpu-llama3/runtime/src/main/java/io/quarkiverse/langchain4j/gpullama3/GPULlama3ChatModel.java
+++ b/model-providers/gpu-llama3/runtime/src/main/java/io/quarkiverse/langchain4j/gpullama3/GPULlama3ChatModel.java
@@ -1,16 +1,21 @@
 package io.quarkiverse.langchain4j.gpullama3;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
+import org.beehive.gpullama3.model.format.ToolCallExtract;
 import org.jboss.logging.Logger;
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.internal.ChatRequestValidationUtils;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
 
 public class GPULlama3ChatModel extends GPULlama3BaseModel implements ChatModel {
 
@@ -36,12 +41,46 @@ public class GPULlama3ChatModel extends GPULlama3BaseModel implements ChatModel 
         ChatRequestValidationUtils.validate(parameters.toolChoice());
         ChatRequestValidationUtils.validate(parameters.responseFormat());
 
+        boolean hasPriorToolResult = chatRequest.messages().stream()
+                .anyMatch(m -> m.type() == dev.langchain4j.data.message.ChatMessageType.TOOL_EXECUTION_RESULT);
+
         try {
             // Generate a raw response from the model
             String rawResponse = modelResponse(chatRequest, null);
 
-            // Parse thinking and actual response using the GPULlama3ResponseParser
+            // Use extractAllToolCalls to handle batched tool calls (matches ToolCallingSession)
+            List<ToolCallExtract> toolCalls = holder.chatFormat.extractAllToolCalls(rawResponse);
+            LOG.debugf("extractAllToolCalls result: %d call(s)", toolCalls.size());
+            if (!toolCalls.isEmpty()) {
+                LOG.infof("[LLM → tool call]\n%s", rawResponse.strip());
+                GPULlama3ResponseParser.ParsedResponse parsed = GPULlama3ResponseParser.parseResponse(rawResponse);
+                LOG.debugf("[Parsed tool turn] toolCalls=%d  thinking=>>>%s<<<",
+                        toolCalls.size(), parsed.getThinkingContent());
+                List<ToolExecutionRequest> toolReqs = new ArrayList<>();
+                for (ToolCallExtract tc : toolCalls) {
+                    String callId = tc.id().orElseGet(() -> generateCallId());
+                    LOG.infof("[Tool call]  → %s(%s)", tc.name(),
+                            tc.argumentsJson().replace("\n", "").replaceAll("\\s+", " "));
+                    toolReqs.add(ToolExecutionRequest.builder()
+                            .id(callId)
+                            .name(tc.name())
+                            .arguments(tc.argumentsJson())
+                            .build());
+                }
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.builder()
+                                .thinking(parsed.getThinkingContent())
+                                .toolExecutionRequests(toolReqs)
+                                .build())
+                        .finishReason(FinishReason.TOOL_EXECUTION)
+                        .build();
+            }
+
+            // Plain text response — separate thinking content if present
             GPULlama3ResponseParser.ParsedResponse parsed = GPULlama3ResponseParser.parseResponse(rawResponse);
+
+            LOG.debugf("[Parsed response] thinking=>>>%s<<<", parsed.getThinkingContent());
+            LOG.infof("[LLM response]\n%s", parsed.getActualResponse());
 
             return ChatResponse.builder()
                     .aiMessage(AiMessage.builder()
@@ -69,6 +108,10 @@ public class GPULlama3ChatModel extends GPULlama3BaseModel implements ChatModel 
         private Integer seed;
         private Integer maxTokens;
         private Boolean onGPU;
+        private Boolean withPrefillDecode;
+        private Integer prefillBatchSize;
+        private Boolean enableThinking;
+        private String deviceMemory;
 
         public Builder() {
             // This is public so it can be extended
@@ -119,11 +162,32 @@ public class GPULlama3ChatModel extends GPULlama3BaseModel implements ChatModel 
             return this;
         }
 
+        public Builder withPrefillDecode(Boolean withPrefillDecode) {
+            this.withPrefillDecode = withPrefillDecode;
+            return this;
+        }
+
+        public Builder prefillBatchSize(Integer prefillBatchSize) {
+            this.prefillBatchSize = prefillBatchSize;
+            return this;
+        }
+
+        public Builder enableThinking(Boolean enableThinking) {
+            this.enableThinking = enableThinking;
+            return this;
+        }
+
+        public Builder deviceMemory(String deviceMemory) {
+            this.deviceMemory = deviceMemory;
+            return this;
+        }
+
         public GPULlama3ChatModel build() {
             GPULlama3ModelHolder h = modelHolder != null
                     ? modelHolder
                     : new GPULlama3ModelHolder(modelCachePath, modelName, quantization,
-                            temperature, topP, seed, maxTokens, onGPU);
+                            temperature, topP, seed, maxTokens, onGPU, withPrefillDecode, prefillBatchSize, enableThinking,
+                            deviceMemory);
             return new GPULlama3ChatModel(h);
         }
     }

--- a/model-providers/gpu-llama3/runtime/src/main/java/io/quarkiverse/langchain4j/gpullama3/GPULlama3ModelHolder.java
+++ b/model-providers/gpu-llama3/runtime/src/main/java/io/quarkiverse/langchain4j/gpullama3/GPULlama3ModelHolder.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.beehive.gpullama3.inference.sampler.Sampler;
 import org.beehive.gpullama3.inference.state.State;
@@ -33,6 +34,10 @@ public class GPULlama3ModelHolder {
     private final int seed;
     final int maxTokens;
     final boolean onGPU;
+    private final boolean withPrefillDecode;
+    private final int prefillBatchSize;
+    final boolean enableThinking;
+    private final String deviceMemory;
 
     // force happens-before relationship between initialization and usage
     private volatile boolean initialized = false;
@@ -51,15 +56,38 @@ public class GPULlama3ModelHolder {
             Double topP,
             Integer seed,
             Integer maxTokens,
-            Boolean onGPU) {
+            Boolean onGPU,
+            Boolean withPrefillDecode,
+            Integer prefillBatchSize,
+            Boolean enableThinking,
+            String deviceMemory) {
+        DefaultConfig defaultConfig = defaultConfigForModel(modelName);
         this.modelCachePath = modelCachePath;
         this.modelName = modelName;
         this.quantization = quantization;
-        this.temperature = getOrDefault(temperature, 0.1);
-        this.topP = getOrDefault(topP, 1.0);
-        this.seed = getOrDefault(seed, 12345);
-        this.maxTokens = getOrDefault(maxTokens, 512);
+        this.temperature = getOrDefault(temperature, defaultConfig.temperature());
+        this.topP = getOrDefault(topP, defaultConfig.topP());
+        this.seed = getOrDefault(seed, ThreadLocalRandom.current().nextInt());
+        this.maxTokens = getOrDefault(maxTokens, defaultConfig.maxTokens());
         this.onGPU = getOrDefault(onGPU, Boolean.TRUE);
+        this.withPrefillDecode = getOrDefault(withPrefillDecode, Boolean.TRUE);
+        this.prefillBatchSize = getOrDefault(prefillBatchSize, 32);
+        this.enableThinking = getOrDefault(enableThinking, Boolean.TRUE);
+        this.deviceMemory = getOrDefault(deviceMemory, "4GB");
+    }
+
+    private static DefaultConfig defaultConfigForModel(String modelName) {
+        String normalizedName = modelName != null ? modelName.toLowerCase() : "";
+        if (normalizedName.contains("qwen")) {
+            return new DefaultConfig(0.8, 0.9, 2048);
+        }
+        if (normalizedName.contains("llama")) {
+            return new DefaultConfig(0.3, 0.95, 2048);
+        }
+        return new DefaultConfig(0.7, 0.9, 2048);
+    }
+
+    private record DefaultConfig(double temperature, double topP, int maxTokens) {
     }
 
     public synchronized void ensureInitialized() {
@@ -70,12 +98,22 @@ public class GPULlama3ModelHolder {
         try {
             Path modelPath = registry.downloadModel(modelName, quantization, Optional.empty(), Optional.empty());
 
+            // The engine reads these JVM-global flags during class loading, so set them
+            // before ModelLoader initializes the model and TornadoVM plan.
+            System.setProperty("llama.withPrefillDecode", Boolean.toString(withPrefillDecode));
+            System.setProperty("llama.prefillBatchSize", Integer.toString(prefillBatchSize));
+            System.setProperty("tornado.device.memory", deviceMemory);
+
             LOG.info("GPULlama3 model initialization {modelPath=" + modelPath
                     + ", temperature=" + temperature
                     + ", topP=" + topP
                     + ", seed=" + seed
                     + ", maxTokens=" + maxTokens
-                    + ", onGPU=" + onGPU + "}...");
+                    + ", onGPU=" + onGPU
+                    + ", withPrefillDecode=" + withPrefillDecode
+                    + ", prefillBatchSize=" + prefillBatchSize
+                    + ", enableThinking=" + enableThinking
+                    + ", deviceMemory=" + deviceMemory + "}...");
 
             this.model = ModelLoader.loadModel(modelPath, maxTokens, true, onGPU);
             this.state = model.createNewState();
@@ -85,6 +123,10 @@ public class GPULlama3ModelHolder {
                     (float) topP,
                     seed);
             this.chatFormat = model.chatFormat();
+            if (!chatFormat.supportsThinking()) {
+                LOG.debugf("Thinking control not applicable for %s; enable-thinking=%s has no effect.",
+                        chatFormat.getClass().getSimpleName(), enableThinking);
+            }
             if (onGPU) {
                 this.tornadoVMPlan = TornadoVMMasterPlan.initializeTornadoVMPlan(state, model);
             }

--- a/model-providers/gpu-llama3/runtime/src/main/java/io/quarkiverse/langchain4j/gpullama3/GPULlama3ResponseParser.java
+++ b/model-providers/gpu-llama3/runtime/src/main/java/io/quarkiverse/langchain4j/gpullama3/GPULlama3ResponseParser.java
@@ -1,5 +1,12 @@
 package io.quarkiverse.langchain4j.gpullama3;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.beehive.gpullama3.model.format.ToolCallExtract;
+import org.beehive.gpullama3.model.format.ToolCallParserUtils;
+
 import dev.langchain4j.model.chat.response.PartialThinking;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 
@@ -60,24 +67,40 @@ public class GPULlama3ResponseParser {
         String thinking = null;
         String actualResponse = rawResponse;
 
-        // Find <think> and </think> positions
         int thinkStart = rawResponse.indexOf("<think>");
         int thinkEnd = rawResponse.indexOf("</think>");
 
-        if (thinkStart != -1 && thinkEnd != -1 && thinkEnd > thinkStart) {
-            // Extract thinking content INCLUDING the tags
-            thinking = rawResponse.substring(thinkStart, thinkEnd + 8).trim(); // Include </think>
-
-            // Remove the entire thinking block from response
-            String beforeThink = rawResponse.substring(0, thinkStart);
-            String afterThink = rawResponse.substring(thinkEnd + 8); // Skip </think>
-            actualResponse = (beforeThink + afterThink).trim();
-
-            // Clean up any extra whitespace
-            actualResponse = actualResponse.replaceAll("\\s+", " ").trim();
+        // Strip the reasoning block whenever the CLOSING </think> appears, because the opening
+        // <think> may be absent from the *generated* text. In thinking-disabled mode the primer
+        // puts a <think>…</think> block into the PROMPT, so when a small model still reasons it
+        // emits trailing reasoning plus its own </think> without re-opening the tag. The engine
+        // never injects a stray </think> (verified: it only ever primes <think> openings), so a
+        // lone </think> always marks the end of genuine reasoning. When the opening tag is also
+        // present we strip from it; otherwise everything up to and including </think> is reasoning.
+        if (thinkEnd != -1) {
+            int blockStart = (thinkStart != -1 && thinkStart < thinkEnd) ? thinkStart : 0;
+            // Extract thinking content INCLUDING the tags. Preserve the answer's own formatting
+            // (newlines, indentation) — never collapse internal whitespace, or code and
+            // multi-line answers would be flattened to a single line.
+            thinking = rawResponse.substring(blockStart, thinkEnd + 8).trim(); // Include </think>
+            String before = rawResponse.substring(0, blockStart);
+            String after = rawResponse.substring(thinkEnd + 8); // Skip </think>
+            actualResponse = (before + after).trim();
         }
 
+        // Defensively strip any residual control tags the model emitted without a matching pair
+        // (e.g. a stray </tool_call> or an extra </think> on small models), so they never leak
+        // into the user-facing answer.
+        actualResponse = stripControlTags(actualResponse).trim();
+
         return new ParsedResponse(thinking, actualResponse);
+    }
+
+    private static String stripControlTags(String text) {
+        return text.replace("<think>", "")
+                .replace("</think>", "")
+                .replace("<tool_call>", "")
+                .replace("</tool_call>", "");
     }
 
     public static String extractThinking(String rawResponse) {
@@ -101,10 +124,19 @@ public class GPULlama3ResponseParser {
      * The thinking tags are preserved and streamed as part of the thinking content.
      */
     public static class StreamingParser {
+        private static final String TOOL_CALL_OPEN = "<tool_call>";
+        private static final String TOOL_CALL_CLOSE = "</tool_call>";
+        private static final String PYTHON_TAG = "<|python_tag|>";
+
         private final StreamingChatResponseHandler handler;
         private final org.beehive.gpullama3.model.Model model;
         private final StringBuilder buffer = new StringBuilder();
         private boolean insideThinking = false;
+        private boolean insideToolCall = false;
+        private boolean insidePythonTagCall = false;
+        private final StringBuilder toolCallBuffer = new StringBuilder();
+        private final StringBuilder thinkingAccumulator = new StringBuilder();
+        private final List<ToolCallExtract> detectedToolCalls = new ArrayList<>();
         private int lastProcessedLength = 0;
 
         /**
@@ -125,8 +157,8 @@ public class GPULlama3ResponseParser {
          */
         public void onToken(int tokenId) {
             // Check if this is a stop token and skip it
-            if (model.chatFormat().getStopTokens().contains(tokenId)) {
-                return; // Don't stream stop tokens like <|im_end|>
+            if (model.chatFormat().getToolAwareStopTokens().contains(tokenId)) {
+                return; // Don't stream stop tokens like <|im_end|> or <|eom_id|>
             }
 
             // Decode the token and add to buffer
@@ -140,8 +172,18 @@ public class GPULlama3ResponseParser {
         }
 
         /**
-         * Processes new content in the buffer, detecting thinking state transitions
-         * and routing content to appropriate handler methods.
+         * Processes new content in the buffer, detecting thinking and tool-call state
+         * transitions and routing content to the appropriate handler methods.
+         *
+         * <p>
+         * Tool-call markers handled:
+         * <ul>
+         * <li>{@code <tool_call>} / {@code </tool_call>} — LLaMA 3.2 and Qwen3</li>
+         * <li>{@code <|python_tag|>} — LLaMA 3.1 (no explicit close tag; resolved in
+         * {@link #finish()})</li>
+         * </ul>
+         * Characters inside a tool-call block are buffered rather than forwarded to the
+         * handler, so the client never sees raw tool-call JSON as a partial response.
          */
         private void processNewContent(String currentText) {
             if (currentText.length() <= lastProcessedLength) {
@@ -152,29 +194,67 @@ public class GPULlama3ResponseParser {
 
             // Process each character in the new content
             for (int i = 0; i < newContent.length(); i++) {
-                int currentPosition = lastProcessedLength + i;
+                int pos = lastProcessedLength + i;
 
-                // Check if we're starting thinking
-                if (!insideThinking && isStartOfThinkTag(currentText, currentPosition)) {
+                // Inside <tool_call>…</tool_call>
+                if (insideToolCall) {
+                    if (regionMatches(currentText, pos, TOOL_CALL_CLOSE)) {
+                        ToolCallParserUtils.parseToolCallResponse(
+                                TOOL_CALL_OPEN + toolCallBuffer + TOOL_CALL_CLOSE)
+                                .ifPresent(detectedToolCalls::add);
+                        toolCallBuffer.setLength(0);
+                        insideToolCall = false;
+                        i += TOOL_CALL_CLOSE.length() - 1;
+                    } else {
+                        toolCallBuffer.append(newContent.charAt(i));
+                    }
+                    continue;
+                }
+
+                // Inside <|python_tag|>… (no close tag, resolved in finish())
+                if (insidePythonTagCall) {
+                    toolCallBuffer.append(newContent.charAt(i));
+                    continue;
+                }
+
+                // Thinking open
+                if (!insideThinking && isStartOfThinkTag(currentText, pos)) {
                     insideThinking = true;
                     // Stream the opening tag as thinking
+                    thinkingAccumulator.append("<think>");
                     handler.onPartialThinking(new PartialThinking("<think>"));
                     i += 6; // Skip the rest of "<think>"
                     continue;
                 }
 
-                // Check if we're ending thinking
-                if (insideThinking && isStartOfEndThinkTag(currentText, currentPosition)) {
+                // Thinking close
+                if (insideThinking && isStartOfEndThinkTag(currentText, pos)) {
                     // Stream the closing tag as thinking
+                    thinkingAccumulator.append("</think>");
                     handler.onPartialThinking(new PartialThinking("</think>"));
                     insideThinking = false;
                     i += 7; // Skip the rest of "</think>"
                     continue;
                 }
 
-                // Stream the character to appropriate handler
+                // Tool call open (<tool_call>)
+                if (!insideThinking && regionMatches(currentText, pos, TOOL_CALL_OPEN)) {
+                    insideToolCall = true;
+                    i += TOOL_CALL_OPEN.length() - 1;
+                    continue;
+                }
+
+                // LLaMA 3.1 python tag (<|python_tag|>)
+                if (!insideThinking && regionMatches(currentText, pos, PYTHON_TAG)) {
+                    insidePythonTagCall = true;
+                    i += PYTHON_TAG.length() - 1;
+                    continue;
+                }
+
+                // Route the character to appropriate handler
                 char c = newContent.charAt(i);
                 if (insideThinking) {
+                    thinkingAccumulator.append(c);
                     handler.onPartialThinking(new PartialThinking(String.valueOf(c)));
                 } else {
                     handler.onPartialResponse(String.valueOf(c));
@@ -182,6 +262,36 @@ public class GPULlama3ResponseParser {
             }
 
             lastProcessedLength = currentText.length();
+        }
+
+        /**
+         * Must be called after the model finishes generating tokens.
+         * Parses any buffered {@code <|python_tag|>} tool call (LLaMA 3.1), which has
+         * no explicit close tag and is only complete when generation stops.
+         *
+         * @return unmodifiable list of all tool calls detected during this generation
+         */
+        public List<ToolCallExtract> finish() {
+            if (insidePythonTagCall && !toolCallBuffer.isEmpty()) {
+                ToolCallParserUtils.parseToolCallResponse(PYTHON_TAG + toolCallBuffer)
+                        .ifPresent(detectedToolCalls::add);
+            }
+            return Collections.unmodifiableList(detectedToolCalls);
+        }
+
+        /**
+         * Returns the thinking content accumulated during generation (including
+         * {@code <think>} and {@code </think>} tags), or {@code null} if no
+         * thinking block was emitted.
+         */
+        public String getThinkingContent() {
+            String s = thinkingAccumulator.toString().strip();
+            return s.isEmpty() ? null : s;
+        }
+
+        private static boolean regionMatches(String text, int start, String marker) {
+            return start + marker.length() <= text.length()
+                    && text.regionMatches(start, marker, 0, marker.length());
         }
 
         /**

--- a/model-providers/gpu-llama3/runtime/src/main/java/io/quarkiverse/langchain4j/gpullama3/GPULlama3StreamingChatModel.java
+++ b/model-providers/gpu-llama3/runtime/src/main/java/io/quarkiverse/langchain4j/gpullama3/GPULlama3StreamingChatModel.java
@@ -3,10 +3,14 @@ package io.quarkiverse.langchain4j.gpullama3;
 import static io.quarkiverse.langchain4j.runtime.VertxUtil.runOutEventLoop;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
+import org.beehive.gpullama3.model.format.ToolCallExtract;
 import org.jboss.logging.Logger;
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.internal.ChatRequestValidationUtils;
 import dev.langchain4j.model.chat.StreamingChatModel;
@@ -14,6 +18,7 @@ import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.output.FinishReason;
 
 /**
  * GPULlama3StreamingChatModel is a specialized implementation of the {@link StreamingChatModel} for Quarkus-Langchain4j
@@ -82,20 +87,58 @@ public class GPULlama3StreamingChatModel extends GPULlama3BaseModel implements S
      */
     private void coreDoChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
         try {
+            // The StreamingParser detects and buffers tool-call JSON in real time (<tool_call> and
+            // <|python_tag|> markers), so streaming is never suppressed — plain-text responses
+            // stream token-by-token even when tool specifications are registered.
             GPULlama3ResponseParser.StreamingParser parser = GPULlama3ResponseParser.createStreamingParser(handler, getModel());
 
             String rawResponse = modelResponse(chatRequest, parser::onToken);
 
+            // Finalize parser: resolves any unclosed <|python_tag|> tool call (LLaMA 3.1)
+            List<ToolCallExtract> toolCalls = parser.finish();
+
+            // Check for tool calls
+            // Fallback for models that emit raw JSON without <tool_call> tags (rare)
+            if (toolCalls.isEmpty()) {
+                toolCalls = holder.chatFormat.extractAllToolCalls(rawResponse);
+            }
+            if (!toolCalls.isEmpty()) {
+                LOG.infof("[LLM → tool call]\n%s", rawResponse.strip());
+                String thinkingContent = parser.getThinkingContent();
+                LOG.debugf("[Parsed tool turn] toolCalls=%d  thinking=>>>%s<<<", toolCalls.size(), thinkingContent);
+                List<ToolExecutionRequest> toolReqs = new ArrayList<>();
+                for (ToolCallExtract tc : toolCalls) {
+                    String callId = tc.id().orElseGet(() -> generateCallId());
+                    LOG.infof("[Tool call] → %s(%s)", tc.name(),
+                            tc.argumentsJson().replace("\n", "").replaceAll("\\s+", " "));
+                    toolReqs.add(ToolExecutionRequest.builder()
+                            .id(callId)
+                            .name(tc.name())
+                            .arguments(tc.argumentsJson())
+                            .build());
+                }
+                handler.onCompleteResponse(ChatResponse.builder()
+                        .aiMessage(AiMessage.builder()
+                                .thinking(thinkingContent)
+                                .toolExecutionRequests(toolReqs)
+                                .build())
+                        .finishReason(FinishReason.TOOL_EXECUTION)
+                        .build());
+                return;
+            }
+
+            // Plain text — parse thinking and deliver final response
             GPULlama3ResponseParser.ParsedResponse parsed = GPULlama3ResponseParser.parseResponse(rawResponse);
 
-            ChatResponse chatResponse = ChatResponse.builder()
+            LOG.debugf("[Parsed response] thinking=>>>%s<<<", parsed.getThinkingContent());
+            LOG.infof("[LLM response]\n%s", parsed.getActualResponse());
+
+            handler.onCompleteResponse(ChatResponse.builder()
                     .aiMessage(AiMessage.builder()
                             .text(parsed.getActualResponse())
                             .thinking(parsed.getThinkingContent())
                             .build())
-                    .build();
-
-            handler.onCompleteResponse(chatResponse);
+                    .build());
         } catch (Exception e) {
             LOG.error("Error in GPULlama3 coreDoChat", e);
             handler.onError(e);
@@ -117,6 +160,10 @@ public class GPULlama3StreamingChatModel extends GPULlama3BaseModel implements S
         private Integer seed;
         private Integer maxTokens;
         private Boolean onGPU;
+        private Boolean withPrefillDecode;
+        private Integer prefillBatchSize;
+        private Boolean enableThinking;
+        private String deviceMemory;
 
         public Builder() {
             // This is public so it can be extended
@@ -167,11 +214,32 @@ public class GPULlama3StreamingChatModel extends GPULlama3BaseModel implements S
             return this;
         }
 
+        public Builder withPrefillDecode(Boolean withPrefillDecode) {
+            this.withPrefillDecode = withPrefillDecode;
+            return this;
+        }
+
+        public Builder prefillBatchSize(Integer prefillBatchSize) {
+            this.prefillBatchSize = prefillBatchSize;
+            return this;
+        }
+
+        public Builder enableThinking(Boolean enableThinking) {
+            this.enableThinking = enableThinking;
+            return this;
+        }
+
+        public Builder deviceMemory(String deviceMemory) {
+            this.deviceMemory = deviceMemory;
+            return this;
+        }
+
         public GPULlama3StreamingChatModel build() {
             GPULlama3ModelHolder h = modelHolder != null
                     ? modelHolder
                     : new GPULlama3ModelHolder(modelCachePath, modelName, quantization,
-                            temperature, topP, seed, maxTokens, onGPU);
+                            temperature, topP, seed, maxTokens, onGPU, withPrefillDecode, prefillBatchSize, enableThinking,
+                            deviceMemory);
             return new GPULlama3StreamingChatModel(h);
         }
     }

--- a/model-providers/gpu-llama3/runtime/src/main/java/io/quarkiverse/langchain4j/gpullama3/runtime/GPULlama3Recorder.java
+++ b/model-providers/gpu-llama3/runtime/src/main/java/io/quarkiverse/langchain4j/gpullama3/runtime/GPULlama3Recorder.java
@@ -39,7 +39,7 @@ public class GPULlama3Recorder {
         var gpuLlama3Config = correspondingConfig(configName);
 
         if (gpuLlama3Config.enableIntegration()) {
-            LOG.info("Registering GPULlama3ChatModel CDI Bean for config: " + configName);
+            LOG.debugf("Registering GPULlama3ChatModel CDI Bean for config: %s", configName);
             return () -> GPULlama3ChatModel.create(getOrCreateHolder(configName));
         } else {
             return () -> new DisabledChatModel();
@@ -50,7 +50,7 @@ public class GPULlama3Recorder {
         var gpuLlama3Config = correspondingConfig(configName);
 
         if (gpuLlama3Config.enableIntegration()) {
-            LOG.info("Registering GPULlama3StreamingChatModel CDI Bean for config: " + configName);
+            LOG.debugf("Registering GPULlama3StreamingChatModel CDI Bean for config: %s", configName);
             return () -> GPULlama3StreamingChatModel.create(getOrCreateHolder(configName));
         } else {
             return () -> new DisabledStreamingChatModel();
@@ -70,7 +70,11 @@ public class GPULlama3Recorder {
                     chatModelConfig.topP().isPresent() ? chatModelConfig.topP().getAsDouble() : null,
                     chatModelConfig.seed().isPresent() ? chatModelConfig.seed().getAsInt() : null,
                     chatModelConfig.maxTokens().isPresent() ? chatModelConfig.maxTokens().getAsInt() : null,
-                    Boolean.TRUE);
+                    Boolean.TRUE,
+                    chatModelConfig.prefillDecode(),
+                    chatModelConfig.prefillBatchSize(),
+                    chatModelConfig.enableThinking(),
+                    chatModelConfig.deviceMemory().orElse(null));
         });
     }
 

--- a/model-providers/gpu-llama3/runtime/src/main/java/io/quarkiverse/langchain4j/gpullama3/runtime/config/ChatModelConfig.java
+++ b/model-providers/gpu-llama3/runtime/src/main/java/io/quarkiverse/langchain4j/gpullama3/runtime/config/ChatModelConfig.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.langchain4j.gpullama3.runtime.config;
 
+import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 
@@ -38,4 +39,45 @@ public interface ChatModelConfig {
      */
     @ConfigDocDefault("512")
     OptionalInt maxTokens();
+
+    /**
+     * Whether to use the prefill/decode inference path, which processes the prompt in a
+     * dedicated prefill phase before single-token decoding. Combined with a
+     * {@link #prefillBatchSize()} greater than 1 this enables the batched prefill path,
+     * which significantly speeds up prompt processing on the GPU.
+     * <p>
+     * Note: this maps to the JVM-global engine flags {@code llama.withPrefillDecode} /
+     * {@code llama.prefillBatchSize}, so when multiple models are configured the first one
+     * to initialize wins.
+     */
+    @WithDefault("true")
+    boolean prefillDecode();
+
+    /**
+     * Number of prompt tokens processed per batch during the prefill phase. Only used when
+     * {@link #prefillDecode()} is {@code true}: a value greater than 1 enables the batched
+     * prefill path, while 1 falls back to sequential prefill/decode.
+     */
+    @WithDefault("32")
+    int prefillBatchSize();
+
+    /**
+     * Whether to enable the model's thinking/reasoning phase. Only models with a thinking mode
+     * (e.g. Qwen3) honor this; for other models it has no effect.
+     * <p>
+     * When {@code true}, the model reasons inside
+     * {@code <think>…</think>} before answering, which tends to improve tool-calling decisions.
+     * Set to {@code false} for faster responses by skipping the reasoning phase.
+     */
+    @WithDefault("false")
+    boolean enableThinking();
+
+    /**
+     * Amount of GPU memory TornadoVM is allowed to allocate e.g. {@code "7GB"}, {@code "512MB"}.
+     * <p>
+     * Note: this maps to the JVM-global engine flag {@code tornado.device.memory}, so when
+     * multiple models are configured the first one to initialize wins.
+     */
+    @ConfigDocDefault("4GB")
+    Optional<String> deviceMemory();
 }

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <quarkus-neo4j.version>5.7.0</quarkus-neo4j.version>
     <jlama.version>0.8.4</jlama.version>
     <google-auth-library-oauth2-http.version>1.42.1</google-auth-library-oauth2-http.version>
-    <gpu-llama3.version>0.4.0</gpu-llama3.version>
+    <gpu-llama3.version>1.0.0-jdk21</gpu-llama3.version>
     <smallrye-certificate-generator.version>0.9.2</smallrye-certificate-generator.version>
   </properties>
   <dependencyManagement>
@@ -397,7 +397,7 @@
             <jdk>[25,)</jdk>
         </activation>
         <properties>
-            <gpu-llama3.version>0.4.0-jdk25</gpu-llama3.version>
+            <gpu-llama3.version>1.0.0-jdk25</gpu-llama3.version>
         </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
### Description
This PR adds tool-calling support to the GPULlama3 chat models.

The implementation wires LangChain4j tool specifications into the GPULlama3 prompt format, supports model-emitted tool call extraction, and returns `ToolExecutionRequest` responses. It also handles tool execution result messages so follow-up model turns can synthesize final answers from tool output.

### Main Changes
- Add tool-aware prompt construction for GPULlama3.
- Support tool call extraction for non-streaming and streaming chat models.
- Preserve thinking content while separating it from final responses.
- Add support for multiple tool calls in a single response.
- Add tool result encoding back into the conversation.
- Add configurable model options used by the GPULlama3 tool-calling flow:
      - `enable-thinking`
      - `prefill-decode`
      - `prefill-batch-size`
      - `device-memory`