### PR TITLE
Integrate Quarkus Proxy Registry into Bedrock provider

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-bedrock.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-bedrock.adoc
@@ -280,85 +280,29 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-langchain4j-bedrock_quarkus-langchain4j[icon:question-circle[title=More information about the Duration format]]
 |`+++10s+++`
 
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-address]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-address[`+++quarkus.langchain4j.bedrock.client.proxy-address+++`]##
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-configuration-name]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-configuration-name[`+++quarkus.langchain4j.bedrock.client.proxy-configuration-name+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock.client.proxy-address+++[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.client.proxy-configuration-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-A string value in the form of `:` that specifies the HTTP proxy server hostname (or IP address) and port for requests of clients to use.
+The name of the proxy configuration to use, as registered in the Quarkus Proxy Registry.
+
+Precedence rules:
+
+ - If set, it takes precedence over the deprecated `proxy-address`, `proxy-user`, `proxy-password` and `non-proxy-hosts` properties, which are ignored.
+ - If not set and a default proxy configuration is configured (`quarkus.proxy.++*++`), then that one is used.
+ - If set, the configuration from `quarkus.proxy.<name>.++*++` is used.
+ - If set but no proxy configuration is found with that name, an error is thrown at runtime.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_ADDRESS+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_CONFIGURATION_NAME+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_ADDRESS+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-user]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-user[`+++quarkus.langchain4j.bedrock.client.proxy-user+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock.client.proxy-user+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy username, equivalent to the http.proxy or https.proxy JVM settings.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_USER+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_USER+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-password]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-password[`+++quarkus.langchain4j.bedrock.client.proxy-password+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock.client.proxy-password+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy password, equivalent to the http.proxyPassword or https.proxyPassword JVM settings.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_PASSWORD+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_PASSWORD+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-non-proxy-hosts]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-non-proxy-hosts[`+++quarkus.langchain4j.bedrock.client.non-proxy-hosts+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock.client.non-proxy-hosts+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Hosts to access without proxy, similar to the http.nonProxyHosts or https.nonProxyHosts JVM settings. Please note that unlike the JVM settings, this property is empty by default.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_NON_PROXY_HOSTS+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_NON_PROXY_HOSTS+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_CONFIGURATION_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
@@ -1004,85 +948,29 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-langchain4j-bedrock_quarkus-langchain4j[icon:question-circle[title=More information about the Duration format]]
 |`+++10s+++`
 
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-address]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-address[`+++quarkus.langchain4j.bedrock.chat-model.client.proxy-address+++`]##
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-configuration-name]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-configuration-name[`+++quarkus.langchain4j.bedrock.chat-model.client.proxy-configuration-name+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock.chat-model.client.proxy-address+++[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.chat-model.client.proxy-configuration-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-A string value in the form of `:` that specifies the HTTP proxy server hostname (or IP address) and port for requests of clients to use.
+The name of the proxy configuration to use, as registered in the Quarkus Proxy Registry.
+
+Precedence rules:
+
+ - If set, it takes precedence over the deprecated `proxy-address`, `proxy-user`, `proxy-password` and `non-proxy-hosts` properties, which are ignored.
+ - If not set and a default proxy configuration is configured (`quarkus.proxy.++*++`), then that one is used.
+ - If set, the configuration from `quarkus.proxy.<name>.++*++` is used.
+ - If set but no proxy configuration is found with that name, an error is thrown at runtime.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_ADDRESS+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_CONFIGURATION_NAME+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_ADDRESS+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-user]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-user[`+++quarkus.langchain4j.bedrock.chat-model.client.proxy-user+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock.chat-model.client.proxy-user+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy username, equivalent to the http.proxy or https.proxy JVM settings.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_USER+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_USER+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-password]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-password[`+++quarkus.langchain4j.bedrock.chat-model.client.proxy-password+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock.chat-model.client.proxy-password+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy password, equivalent to the http.proxyPassword or https.proxyPassword JVM settings.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_PASSWORD+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_PASSWORD+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-non-proxy-hosts]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-non-proxy-hosts[`+++quarkus.langchain4j.bedrock.chat-model.client.non-proxy-hosts+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock.chat-model.client.non-proxy-hosts+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Hosts to access without proxy, similar to the http.nonProxyHosts or https.nonProxyHosts JVM settings. Please note that unlike the JVM settings, this property is empty by default.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_NON_PROXY_HOSTS+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_NON_PROXY_HOSTS+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_CONFIGURATION_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
@@ -1783,85 +1671,29 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-langchain4j-bedrock_quarkus-langchain4j[icon:question-circle[title=More information about the Duration format]]
 |`+++10s+++`
 
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-address]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-address[`+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-address+++`]##
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-configuration-name]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-configuration-name[`+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-configuration-name+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-address+++[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-configuration-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-A string value in the form of `:` that specifies the HTTP proxy server hostname (or IP address) and port for requests of clients to use.
+The name of the proxy configuration to use, as registered in the Quarkus Proxy Registry.
+
+Precedence rules:
+
+ - If set, it takes precedence over the deprecated `proxy-address`, `proxy-user`, `proxy-password` and `non-proxy-hosts` properties, which are ignored.
+ - If not set and a default proxy configuration is configured (`quarkus.proxy.++*++`), then that one is used.
+ - If set, the configuration from `quarkus.proxy.<name>.++*++` is used.
+ - If set but no proxy configuration is found with that name, an error is thrown at runtime.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_ADDRESS+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_CONFIGURATION_NAME+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_ADDRESS+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-user]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-user[`+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-user+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-user+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy username, equivalent to the http.proxy or https.proxy JVM settings.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_USER+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_USER+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-password]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-password[`+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-password+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-password+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy password, equivalent to the http.proxyPassword or https.proxyPassword JVM settings.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_PASSWORD+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_PASSWORD+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-non-proxy-hosts]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-non-proxy-hosts[`+++quarkus.langchain4j.bedrock.embedding-model.client.non-proxy-hosts+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock.embedding-model.client.non-proxy-hosts+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Hosts to access without proxy, similar to the http.nonProxyHosts or https.nonProxyHosts JVM settings. Please note that unlike the JVM settings, this property is empty by default.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_NON_PROXY_HOSTS+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_NON_PROXY_HOSTS+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_CONFIGURATION_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
@@ -2142,6 +1974,282 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-address]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-address[[.line-through]#`+++quarkus.langchain4j.bedrock.client.proxy-address+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.client.proxy-address+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `proxy-configuration-name` with the Quarkus Proxy Registry instead._
+
+A string value in the form of `:` that specifies the HTTP proxy server hostname (or IP address) and port for requests of clients to use.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_ADDRESS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_ADDRESS+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-user]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-user[[.line-through]#`+++quarkus.langchain4j.bedrock.client.proxy-user+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.client.proxy-user+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `proxy-configuration-name` with the Quarkus Proxy Registry instead._
+
+Proxy username, equivalent to the http.proxy or https.proxy JVM settings.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_USER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-password]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-password[[.line-through]#`+++quarkus.langchain4j.bedrock.client.proxy-password+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.client.proxy-password+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `proxy-configuration-name` with the Quarkus Proxy Registry instead._
+
+Proxy password, equivalent to the http.proxyPassword or https.proxyPassword JVM settings.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-non-proxy-hosts]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-non-proxy-hosts[[.line-through]#`+++quarkus.langchain4j.bedrock.client.non-proxy-hosts+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.client.non-proxy-hosts+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `proxy-configuration-name` with the Quarkus Proxy Registry instead._
+
+Hosts to access without proxy, similar to the http.nonProxyHosts or https.nonProxyHosts JVM settings. Please note that unlike the JVM settings, this property is empty by default.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_NON_PROXY_HOSTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_NON_PROXY_HOSTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-address]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-address[[.line-through]#`+++quarkus.langchain4j.bedrock.chat-model.client.proxy-address+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.chat-model.client.proxy-address+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `proxy-configuration-name` with the Quarkus Proxy Registry instead._
+
+A string value in the form of `:` that specifies the HTTP proxy server hostname (or IP address) and port for requests of clients to use.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_ADDRESS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_ADDRESS+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-user]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-user[[.line-through]#`+++quarkus.langchain4j.bedrock.chat-model.client.proxy-user+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.chat-model.client.proxy-user+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `proxy-configuration-name` with the Quarkus Proxy Registry instead._
+
+Proxy username, equivalent to the http.proxy or https.proxy JVM settings.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_USER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-password]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-password[[.line-through]#`+++quarkus.langchain4j.bedrock.chat-model.client.proxy-password+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.chat-model.client.proxy-password+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `proxy-configuration-name` with the Quarkus Proxy Registry instead._
+
+Proxy password, equivalent to the http.proxyPassword or https.proxyPassword JVM settings.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-non-proxy-hosts]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-non-proxy-hosts[[.line-through]#`+++quarkus.langchain4j.bedrock.chat-model.client.non-proxy-hosts+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.chat-model.client.non-proxy-hosts+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `proxy-configuration-name` with the Quarkus Proxy Registry instead._
+
+Hosts to access without proxy, similar to the http.nonProxyHosts or https.nonProxyHosts JVM settings. Please note that unlike the JVM settings, this property is empty by default.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_NON_PROXY_HOSTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_NON_PROXY_HOSTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-address]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-address[[.line-through]#`+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-address+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-address+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `proxy-configuration-name` with the Quarkus Proxy Registry instead._
+
+A string value in the form of `:` that specifies the HTTP proxy server hostname (or IP address) and port for requests of clients to use.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_ADDRESS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_ADDRESS+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-user]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-user[[.line-through]#`+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-user+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-user+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `proxy-configuration-name` with the Quarkus Proxy Registry instead._
+
+Proxy username, equivalent to the http.proxy or https.proxy JVM settings.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_USER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-password]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-password[[.line-through]#`+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-password+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-password+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `proxy-configuration-name` with the Quarkus Proxy Registry instead._
+
+Proxy password, equivalent to the http.proxyPassword or https.proxyPassword JVM settings.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-non-proxy-hosts]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-non-proxy-hosts[[.line-through]#`+++quarkus.langchain4j.bedrock.embedding-model.client.non-proxy-hosts+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.embedding-model.client.non-proxy-hosts+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `proxy-configuration-name` with the Quarkus Proxy Registry instead._
+
+Hosts to access without proxy, similar to the http.nonProxyHosts or https.nonProxyHosts JVM settings. Please note that unlike the JVM settings, this property is empty by default.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_NON_PROXY_HOSTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_NON_PROXY_HOSTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
 h|[[quarkus-langchain4j-bedrock_section_quarkus-langchain4j-bedrock]] [.section-name.section-level0]##link:#quarkus-langchain4j-bedrock_section_quarkus-langchain4j-bedrock[Named model config]##
 h|Type
 h|Default
@@ -2377,85 +2485,29 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-langchain4j-bedrock_quarkus-langchain4j[icon:question-circle[title=More information about the Duration format]]
 |`+++10s+++`
 
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-client-proxy-address]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-client-proxy-address[`+++quarkus.langchain4j.bedrock."model-name".client.proxy-address+++`]##
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-client-proxy-configuration-name]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-client-proxy-configuration-name[`+++quarkus.langchain4j.bedrock."model-name".client.proxy-configuration-name+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".client.proxy-address+++[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".client.proxy-configuration-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-A string value in the form of `:` that specifies the HTTP proxy server hostname (or IP address) and port for requests of clients to use.
+The name of the proxy configuration to use, as registered in the Quarkus Proxy Registry.
+
+Precedence rules:
+
+ - If set, it takes precedence over the deprecated `proxy-address`, `proxy-user`, `proxy-password` and `non-proxy-hosts` properties, which are ignored.
+ - If not set and a default proxy configuration is configured (`quarkus.proxy.++*++`), then that one is used.
+ - If set, the configuration from `quarkus.proxy.<name>.++*++` is used.
+ - If set but no proxy configuration is found with that name, an error is thrown at runtime.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CLIENT_PROXY_ADDRESS+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CLIENT_PROXY_CONFIGURATION_NAME+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CLIENT_PROXY_ADDRESS+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-client-proxy-user]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-client-proxy-user[`+++quarkus.langchain4j.bedrock."model-name".client.proxy-user+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".client.proxy-user+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy username, equivalent to the http.proxy or https.proxy JVM settings.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CLIENT_PROXY_USER+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CLIENT_PROXY_USER+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-client-proxy-password]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-client-proxy-password[`+++quarkus.langchain4j.bedrock."model-name".client.proxy-password+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".client.proxy-password+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy password, equivalent to the http.proxyPassword or https.proxyPassword JVM settings.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CLIENT_PROXY_PASSWORD+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CLIENT_PROXY_PASSWORD+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-client-non-proxy-hosts]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-client-non-proxy-hosts[`+++quarkus.langchain4j.bedrock."model-name".client.non-proxy-hosts+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".client.non-proxy-hosts+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Hosts to access without proxy, similar to the http.nonProxyHosts or https.nonProxyHosts JVM settings. Please note that unlike the JVM settings, this property is empty by default.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CLIENT_NON_PROXY_HOSTS+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CLIENT_NON_PROXY_HOSTS+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CLIENT_PROXY_CONFIGURATION_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
@@ -3101,85 +3153,29 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-langchain4j-bedrock_quarkus-langchain4j[icon:question-circle[title=More information about the Duration format]]
 |`+++10s+++`
 
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-chat-model-client-proxy-address]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-chat-model-client-proxy-address[`+++quarkus.langchain4j.bedrock."model-name".chat-model.client.proxy-address+++`]##
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-chat-model-client-proxy-configuration-name]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-chat-model-client-proxy-configuration-name[`+++quarkus.langchain4j.bedrock."model-name".chat-model.client.proxy-configuration-name+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".chat-model.client.proxy-address+++[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".chat-model.client.proxy-configuration-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-A string value in the form of `:` that specifies the HTTP proxy server hostname (or IP address) and port for requests of clients to use.
+The name of the proxy configuration to use, as registered in the Quarkus Proxy Registry.
+
+Precedence rules:
+
+ - If set, it takes precedence over the deprecated `proxy-address`, `proxy-user`, `proxy-password` and `non-proxy-hosts` properties, which are ignored.
+ - If not set and a default proxy configuration is configured (`quarkus.proxy.++*++`), then that one is used.
+ - If set, the configuration from `quarkus.proxy.<name>.++*++` is used.
+ - If set but no proxy configuration is found with that name, an error is thrown at runtime.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CHAT_MODEL_CLIENT_PROXY_ADDRESS+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CHAT_MODEL_CLIENT_PROXY_CONFIGURATION_NAME+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CHAT_MODEL_CLIENT_PROXY_ADDRESS+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-chat-model-client-proxy-user]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-chat-model-client-proxy-user[`+++quarkus.langchain4j.bedrock."model-name".chat-model.client.proxy-user+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".chat-model.client.proxy-user+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy username, equivalent to the http.proxy or https.proxy JVM settings.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CHAT_MODEL_CLIENT_PROXY_USER+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CHAT_MODEL_CLIENT_PROXY_USER+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-chat-model-client-proxy-password]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-chat-model-client-proxy-password[`+++quarkus.langchain4j.bedrock."model-name".chat-model.client.proxy-password+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".chat-model.client.proxy-password+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy password, equivalent to the http.proxyPassword or https.proxyPassword JVM settings.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CHAT_MODEL_CLIENT_PROXY_PASSWORD+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CHAT_MODEL_CLIENT_PROXY_PASSWORD+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-chat-model-client-non-proxy-hosts]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-chat-model-client-non-proxy-hosts[`+++quarkus.langchain4j.bedrock."model-name".chat-model.client.non-proxy-hosts+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".chat-model.client.non-proxy-hosts+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Hosts to access without proxy, similar to the http.nonProxyHosts or https.nonProxyHosts JVM settings. Please note that unlike the JVM settings, this property is empty by default.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CHAT_MODEL_CLIENT_NON_PROXY_HOSTS+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CHAT_MODEL_CLIENT_NON_PROXY_HOSTS+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CHAT_MODEL_CLIENT_PROXY_CONFIGURATION_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
@@ -3880,85 +3876,29 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-langchain4j-bedrock_quarkus-langchain4j[icon:question-circle[title=More information about the Duration format]]
 |`+++10s+++`
 
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-embedding-model-client-proxy-address]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-embedding-model-client-proxy-address[`+++quarkus.langchain4j.bedrock."model-name".embedding-model.client.proxy-address+++`]##
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-embedding-model-client-proxy-configuration-name]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-embedding-model-client-proxy-configuration-name[`+++quarkus.langchain4j.bedrock."model-name".embedding-model.client.proxy-configuration-name+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".embedding-model.client.proxy-address+++[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".embedding-model.client.proxy-configuration-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-A string value in the form of `:` that specifies the HTTP proxy server hostname (or IP address) and port for requests of clients to use.
+The name of the proxy configuration to use, as registered in the Quarkus Proxy Registry.
+
+Precedence rules:
+
+ - If set, it takes precedence over the deprecated `proxy-address`, `proxy-user`, `proxy-password` and `non-proxy-hosts` properties, which are ignored.
+ - If not set and a default proxy configuration is configured (`quarkus.proxy.++*++`), then that one is used.
+ - If set, the configuration from `quarkus.proxy.<name>.++*++` is used.
+ - If set but no proxy configuration is found with that name, an error is thrown at runtime.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__EMBEDDING_MODEL_CLIENT_PROXY_ADDRESS+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__EMBEDDING_MODEL_CLIENT_PROXY_CONFIGURATION_NAME+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__EMBEDDING_MODEL_CLIENT_PROXY_ADDRESS+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-embedding-model-client-proxy-user]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-embedding-model-client-proxy-user[`+++quarkus.langchain4j.bedrock."model-name".embedding-model.client.proxy-user+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".embedding-model.client.proxy-user+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy username, equivalent to the http.proxy or https.proxy JVM settings.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__EMBEDDING_MODEL_CLIENT_PROXY_USER+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__EMBEDDING_MODEL_CLIENT_PROXY_USER+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-embedding-model-client-proxy-password]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-embedding-model-client-proxy-password[`+++quarkus.langchain4j.bedrock."model-name".embedding-model.client.proxy-password+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".embedding-model.client.proxy-password+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy password, equivalent to the http.proxyPassword or https.proxyPassword JVM settings.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__EMBEDDING_MODEL_CLIENT_PROXY_PASSWORD+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__EMBEDDING_MODEL_CLIENT_PROXY_PASSWORD+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-embedding-model-client-non-proxy-hosts]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-embedding-model-client-non-proxy-hosts[`+++quarkus.langchain4j.bedrock."model-name".embedding-model.client.non-proxy-hosts+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".embedding-model.client.non-proxy-hosts+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Hosts to access without proxy, similar to the http.nonProxyHosts or https.nonProxyHosts JVM settings. Please note that unlike the JVM settings, this property is empty by default.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__EMBEDDING_MODEL_CLIENT_NON_PROXY_HOSTS+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__EMBEDDING_MODEL_CLIENT_NON_PROXY_HOSTS+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__EMBEDDING_MODEL_CLIENT_PROXY_CONFIGURATION_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-bedrock_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-bedrock_quarkus.langchain4j.adoc
@@ -280,85 +280,29 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-langchain4j-bedrock_quarkus-langchain4j[icon:question-circle[title=More information about the Duration format]]
 |`+++10s+++`
 
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-address]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-address[`+++quarkus.langchain4j.bedrock.client.proxy-address+++`]##
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-configuration-name]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-configuration-name[`+++quarkus.langchain4j.bedrock.client.proxy-configuration-name+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock.client.proxy-address+++[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.client.proxy-configuration-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-A string value in the form of `:` that specifies the HTTP proxy server hostname (or IP address) and port for requests of clients to use.
+The name of the proxy configuration to use, as registered in the Quarkus Proxy Registry.
+
+Precedence rules:
+
+ - If set, it takes precedence over the deprecated `proxy-address`, `proxy-user`, `proxy-password` and `non-proxy-hosts` properties, which are ignored.
+ - If not set and a default proxy configuration is configured (`quarkus.proxy.++*++`), then that one is used.
+ - If set, the configuration from `quarkus.proxy.<name>.++*++` is used.
+ - If set but no proxy configuration is found with that name, an error is thrown at runtime.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_ADDRESS+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_CONFIGURATION_NAME+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_ADDRESS+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-user]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-user[`+++quarkus.langchain4j.bedrock.client.proxy-user+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock.client.proxy-user+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy username, equivalent to the http.proxy or https.proxy JVM settings.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_USER+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_USER+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-password]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-password[`+++quarkus.langchain4j.bedrock.client.proxy-password+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock.client.proxy-password+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy password, equivalent to the http.proxyPassword or https.proxyPassword JVM settings.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_PASSWORD+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_PASSWORD+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-non-proxy-hosts]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-non-proxy-hosts[`+++quarkus.langchain4j.bedrock.client.non-proxy-hosts+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock.client.non-proxy-hosts+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Hosts to access without proxy, similar to the http.nonProxyHosts or https.nonProxyHosts JVM settings. Please note that unlike the JVM settings, this property is empty by default.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_NON_PROXY_HOSTS+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_NON_PROXY_HOSTS+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_CONFIGURATION_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
@@ -1004,85 +948,29 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-langchain4j-bedrock_quarkus-langchain4j[icon:question-circle[title=More information about the Duration format]]
 |`+++10s+++`
 
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-address]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-address[`+++quarkus.langchain4j.bedrock.chat-model.client.proxy-address+++`]##
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-configuration-name]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-configuration-name[`+++quarkus.langchain4j.bedrock.chat-model.client.proxy-configuration-name+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock.chat-model.client.proxy-address+++[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.chat-model.client.proxy-configuration-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-A string value in the form of `:` that specifies the HTTP proxy server hostname (or IP address) and port for requests of clients to use.
+The name of the proxy configuration to use, as registered in the Quarkus Proxy Registry.
+
+Precedence rules:
+
+ - If set, it takes precedence over the deprecated `proxy-address`, `proxy-user`, `proxy-password` and `non-proxy-hosts` properties, which are ignored.
+ - If not set and a default proxy configuration is configured (`quarkus.proxy.++*++`), then that one is used.
+ - If set, the configuration from `quarkus.proxy.<name>.++*++` is used.
+ - If set but no proxy configuration is found with that name, an error is thrown at runtime.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_ADDRESS+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_CONFIGURATION_NAME+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_ADDRESS+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-user]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-user[`+++quarkus.langchain4j.bedrock.chat-model.client.proxy-user+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock.chat-model.client.proxy-user+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy username, equivalent to the http.proxy or https.proxy JVM settings.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_USER+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_USER+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-password]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-password[`+++quarkus.langchain4j.bedrock.chat-model.client.proxy-password+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock.chat-model.client.proxy-password+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy password, equivalent to the http.proxyPassword or https.proxyPassword JVM settings.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_PASSWORD+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_PASSWORD+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-non-proxy-hosts]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-non-proxy-hosts[`+++quarkus.langchain4j.bedrock.chat-model.client.non-proxy-hosts+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock.chat-model.client.non-proxy-hosts+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Hosts to access without proxy, similar to the http.nonProxyHosts or https.nonProxyHosts JVM settings. Please note that unlike the JVM settings, this property is empty by default.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_NON_PROXY_HOSTS+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_NON_PROXY_HOSTS+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_CONFIGURATION_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
@@ -1783,85 +1671,29 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-langchain4j-bedrock_quarkus-langchain4j[icon:question-circle[title=More information about the Duration format]]
 |`+++10s+++`
 
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-address]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-address[`+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-address+++`]##
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-configuration-name]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-configuration-name[`+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-configuration-name+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-address+++[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-configuration-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-A string value in the form of `:` that specifies the HTTP proxy server hostname (or IP address) and port for requests of clients to use.
+The name of the proxy configuration to use, as registered in the Quarkus Proxy Registry.
+
+Precedence rules:
+
+ - If set, it takes precedence over the deprecated `proxy-address`, `proxy-user`, `proxy-password` and `non-proxy-hosts` properties, which are ignored.
+ - If not set and a default proxy configuration is configured (`quarkus.proxy.++*++`), then that one is used.
+ - If set, the configuration from `quarkus.proxy.<name>.++*++` is used.
+ - If set but no proxy configuration is found with that name, an error is thrown at runtime.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_ADDRESS+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_CONFIGURATION_NAME+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_ADDRESS+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-user]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-user[`+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-user+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-user+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy username, equivalent to the http.proxy or https.proxy JVM settings.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_USER+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_USER+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-password]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-password[`+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-password+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-password+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy password, equivalent to the http.proxyPassword or https.proxyPassword JVM settings.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_PASSWORD+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_PASSWORD+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-non-proxy-hosts]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-non-proxy-hosts[`+++quarkus.langchain4j.bedrock.embedding-model.client.non-proxy-hosts+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock.embedding-model.client.non-proxy-hosts+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Hosts to access without proxy, similar to the http.nonProxyHosts or https.nonProxyHosts JVM settings. Please note that unlike the JVM settings, this property is empty by default.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_NON_PROXY_HOSTS+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_NON_PROXY_HOSTS+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_CONFIGURATION_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
@@ -2142,6 +1974,282 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-address]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-address[[.line-through]#`+++quarkus.langchain4j.bedrock.client.proxy-address+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.client.proxy-address+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `proxy-configuration-name` with the Quarkus Proxy Registry instead._
+
+A string value in the form of `:` that specifies the HTTP proxy server hostname (or IP address) and port for requests of clients to use.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_ADDRESS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_ADDRESS+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-user]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-user[[.line-through]#`+++quarkus.langchain4j.bedrock.client.proxy-user+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.client.proxy-user+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `proxy-configuration-name` with the Quarkus Proxy Registry instead._
+
+Proxy username, equivalent to the http.proxy or https.proxy JVM settings.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_USER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-password]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-proxy-password[[.line-through]#`+++quarkus.langchain4j.bedrock.client.proxy-password+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.client.proxy-password+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `proxy-configuration-name` with the Quarkus Proxy Registry instead._
+
+Proxy password, equivalent to the http.proxyPassword or https.proxyPassword JVM settings.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_PROXY_PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-non-proxy-hosts]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-client-non-proxy-hosts[[.line-through]#`+++quarkus.langchain4j.bedrock.client.non-proxy-hosts+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.client.non-proxy-hosts+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `proxy-configuration-name` with the Quarkus Proxy Registry instead._
+
+Hosts to access without proxy, similar to the http.nonProxyHosts or https.nonProxyHosts JVM settings. Please note that unlike the JVM settings, this property is empty by default.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_NON_PROXY_HOSTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CLIENT_NON_PROXY_HOSTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-address]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-address[[.line-through]#`+++quarkus.langchain4j.bedrock.chat-model.client.proxy-address+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.chat-model.client.proxy-address+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `proxy-configuration-name` with the Quarkus Proxy Registry instead._
+
+A string value in the form of `:` that specifies the HTTP proxy server hostname (or IP address) and port for requests of clients to use.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_ADDRESS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_ADDRESS+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-user]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-user[[.line-through]#`+++quarkus.langchain4j.bedrock.chat-model.client.proxy-user+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.chat-model.client.proxy-user+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `proxy-configuration-name` with the Quarkus Proxy Registry instead._
+
+Proxy username, equivalent to the http.proxy or https.proxy JVM settings.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_USER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-password]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-proxy-password[[.line-through]#`+++quarkus.langchain4j.bedrock.chat-model.client.proxy-password+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.chat-model.client.proxy-password+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `proxy-configuration-name` with the Quarkus Proxy Registry instead._
+
+Proxy password, equivalent to the http.proxyPassword or https.proxyPassword JVM settings.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_PROXY_PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-non-proxy-hosts]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-chat-model-client-non-proxy-hosts[[.line-through]#`+++quarkus.langchain4j.bedrock.chat-model.client.non-proxy-hosts+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.chat-model.client.non-proxy-hosts+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `proxy-configuration-name` with the Quarkus Proxy Registry instead._
+
+Hosts to access without proxy, similar to the http.nonProxyHosts or https.nonProxyHosts JVM settings. Please note that unlike the JVM settings, this property is empty by default.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_NON_PROXY_HOSTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_CHAT_MODEL_CLIENT_NON_PROXY_HOSTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-address]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-address[[.line-through]#`+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-address+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-address+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `proxy-configuration-name` with the Quarkus Proxy Registry instead._
+
+A string value in the form of `:` that specifies the HTTP proxy server hostname (or IP address) and port for requests of clients to use.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_ADDRESS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_ADDRESS+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-user]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-user[[.line-through]#`+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-user+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-user+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `proxy-configuration-name` with the Quarkus Proxy Registry instead._
+
+Proxy username, equivalent to the http.proxy or https.proxy JVM settings.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_USER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-password]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-proxy-password[[.line-through]#`+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-password+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.embedding-model.client.proxy-password+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `proxy-configuration-name` with the Quarkus Proxy Registry instead._
+
+Proxy password, equivalent to the http.proxyPassword or https.proxyPassword JVM settings.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_PROXY_PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-non-proxy-hosts]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-embedding-model-client-non-proxy-hosts[[.line-through]#`+++quarkus.langchain4j.bedrock.embedding-model.client.non-proxy-hosts+++`#]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock.embedding-model.client.non-proxy-hosts+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+_This property is deprecated: Use `proxy-configuration-name` with the Quarkus Proxy Registry instead._
+
+Hosts to access without proxy, similar to the http.nonProxyHosts or https.nonProxyHosts JVM settings. Please note that unlike the JVM settings, this property is empty by default.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_NON_PROXY_HOSTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK_EMBEDDING_MODEL_CLIENT_NON_PROXY_HOSTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
 h|[[quarkus-langchain4j-bedrock_section_quarkus-langchain4j-bedrock]] [.section-name.section-level0]##link:#quarkus-langchain4j-bedrock_section_quarkus-langchain4j-bedrock[Named model config]##
 h|Type
 h|Default
@@ -2377,85 +2485,29 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-langchain4j-bedrock_quarkus-langchain4j[icon:question-circle[title=More information about the Duration format]]
 |`+++10s+++`
 
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-client-proxy-address]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-client-proxy-address[`+++quarkus.langchain4j.bedrock."model-name".client.proxy-address+++`]##
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-client-proxy-configuration-name]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-client-proxy-configuration-name[`+++quarkus.langchain4j.bedrock."model-name".client.proxy-configuration-name+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".client.proxy-address+++[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".client.proxy-configuration-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-A string value in the form of `:` that specifies the HTTP proxy server hostname (or IP address) and port for requests of clients to use.
+The name of the proxy configuration to use, as registered in the Quarkus Proxy Registry.
+
+Precedence rules:
+
+ - If set, it takes precedence over the deprecated `proxy-address`, `proxy-user`, `proxy-password` and `non-proxy-hosts` properties, which are ignored.
+ - If not set and a default proxy configuration is configured (`quarkus.proxy.++*++`), then that one is used.
+ - If set, the configuration from `quarkus.proxy.<name>.++*++` is used.
+ - If set but no proxy configuration is found with that name, an error is thrown at runtime.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CLIENT_PROXY_ADDRESS+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CLIENT_PROXY_CONFIGURATION_NAME+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CLIENT_PROXY_ADDRESS+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-client-proxy-user]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-client-proxy-user[`+++quarkus.langchain4j.bedrock."model-name".client.proxy-user+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".client.proxy-user+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy username, equivalent to the http.proxy or https.proxy JVM settings.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CLIENT_PROXY_USER+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CLIENT_PROXY_USER+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-client-proxy-password]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-client-proxy-password[`+++quarkus.langchain4j.bedrock."model-name".client.proxy-password+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".client.proxy-password+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy password, equivalent to the http.proxyPassword or https.proxyPassword JVM settings.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CLIENT_PROXY_PASSWORD+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CLIENT_PROXY_PASSWORD+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-client-non-proxy-hosts]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-client-non-proxy-hosts[`+++quarkus.langchain4j.bedrock."model-name".client.non-proxy-hosts+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".client.non-proxy-hosts+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Hosts to access without proxy, similar to the http.nonProxyHosts or https.nonProxyHosts JVM settings. Please note that unlike the JVM settings, this property is empty by default.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CLIENT_NON_PROXY_HOSTS+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CLIENT_NON_PROXY_HOSTS+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CLIENT_PROXY_CONFIGURATION_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
@@ -3101,85 +3153,29 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-langchain4j-bedrock_quarkus-langchain4j[icon:question-circle[title=More information about the Duration format]]
 |`+++10s+++`
 
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-chat-model-client-proxy-address]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-chat-model-client-proxy-address[`+++quarkus.langchain4j.bedrock."model-name".chat-model.client.proxy-address+++`]##
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-chat-model-client-proxy-configuration-name]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-chat-model-client-proxy-configuration-name[`+++quarkus.langchain4j.bedrock."model-name".chat-model.client.proxy-configuration-name+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".chat-model.client.proxy-address+++[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".chat-model.client.proxy-configuration-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-A string value in the form of `:` that specifies the HTTP proxy server hostname (or IP address) and port for requests of clients to use.
+The name of the proxy configuration to use, as registered in the Quarkus Proxy Registry.
+
+Precedence rules:
+
+ - If set, it takes precedence over the deprecated `proxy-address`, `proxy-user`, `proxy-password` and `non-proxy-hosts` properties, which are ignored.
+ - If not set and a default proxy configuration is configured (`quarkus.proxy.++*++`), then that one is used.
+ - If set, the configuration from `quarkus.proxy.<name>.++*++` is used.
+ - If set but no proxy configuration is found with that name, an error is thrown at runtime.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CHAT_MODEL_CLIENT_PROXY_ADDRESS+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CHAT_MODEL_CLIENT_PROXY_CONFIGURATION_NAME+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CHAT_MODEL_CLIENT_PROXY_ADDRESS+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-chat-model-client-proxy-user]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-chat-model-client-proxy-user[`+++quarkus.langchain4j.bedrock."model-name".chat-model.client.proxy-user+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".chat-model.client.proxy-user+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy username, equivalent to the http.proxy or https.proxy JVM settings.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CHAT_MODEL_CLIENT_PROXY_USER+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CHAT_MODEL_CLIENT_PROXY_USER+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-chat-model-client-proxy-password]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-chat-model-client-proxy-password[`+++quarkus.langchain4j.bedrock."model-name".chat-model.client.proxy-password+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".chat-model.client.proxy-password+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy password, equivalent to the http.proxyPassword or https.proxyPassword JVM settings.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CHAT_MODEL_CLIENT_PROXY_PASSWORD+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CHAT_MODEL_CLIENT_PROXY_PASSWORD+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-chat-model-client-non-proxy-hosts]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-chat-model-client-non-proxy-hosts[`+++quarkus.langchain4j.bedrock."model-name".chat-model.client.non-proxy-hosts+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".chat-model.client.non-proxy-hosts+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Hosts to access without proxy, similar to the http.nonProxyHosts or https.nonProxyHosts JVM settings. Please note that unlike the JVM settings, this property is empty by default.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CHAT_MODEL_CLIENT_NON_PROXY_HOSTS+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CHAT_MODEL_CLIENT_NON_PROXY_HOSTS+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__CHAT_MODEL_CLIENT_PROXY_CONFIGURATION_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
@@ -3880,85 +3876,29 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-langchain4j-bedrock_quarkus-langchain4j[icon:question-circle[title=More information about the Duration format]]
 |`+++10s+++`
 
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-embedding-model-client-proxy-address]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-embedding-model-client-proxy-address[`+++quarkus.langchain4j.bedrock."model-name".embedding-model.client.proxy-address+++`]##
+a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-embedding-model-client-proxy-configuration-name]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-embedding-model-client-proxy-configuration-name[`+++quarkus.langchain4j.bedrock."model-name".embedding-model.client.proxy-configuration-name+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".embedding-model.client.proxy-address+++[]
+config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".embedding-model.client.proxy-configuration-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
 [.description]
 --
-A string value in the form of `:` that specifies the HTTP proxy server hostname (or IP address) and port for requests of clients to use.
+The name of the proxy configuration to use, as registered in the Quarkus Proxy Registry.
+
+Precedence rules:
+
+ - If set, it takes precedence over the deprecated `proxy-address`, `proxy-user`, `proxy-password` and `non-proxy-hosts` properties, which are ignored.
+ - If not set and a default proxy configuration is configured (`quarkus.proxy.++*++`), then that one is used.
+ - If set, the configuration from `quarkus.proxy.<name>.++*++` is used.
+ - If set but no proxy configuration is found with that name, an error is thrown at runtime.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__EMBEDDING_MODEL_CLIENT_PROXY_ADDRESS+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__EMBEDDING_MODEL_CLIENT_PROXY_CONFIGURATION_NAME+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__EMBEDDING_MODEL_CLIENT_PROXY_ADDRESS+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-embedding-model-client-proxy-user]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-embedding-model-client-proxy-user[`+++quarkus.langchain4j.bedrock."model-name".embedding-model.client.proxy-user+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".embedding-model.client.proxy-user+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy username, equivalent to the http.proxy or https.proxy JVM settings.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__EMBEDDING_MODEL_CLIENT_PROXY_USER+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__EMBEDDING_MODEL_CLIENT_PROXY_USER+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-embedding-model-client-proxy-password]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-embedding-model-client-proxy-password[`+++quarkus.langchain4j.bedrock."model-name".embedding-model.client.proxy-password+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".embedding-model.client.proxy-password+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Proxy password, equivalent to the http.proxyPassword or https.proxyPassword JVM settings.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__EMBEDDING_MODEL_CLIENT_PROXY_PASSWORD+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__EMBEDDING_MODEL_CLIENT_PROXY_PASSWORD+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a| [[quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-embedding-model-client-non-proxy-hosts]] [.property-path]##link:#quarkus-langchain4j-bedrock_quarkus-langchain4j-bedrock-model-name-embedding-model-client-non-proxy-hosts[`+++quarkus.langchain4j.bedrock."model-name".embedding-model.client.non-proxy-hosts+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.bedrock."model-name".embedding-model.client.non-proxy-hosts+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Hosts to access without proxy, similar to the http.nonProxyHosts or https.nonProxyHosts JVM settings. Please note that unlike the JVM settings, this property is empty by default.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__EMBEDDING_MODEL_CLIENT_NON_PROXY_HOSTS+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__EMBEDDING_MODEL_CLIENT_NON_PROXY_HOSTS+++`
+Environment variable: `+++QUARKUS_LANGCHAIN4J_BEDROCK__MODEL_NAME__EMBEDDING_MODEL_CLIENT_PROXY_CONFIGURATION_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string

--- a/model-providers/bedrock/deployment/src/main/java/io/quarkiverse/langchain4j/bedrock/deployment/BedrockProcessor.java
+++ b/model-providers/bedrock/deployment/src/main/java/io/quarkiverse/langchain4j/bedrock/deployment/BedrockProcessor.java
@@ -34,6 +34,7 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
+import io.quarkus.proxy.ProxyConfigurationRegistry;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
 import io.smallrye.config.ConfigSourceInterceptor;
 
@@ -93,6 +94,7 @@ public class BedrockProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
+                        .addInjectionPoint(Type.create(ProxyConfigurationRegistry.class))
                         .addInjectionPoint(ParameterizedType.create(
                                 DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
@@ -111,6 +113,7 @@ public class BedrockProcessor {
                         .setRuntimeInit()
                         .defaultBean()
                         .scope(ApplicationScoped.class)
+                        .addInjectionPoint(Type.create(ProxyConfigurationRegistry.class))
                         .addInjectionPoint(ParameterizedType.create(
                                 DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
@@ -133,6 +136,7 @@ public class BedrockProcessor {
                         .defaultBean()
                         .unremovable()
                         .scope(ApplicationScoped.class)
+                        .addInjectionPoint(Type.create(ProxyConfigurationRegistry.class))
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
                                         new Type[] { ClassType.create(BEDROCK_COHERE_EMBEDDING_MODEL_BUILDER) }, null) },

--- a/model-providers/bedrock/deployment/src/test/java/io/quarkiverse/langchain4j/bedrock/deployment/proxy/BedrockDefaultProxyRegistryTest.java
+++ b/model-providers/bedrock/deployment/src/test/java/io/quarkiverse/langchain4j/bedrock/deployment/proxy/BedrockDefaultProxyRegistryTest.java
@@ -1,0 +1,77 @@
+package io.quarkiverse.langchain4j.bedrock.deployment.proxy;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.quarkiverse.langchain4j.bedrock.deployment.BedrockTestBase;
+import io.quarkiverse.langchain4j.bedrock.deployment.TestCredentialsProvider;
+import io.quarkus.test.QuarkusUnitTest;
+
+class BedrockDefaultProxyRegistryTest extends BedrockTestBase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(TestCredentialsProvider.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bedrock.chat-model.model-id", "amazon.titan-text-express-v1")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bedrock.chat-model.aws.region", "eu-central-1")
+            // Nothing listens on this port: the request can only succeed when routed through the proxy.
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bedrock.chat-model.aws.endpoint-override",
+                    "http://localhost:18299")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bedrock.chat-model.aws.credentials-provider",
+                    "TestCredentialsProvider")
+            .overrideRuntimeConfigKey("quarkus.proxy.host", "localhost")
+            .overrideRuntimeConfigKey("quarkus.proxy.port", String.valueOf(WM_PORT));
+
+    @Inject
+    ChatModel chatModel;
+
+    @Test
+    void should_route_request_through_default_proxy() {
+        stubFor(post(anyUrl())
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {
+                                  "output": {
+                                    "message": {
+                                      "role": "assistant",
+                                      "content": [
+                                        {
+                                          "text": "Routed through proxy"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "stopReason": "end_turn",
+                                  "usage": {
+                                    "inputTokens": 5,
+                                    "outputTokens": 3,
+                                    "totalTokens": 8
+                                  },
+                                  "metrics": {
+                                    "latencyMs": 1
+                                  }
+                                }
+                                """)));
+
+        var response = chatModel.chat("Hello");
+
+        assertThat(response).isEqualTo("Routed through proxy");
+        verify(postRequestedFor(anyUrl()));
+    }
+}

--- a/model-providers/bedrock/deployment/src/test/java/io/quarkiverse/langchain4j/bedrock/deployment/proxy/BedrockDeprecatedProxyAddressTest.java
+++ b/model-providers/bedrock/deployment/src/test/java/io/quarkiverse/langchain4j/bedrock/deployment/proxy/BedrockDeprecatedProxyAddressTest.java
@@ -1,0 +1,86 @@
+package io.quarkiverse.langchain4j.bedrock.deployment.proxy;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.logging.LogRecord;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.quarkiverse.langchain4j.bedrock.deployment.BedrockTestBase;
+import io.quarkiverse.langchain4j.bedrock.deployment.TestCredentialsProvider;
+import io.quarkus.test.QuarkusUnitTest;
+
+class BedrockDeprecatedProxyAddressTest extends BedrockTestBase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(TestCredentialsProvider.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bedrock.chat-model.model-id", "amazon.titan-text-express-v1")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bedrock.chat-model.aws.region", "eu-central-1")
+            // Nothing listens on this port: the request can only succeed through the proxy.
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bedrock.chat-model.aws.endpoint-override",
+                    "http://localhost:18299")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bedrock.chat-model.aws.credentials-provider",
+                    "TestCredentialsProvider")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bedrock.client.proxy-address", "localhost:" + WM_PORT)
+            .setLogRecordPredicate(record -> true)
+            .assertLogRecords(BedrockDeprecatedProxyAddressTest::verifyDeprecationWarning);
+
+    private static void verifyDeprecationWarning(List<LogRecord> logRecords) {
+        assertThat(logRecords.stream().map(LogRecord::getMessage))
+                .anyMatch(message -> message.contains("Using the deprecated 'proxy-address' configuration"));
+    }
+
+    @Inject
+    ChatModel chatModel;
+
+    @Test
+    void should_route_through_deprecated_proxy_address() {
+        stubFor(post(anyUrl())
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {
+                                  "output": {
+                                    "message": {
+                                      "role": "assistant",
+                                      "content": [
+                                        {
+                                          "text": "Routed through proxy"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "stopReason": "end_turn",
+                                  "usage": {
+                                    "inputTokens": 5,
+                                    "outputTokens": 3,
+                                    "totalTokens": 8
+                                  },
+                                  "metrics": {
+                                    "latencyMs": 1
+                                  }
+                                }
+                                """)));
+
+        var response = chatModel.chat("Hello");
+
+        assertThat(response).isEqualTo("Routed through proxy");
+        verify(postRequestedFor(anyUrl()));
+    }
+}

--- a/model-providers/bedrock/deployment/src/test/java/io/quarkiverse/langchain4j/bedrock/deployment/proxy/BedrockNamedProxyRegistryTest.java
+++ b/model-providers/bedrock/deployment/src/test/java/io/quarkiverse/langchain4j/bedrock/deployment/proxy/BedrockNamedProxyRegistryTest.java
@@ -1,0 +1,78 @@
+package io.quarkiverse.langchain4j.bedrock.deployment.proxy;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.quarkiverse.langchain4j.bedrock.deployment.BedrockTestBase;
+import io.quarkiverse.langchain4j.bedrock.deployment.TestCredentialsProvider;
+import io.quarkus.test.QuarkusUnitTest;
+
+class BedrockNamedProxyRegistryTest extends BedrockTestBase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(TestCredentialsProvider.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bedrock.chat-model.model-id", "amazon.titan-text-express-v1")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bedrock.chat-model.aws.region", "eu-central-1")
+            // Nothing listens on this port: the request can only succeed when routed through the proxy.
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bedrock.chat-model.aws.endpoint-override",
+                    "http://localhost:18299")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bedrock.chat-model.aws.credentials-provider",
+                    "TestCredentialsProvider")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bedrock.client.proxy-configuration-name", "local")
+            .overrideRuntimeConfigKey("quarkus.proxy.local.host", "localhost")
+            .overrideRuntimeConfigKey("quarkus.proxy.local.port", String.valueOf(WM_PORT));
+
+    @Inject
+    ChatModel chatModel;
+
+    @Test
+    void should_route_request_through_named_proxy() {
+        stubFor(post(anyUrl())
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {
+                                  "output": {
+                                    "message": {
+                                      "role": "assistant",
+                                      "content": [
+                                        {
+                                          "text": "Routed through named proxy"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "stopReason": "end_turn",
+                                  "usage": {
+                                    "inputTokens": 5,
+                                    "outputTokens": 4,
+                                    "totalTokens": 9
+                                  },
+                                  "metrics": {
+                                    "latencyMs": 1
+                                  }
+                                }
+                                """)));
+
+        var response = chatModel.chat("Hello");
+
+        assertThat(response).isEqualTo("Routed through named proxy");
+        verify(postRequestedFor(anyUrl()));
+    }
+}

--- a/model-providers/bedrock/deployment/src/test/java/io/quarkiverse/langchain4j/bedrock/deployment/proxy/BedrockProxyConfigurationNameMissingTest.java
+++ b/model-providers/bedrock/deployment/src/test/java/io/quarkiverse/langchain4j/bedrock/deployment/proxy/BedrockProxyConfigurationNameMissingTest.java
@@ -1,0 +1,36 @@
+package io.quarkiverse.langchain4j.bedrock.deployment.proxy;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.quarkiverse.langchain4j.bedrock.deployment.TestCredentialsProvider;
+import io.quarkus.test.QuarkusUnitTest;
+
+class BedrockProxyConfigurationNameMissingTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(TestCredentialsProvider.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bedrock.chat-model.aws.region", "eu-central-1")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bedrock.chat-model.aws.credentials-provider",
+                    "TestCredentialsProvider")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bedrock.client.proxy-configuration-name", "missing");
+
+    @Inject
+    ChatModel chatModel;
+
+    @Test
+    void shouldFailWhenNamedProxyIsMissing() {
+        assertThatThrownBy(() -> chatModel.chat("hello"))
+                .hasStackTraceContaining("Proxy configuration with name missing was requested")
+                .hasStackTraceContaining("quarkus.proxy.\"missing\".host is not defined");
+    }
+}

--- a/model-providers/bedrock/deployment/src/test/java/io/quarkiverse/langchain4j/bedrock/deployment/proxy/BedrockProxyNamePrecedenceTest.java
+++ b/model-providers/bedrock/deployment/src/test/java/io/quarkiverse/langchain4j/bedrock/deployment/proxy/BedrockProxyNamePrecedenceTest.java
@@ -1,0 +1,91 @@
+package io.quarkiverse.langchain4j.bedrock.deployment.proxy;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.logging.LogRecord;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.quarkiverse.langchain4j.bedrock.deployment.BedrockTestBase;
+import io.quarkiverse.langchain4j.bedrock.deployment.TestCredentialsProvider;
+import io.quarkus.test.QuarkusUnitTest;
+
+class BedrockProxyNamePrecedenceTest extends BedrockTestBase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(TestCredentialsProvider.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bedrock.chat-model.model-id", "amazon.titan-text-express-v1")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bedrock.chat-model.aws.region", "eu-central-1")
+            // Nothing listens on this port: the request can only succeed through the proxy.
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bedrock.chat-model.aws.endpoint-override",
+                    "http://localhost:18299")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bedrock.chat-model.aws.credentials-provider",
+                    "TestCredentialsProvider")
+            // Named proxy points to WireMock; the deprecated proxy-address points nowhere.
+            // If the request reaches WireMock, the named configuration took precedence.
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bedrock.client.proxy-configuration-name", "local")
+            .overrideRuntimeConfigKey("quarkus.proxy.local.host", "localhost")
+            .overrideRuntimeConfigKey("quarkus.proxy.local.port", String.valueOf(WM_PORT))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.bedrock.client.proxy-address", "localhost:1")
+            .setLogRecordPredicate(record -> true)
+            .assertLogRecords(BedrockProxyNamePrecedenceTest::verifyPrecedenceWarning);
+
+    private static void verifyPrecedenceWarning(List<LogRecord> logRecords) {
+        assertThat(logRecords.stream().map(LogRecord::getMessage))
+                .anyMatch(message -> message.contains("The deprecated proxy properties are ignored"));
+    }
+
+    @Inject
+    ChatModel chatModel;
+
+    @Test
+    void should_prefer_named_proxy_over_deprecated_proxy_address() {
+        stubFor(post(anyUrl())
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {
+                                  "output": {
+                                    "message": {
+                                      "role": "assistant",
+                                      "content": [
+                                        {
+                                          "text": "Routed through named proxy"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "stopReason": "end_turn",
+                                  "usage": {
+                                    "inputTokens": 5,
+                                    "outputTokens": 4,
+                                    "totalTokens": 9
+                                  },
+                                  "metrics": {
+                                    "latencyMs": 1
+                                  }
+                                }
+                                """)));
+
+        var response = chatModel.chat("Hello");
+
+        assertThat(response).isEqualTo("Routed through named proxy");
+        verify(postRequestedFor(anyUrl()));
+    }
+}

--- a/model-providers/bedrock/runtime/src/main/java/io/quarkiverse/langchain4j/bedrock/runtime/BedrockRecorder.java
+++ b/model-providers/bedrock/runtime/src/main/java/io/quarkiverse/langchain4j/bedrock/runtime/BedrockRecorder.java
@@ -38,6 +38,7 @@ import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkiverse.langchain4j.runtime.config.LangChain4jConfig;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.proxy.ProxyConfigurationRegistry;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.vertx.core.Vertx;
@@ -114,10 +115,6 @@ public class BedrockRecorder {
 
             var clientBuilder = BedrockRuntimeClient.builder();
 
-            clientBuilder.httpClient(
-                    BedrockSdkHttpClientFactory.createSync(modelConfig.client(), config.client(),
-                            rootRuntimeConfig.getValue(), vertx));
-
             configureClient(clientBuilder, modelConfig, config);
 
             if (modelConfig.responseFormat().isPresent()) {
@@ -126,13 +123,17 @@ public class BedrockRecorder {
 
             var builder = BedrockChatModel.builder()
                     .modelId(modelConfig.modelId().orElse("us.amazon.nova-lite-v1:0"))
-                    .client(clientBuilder.build())
                     .defaultRequestParameters(paramBuilder.build())
                     .supportedCapabilities(Capability.RESPONSE_FORMAT_JSON_SCHEMA);
 
             return new Function<>() {
                 @Override
                 public ChatModel apply(SyntheticCreationalContext<ChatModel> context) {
+                    ProxyConfigurationRegistry proxyRegistry = context.getInjectedReference(ProxyConfigurationRegistry.class);
+                    clientBuilder.httpClient(
+                            BedrockSdkHttpClientFactory.createSync(modelConfig.client(), config.client(),
+                                    rootRuntimeConfig.getValue(), vertx, proxyRegistry));
+                    builder.client(clientBuilder.build());
                     builder.listeners(context.getInjectedReference(CHAT_MODEL_LISTENER_TYPE_LITERAL).stream()
                             .collect(Collectors.toList()));
                     ModelBuilderCustomizer.applyCustomizers(
@@ -176,10 +177,6 @@ public class BedrockRecorder {
 
             var clientBuilder = BedrockRuntimeAsyncClient.builder();
 
-            clientBuilder.httpClient(
-                    BedrockSdkHttpClientFactory.createAsync(modelConfig.client(), config.client(),
-                            rootRuntimeConfig.getValue(), vertx));
-
             configureClient(clientBuilder, modelConfig, config);
 
             var paramsBuilder = BedrockChatRequestParameters.builder()
@@ -219,13 +216,17 @@ public class BedrockRecorder {
 
             var builder = BedrockStreamingChatModel.builder()
                     .modelId(modelConfig.modelId().orElse("anthropic.claude-v2"))
-                    .client(clientBuilder.build())
                     .defaultRequestParameters(paramsBuilder.build())
                     .supportedCapabilities(Capability.RESPONSE_FORMAT_JSON_SCHEMA);
 
             return new Function<>() {
                 @Override
                 public StreamingChatModel apply(SyntheticCreationalContext<StreamingChatModel> context) {
+                    ProxyConfigurationRegistry proxyRegistry = context.getInjectedReference(ProxyConfigurationRegistry.class);
+                    clientBuilder.httpClient(
+                            BedrockSdkHttpClientFactory.createAsync(modelConfig.client(), config.client(),
+                                    rootRuntimeConfig.getValue(), vertx, proxyRegistry));
+                    builder.client(clientBuilder.build());
                     builder.listeners(context.getInjectedReference(CHAT_MODEL_LISTENER_TYPE_LITERAL).stream()
                             .collect(Collectors.toList()));
                     ModelBuilderCustomizer.applyCustomizers(
@@ -253,10 +254,6 @@ public class BedrockRecorder {
 
             var clientBuilder = BedrockRuntimeClient.builder(); //NOSONAR creds can be specified later
 
-            clientBuilder.httpClient(
-                    BedrockSdkHttpClientFactory.createSync(modelConfig.client(), config.client(),
-                            rootRuntimeConfig.getValue(), vertx));
-
             configureClient(clientBuilder, modelConfig, config);
 
             var modelId = modelConfig.modelId();
@@ -264,8 +261,7 @@ public class BedrockRecorder {
             Function<SyntheticCreationalContext<EmbeddingModel>, EmbeddingModel> function;
             if (modelId.contains("cohere")) {
                 var builder = BedrockCohereEmbeddingModel.builder()
-                        .model(modelId)
-                        .client(clientBuilder.build());
+                        .model(modelId);
 
                 if (modelConfig.cohere().inputType().isPresent()) {
                     builder.inputType(modelConfig.cohere().inputType().get());
@@ -278,6 +274,12 @@ public class BedrockRecorder {
                 function = new Function<>() {
                     @Override
                     public EmbeddingModel apply(SyntheticCreationalContext<EmbeddingModel> context) {
+                        ProxyConfigurationRegistry proxyRegistry = context
+                                .getInjectedReference(ProxyConfigurationRegistry.class);
+                        clientBuilder.httpClient(
+                                BedrockSdkHttpClientFactory.createSync(modelConfig.client(), config.client(),
+                                        rootRuntimeConfig.getValue(), vertx, proxyRegistry));
+                        builder.client(clientBuilder.build());
                         ModelBuilderCustomizer.applyCustomizers(
                                 context.getInjectedReference(COHERE_EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL,
                                         Any.Literal.INSTANCE),
@@ -287,8 +289,7 @@ public class BedrockRecorder {
                 };
             } else {
                 var builder = BedrockTitanEmbeddingModel.builder()
-                        .model(modelId)
-                        .client(clientBuilder.build());
+                        .model(modelId);
 
                 if (modelConfig.titan().dimensions().isPresent()) {
                     builder.dimensions(modelConfig.titan().dimensions().getAsInt());
@@ -301,6 +302,12 @@ public class BedrockRecorder {
                 function = new Function<>() {
                     @Override
                     public EmbeddingModel apply(SyntheticCreationalContext<EmbeddingModel> context) {
+                        ProxyConfigurationRegistry proxyRegistry = context
+                                .getInjectedReference(ProxyConfigurationRegistry.class);
+                        clientBuilder.httpClient(
+                                BedrockSdkHttpClientFactory.createSync(modelConfig.client(), config.client(),
+                                        rootRuntimeConfig.getValue(), vertx, proxyRegistry));
+                        builder.client(clientBuilder.build());
                         ModelBuilderCustomizer.applyCustomizers(
                                 context.getInjectedReference(TITAN_EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL,
                                         Any.Literal.INSTANCE),

--- a/model-providers/bedrock/runtime/src/main/java/io/quarkiverse/langchain4j/bedrock/runtime/BedrockSdkHttpClientFactory.java
+++ b/model-providers/bedrock/runtime/src/main/java/io/quarkiverse/langchain4j/bedrock/runtime/BedrockSdkHttpClientFactory.java
@@ -21,6 +21,8 @@ import io.quarkiverse.langchain4j.bedrock.runtime.client.VertxSdkAsyncHttpClient
 import io.quarkiverse.langchain4j.bedrock.runtime.client.VertxSdkHttpClient;
 import io.quarkiverse.langchain4j.bedrock.runtime.config.HttpClientConfig;
 import io.quarkiverse.langchain4j.runtime.config.LangChain4jConfig;
+import io.quarkus.proxy.ProxyConfiguration;
+import io.quarkus.proxy.ProxyConfigurationRegistry;
 import io.quarkus.tls.TlsConfiguration;
 import io.quarkus.tls.TlsConfigurationRegistry;
 import io.quarkus.tls.runtime.config.TlsConfigUtils;
@@ -42,8 +44,8 @@ final class BedrockSdkHttpClientFactory {
     }
 
     static SdkHttpClient createSync(HttpClientConfig modelConfig, HttpClientConfig bedrockConfig,
-            LangChain4jConfig rootConfig, Supplier<Vertx> vertx) {
-        HttpClientOptions options = buildHttpClientOptions(modelConfig, bedrockConfig, rootConfig);
+            LangChain4jConfig rootConfig, Supplier<Vertx> vertx, ProxyConfigurationRegistry proxyRegistry) {
+        HttpClientOptions options = buildHttpClientOptions(modelConfig, bedrockConfig, rootConfig, proxyRegistry);
 
         Duration readTimeout = firstOrDefault(Duration.ofSeconds(10),
                 modelConfig.timeout(), bedrockConfig.timeout(), rootConfig.timeout());
@@ -52,14 +54,14 @@ final class BedrockSdkHttpClientFactory {
     }
 
     static SdkAsyncHttpClient createAsync(HttpClientConfig modelConfig, HttpClientConfig bedrockConfig,
-            LangChain4jConfig rootConfig, Supplier<Vertx> vertx) {
-        HttpClientOptions options = buildHttpClientOptions(modelConfig, bedrockConfig, rootConfig);
+            LangChain4jConfig rootConfig, Supplier<Vertx> vertx, ProxyConfigurationRegistry proxyRegistry) {
+        HttpClientOptions options = buildHttpClientOptions(modelConfig, bedrockConfig, rootConfig, proxyRegistry);
 
         return new VertxSdkAsyncHttpClient(vertx.get().createHttpClient(options));
     }
 
     private static HttpClientOptions buildHttpClientOptions(HttpClientConfig modelConfig, HttpClientConfig bedrockConfig,
-            LangChain4jConfig rootConfig) {
+            LangChain4jConfig rootConfig, ProxyConfigurationRegistry proxyRegistry) {
         HttpClientOptions options = new HttpClientOptions();
 
         Duration connectTimeout = firstOrDefault(Duration.ofSeconds(3),
@@ -96,18 +98,74 @@ final class BedrockSdkHttpClientFactory {
         }
 
         configureTls(options, modelConfig, bedrockConfig);
-        configureProxy(options, modelConfig, bedrockConfig);
+        configureProxy(options, modelConfig, bedrockConfig, proxyRegistry);
 
         return options;
     }
 
+    @SuppressWarnings("removal")
     private static void configureProxy(HttpClientOptions options, HttpClientConfig modelConfig,
-            HttpClientConfig bedrockConfig) {
+            HttpClientConfig bedrockConfig, ProxyConfigurationRegistry proxyRegistry) {
+        String proxyConfigName = firstOrDefault(null, modelConfig.proxyConfigurationName(),
+                bedrockConfig.proxyConfigurationName());
         String proxyAddress = firstOrDefault(null, modelConfig.proxyAddress(), bedrockConfig.proxyAddress());
-        if (proxyAddress == null) {
+
+        if (proxyConfigName != null) {
+            if (proxyAddress != null) {
+                LOG.warnf("Both 'proxy-configuration-name' (%s) and the deprecated 'proxy-address' (%s) are set. " +
+                        "The deprecated proxy properties are ignored. Please remove 'proxy-address', 'proxy-user', " +
+                        "'proxy-password' and 'non-proxy-hosts' from your configuration.", proxyConfigName, proxyAddress);
+            }
+            applyProxyFromRegistry(options, Optional.of(proxyConfigName), proxyRegistry);
             return;
         }
 
+        if (proxyAddress != null) {
+            LOG.warn("Using the deprecated 'proxy-address' configuration. Please migrate to 'proxy-configuration-name' " +
+                    "using the Quarkus Proxy Registry. The 'proxy-address', 'proxy-user', 'proxy-password' and " +
+                    "'non-proxy-hosts' properties will be removed in a future version.");
+            configureProxyFromProperties(options, modelConfig, bedrockConfig, proxyAddress);
+            return;
+        }
+
+        applyProxyFromRegistry(options, Optional.empty(), proxyRegistry);
+    }
+
+    private static void applyProxyFromRegistry(HttpClientOptions options, Optional<String> proxyConfigName,
+            ProxyConfigurationRegistry proxyRegistry) {
+        Optional<ProxyConfiguration> proxyConfig = proxyRegistry.get(proxyConfigName);
+        if (proxyConfig.isEmpty()) {
+            return;
+        }
+
+        ProxyConfiguration pc = proxyConfig.get();
+        ProxyOptions proxyOptions = new ProxyOptions()
+                .setType(ProxyType.valueOf(pc.type().name()))
+                .setHost(pc.host())
+                .setPort(pc.port());
+
+        if (pc.username().isPresent()) {
+            proxyOptions.setUsername(pc.username().get());
+        }
+        if (pc.password().isPresent()) {
+            proxyOptions.setPassword(pc.password().get());
+        }
+
+        options.setProxyOptions(proxyOptions);
+
+        if (pc.nonProxyHosts().isPresent()) {
+            for (String nonProxyHost : pc.nonProxyHosts().get()) {
+                String trimmed = nonProxyHost.trim();
+                if (!trimmed.isEmpty()) {
+                    options.addNonProxyHost(trimmed);
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings("removal")
+    private static void configureProxyFromProperties(HttpClientOptions options, HttpClientConfig modelConfig,
+            HttpClientConfig bedrockConfig, String proxyAddress) {
         int lastColonIndex = proxyAddress.lastIndexOf(':');
         if (lastColonIndex <= 0 || lastColonIndex == proxyAddress.length() - 1) {
             throw new RuntimeException("Invalid proxy string. Expected <hostname>:<port>, found '" + proxyAddress + "'");

--- a/model-providers/bedrock/runtime/src/main/java/io/quarkiverse/langchain4j/bedrock/runtime/config/HttpClientConfig.java
+++ b/model-providers/bedrock/runtime/src/main/java/io/quarkiverse/langchain4j/bedrock/runtime/config/HttpClientConfig.java
@@ -20,25 +20,52 @@ public interface HttpClientConfig {
     Optional<Duration> timeout();
 
     /**
+     * The name of the proxy configuration to use, as registered in the Quarkus Proxy Registry.
+     * <p>
+     * Precedence rules:
+     * <ul>
+     * <li>If set, it takes precedence over the deprecated {@code proxy-address}, {@code proxy-user},
+     * {@code proxy-password} and {@code non-proxy-hosts} properties, which are ignored.</li>
+     * <li>If not set and a default proxy configuration is configured ({@code quarkus.proxy.*}), then that one is
+     * used.</li>
+     * <li>If set, the configuration from {@code quarkus.proxy.<name>.*} is used.</li>
+     * <li>If set but no proxy configuration is found with that name, an error is thrown at runtime.</li>
+     * </ul>
+     */
+    Optional<String> proxyConfigurationName();
+
+    /**
      * A string value in the form of `<proxyHost>:<proxyPort>` that specifies the HTTP proxy server hostname
      * (or IP address) and port for requests of clients to use.
+     *
+     * @deprecated Use {@code proxy-configuration-name} with the Quarkus Proxy Registry instead.
      */
+    @Deprecated(forRemoval = true)
     Optional<String> proxyAddress();
 
     /**
      * Proxy username, equivalent to the http.proxy or https.proxy JVM settings.
+     *
+     * @deprecated Use {@code proxy-configuration-name} with the Quarkus Proxy Registry instead.
      */
+    @Deprecated(forRemoval = true)
     Optional<String> proxyUser();
 
     /**
      * Proxy password, equivalent to the http.proxyPassword or https.proxyPassword JVM settings.
+     *
+     * @deprecated Use {@code proxy-configuration-name} with the Quarkus Proxy Registry instead.
      */
+    @Deprecated(forRemoval = true)
     Optional<String> proxyPassword();
 
     /**
      * Hosts to access without proxy, similar to the http.nonProxyHosts or https.nonProxyHosts JVM settings.
      * Please note that unlike the JVM settings, this property is empty by default.
+     *
+     * @deprecated Use {@code proxy-configuration-name} with the Quarkus Proxy Registry instead.
      */
+    @Deprecated(forRemoval = true)
     Optional<String> nonProxyHosts();
 
     /**


### PR DESCRIPTION
## Describe your changes

Integrates the Quarkus Proxy Registry into the Bedrock provider, following the same approach used in #2312 for OpenAI.

`BedrockSdkHttpClientFactory` now resolves the proxy configuration via `ProxyConfigurationRegistry`, with three precedence levels: named proxy (`proxy-configuration-name`), deprecated `proxy-address`, and the global default proxy. The `ProxyConfigurationRegistry` is wired as a proper injection point in `BedrockProcessor` and received via `context.getInjectedReference()` in the recorder, instead of `CDI.current().select()`.

---

- Closes #2622