### PR TITLE
feat: record token usage as DistributionSummary alongside Counter

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/cost/TokenUsageDistributionMetricsTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/cost/TokenUsageDistributionMetricsTest.java
@@ -1,0 +1,149 @@
+package io.quarkiverse.langchain4j.test.cost;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.chat.listener.ChatModelRequestContext;
+import dev.langchain4j.model.chat.listener.ChatModelResponseContext;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.TokenUsage;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.quarkiverse.langchain4j.runtime.listeners.MetricsChatModelListener;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verifies that {@link MetricsChatModelListener} records per-request token usage as a
+ * {@link DistributionSummary} alongside the existing {@link Counter} metrics, so operators can answer
+ * per-request distribution questions (p50/p95/p99/max prompt size) that a monotonic Counter cannot.
+ * <p>
+ * Each test uses a distinct model name so its meter series are isolated, since the same listener and
+ * the JVM-wide {@link Metrics#globalRegistry} are shared across the test methods of this deployment.
+ */
+class TokenUsageDistributionMetricsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @Inject
+    MetricsChatModelListener listener;
+
+    @Inject
+    MeterRegistry registry;
+
+    @BeforeAll
+    static void addSimpleRegistry() {
+        Metrics.globalRegistry.add(new SimpleMeterRegistry());
+    }
+
+    @Test
+    void recordsCounterAndDistributionSummaryForInputAndOutput() {
+        String model = "happy-path-model";
+        fire(model, new TokenUsage(100, 25));
+
+        Counter inputCounter = registry.find("gen_ai.client.token.usage")
+                .tag("gen_ai.request.model", model)
+                .tag("gen_ai.token.type", "input")
+                .counter();
+        assertThat(inputCounter).isNotNull();
+        assertThat(inputCounter.count()).isEqualTo(100.0);
+
+        DistributionSummary inputDistribution = registry.find("gen_ai.client.token.usage.distribution")
+                .tag("gen_ai.request.model", model)
+                .tag("gen_ai.token.type", "input")
+                .summary();
+        assertThat(inputDistribution).isNotNull();
+        assertThat(inputDistribution.count()).isEqualTo(1L);
+        assertThat(inputDistribution.max()).isEqualTo(100.0);
+        assertThat(inputDistribution.totalAmount()).isEqualTo(100.0);
+
+        DistributionSummary outputDistribution = registry.find("gen_ai.client.token.usage.distribution")
+                .tag("gen_ai.request.model", model)
+                .tag("gen_ai.token.type", "output")
+                .summary();
+        assertThat(outputDistribution).isNotNull();
+        assertThat(outputDistribution.count()).isEqualTo(1L);
+        assertThat(outputDistribution.max()).isEqualTo(25.0);
+        assertThat(outputDistribution.totalAmount()).isEqualTo(25.0);
+    }
+
+    @Test
+    void recordsNothingForNullTokenCounts() {
+        String model = "null-tokens-model";
+        fire(model, new TokenUsage(null, null));
+
+        DistributionSummary inputDistribution = registry.find("gen_ai.client.token.usage.distribution")
+                .tag("gen_ai.request.model", model)
+                .tag("gen_ai.token.type", "input")
+                .summary();
+        DistributionSummary outputDistribution = registry.find("gen_ai.client.token.usage.distribution")
+                .tag("gen_ai.request.model", model)
+                .tag("gen_ai.token.type", "output")
+                .summary();
+
+        // No NPE and no zero-sample pollution: the summary is never created for an absent token count.
+        assertThat(inputDistribution).isNull();
+        assertThat(outputDistribution).isNull();
+    }
+
+    @Test
+    void distributionCapturesOutliersTheCounterHides() {
+        String model = "outlier-model";
+        fire(model, new TokenUsage(100, 10));
+        fire(model, new TokenUsage(10000, 10));
+
+        Counter inputCounter = registry.find("gen_ai.client.token.usage")
+                .tag("gen_ai.request.model", model)
+                .tag("gen_ai.token.type", "input")
+                .counter();
+        assertThat(inputCounter).isNotNull();
+        // Counter only knows the total, hiding that one request was 100x larger than the other.
+        assertThat(inputCounter.count()).isEqualTo(10100.0);
+
+        DistributionSummary inputDistribution = registry.find("gen_ai.client.token.usage.distribution")
+                .tag("gen_ai.request.model", model)
+                .tag("gen_ai.token.type", "input")
+                .summary();
+        assertThat(inputDistribution).isNotNull();
+        assertThat(inputDistribution.count()).isEqualTo(2L);
+        // The distribution exposes the outlier the Counter total cannot.
+        assertThat(inputDistribution.max()).isEqualTo(10000.0);
+        assertThat(inputDistribution.totalAmount()).isEqualTo(10100.0);
+    }
+
+    private void fire(String modelName, TokenUsage tokenUsage) {
+        Map<Object, Object> attributes = new HashMap<>();
+        ChatRequest request = ChatRequest.builder()
+                .messages(List.of(UserMessage.from("hello")))
+                .parameters(DefaultChatRequestParameters.builder().modelName(modelName).build())
+                .build();
+        ChatResponse response = ChatResponse.builder()
+                .aiMessage(AiMessage.from("hi"))
+                .modelName(modelName)
+                .tokenUsage(tokenUsage)
+                .build();
+
+        listener.onRequest(new ChatModelRequestContext(request, ModelProvider.OTHER, attributes));
+        listener.onResponse(new ChatModelResponseContext(response, request, ModelProvider.OTHER, attributes));
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/cost/TokenUsageDistributionMetricsTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/cost/TokenUsageDistributionMetricsTest.java
@@ -32,7 +32,7 @@ import io.quarkiverse.langchain4j.runtime.listeners.MetricsChatModelListener;
 import io.quarkus.test.QuarkusUnitTest;
 
 /**
- * Verifies that {@link MetricsChatModelListener} records per-request token usage as a
+ * Verifies that {@link MetricsChatModelListener} records per-request token usage as a single declared
  * {@link DistributionSummary} alongside the existing {@link Counter} metrics, so operators can answer
  * per-request distribution questions (p50/p95/p99/max prompt size) that a monotonic Counter cannot.
  * <p>
@@ -73,6 +73,8 @@ class TokenUsageDistributionMetricsTest {
                 .tag("gen_ai.token.type", "input")
                 .summary();
         assertThat(inputDistribution).isNotNull();
+        assertThat(inputDistribution.getId().getDescription()).isEqualTo("Distribution of token usage per request");
+        assertThat(inputDistribution.getId().getTag("gen_ai.token.type")).isEqualTo("input");
         assertThat(inputDistribution.count()).isEqualTo(1L);
         assertThat(inputDistribution.max()).isEqualTo(100.0);
         assertThat(inputDistribution.totalAmount()).isEqualTo(100.0);
@@ -82,6 +84,8 @@ class TokenUsageDistributionMetricsTest {
                 .tag("gen_ai.token.type", "output")
                 .summary();
         assertThat(outputDistribution).isNotNull();
+        assertThat(outputDistribution.getId().getDescription()).isEqualTo("Distribution of token usage per request");
+        assertThat(outputDistribution.getId().getTag("gen_ai.token.type")).isEqualTo("output");
         assertThat(outputDistribution.count()).isEqualTo(1L);
         assertThat(outputDistribution.max()).isEqualTo(25.0);
         assertThat(outputDistribution.totalAmount()).isEqualTo(25.0);

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/listeners/MetricsChatModelListener.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/listeners/MetricsChatModelListener.java
@@ -14,6 +14,7 @@ import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.output.TokenUsage;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tags;
@@ -43,6 +44,10 @@ public class MetricsChatModelListener implements ChatModelListener {
     private final Meter.MeterProvider<Counter> outputTokenUsage;
     private final Meter.MeterProvider<Counter> cacheReadInputTokenUsage;
     private final Meter.MeterProvider<Counter> cacheCreationInputTokenUsage;
+    private final Meter.MeterProvider<DistributionSummary> inputTokenUsageDistribution;
+    private final Meter.MeterProvider<DistributionSummary> outputTokenUsageDistribution;
+    private final Meter.MeterProvider<DistributionSummary> cacheReadInputTokenUsageDistribution;
+    private final Meter.MeterProvider<DistributionSummary> cacheCreationInputTokenUsageDistribution;
     private final Meter.MeterProvider<Timer> duration;
     private final Meter.MeterProvider<Counter> estimatedCost;
 
@@ -68,6 +73,28 @@ public class MetricsChatModelListener implements ChatModelListener {
                 .withRegistry(Metrics.globalRegistry);
         this.cacheCreationInputTokenUsage = Counter.builder("gen_ai.client.token.usage")
                 .description("Measures number of input tokens written to the prompt cache")
+                .tag("gen_ai.operation.name", "chat")
+                .tag("gen_ai.token.type", "cache_creation")
+                .withRegistry(Metrics.globalRegistry);
+        this.inputTokenUsageDistribution = DistributionSummary.builder("gen_ai.client.token.usage.distribution")
+                .description("Distribution of input tokens used per request")
+                .tag("gen_ai.operation.name", "chat")
+                .tag("gen_ai.token.type", "input")
+                .withRegistry(Metrics.globalRegistry);
+        this.outputTokenUsageDistribution = DistributionSummary.builder("gen_ai.client.token.usage.distribution")
+                .description("Distribution of output tokens used per request")
+                .tag("gen_ai.operation.name", "chat")
+                .tag("gen_ai.token.type", "output")
+                .withRegistry(Metrics.globalRegistry);
+        this.cacheReadInputTokenUsageDistribution = DistributionSummary
+                .builder("gen_ai.client.token.usage.distribution")
+                .description("Distribution of input tokens read from the prompt cache per request")
+                .tag("gen_ai.operation.name", "chat")
+                .tag("gen_ai.token.type", "cache_read")
+                .withRegistry(Metrics.globalRegistry);
+        this.cacheCreationInputTokenUsageDistribution = DistributionSummary
+                .builder("gen_ai.client.token.usage.distribution")
+                .description("Distribution of input tokens written to the prompt cache per request")
                 .tag("gen_ai.operation.name", "chat")
                 .tag("gen_ai.token.type", "cache_creation")
                 .withRegistry(Metrics.globalRegistry);
@@ -163,12 +190,18 @@ public class MetricsChatModelListener implements ChatModelListener {
             inputTokenUsage
                     .withTags(tags)
                     .increment(inputTokenCount);
+            inputTokenUsageDistribution
+                    .withTags(tags)
+                    .record(inputTokenCount);
         }
         Integer outputTokenCount = tokenUsage.outputTokenCount();
         if (outputTokenCount != null) {
             outputTokenUsage
                     .withTags(tags)
                     .increment(outputTokenCount);
+            outputTokenUsageDistribution
+                    .withTags(tags)
+                    .record(outputTokenCount);
         }
         CacheTokenUsage cacheTokenUsage = cacheTokenUsageResolver.resolve(tokenUsage);
         Integer cacheReadInputTokens = cacheTokenUsage.cacheReadInputTokens();
@@ -176,12 +209,18 @@ public class MetricsChatModelListener implements ChatModelListener {
             cacheReadInputTokenUsage
                     .withTags(tags)
                     .increment(cacheReadInputTokens);
+            cacheReadInputTokenUsageDistribution
+                    .withTags(tags)
+                    .record(cacheReadInputTokens);
         }
         Integer cacheCreationInputTokens = cacheTokenUsage.cacheCreationInputTokens();
         if (cacheCreationInputTokens != null && cacheCreationInputTokens > 0) {
             cacheCreationInputTokenUsage
                     .withTags(tags)
                     .increment(cacheCreationInputTokens);
+            cacheCreationInputTokenUsageDistribution
+                    .withTags(tags)
+                    .record(cacheCreationInputTokens);
         }
         if (inputTokenCount != null && outputTokenCount != null) {
             Cost costEstimate = costEstimatorService.estimate(responseContext);

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/listeners/MetricsChatModelListener.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/listeners/MetricsChatModelListener.java
@@ -40,14 +40,31 @@ public class MetricsChatModelListener implements ChatModelListener {
     private final CostEstimatorService costEstimatorService;
     private final CacheTokenUsageResolver cacheTokenUsageResolver;
 
+    /**
+     * @deprecated This legacy counter will be removed in a future release in favor of
+     *             {@code gen_ai.client.token.usage.distribution}.
+     */
+    @Deprecated(forRemoval = true)
     private final Meter.MeterProvider<Counter> inputTokenUsage;
+    /**
+     * @deprecated This legacy counter will be removed in a future release in favor of
+     *             {@code gen_ai.client.token.usage.distribution}.
+     */
+    @Deprecated(forRemoval = true)
     private final Meter.MeterProvider<Counter> outputTokenUsage;
+    /**
+     * @deprecated This legacy counter will be removed in a future release in favor of
+     *             {@code gen_ai.client.token.usage.distribution}.
+     */
+    @Deprecated(forRemoval = true)
     private final Meter.MeterProvider<Counter> cacheReadInputTokenUsage;
+    /**
+     * @deprecated This legacy counter will be removed in a future release in favor of
+     *             {@code gen_ai.client.token.usage.distribution}.
+     */
+    @Deprecated(forRemoval = true)
     private final Meter.MeterProvider<Counter> cacheCreationInputTokenUsage;
-    private final Meter.MeterProvider<DistributionSummary> inputTokenUsageDistribution;
-    private final Meter.MeterProvider<DistributionSummary> outputTokenUsageDistribution;
-    private final Meter.MeterProvider<DistributionSummary> cacheReadInputTokenUsageDistribution;
-    private final Meter.MeterProvider<DistributionSummary> cacheCreationInputTokenUsageDistribution;
+    private final Meter.MeterProvider<DistributionSummary> tokenUsageDistribution;
     private final Meter.MeterProvider<Timer> duration;
     private final Meter.MeterProvider<Counter> estimatedCost;
 
@@ -76,27 +93,9 @@ public class MetricsChatModelListener implements ChatModelListener {
                 .tag("gen_ai.operation.name", "chat")
                 .tag("gen_ai.token.type", "cache_creation")
                 .withRegistry(Metrics.globalRegistry);
-        this.inputTokenUsageDistribution = DistributionSummary.builder("gen_ai.client.token.usage.distribution")
-                .description("Distribution of input tokens used per request")
+        this.tokenUsageDistribution = DistributionSummary.builder("gen_ai.client.token.usage.distribution")
+                .description("Distribution of token usage per request")
                 .tag("gen_ai.operation.name", "chat")
-                .tag("gen_ai.token.type", "input")
-                .withRegistry(Metrics.globalRegistry);
-        this.outputTokenUsageDistribution = DistributionSummary.builder("gen_ai.client.token.usage.distribution")
-                .description("Distribution of output tokens used per request")
-                .tag("gen_ai.operation.name", "chat")
-                .tag("gen_ai.token.type", "output")
-                .withRegistry(Metrics.globalRegistry);
-        this.cacheReadInputTokenUsageDistribution = DistributionSummary
-                .builder("gen_ai.client.token.usage.distribution")
-                .description("Distribution of input tokens read from the prompt cache per request")
-                .tag("gen_ai.operation.name", "chat")
-                .tag("gen_ai.token.type", "cache_read")
-                .withRegistry(Metrics.globalRegistry);
-        this.cacheCreationInputTokenUsageDistribution = DistributionSummary
-                .builder("gen_ai.client.token.usage.distribution")
-                .description("Distribution of input tokens written to the prompt cache per request")
-                .tag("gen_ai.operation.name", "chat")
-                .tag("gen_ai.token.type", "cache_creation")
                 .withRegistry(Metrics.globalRegistry);
         this.duration = Timer.builder("gen_ai.client.operation.duration")
                 .description("GenAI operation duration")
@@ -190,18 +189,14 @@ public class MetricsChatModelListener implements ChatModelListener {
             inputTokenUsage
                     .withTags(tags)
                     .increment(inputTokenCount);
-            inputTokenUsageDistribution
-                    .withTags(tags)
-                    .record(inputTokenCount);
+            recordTokenUsageDistribution(tags, "input", inputTokenCount);
         }
         Integer outputTokenCount = tokenUsage.outputTokenCount();
         if (outputTokenCount != null) {
             outputTokenUsage
                     .withTags(tags)
                     .increment(outputTokenCount);
-            outputTokenUsageDistribution
-                    .withTags(tags)
-                    .record(outputTokenCount);
+            recordTokenUsageDistribution(tags, "output", outputTokenCount);
         }
         CacheTokenUsage cacheTokenUsage = cacheTokenUsageResolver.resolve(tokenUsage);
         Integer cacheReadInputTokens = cacheTokenUsage.cacheReadInputTokens();
@@ -209,18 +204,14 @@ public class MetricsChatModelListener implements ChatModelListener {
             cacheReadInputTokenUsage
                     .withTags(tags)
                     .increment(cacheReadInputTokens);
-            cacheReadInputTokenUsageDistribution
-                    .withTags(tags)
-                    .record(cacheReadInputTokens);
+            recordTokenUsageDistribution(tags, "cache_read", cacheReadInputTokens);
         }
         Integer cacheCreationInputTokens = cacheTokenUsage.cacheCreationInputTokens();
         if (cacheCreationInputTokens != null && cacheCreationInputTokens > 0) {
             cacheCreationInputTokenUsage
                     .withTags(tags)
                     .increment(cacheCreationInputTokens);
-            cacheCreationInputTokenUsageDistribution
-                    .withTags(tags)
-                    .record(cacheCreationInputTokens);
+            recordTokenUsageDistribution(tags, "cache_creation", cacheCreationInputTokens);
         }
         if (inputTokenCount != null && outputTokenCount != null) {
             Cost costEstimate = costEstimatorService.estimate(responseContext);
@@ -229,6 +220,12 @@ public class MetricsChatModelListener implements ChatModelListener {
                         .increment(costEstimate.number().doubleValue());
             }
         }
+    }
+
+    private void recordTokenUsageDistribution(Tags tags, String tokenType, int tokenCount) {
+        tokenUsageDistribution
+                .withTags(tags.and("gen_ai.token.type", tokenType))
+                .record(tokenCount);
     }
 
     private void recordDuration(ChatModelResponseContext responseContext, long endTime, Tags tags) {


### PR DESCRIPTION
## Summary

Records per-request token usage as a Micrometer `DistributionSummary` alongside the existing `Counter` metrics in `MetricsChatModelListener`. A new meter family `gen_ai.client.token.usage.distribution` is emitted for the `input`, `output`, `cache_read` and `cache_creation` token types, carrying the same `gen_ai.operation.name` / `gen_ai.token.type` tag set as the existing counters. The existing `gen_ai.client.token.usage` counters are left untouched, so this is additive with no breaking change.

- Fixes: #2521
