### PR TITLE
[1.2] Update to LangChain4j 1.5.1

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
 :project-version: 1.2.4
-:langchain4j-version: 1.5.0
-:langchain4j-embeddings-version: 1.5.0-beta11
+:langchain4j-version: 1.5.1
+:langchain4j-embeddings-version: 1.5.1-beta11
 :examples-dir: ./../examples/

--- a/pom.xml
+++ b/pom.xml
@@ -37,11 +37,11 @@
   <properties>
     <quarkus.version>3.20.2.2</quarkus.version>
     <quarkus.extension-processor.version>${quarkus.version}</quarkus.extension-processor.version>
-    <langchain4j.version>1.5.0</langchain4j.version>
-    <langchain4j-beta.version>1.5.0-beta11</langchain4j-beta.version>
-    <langchain4j-agentic.version>1.5.0-beta11</langchain4j-agentic.version>
+    <langchain4j.version>1.5.1</langchain4j.version>
+    <langchain4j-beta.version>1.5.1-beta11</langchain4j-beta.version>
+    <langchain4j-agentic.version>1.5.1-beta11</langchain4j-agentic.version>
     <langchain4j-community.version>1.4.0-beta10</langchain4j-community.version>
-    <langchain4j-embeddings.version>1.5.0-beta11</langchain4j-embeddings.version>
+    <langchain4j-embeddings.version>1.5.1-beta11</langchain4j-embeddings.version>
     <quarkus-antora.version>2.2.0</quarkus-antora.version>
     <quarkus-poi.version>2.0.4</quarkus-poi.version> <!-- we need to use this version because langchain4j uses POI 5.2.3 instead of 5.2.5 and the substitution needed is different in the two versions -->
     <assertj.version>3.27.3</assertj.version>


### PR DESCRIPTION
Fixes a SQL injection vulnerability (https://github.com/langchain4j/langchain4j/commit/13a0698bdfaf105d8aaf0367881df51358596219)

This is for Quarkus 3.27