### PR TITLE
Add Workload ModelAuthProvider, update vanilla OpenAI and Anthropic model providers to support ModelAuthProvider

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-workload-model-auth-provider.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-workload-model-auth-provider.adoc
@@ -1,0 +1,74 @@
+[.configuration-legend]
+icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
+[.configuration-reference.searchable, cols="80,.^10,.^10"]
+|===
+
+h|[.header-title]##Configuration property##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-workload-model-auth-provider_quarkus-langchain4j-workload-model-auth-provider-enabled]] [.property-path]##link:#quarkus-langchain4j-workload-model-auth-provider_quarkus-langchain4j-workload-model-auth-provider-enabled[`+++quarkus.langchain4j.workload-model-auth-provider.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.workload-model-auth-provider.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the Workload Identity Federation ModelAuthProvider should be enabled
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WORKLOAD_MODEL_AUTH_PROVIDER_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WORKLOAD_MODEL_AUTH_PROVIDER_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-workload-model-auth-provider_quarkus-langchain4j-workload-model-auth-provider-oidc-client-name]] [.property-path]##link:#quarkus-langchain4j-workload-model-auth-provider_quarkus-langchain4j-workload-model-auth-provider-oidc-client-name[`+++quarkus.langchain4j.workload-model-auth-provider.oidc-client-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.workload-model-auth-provider.oidc-client-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The name of the OIDC client to use for the token exchange. If not set, the default OIDC client is used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WORKLOAD_MODEL_AUTH_PROVIDER_OIDC_CLIENT_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WORKLOAD_MODEL_AUTH_PROVIDER_OIDC_CLIENT_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-workload-model-auth-provider_quarkus-langchain4j-workload-model-auth-provider-token-path]] [.property-path]##link:#quarkus-langchain4j-workload-model-auth-provider_quarkus-langchain4j-workload-model-auth-provider-token-path[`+++quarkus.langchain4j.workload-model-auth-provider.token-path+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.workload-model-auth-provider.token-path+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Path to the workload identity provider token file, for example, a SPIFFE JWT-SVID. The token is read from this path and periodically refreshed based on its expiry claim.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WORKLOAD_MODEL_AUTH_PROVIDER_TOKEN_PATH+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WORKLOAD_MODEL_AUTH_PROVIDER_TOKEN_PATH+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|required icon:exclamation-circle[title=Configuration property is required]
+
+|===
+

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-workload-model-auth-provider_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-workload-model-auth-provider_quarkus.langchain4j.adoc
@@ -1,0 +1,74 @@
+[.configuration-legend]
+icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
+[.configuration-reference.searchable, cols="80,.^10,.^10"]
+|===
+
+h|[.header-title]##Configuration property##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-workload-model-auth-provider_quarkus-langchain4j-workload-model-auth-provider-enabled]] [.property-path]##link:#quarkus-langchain4j-workload-model-auth-provider_quarkus-langchain4j-workload-model-auth-provider-enabled[`+++quarkus.langchain4j.workload-model-auth-provider.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.workload-model-auth-provider.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the Workload Identity Federation ModelAuthProvider should be enabled
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WORKLOAD_MODEL_AUTH_PROVIDER_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WORKLOAD_MODEL_AUTH_PROVIDER_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-workload-model-auth-provider_quarkus-langchain4j-workload-model-auth-provider-oidc-client-name]] [.property-path]##link:#quarkus-langchain4j-workload-model-auth-provider_quarkus-langchain4j-workload-model-auth-provider-oidc-client-name[`+++quarkus.langchain4j.workload-model-auth-provider.oidc-client-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.workload-model-auth-provider.oidc-client-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The name of the OIDC client to use for the token exchange. If not set, the default OIDC client is used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WORKLOAD_MODEL_AUTH_PROVIDER_OIDC_CLIENT_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WORKLOAD_MODEL_AUTH_PROVIDER_OIDC_CLIENT_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-workload-model-auth-provider_quarkus-langchain4j-workload-model-auth-provider-token-path]] [.property-path]##link:#quarkus-langchain4j-workload-model-auth-provider_quarkus-langchain4j-workload-model-auth-provider-token-path[`+++quarkus.langchain4j.workload-model-auth-provider.token-path+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.workload-model-auth-provider.token-path+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Path to the workload identity provider token file, for example, a SPIFFE JWT-SVID. The token is read from this path and periodically refreshed based on its expiry claim.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WORKLOAD_MODEL_AUTH_PROVIDER_TOKEN_PATH+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WORKLOAD_MODEL_AUTH_PROVIDER_TOKEN_PATH+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|required icon:exclamation-circle[title=Configuration property is required]
+
+|===
+

--- a/model-auth-providers/workload-model-auth-provider/deployment/pom.xml
+++ b/model-auth-providers/workload-model-auth-provider/deployment/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkiverse.langchain4j</groupId>
+        <artifactId>quarkus-langchain4j-workload-model-auth-provider-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <artifactId>quarkus-langchain4j-workload-model-auth-provider-deployment</artifactId>
+    <name>Quarkus LangChain4j - Workload Identity Federation ModelAuthProvider - Deployment</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkiverse.langchain4j</groupId>
+            <artifactId>quarkus-langchain4j-workload-model-auth-provider</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.langchain4j</groupId>
+            <artifactId>quarkus-langchain4j-core-deployment</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-oidc-client-deployment</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/model-auth-providers/workload-model-auth-provider/deployment/src/main/java/io/quarkiverse/langchain4j/workload/deployment/WorkloadModelAuthProviderBuildConfig.java
+++ b/model-auth-providers/workload-model-auth-provider/deployment/src/main/java/io/quarkiverse/langchain4j/workload/deployment/WorkloadModelAuthProviderBuildConfig.java
@@ -22,4 +22,11 @@ public interface WorkloadModelAuthProviderBuildConfig {
      * If not set, the default OIDC client is used.
      */
     Optional<String> oidcClientName();
+
+    /**
+     * The model provider name to bind this model authentication provider to.
+     * When set, the provider is qualified with {@link io.quarkiverse.langchain4j.ModelName} and only used
+     * by the matching model provider. When not set, the provider is registered as a global default.
+     */
+    Optional<String> modelName();
 }

--- a/model-auth-providers/workload-model-auth-provider/deployment/src/main/java/io/quarkiverse/langchain4j/workload/deployment/WorkloadModelAuthProviderBuildConfig.java
+++ b/model-auth-providers/workload-model-auth-provider/deployment/src/main/java/io/quarkiverse/langchain4j/workload/deployment/WorkloadModelAuthProviderBuildConfig.java
@@ -1,0 +1,25 @@
+package io.quarkiverse.langchain4j.workload.deployment;
+
+import static io.quarkus.runtime.annotations.ConfigPhase.BUILD_TIME;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigDocDefault;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+
+@ConfigRoot(phase = BUILD_TIME)
+@ConfigMapping(prefix = "quarkus.langchain4j.workload-model-auth-provider")
+public interface WorkloadModelAuthProviderBuildConfig {
+    /**
+     * Whether the Workload Identity Federation ModelAuthProvider should be enabled
+     */
+    @ConfigDocDefault("true")
+    Optional<Boolean> enabled();
+
+    /**
+     * The name of the OIDC client to use for the token exchange.
+     * If not set, the default OIDC client is used.
+     */
+    Optional<String> oidcClientName();
+}

--- a/model-auth-providers/workload-model-auth-provider/deployment/src/main/java/io/quarkiverse/langchain4j/workload/deployment/WorkloadModelAuthProviderProcessor.java
+++ b/model-auth-providers/workload-model-auth-provider/deployment/src/main/java/io/quarkiverse/langchain4j/workload/deployment/WorkloadModelAuthProviderProcessor.java
@@ -1,0 +1,67 @@
+package io.quarkiverse.langchain4j.workload.deployment;
+
+import java.util.function.BooleanSupplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
+
+import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
+import io.quarkiverse.langchain4j.workload.runtime.WorkloadModelAuthProviderRecorder;
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.oidc.client.OidcClient;
+import io.quarkus.oidc.client.OidcClients;
+import io.vertx.core.Vertx;
+
+@BuildSteps(onlyIf = WorkloadModelAuthProviderProcessor.IsEnabled.class)
+public class WorkloadModelAuthProviderProcessor {
+
+    private static final String FEATURE = "langchain4j-workload-model-auth-provider";
+    private static final DotName MODEL_AUTH_PROVIDER = DotName.createSimple(ModelAuthProvider.class);
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    public void registerBeans(
+            WorkloadModelAuthProviderBuildConfig buildConfig,
+            BuildProducer<SyntheticBeanBuildItem> beanProducer,
+            WorkloadModelAuthProviderRecorder recorder) {
+
+        var builder = SyntheticBeanBuildItem
+                .configure(MODEL_AUTH_PROVIDER)
+                .setRuntimeInit()
+                .defaultBean()
+                .unremovable()
+                .scope(ApplicationScoped.class)
+                .addInjectionPoint(ClassType.create(DotName.createSimple(Vertx.class)));
+
+        if (buildConfig.oidcClientName().isPresent()) {
+            builder.addInjectionPoint(ClassType.create(DotName.createSimple(OidcClients.class)))
+                    .createWith(recorder.namedProvider(buildConfig.oidcClientName().get()));
+        } else {
+            builder.addInjectionPoint(ClassType.create(DotName.createSimple(OidcClient.class)))
+                    .createWith(recorder.defaultProvider());
+        }
+
+        beanProducer.produce(builder.done());
+    }
+
+    public static class IsEnabled implements BooleanSupplier {
+        WorkloadModelAuthProviderBuildConfig config;
+
+        public boolean getAsBoolean() {
+            return config.enabled().orElse(true);
+        }
+    }
+}

--- a/model-auth-providers/workload-model-auth-provider/deployment/src/main/java/io/quarkiverse/langchain4j/workload/deployment/WorkloadModelAuthProviderProcessor.java
+++ b/model-auth-providers/workload-model-auth-provider/deployment/src/main/java/io/quarkiverse/langchain4j/workload/deployment/WorkloadModelAuthProviderProcessor.java
@@ -7,6 +7,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import org.jboss.jandex.ClassType;
 import org.jboss.jandex.DotName;
 
+import io.quarkiverse.langchain4j.ModelName;
 import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
 import io.quarkiverse.langchain4j.workload.runtime.WorkloadModelAuthProviderRecorder;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
@@ -45,6 +46,11 @@ public class WorkloadModelAuthProviderProcessor {
                 .unremovable()
                 .scope(ApplicationScoped.class)
                 .addInjectionPoint(ClassType.create(DotName.createSimple(Vertx.class)));
+
+        if (buildConfig.modelName().isPresent()) {
+            builder.addQualifier().annotation(ModelName.class)
+                    .addValue("value", buildConfig.modelName().get()).done();
+        }
 
         if (buildConfig.oidcClientName().isPresent()) {
             builder.addInjectionPoint(ClassType.create(DotName.createSimple(OidcClients.class)))

--- a/model-auth-providers/workload-model-auth-provider/pom.xml
+++ b/model-auth-providers/workload-model-auth-provider/pom.xml
@@ -5,14 +5,16 @@
         <groupId>io.quarkiverse.langchain4j</groupId>
         <artifactId>quarkus-langchain4j-parent</artifactId>
         <version>999-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
-    <artifactId>quarkus-langchain4j-model-auth-providers-parent</artifactId>
-    <name>Quarkus LangChain4j - Model Auth Providers - Parent</name>
+    <artifactId>quarkus-langchain4j-workload-model-auth-provider-parent</artifactId>
+    <name>Quarkus LangChain4j - Workload Identity Federation ModelAuthProvider - Parent</name>
     <packaging>pom</packaging>
 
     <modules>
-        <module>oidc-model-auth-provider</module>
-        <module>workload-model-auth-provider</module>
+        <module>deployment</module>
+        <module>runtime</module>
     </modules>
-    
+
+
 </project>

--- a/model-auth-providers/workload-model-auth-provider/runtime/pom.xml
+++ b/model-auth-providers/workload-model-auth-provider/runtime/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkiverse.langchain4j</groupId>
+        <artifactId>quarkus-langchain4j-workload-model-auth-provider-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <artifactId>quarkus-langchain4j-workload-model-auth-provider</artifactId>
+    <name>Quarkus LangChain4j - Workload Identity Federation ModelAuthProvider - Runtime</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-oidc-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.langchain4j</groupId>
+            <artifactId>quarkus-langchain4j-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <configuration>
+                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/model-auth-providers/workload-model-auth-provider/runtime/src/main/java/io/quarkiverse/langchain4j/workload/runtime/WorkloadModelAuthProvider.java
+++ b/model-auth-providers/workload-model-auth-provider/runtime/src/main/java/io/quarkiverse/langchain4j/workload/runtime/WorkloadModelAuthProvider.java
@@ -12,10 +12,18 @@ import org.jboss.logging.Logger;
 import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
 import io.quarkus.oidc.client.OidcClient;
 import io.quarkus.oidc.client.runtime.TokensHelper;
+import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 
 public class WorkloadModelAuthProvider implements ModelAuthProvider {
+
+    private record IdentityToken(String token, long expiresAt, long timerId) {
+        private boolean isExpired() {
+            final long nowSecs = System.currentTimeMillis() / 1000;
+            return nowSecs > expiresAt;
+        }
+    }
 
     private static final Logger LOG = Logger.getLogger(WorkloadModelAuthProvider.class);
 
@@ -24,8 +32,7 @@ public class WorkloadModelAuthProvider implements ModelAuthProvider {
     private final TokensHelper tokensHelper = new TokensHelper();
     private final Path tokenPath;
     private final String tokenParamName;
-    private volatile String identityToken;
-    private volatile long timerId = -1;
+    private volatile IdentityToken identityToken;
 
     WorkloadModelAuthProvider(Vertx vertx, OidcClient oidcClient, String tokenPath, String tokenParamName) {
         this.vertx = vertx;
@@ -37,64 +44,72 @@ public class WorkloadModelAuthProvider implements ModelAuthProvider {
 
     @Override
     public String getAuthorization(Input input) {
-        String token = identityToken;
-        if (token == null) {
-            token = reloadIdentityToken();
+        IdentityToken current = identityToken;
+        if (isInvalid(current)) {
+            current = loadIdentityToken();
         }
-        if (token == null) {
+        if (current == null) {
             return null;
         }
-        return "Bearer " + tokensHelper.getTokens(oidcClient, Map.of(tokenParamName, token), false)
+        return "Bearer " + tokensHelper.getTokens(oidcClient, Map.of(tokenParamName, current.token), false)
                 .await().indefinitely().getAccessToken();
     }
 
-    private synchronized String reloadIdentityToken() {
-        if (identityToken == null) {
+    private synchronized IdentityToken loadIdentityToken() {
+        if (isInvalid(identityToken)) {
+            cancelRefresh();
             identityToken = loadFromFileSystem();
         }
         return identityToken;
     }
 
-    private String loadFromFileSystem() {
-        if (!Files.exists(tokenPath)) {
-            LOG.warnf("Workload identity token file not found: %s", tokenPath);
-            return null;
-        }
-        try {
-            String token = Files.readString(tokenPath).trim();
-            if (token.isEmpty()) {
-                LOG.errorf("Workload identity token file is empty: %s", tokenPath);
-                return null;
-            }
-            Long expiresAt = getExpiresAt(token);
-            if (expiresAt != null) {
-                scheduleRefresh(expiresAt);
-            }
-            return token;
-        } catch (IOException e) {
-            LOG.errorf(e, "Failed to read workload identity token file: %s", tokenPath);
-            return null;
-        }
-    }
-
-    private void scheduleRefresh(long expiresAt) {
-        cancelRefresh();
+    private long scheduleRefresh(long expiresAt) {
         long nowSecs = System.currentTimeMillis() / 1000;
         long ttlMs = (expiresAt - nowSecs) * 1000;
         // refresh at 85% of TTL, matching Kubernetes token rotation conventions
         long delayMs = (long) (ttlMs * 0.85);
-        if (delayMs > 0) {
-            timerId = vertx.setTimer(delayMs, id -> {
-                identityToken = loadFromFileSystem();
-            });
+        if (delayMs <= 0) {
+            return -1;
         }
+        return vertx.setTimer(delayMs, new Handler<Long>() {
+            @Override
+            public void handle(Long ignored) {
+                WorkloadModelAuthProvider.this.identityToken = loadFromFileSystem();
+            }
+        });
     }
 
     private void cancelRefresh() {
-        if (timerId >= 0) {
-            vertx.cancelTimer(timerId);
-            timerId = -1;
+        if (identityToken != null) {
+            vertx.cancelTimer(identityToken.timerId);
         }
+    }
+
+    private IdentityToken loadFromFileSystem() {
+        if (Files.exists(tokenPath)) {
+            try {
+                String token = Files.readString(tokenPath).trim();
+                if (token.isEmpty()) {
+                    LOG.errorf("Workload identity token file is empty: %s", tokenPath);
+                    return null;
+                }
+                Long expiresAt = getExpiresAt(token);
+                if (expiresAt != null) {
+                    return new IdentityToken(token, expiresAt, scheduleRefresh(expiresAt));
+                } else {
+                    LOG.errorf("Workload identity token or its 'exp' claim is invalid: %s", tokenPath);
+                }
+            } catch (IOException e) {
+                LOG.errorf(e, "Failed to read workload identity token file: %s", tokenPath);
+            }
+        } else {
+            LOG.warnf("Workload identity token file not found: %s", tokenPath);
+        }
+        return null;
+    }
+
+    private static boolean isInvalid(IdentityToken identityToken) {
+        return identityToken == null || identityToken.isExpired();
     }
 
     static Long getExpiresAt(String jwt) {
@@ -105,7 +120,10 @@ public class WorkloadModelAuthProvider implements ModelAuthProvider {
         try {
             String payload = new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8);
             JsonObject claims = new JsonObject(payload);
-            return claims.containsKey("exp") ? claims.getLong("exp") : null;
+            if (!claims.containsKey("exp")) {
+                return null;
+            }
+            return claims.getLong("exp");
         } catch (Exception e) {
             LOG.debugf("Failed to decode JWT expiry claim: %s", e.getMessage());
             return null;

--- a/model-auth-providers/workload-model-auth-provider/runtime/src/main/java/io/quarkiverse/langchain4j/workload/runtime/WorkloadModelAuthProvider.java
+++ b/model-auth-providers/workload-model-auth-provider/runtime/src/main/java/io/quarkiverse/langchain4j/workload/runtime/WorkloadModelAuthProvider.java
@@ -1,0 +1,114 @@
+package io.quarkiverse.langchain4j.workload.runtime;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.Map;
+
+import org.jboss.logging.Logger;
+
+import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
+import io.quarkus.oidc.client.OidcClient;
+import io.quarkus.oidc.client.runtime.TokensHelper;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+
+public class WorkloadModelAuthProvider implements ModelAuthProvider {
+
+    private static final Logger LOG = Logger.getLogger(WorkloadModelAuthProvider.class);
+
+    private final Vertx vertx;
+    private final OidcClient oidcClient;
+    private final TokensHelper tokensHelper = new TokensHelper();
+    private final Path tokenPath;
+    private final String tokenParamName;
+    private volatile String identityToken;
+    private volatile long timerId = -1;
+
+    WorkloadModelAuthProvider(Vertx vertx, OidcClient oidcClient, String tokenPath, String tokenParamName) {
+        this.vertx = vertx;
+        this.oidcClient = oidcClient;
+        this.tokenPath = Path.of(tokenPath);
+        this.tokenParamName = tokenParamName;
+        this.identityToken = loadFromFileSystem();
+    }
+
+    @Override
+    public String getAuthorization(Input input) {
+        String token = identityToken;
+        if (token == null) {
+            token = reloadIdentityToken();
+        }
+        if (token == null) {
+            return null;
+        }
+        return "Bearer " + tokensHelper.getTokens(oidcClient, Map.of(tokenParamName, token), false)
+                .await().indefinitely().getAccessToken();
+    }
+
+    private synchronized String reloadIdentityToken() {
+        if (identityToken == null) {
+            identityToken = loadFromFileSystem();
+        }
+        return identityToken;
+    }
+
+    private String loadFromFileSystem() {
+        if (!Files.exists(tokenPath)) {
+            LOG.warnf("Workload identity token file not found: %s", tokenPath);
+            return null;
+        }
+        try {
+            String token = Files.readString(tokenPath).trim();
+            if (token.isEmpty()) {
+                LOG.errorf("Workload identity token file is empty: %s", tokenPath);
+                return null;
+            }
+            Long expiresAt = getExpiresAt(token);
+            if (expiresAt != null) {
+                scheduleRefresh(expiresAt);
+            }
+            return token;
+        } catch (IOException e) {
+            LOG.errorf(e, "Failed to read workload identity token file: %s", tokenPath);
+            return null;
+        }
+    }
+
+    private void scheduleRefresh(long expiresAt) {
+        cancelRefresh();
+        long nowSecs = System.currentTimeMillis() / 1000;
+        long ttlMs = (expiresAt - nowSecs) * 1000;
+        // refresh at 85% of TTL, matching Kubernetes token rotation conventions
+        long delayMs = (long) (ttlMs * 0.85);
+        if (delayMs > 0) {
+            timerId = vertx.setTimer(delayMs, id -> {
+                identityToken = loadFromFileSystem();
+            });
+        }
+    }
+
+    private void cancelRefresh() {
+        if (timerId >= 0) {
+            vertx.cancelTimer(timerId);
+            timerId = -1;
+        }
+    }
+
+    static Long getExpiresAt(String jwt) {
+        String[] parts = jwt.split("\\.");
+        if (parts.length != 3) {
+            return null;
+        }
+        try {
+            String payload = new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8);
+            JsonObject claims = new JsonObject(payload);
+            return claims.containsKey("exp") ? claims.getLong("exp") : null;
+        } catch (Exception e) {
+            LOG.debugf("Failed to decode JWT expiry claim: %s", e.getMessage());
+            return null;
+        }
+    }
+}

--- a/model-auth-providers/workload-model-auth-provider/runtime/src/main/java/io/quarkiverse/langchain4j/workload/runtime/WorkloadModelAuthProviderConfig.java
+++ b/model-auth-providers/workload-model-auth-provider/runtime/src/main/java/io/quarkiverse/langchain4j/workload/runtime/WorkloadModelAuthProviderConfig.java
@@ -1,0 +1,17 @@
+package io.quarkiverse.langchain4j.workload.runtime;
+
+import static io.quarkus.runtime.annotations.ConfigPhase.RUN_TIME;
+
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+
+@ConfigRoot(phase = RUN_TIME)
+@ConfigMapping(prefix = "quarkus.langchain4j.workload-model-auth-provider")
+public interface WorkloadModelAuthProviderConfig {
+
+    /**
+     * Path to the workload identity provider token file, for example, a SPIFFE JWT-SVID.
+     * The token is read from this path and periodically refreshed based on its expiry claim.
+     */
+    String tokenPath();
+}

--- a/model-auth-providers/workload-model-auth-provider/runtime/src/main/java/io/quarkiverse/langchain4j/workload/runtime/WorkloadModelAuthProviderRecorder.java
+++ b/model-auth-providers/workload-model-auth-provider/runtime/src/main/java/io/quarkiverse/langchain4j/workload/runtime/WorkloadModelAuthProviderRecorder.java
@@ -1,0 +1,57 @@
+package io.quarkiverse.langchain4j.workload.runtime;
+
+import java.util.function.Function;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
+import io.quarkus.arc.SyntheticCreationalContext;
+import io.quarkus.oidc.client.OidcClient;
+import io.quarkus.oidc.client.OidcClients;
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Recorder;
+import io.vertx.core.Vertx;
+
+@Recorder
+public class WorkloadModelAuthProviderRecorder {
+
+    private static final String SUBJECT_TOKEN = "subject_token";
+    private static final String ASSERTION = "assertion";
+
+    private final RuntimeValue<WorkloadModelAuthProviderConfig> config;
+
+    public WorkloadModelAuthProviderRecorder(RuntimeValue<WorkloadModelAuthProviderConfig> config) {
+        this.config = config;
+    }
+
+    public Function<SyntheticCreationalContext<ModelAuthProvider>, ModelAuthProvider> defaultProvider() {
+        return context -> {
+            String tokenParamName = deriveTokenParamName("quarkus.oidc-client.grant.type");
+            return new WorkloadModelAuthProvider(
+                    context.getInjectedReference(Vertx.class),
+                    context.getInjectedReference(OidcClient.class),
+                    config.getValue().tokenPath(),
+                    tokenParamName);
+        };
+    }
+
+    public Function<SyntheticCreationalContext<ModelAuthProvider>, ModelAuthProvider> namedProvider(
+            String oidcClientName) {
+        return context -> {
+            String tokenParamName = deriveTokenParamName(
+                    "quarkus.oidc-client." + oidcClientName + ".grant.type");
+            return new WorkloadModelAuthProvider(
+                    context.getInjectedReference(Vertx.class),
+                    context.getInjectedReference(OidcClients.class).getClient(oidcClientName),
+                    config.getValue().tokenPath(),
+                    tokenParamName);
+        };
+    }
+
+    private static String deriveTokenParamName(String configKey) {
+        String grantType = ConfigProvider.getConfig()
+                .getOptionalValue(configKey, String.class)
+                .orElse("client");
+        return "jwt".equals(grantType) ? ASSERTION : SUBJECT_TOKEN;
+    }
+}

--- a/model-auth-providers/workload-model-auth-provider/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/model-auth-providers/workload-model-auth-provider/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,14 @@
+name: LangChain4j Workload Identity Federation ModelAuthProvider
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+description: Provides ModelAuthProvider that reads a workload identity token from disk and exchanges it for model API access tokens via OidcClient
+metadata:
+  keywords:
+    - ai
+    - langchain4j
+    - oidc
+    - security
+    - workload-identity
+  guide: "https://docs.quarkiverse.io/quarkus-langchain4j/dev/index.html"
+  categories:
+    - "security"
+  status: "preview"

--- a/model-providers/anthropic/deployment/src/main/java/io/quarkiverse/langchain4j/anthropic/deployment/AnthropicProcessor.java
+++ b/model-providers/anthropic/deployment/src/main/java/io/quarkiverse/langchain4j/anthropic/deployment/AnthropicProcessor.java
@@ -74,6 +74,8 @@ public class AnthropicProcessor {
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ClassType.create(DotNames.MODEL_AUTH_PROVIDER) }, null))
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
                                         new Type[] { ClassType.create(ANTHROPIC_CHAT_MODEL_BUILDER) }, null) },
                                 null), ANY)
@@ -89,6 +91,8 @@ public class AnthropicProcessor {
                         .scope(ApplicationScoped.class)
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ClassType.create(DotNames.MODEL_AUTH_PROVIDER) }, null))
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
                                         new Type[] { ClassType.create(ANTHROPIC_STREAMING_CHAT_MODEL_BUILDER) },

--- a/model-providers/anthropic/deployment/src/test/java/io/quarkiverse/langchain4j/anthropic/deployment/ModelAuthProviderSmokeTest.java
+++ b/model-providers/anthropic/deployment/src/test/java/io/quarkiverse/langchain4j/anthropic/deployment/ModelAuthProviderSmokeTest.java
@@ -1,0 +1,91 @@
+package io.quarkiverse.langchain4j.anthropic.deployment;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.absent;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.not;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.model.anthropic.AnthropicChatModel;
+import dev.langchain4j.model.anthropic.AnthropicStreamingChatModel;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
+import io.quarkus.arc.ClientProxy;
+import io.quarkus.test.QuarkusUnitTest;
+
+class ModelAuthProviderSmokeTest extends AnthropicSmokeTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.anthropic.base-url",
+                    "http://localhost:%d".formatted(WIREMOCK_PORT));
+
+    @Inject
+    ChatModel chatModel;
+
+    @Inject
+    StreamingChatModel streamingChatModel;
+
+    @Test
+    void testModelAuthProviderUsed() {
+        assertThat(ClientProxy.unwrap(chatModel)).isInstanceOf(AnthropicChatModel.class);
+        assertThat(ClientProxy.unwrap(streamingChatModel)).isInstanceOf(AnthropicStreamingChatModel.class);
+
+        wireMockServer.stubFor(
+                post(urlPathEqualTo("/messages"))
+                        .withHeader("Authorization", equalTo("Bearer token"))
+                        .withHeader("x-api-key", absent())
+                        .withHeader("anthropic-version", not(absent()))
+                        .willReturn(
+                                okJson("""
+                                        {
+                                          "id": "msg_01EwYzt25EaVu4rNUewCkdP3",
+                                          "type": "message",
+                                          "role": "assistant",
+                                          "content": [
+                                              {
+                                                  "type": "text",
+                                                  "text": "Hello!"
+                                              }
+                                          ],
+                                          "model": "claude-3-haiku-20240307",
+                                          "stop_reason": "end_turn",
+                                          "stop_sequence": null,
+                                          "usage": {
+                                              "input_tokens": 14,
+                                              "output_tokens": 5
+                                          }
+                                        }
+                                        """)));
+
+        String response = chatModel.chat("hello");
+        assertThat(response).isEqualTo("Hello!");
+
+        assertThat(wireMockServer.getAllServeEvents()).hasSize(1);
+
+        var loggedRequest = wireMockServer.getAllServeEvents().get(0).getRequest();
+        assertThat(loggedRequest.getHeader("Authorization")).isEqualTo("Bearer token");
+        assertThat(loggedRequest.getHeader("x-api-key")).isNull();
+    }
+
+    @ApplicationScoped
+    public static class DummyModelAuthProvider implements ModelAuthProvider {
+
+        @Override
+        public String getAuthorization(Input input) {
+            return "Bearer token";
+        }
+    }
+}

--- a/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/AnthropicRestApi.java
+++ b/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/AnthropicRestApi.java
@@ -76,10 +76,6 @@ public interface AnthropicRestApi {
         public final String beta;
 
         private ApiMetadata(String apiKey, String anthropicVersion, String beta) {
-            if ((apiKey == null) || apiKey.isBlank()) {
-                throw new IllegalArgumentException("apiKey cannot be null or blank");
-            }
-
             if ((anthropicVersion == null) || anthropicVersion.isBlank()) {
                 throw new IllegalArgumentException("anthropicVersion cannot be null or blank");
             }

--- a/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/QuarkusAnthropicClient.java
+++ b/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/QuarkusAnthropicClient.java
@@ -16,14 +16,18 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Flow.Subscription;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.eclipse.microprofile.context.ManagedExecutor;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.client.api.ClientLogger;
 import org.jboss.resteasy.reactive.client.api.LoggingScope;
+import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientRequestContext;
+import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientRequestFilter;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
@@ -51,8 +55,12 @@ import dev.langchain4j.model.chat.response.PartialToolCall;
 import dev.langchain4j.model.chat.response.PartialToolCallContext;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.chat.response.StreamingHandle;
+import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
 import io.quarkiverse.langchain4j.runtime.CurlRequestLogger;
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.subscription.MultiSubscriber;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -67,6 +75,8 @@ public class QuarkusAnthropicClient extends AnthropicClient {
     private final String configuredBeta;
     private final Boolean disableBetaHeader;
     private final AnthropicRestApi restApi;
+
+    private final boolean hasModelAuthProvider;
 
     public QuarkusAnthropicClient(Builder builder) {
         this.apiKey = builder.apiKey;
@@ -84,6 +94,11 @@ public class QuarkusAnthropicClient extends AnthropicClient {
                         new QuarkusAnthropicClient.AnthropicClientLogger(builder.logRequests, builder.logResponses,
                                 builder.logCurl));
             }
+
+            var modelAuthProvider = ModelAuthProvider.resolve(builder.configName);
+            this.hasModelAuthProvider = modelAuthProvider.isPresent();
+            modelAuthProvider.ifPresent(provider -> restApiBuilder
+                    .register(new AnthropicRestAPIFilter(provider)));
 
             this.restApi = restApiBuilder.build(AnthropicRestApi.class);
         } catch (URISyntaxException e) {
@@ -112,7 +127,7 @@ public class QuarkusAnthropicClient extends AnthropicClient {
 
     private AnthropicRestApi.ApiMetadata createMetadata(AnthropicCreateMessageRequest request) {
         var builder = AnthropicRestApi.ApiMetadata.builder()
-                .apiKey(apiKey)
+                .apiKey(hasModelAuthProvider ? null : apiKey)
                 .anthropicVersion(anthropicVersion);
 
         String betaHeader = buildBetaHeaderForRequest(request);
@@ -495,12 +510,25 @@ public class QuarkusAnthropicClient extends AnthropicClient {
         return value != null && value;
     }
 
+    private static final ThreadLocal<String> CONFIG_NAME_HINT = new ThreadLocal<>();
+
+    public static void setConfigNameHint(String configName) {
+        CONFIG_NAME_HINT.set(configName);
+    }
+
+    static String getAndClearConfigNameHint() {
+        String value = CONFIG_NAME_HINT.get();
+        CONFIG_NAME_HINT.remove();
+        return value;
+    }
+
     public static class QuarkusAnthropicClientBuilderFactory implements AnthropicClientBuilderFactory {
         @Override
         public AnthropicClient.Builder get() {
             Builder builder = new Builder();
             builder.logCurl = getAndClearLogCurlHint();
             builder.disableBetaHeader = getAndClearDisableBetaHint();
+            builder.configName = getAndClearConfigNameHint();
             return builder;
         }
     }
@@ -508,6 +536,7 @@ public class QuarkusAnthropicClient extends AnthropicClient {
     public static class Builder extends AnthropicClient.Builder<QuarkusAnthropicClient, Builder> {
         public boolean logCurl;
         public boolean disableBetaHeader;
+        public String configName;
 
         @Override
         public QuarkusAnthropicClient build() {
@@ -602,6 +631,51 @@ public class QuarkusAnthropicClient extends AnthropicClient {
             } catch (Exception e) {
                 return "Failed to mask the API key.";
             }
+        }
+    }
+
+    static class AnthropicRestAPIFilter implements ResteasyReactiveClientRequestFilter {
+        private final ModelAuthProvider authorizer;
+
+        AnthropicRestAPIFilter(ModelAuthProvider authorizer) {
+            this.authorizer = authorizer;
+        }
+
+        @Override
+        public void filter(ResteasyReactiveClientRequestContext requestContext) {
+            Executor executor = createExecutor();
+            requestContext.suspend();
+            executor.execute(() -> {
+                try {
+                    String authValue = authorizer.getAuthorization(new ModelAuthProvider.Input() {
+                        @Override
+                        public String method() {
+                            return requestContext.getMethod();
+                        }
+
+                        @Override
+                        public URI uri() {
+                            return requestContext.getUri();
+                        }
+
+                        @Override
+                        public Map<String, List<Object>> headers() {
+                            return requestContext.getHeaders();
+                        }
+                    });
+                    if (authValue != null) {
+                        requestContext.getHeaders().putSingle("Authorization", authValue);
+                    }
+                    requestContext.resume();
+                } catch (Exception e) {
+                    requestContext.resume(e);
+                }
+            });
+        }
+
+        private static Executor createExecutor() {
+            InstanceHandle<ManagedExecutor> executor = Arc.container().instance(ManagedExecutor.class);
+            return executor.isAvailable() ? executor.get() : Infrastructure.getDefaultExecutor();
         }
     }
 }

--- a/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/AnthropicRecorder.java
+++ b/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/runtime/AnthropicRecorder.java
@@ -31,6 +31,7 @@ import io.quarkiverse.langchain4j.anthropic.QuarkusAnthropicClient;
 import io.quarkiverse.langchain4j.anthropic.runtime.config.ChatModelConfig;
 import io.quarkiverse.langchain4j.anthropic.runtime.config.LangChain4jAnthropicConfig;
 import io.quarkiverse.langchain4j.anthropic.runtime.config.ToolSearchType;
+import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.runtime.RuntimeValue;
@@ -46,6 +47,8 @@ public class AnthropicRecorder {
     private static final TypeLiteral<Instance<ModelBuilderCustomizer<AnthropicChatModel.AnthropicChatModelBuilder>>> CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
     };
     private static final TypeLiteral<Instance<ModelBuilderCustomizer<AnthropicStreamingChatModel.AnthropicStreamingChatModelBuilder>>> STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelAuthProvider>> MODEL_AUTH_PROVIDER_TYPE_LITERAL = new TypeLiteral<>() {
     };
 
     private static final String DUMMY_KEY = "dummy";
@@ -64,10 +67,6 @@ public class AnthropicRecorder {
         if (anthropicConfig.enableIntegration()) {
             var chatModelConfig = anthropicConfig.chatModel();
             var apiKey = anthropicConfig.apiKey();
-
-            if (DUMMY_KEY.equals(apiKey)) {
-                throw new ConfigValidationException(createApiKeyConfigProblem(configName));
-            }
 
             if (chatModelConfig.maxRetries() < 1) {
                 throw new ConfigValidationException(createMaxRetriesConfigProblem(configName));
@@ -192,10 +191,12 @@ public class AnthropicRecorder {
             return new Function<>() {
                 @Override
                 public ChatModel apply(SyntheticCreationalContext<ChatModel> context) {
+                    throwIfApiKeyNotConfigured(apiKey, context, configName);
                     builder.listeners(context.getInjectedReference(CHAT_MODEL_LISTENER_TYPE_LITERAL).stream()
                             .collect(Collectors.toList()));
                     QuarkusAnthropicClient.setLogCurlHint(logCurl);
                     QuarkusAnthropicClient.setDisableBetaHint(disableBeta);
+                    QuarkusAnthropicClient.setConfigNameHint(configName);
                     ModelBuilderCustomizer.applyCustomizers(
                             context.getInjectedReference(CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
                             builder, configName);
@@ -219,10 +220,6 @@ public class AnthropicRecorder {
         if (anthropicConfig.enableIntegration()) {
             var chatModelConfig = anthropicConfig.chatModel();
             var apiKey = anthropicConfig.apiKey();
-
-            if (DUMMY_KEY.equals(apiKey)) {
-                throw new ConfigValidationException(createApiKeyConfigProblem(configName));
-            }
 
             var builder = AnthropicStreamingChatModel.builder()
                     .baseUrl(anthropicConfig.baseUrl())
@@ -341,10 +338,12 @@ public class AnthropicRecorder {
             return new Function<>() {
                 @Override
                 public StreamingChatModel apply(SyntheticCreationalContext<StreamingChatModel> context) {
+                    throwIfApiKeyNotConfigured(apiKey, context, configName);
                     builder.listeners(context.getInjectedReference(CHAT_MODEL_LISTENER_TYPE_LITERAL).stream()
                             .collect(Collectors.toList()));
                     QuarkusAnthropicClient.setLogCurlHint(logCurl);
                     QuarkusAnthropicClient.setDisableBetaHint(disableBeta);
+                    QuarkusAnthropicClient.setConfigNameHint(configName);
                     ModelBuilderCustomizer.applyCustomizers(
                             context.getInjectedReference(STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL,
                                     Any.Literal.INSTANCE),
@@ -360,6 +359,17 @@ public class AnthropicRecorder {
                 }
             };
         }
+    }
+
+    private static <T> void throwIfApiKeyNotConfigured(String apiKey,
+            SyntheticCreationalContext<T> context, String configName) {
+        if (DUMMY_KEY.equals(apiKey) && !isAuthProviderAvailable(context, configName)) {
+            throw new ConfigValidationException(createApiKeyConfigProblem(configName));
+        }
+    }
+
+    private static <T> boolean isAuthProviderAvailable(SyntheticCreationalContext<T> context, String configName) {
+        return context.getInjectedReference(MODEL_AUTH_PROVIDER_TYPE_LITERAL).isResolvable();
     }
 
     private LangChain4jAnthropicConfig.AnthropicConfig correspondingAnthropicConfig(

--- a/model-providers/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/OpenAiProcessor.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/OpenAiProcessor.java
@@ -168,6 +168,8 @@ public class OpenAiProcessor {
                         .scope(ApplicationScoped.class)
                         .addInjectionPoint(Type.create(ProxyConfigurationRegistry.class))
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ClassType.create(DotNames.MODEL_AUTH_PROVIDER) }, null))
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
                                         new Type[] { ClassType.create(OPENAI_EMBEDDING_MODEL_BUILDER) }, null) },
                                 null), ANY)
@@ -186,6 +188,8 @@ public class OpenAiProcessor {
                         .defaultBean()
                         .scope(ApplicationScoped.class)
                         .addInjectionPoint(Type.create(ProxyConfigurationRegistry.class))
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ClassType.create(DotNames.MODEL_AUTH_PROVIDER) }, null))
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
                                         new Type[] { ClassType.create(OPENAI_MODERATION_MODEL_BUILDER) }, null) },
@@ -206,6 +210,8 @@ public class OpenAiProcessor {
                         .scope(ApplicationScoped.class)
                         .addInjectionPoint(Type.create(ProxyConfigurationRegistry.class))
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ClassType.create(DotNames.MODEL_AUTH_PROVIDER) }, null))
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
                                         new Type[] { ClassType.create(OPENAI_IMAGE_MODEL_BUILDER) }, null) },
                                 null), ANY)
@@ -224,6 +230,8 @@ public class OpenAiProcessor {
                         .defaultBean()
                         .scope(ApplicationScoped.class)
                         .addInjectionPoint(Type.create(ProxyConfigurationRegistry.class))
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ClassType.create(DotNames.MODEL_AUTH_PROVIDER) }, null))
                         .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                                 new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
                                         new Type[] { ClassType.create(OPENAI_AUDIO_TRANSCRIPTION_MODEL_BUILDER) }, null) },
@@ -244,6 +252,8 @@ public class OpenAiProcessor {
                 .scope(ApplicationScoped.class)
                 .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                         new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
+                .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                        new Type[] { ClassType.create(DotNames.MODEL_AUTH_PROVIDER) }, null))
                 .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                         new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
                                 new Type[] { ClassType.create(builderCustomizerType) }, null) },

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/ModelAuthProviderSmokeTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/ModelAuthProviderSmokeTest.java
@@ -1,0 +1,60 @@
+package io.quarkiverse.langchain4j.openai.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
+import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.arc.ClientProxy;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ModelAuthProviderSmokeTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    ChatModel chatModel;
+
+    @Inject
+    StreamingChatModel streamingChatModel;
+
+    @Test
+    void testModelAuthProviderUsed() {
+        assertThat(ClientProxy.unwrap(chatModel)).isInstanceOf(OpenAiChatModel.class);
+        assertThat(ClientProxy.unwrap(streamingChatModel)).isInstanceOf(OpenAiStreamingChatModel.class);
+
+        setChatCompletionMessageContent("whatever");
+        String response = chatModel.chat("hello");
+        assertThat(response).isNotBlank();
+
+        LoggedRequest loggedRequest = singleLoggedRequest();
+        assertThat(loggedRequest.getHeader("Authorization")).isEqualTo("Bearer token");
+    }
+
+    @ApplicationScoped
+    public static class DummyModelAuthProvider implements ModelAuthProvider {
+
+        @Override
+        public String getAuthorization(Input input) {
+            return "Bearer token";
+        }
+    }
+}

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
@@ -44,6 +44,7 @@ import dev.langchain4j.model.openai.OpenAiResponsesChatModel;
 import dev.langchain4j.model.openai.OpenAiResponsesStreamingChatModel;
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
 import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
+import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
 import io.quarkiverse.langchain4j.jaxrsclient.JaxRsHttpClientBuilder;
 import io.quarkiverse.langchain4j.openai.DisabledAudioTranscriptionModel;
 import io.quarkiverse.langchain4j.openai.QuarkusOpenAiAudioTranscriptionModelBuilderFactory;
@@ -95,6 +96,8 @@ public class OpenAiRecorder {
     };
     private static final TypeLiteral<Instance<ModelBuilderCustomizer<OpenAiAudioTranscriptionModel.Builder>>> AUDIO_TRANSCRIPTION_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
     };
+    private static final TypeLiteral<Instance<ModelAuthProvider>> MODEL_AUTH_PROVIDER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
 
     private static final String DUMMY_KEY = "dummy";
     private static final String OPENAI_BASE_URL = "https://api.openai.com/v1/";
@@ -111,9 +114,6 @@ public class OpenAiRecorder {
 
         if (openAiConfig.enableIntegration()) {
             String apiKey = openAiConfig.apiKey();
-            if (DUMMY_KEY.equals(apiKey) && OPENAI_BASE_URL.equals(openAiConfig.baseUrl())) {
-                throw new ConfigValidationException(createApiKeyConfigProblems(configName));
-            }
             if (openAiConfig.maxRetries() < 1) {
                 throw new ConfigValidationException(createMaxRetriesConfigProblems(configName));
             }
@@ -158,6 +158,7 @@ public class OpenAiRecorder {
             return new Function<>() {
                 @Override
                 public ChatModel apply(SyntheticCreationalContext<ChatModel> context) {
+                    throwIfApiKeyNotConfigured(apiKey, openAiConfig.baseUrl(), context, configName);
                     builder.listeners(context.getInjectedReference(CHAT_MODEL_LISTENER_TYPE_LITERAL).stream()
                             .collect(Collectors.toList()));
 
@@ -192,9 +193,6 @@ public class OpenAiRecorder {
 
         if (openAiConfig.enableIntegration()) {
             String apiKey = openAiConfig.apiKey();
-            if (DUMMY_KEY.equals(apiKey) && OPENAI_BASE_URL.equals(openAiConfig.baseUrl())) {
-                throw new ConfigValidationException(createApiKeyConfigProblems(configName));
-            }
             ChatModelConfig chatModelConfig = openAiConfig.chatModel();
             var builder = (QuarkusOpenAiStreamingChatModelBuilderFactory.Builder) OpenAiStreamingChatModel.builder();
             builder.logCurl(firstOrDefault(false, openAiConfig.logRequestsCurl()));
@@ -227,6 +225,7 @@ public class OpenAiRecorder {
                 @Override
                 public StreamingChatModel apply(
                         SyntheticCreationalContext<StreamingChatModel> context) {
+                    throwIfApiKeyNotConfigured(apiKey, openAiConfig.baseUrl(), context, configName);
                     builder.listeners(context.getInjectedReference(CHAT_MODEL_LISTENER_TYPE_LITERAL).stream()
                             .collect(Collectors.toList()));
 
@@ -519,9 +518,6 @@ public class OpenAiRecorder {
 
         if (openAiConfig.enableIntegration()) {
             String apiKey = openAiConfig.apiKey();
-            if (DUMMY_KEY.equals(apiKey) && OPENAI_BASE_URL.equals(openAiConfig.baseUrl())) {
-                throw new ConfigValidationException(createApiKeyConfigProblems(configName));
-            }
             if (openAiConfig.maxRetries() < 1) {
                 throw new ConfigValidationException(createMaxRetriesConfigProblems(configName));
             }
@@ -547,6 +543,7 @@ public class OpenAiRecorder {
             return new Function<>() {
                 @Override
                 public EmbeddingModel apply(SyntheticCreationalContext<EmbeddingModel> context) {
+                    throwIfApiKeyNotConfigured(apiKey, openAiConfig.baseUrl(), context, configName);
                     ProxyConfigurationRegistry proxyRegistry = context.getInjectedReference(ProxyConfigurationRegistry.class);
                     Optional<Proxy> embeddingProxy = resolveProxy(openAiConfig, proxyRegistry);
                     if (embeddingProxy.isPresent()) {
@@ -575,9 +572,6 @@ public class OpenAiRecorder {
 
         if (openAiConfig.enableIntegration()) {
             String apiKey = openAiConfig.apiKey();
-            if (DUMMY_KEY.equals(apiKey) && OPENAI_BASE_URL.equals(openAiConfig.baseUrl())) {
-                throw new ConfigValidationException(createApiKeyConfigProblems(configName));
-            }
             if (openAiConfig.maxRetries() < 1) {
                 throw new ConfigValidationException(createMaxRetriesConfigProblems(configName));
             }
@@ -600,6 +594,7 @@ public class OpenAiRecorder {
             return new Function<>() {
                 @Override
                 public ModerationModel apply(SyntheticCreationalContext<ModerationModel> context) {
+                    throwIfApiKeyNotConfigured(apiKey, openAiConfig.baseUrl(), context, configName);
                     ModelBuilderCustomizer.applyCustomizers(
                             context.getInjectedReference(MODERATION_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
                             builder, configName);
@@ -626,9 +621,6 @@ public class OpenAiRecorder {
 
         if (openAiConfig.enableIntegration()) {
             String apiKey = openAiConfig.apiKey();
-            if (DUMMY_KEY.equals(apiKey) && OPENAI_BASE_URL.equals(openAiConfig.baseUrl())) {
-                throw new ConfigValidationException(createApiKeyConfigProblems(configName));
-            }
             ImageModelConfig imageModelConfig = openAiConfig.imageModel();
             var builder = QuarkusOpenAiImageModel.builder()
                     .configName(configName)
@@ -675,6 +667,7 @@ public class OpenAiRecorder {
             return new Function<>() {
                 @Override
                 public ImageModel apply(SyntheticCreationalContext<ImageModel> context) {
+                    throwIfApiKeyNotConfigured(apiKey, openAiConfig.baseUrl(), context, configName);
                     ModelBuilderCustomizer.applyCustomizers(
                             context.getInjectedReference(IMAGE_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
                             builder, configName);
@@ -703,9 +696,6 @@ public class OpenAiRecorder {
 
         if (openAiConfig.enableIntegration()) {
             String apiKey = openAiConfig.apiKey();
-            if (DUMMY_KEY.equals(apiKey) && OPENAI_BASE_URL.equals(openAiConfig.baseUrl())) {
-                throw new ConfigValidationException(createApiKeyConfigProblems(configName));
-            }
             if (openAiConfig.maxRetries() < 1) {
                 throw new ConfigValidationException(createMaxRetriesConfigProblems(configName));
             }
@@ -729,6 +719,7 @@ public class OpenAiRecorder {
             return new Function<>() {
                 @Override
                 public AudioTranscriptionModel apply(SyntheticCreationalContext<AudioTranscriptionModel> context) {
+                    throwIfApiKeyNotConfigured(apiKey, openAiConfig.baseUrl(), context, configName);
                     ModelBuilderCustomizer.applyCustomizers(
                             context.getInjectedReference(AUDIO_TRANSCRIPTION_MODEL_CUSTOMIZER_TYPE_LITERAL,
                                     Any.Literal.INSTANCE),
@@ -808,24 +799,35 @@ public class OpenAiRecorder {
         return openAiConfig;
     }
 
-    private ConfigValidationException.Problem[] createApiKeyConfigProblems(String configName) {
+    private static ConfigValidationException.Problem[] createApiKeyConfigProblems(String configName) {
         return createConfigProblems("api-key", configName);
     }
 
-    private ConfigValidationException.Problem[] createMaxRetriesConfigProblems(String configName) {
+    private static ConfigValidationException.Problem[] createMaxRetriesConfigProblems(String configName) {
         return new ConfigValidationException.Problem[] { new ConfigValidationException.Problem(String.format(
                 "SRCFG00014: The config property quarkus.langchain4j.openai%smax-retries must be greater than zero",
                 NamedConfigUtil.isDefault(configName) ? "." : ("." + configName + "."))) };
     }
 
-    private ConfigValidationException.Problem[] createConfigProblems(String key, String configName) {
+    private static ConfigValidationException.Problem[] createConfigProblems(String key, String configName) {
         return new ConfigValidationException.Problem[] { createConfigProblem(key, configName) };
     }
 
-    private ConfigValidationException.Problem createConfigProblem(String key, String configName) {
+    private static ConfigValidationException.Problem createConfigProblem(String key, String configName) {
         return new ConfigValidationException.Problem(String.format(
                 "SRCFG00014: The config property quarkus.langchain4j.openai%s%s is required but it could not be found in any config source",
                 NamedConfigUtil.isDefault(configName) ? "." : ("." + configName + "."), key));
+    }
+
+    private static <T> void throwIfApiKeyNotConfigured(String apiKey, String baseUrl,
+            SyntheticCreationalContext<T> context, String configName) {
+        if (DUMMY_KEY.equals(apiKey) && OPENAI_BASE_URL.equals(baseUrl) && !isAuthProviderAvailable(context, configName)) {
+            throw new ConfigValidationException(createApiKeyConfigProblems(configName));
+        }
+    }
+
+    private static <T> boolean isAuthProviderAvailable(SyntheticCreationalContext<T> context, String configName) {
+        return context.getInjectedReference(MODEL_AUTH_PROVIDER_TYPE_LITERAL).isResolvable();
     }
 
     public void cleanUp(ShutdownContext shutdown) {

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -38,6 +38,8 @@
         <module>weather-agent</module>
         <module>react-chatbot</module>
         <module>skills</module>
+        <module>workload-identity-federation-spiffe</module>
+        <module>workload-identity-federation-kubernetes</module>
     </modules>
 
     <build>

--- a/samples/workload-identity-federation-kubernetes/README.md
+++ b/samples/workload-identity-federation-kubernetes/README.md
@@ -1,0 +1,108 @@
+# Workload Identity Federation with Kubernetes Projected Tokens
+
+A Quarkus chat application that authenticates to Anthropic Claude using [Workload Identity Federation](https://docs.anthropic.com/en/docs/build-with-claude/workload-identity-federation) with [Kubernetes Identity Provider](https://platform.claude.com/docs/en/manage-claude/wif-providers/kubernetes) projected service account tokens.
+
+No API keys are stored or distributed — the workload proves its identity through a Kubernetes-issued JWT token, which is exchanged for a short-lived Anthropic access token.
+
+Unlike the `workload-identity-federation-spiffe` sample, this approach uses Kubernetes-native token projection and does not require SPIRE or any additional identity infrastructure — making it a good fit for single-cluster deployments. For multi-cluster or hybrid environments where a unified identity layer is needed, see the `workload-identity-federation-spiffe` sample.
+
+## Prerequisites
+
+- A Kubernetes or OpenShift cluster
+- `kubectl` (`oc` for OpenShift)
+- An Anthropic organization with Workload Identity Federation access
+
+## 1. Identify the cluster issuer URL and subject
+
+When configuring Anthropic (next step), you need two values from the Kubernetes service account token:
+
+- **Issuer URL** (`iss`): the cluster's service account issuer. Retrieve it with:
+
+```bash
+kubectl get --raw /.well-known/openid-configuration | jq -r .issuer
+```
+
+- **Subject** (`sub`): follows the format `system:serviceaccount:<namespace>:<service-account-name>`. For this sample: `system:serviceaccount:workload-identity-k8s:workload-identity-federation-kubernetes`
+
+If the issuer URL is not publicly reachable, you will need to register it with Anthropic in `inline` JWKS mode. Fetch the cluster's signing keys:
+
+```bash
+kubectl get --raw /openid/v1/jwks
+```
+
+You can also verify these values by decoding a token from a running pod:
+
+```bash
+oc exec deployment/workload-identity-federation-kubernetes -n workload-identity-k8s -c app \
+    -- cat /var/run/secrets/tokens/kubernetes-service-token | cut -d. -f2 | base64 -d 2>/dev/null | python3 -m json.tool
+```
+
+## 2. Configure Anthropic
+
+Follow the [Anthropic Kubernetes WIF setup guide](https://platform.claude.com/docs/en/manage-claude/wif-providers/kubernetes) to:
+
+1. Register a **federation issuer** using the cluster issuer URL from step 1. If the issuer is not publicly reachable, use `inline` JWKS mode and paste the keys from `kubectl get --raw /openid/v1/jwks`
+2. Create an Anthropic **service account** — this is the identity the workload assumes on the Anthropic side; the access token returned after the token exchange is scoped to it. Its `service_account_id` is included in the OIDC client token exchange request alongside the workload token
+3. Create a **federation rule** matching:
+   - Subject: `system:serviceaccount:workload-identity-k8s:workload-identity-federation-kubernetes` (where `serviceaccount` refers to the Kubernetes service account name)
+   - Audience: `https://api.anthropic.com`
+
+Note the `federation_rule_id`, `organization_id`, and `service_account_id` values — they are needed for the Kubernetes secret in step 4.
+
+## 3. Create the namespace and workload identity
+
+```bash
+oc create namespace workload-identity-k8s
+oc project workload-identity-k8s
+oc apply -f deploy/service-account.yml
+```
+
+## 4. Create the Anthropic WIF secret
+
+Edit `deploy/secret.yml` with the values from step 2, then apply:
+
+```bash
+oc apply -f deploy/secret.yml
+```
+
+Or create it directly:
+
+```bash
+oc create secret generic anthropic-wif \
+    --namespace workload-identity-k8s \
+    --from-literal=ANTHROPIC_FEDERATION_RULE_ID=fdrl_... \
+    --from-literal=ANTHROPIC_ORGANIZATION_ID=... \
+    --from-literal=ANTHROPIC_SERVICE_ACCOUNT_ID=svac_...
+```
+
+## 5. Build and deploy
+
+Build the container image using the OpenShift binary build:
+
+```bash
+mvn package -DskipTests -Dquarkus.container-image.build=true
+```
+
+Deploy the application:
+
+```bash
+oc apply -f deploy/deployment.yml
+oc apply -f deploy/service.yml
+oc apply -f deploy/route.yml
+```
+
+Wait for the pod to be ready:
+
+```bash
+oc wait pod -l app.kubernetes.io/name=workload-identity-federation-kubernetes -n workload-identity-k8s --for=condition=Ready --timeout=120s
+```
+
+## 6. Access the chat UI
+
+Get the route URL:
+
+```bash
+oc get route workload-identity-federation-kubernetes -n workload-identity-k8s -o jsonpath='{.spec.host}'
+```
+
+Open `https://<route-host>/chat.html` in your browser and type a message such as `What is your name?` to verify the application can authenticate and chat with the model.

--- a/samples/workload-identity-federation-kubernetes/deploy/deployment.yml
+++ b/samples/workload-identity-federation-kubernetes/deploy/deployment.yml
@@ -1,0 +1,37 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: workload-identity-federation-kubernetes
+  namespace: workload-identity-k8s
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: workload-identity-federation-kubernetes
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: workload-identity-federation-kubernetes
+    spec:
+      restartPolicy: Always
+      serviceAccountName: workload-identity-federation-kubernetes
+      containers:
+        - name: app
+          image: quarkus-langchain4j-sample-workload-identity-k8s:1.0.0-SNAPSHOT
+          envFrom:
+            - secretRef:
+                name: anthropic-wif
+          volumeMounts:
+            - name: anthropic-token
+              readOnly: true
+              mountPath: /var/run/secrets/tokens
+      volumes:
+        - name: anthropic-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  audience: https://api.anthropic.com
+                  expirationSeconds: 3600
+                  path: kubernetes-service-token
+  strategy:
+    type: Recreate

--- a/samples/workload-identity-federation-kubernetes/deploy/route.yml
+++ b/samples/workload-identity-federation-kubernetes/deploy/route.yml
@@ -1,0 +1,13 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: workload-identity-federation-kubernetes
+  namespace: workload-identity-k8s
+spec:
+  to:
+    kind: Service
+    name: workload-identity-federation-kubernetes
+  port:
+    targetPort: 8080
+  tls:
+    termination: edge

--- a/samples/workload-identity-federation-kubernetes/deploy/secret.yml
+++ b/samples/workload-identity-federation-kubernetes/deploy/secret.yml
@@ -1,0 +1,10 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: anthropic-wif
+  namespace: workload-identity-k8s
+type: Opaque
+stringData:
+  ANTHROPIC_FEDERATION_RULE_ID: <your-federation-rule-id>
+  ANTHROPIC_ORGANIZATION_ID: <your-organization-id>
+  ANTHROPIC_SERVICE_ACCOUNT_ID: <your-service-account-id>

--- a/samples/workload-identity-federation-kubernetes/deploy/service-account.yml
+++ b/samples/workload-identity-federation-kubernetes/deploy/service-account.yml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: workload-identity-federation-kubernetes
+  namespace: workload-identity-k8s

--- a/samples/workload-identity-federation-kubernetes/deploy/service.yml
+++ b/samples/workload-identity-federation-kubernetes/deploy/service.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: workload-identity-federation-kubernetes
+  namespace: workload-identity-k8s
+spec:
+  selector:
+    app.kubernetes.io/name: workload-identity-federation-kubernetes
+  ports:
+    - port: 8080
+      targetPort: 8080
+      protocol: TCP

--- a/samples/workload-identity-federation-kubernetes/pom.xml
+++ b/samples/workload-identity-federation-kubernetes/pom.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.quarkiverse.langchain4j</groupId>
+    <artifactId>quarkus-langchain4j-sample-workload-identity-k8s</artifactId>
+    <name>Quarkus LangChain4j - Sample - Workload Identity Federation (Kubernetes Projected Tokens)</name>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <properties>
+        <compiler-plugin.version>3.15.0</compiler-plugin.version>
+        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.34.2</quarkus.platform.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
+        <quarkus-langchain4j.version>999-SNAPSHOT</quarkus-langchain4j.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-qute</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-web-dependency-locator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mvnpm</groupId>
+            <artifactId>htmx.org</artifactId>
+            <version>2.0.4</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kubernetes</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-container-image-openshift</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.langchain4j</groupId>
+            <artifactId>quarkus-langchain4j-anthropic</artifactId>
+            <version>${quarkus-langchain4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.langchain4j</groupId>
+            <artifactId>quarkus-langchain4j-workload-model-auth-provider</artifactId>
+            <version>${quarkus-langchain4j.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire-plugin.version}</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.package.jar.enabled>false</quarkus.package.jar.enabled>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/samples/workload-identity-federation-kubernetes/src/main/java/io/quarkiverse/langchain4j/sample/wif/ChatAiService.java
+++ b/samples/workload-identity-federation-kubernetes/src/main/java/io/quarkiverse/langchain4j/sample/wif/ChatAiService.java
@@ -1,0 +1,14 @@
+package io.quarkiverse.langchain4j.sample.wif;
+
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@RegisterAiService(chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
+@ApplicationScoped
+public interface ChatAiService {
+
+    @SystemMessage("You are a friendly AI assistant. Answer questions concisely.")
+    String chat(@UserMessage String message);
+}

--- a/samples/workload-identity-federation-kubernetes/src/main/java/io/quarkiverse/langchain4j/sample/wif/ChatResource.java
+++ b/samples/workload-identity-federation-kubernetes/src/main/java/io/quarkiverse/langchain4j/sample/wif/ChatResource.java
@@ -1,0 +1,27 @@
+package io.quarkiverse.langchain4j.sample.wif;
+
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.TemplateInstance;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/api/chat")
+public class ChatResource {
+
+    @CheckedTemplate
+    public static class Templates {
+        public static native TemplateInstance chatMessage(String response);
+    }
+
+    @Inject
+    ChatAiService aiService;
+
+    @POST
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance chat(@FormParam("message") String message) {
+        String response = aiService.chat(message);
+        return Templates.chatMessage(response);
+    }
+}

--- a/samples/workload-identity-federation-kubernetes/src/main/resources/META-INF/resources/chat.html
+++ b/samples/workload-identity-federation-kubernetes/src/main/resources/META-INF/resources/chat.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Workload Identity Federation Chat</title>
+    <script src="/_static/htmx.org/dist/htmx.min.js"></script>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            background: #f5f5f5;
+            padding: 20px;
+            height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .container {
+            max-width: 900px;
+            margin: 0 auto;
+            width: 100%;
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+
+        header {
+            background: white;
+            padding: 20px;
+            border-radius: 10px;
+            margin-bottom: 20px;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        h1 {
+            color: #333;
+        }
+
+        .chat-container {
+            background: white;
+            border-radius: 10px;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+        }
+
+        .messages-container {
+            flex: 1;
+            overflow-y: auto;
+            padding: 20px;
+        }
+
+        .message {
+            margin-bottom: 20px;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .message.user {
+            align-items: flex-end;
+        }
+
+        .message.assistant {
+            align-items: flex-start;
+        }
+
+        .message-bubble {
+            max-width: 70%;
+            padding: 12px 16px;
+            border-radius: 12px;
+            word-wrap: break-word;
+            white-space: pre-wrap;
+        }
+
+        .message.user .message-bubble {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+        }
+
+        .message.assistant .message-bubble {
+            background: #f0f0f0;
+            color: #333;
+        }
+
+        .message-label {
+            font-size: 0.85em;
+            color: #666;
+            margin-bottom: 4px;
+            font-weight: 500;
+        }
+
+        .input-container {
+            border-top: 1px solid #e0e0e0;
+            padding: 20px;
+            display: flex;
+            gap: 12px;
+        }
+
+        input {
+            flex: 1;
+            padding: 12px 16px;
+            border: 1px solid #ddd;
+            border-radius: 24px;
+            font-size: 14px;
+            font-family: inherit;
+        }
+
+        input:focus {
+            outline: none;
+            border-color: #667eea;
+        }
+
+        button {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            border: none;
+            padding: 12px 24px;
+            border-radius: 24px;
+            font-size: 14px;
+            font-weight: 500;
+            cursor: pointer;
+            transition: transform 0.2s;
+        }
+
+        button:hover:not(:disabled) {
+            transform: translateY(-2px);
+        }
+
+        button:active:not(:disabled) {
+            transform: translateY(0);
+        }
+
+        button:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
+        .loading {
+            display: flex;
+            gap: 8px;
+            padding: 12px 16px;
+        }
+
+        .loading-dot {
+            width: 8px;
+            height: 8px;
+            background: #667eea;
+            border-radius: 50%;
+            animation: bounce 1.4s infinite ease-in-out both;
+        }
+
+        .loading-dot:nth-child(1) {
+            animation-delay: -0.32s;
+        }
+
+        .loading-dot:nth-child(2) {
+            animation-delay: -0.16s;
+        }
+
+        @keyframes bounce {
+            0%, 80%, 100% {
+                transform: scale(0);
+            }
+            40% {
+                transform: scale(1);
+            }
+        }
+
+        .empty-state {
+            flex: 1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #999;
+            font-size: 1.1em;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Workload Identity Federation Chat</h1>
+        </header>
+
+        <div class="chat-container">
+            <div class="messages-container">
+                <div id="messages">
+                    <div class="empty-state">
+                        Start a conversation by typing a message below
+                    </div>
+                </div>
+                <div id="loading-indicator" class="htmx-indicator message assistant">
+                    <div class="message-label">Assistant</div>
+                    <div class="message-bubble">
+                        <div class="loading">
+                            <div class="loading-dot"></div>
+                            <div class="loading-dot"></div>
+                            <div class="loading-dot"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="input-container">
+                <form id="chat-form"
+                      hx-post="/api/chat"
+                      hx-target="#messages"
+                      hx-swap="beforeend"
+                      hx-indicator="#loading-indicator"
+                      style="display: flex; gap: 12px; flex: 1;">
+                    <input
+                        type="text"
+                        id="messageInput"
+                        name="message"
+                        placeholder="Type your message..."
+                        required
+                        autocomplete="off"
+                    />
+                    <button type="submit">Send</button>
+                </form>
+            </div>
+
+        </div>
+    </div>
+
+    <script>
+        document.body.addEventListener('htmx:beforeRequest', function(evt) {
+            if (evt.detail.target.id === 'messages') {
+                var emptyState = document.querySelector('.empty-state');
+                if (emptyState) {
+                    emptyState.remove();
+                }
+
+                var formData = new FormData(evt.detail.requestConfig.elt);
+                var message = formData.get('message');
+
+                if (message && message.trim()) {
+                    var messagesContainer = document.getElementById('messages');
+                    var userMessageDiv = document.createElement('div');
+                    userMessageDiv.className = 'message user';
+                    userMessageDiv.innerHTML =
+                        '<div class="message-label">You</div>' +
+                        '<div class="message-bubble">' + escapeHtml(message) + '</div>';
+                    messagesContainer.appendChild(userMessageDiv);
+                    messagesContainer.scrollTop = messagesContainer.scrollHeight;
+                }
+            }
+        });
+
+        document.body.addEventListener('htmx:afterSwap', function(evt) {
+            if (evt.detail.target.id === 'messages') {
+                document.getElementById('messageInput').value = '';
+                var messagesContainer = document.getElementById('messages');
+                messagesContainer.scrollTop = messagesContainer.scrollHeight;
+            }
+        });
+
+        function escapeHtml(text) {
+            var div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+
+        window.addEventListener('load', function() {
+            document.getElementById('messageInput').focus();
+        });
+    </script>
+</body>
+</html>

--- a/samples/workload-identity-federation-kubernetes/src/main/resources/application.properties
+++ b/samples/workload-identity-federation-kubernetes/src/main/resources/application.properties
@@ -1,0 +1,17 @@
+quarkus.langchain4j.anthropic.chat-model.model-name=claude-sonnet-4-6
+quarkus.langchain4j.anthropic.timeout=60s
+
+# Workload Identity Federation
+quarkus.langchain4j.workload-model-auth-provider.token-path=/var/run/secrets/tokens/kubernetes-service-token
+
+# OIDC Client - JWT bearer grant to Anthropic
+quarkus.oidc-client.client-id=none
+quarkus.oidc-client.token-path=https://api.anthropic.com/v1/oauth/token
+quarkus.oidc-client.grant.type=jwt
+quarkus.oidc-client.grant-options.jwt.federation_rule_id=${ANTHROPIC_FEDERATION_RULE_ID}
+quarkus.oidc-client.grant-options.jwt.organization_id=${ANTHROPIC_ORGANIZATION_ID}
+quarkus.oidc-client.grant-options.jwt.service_account_id=${ANTHROPIC_SERVICE_ACCOUNT_ID}
+
+quarkus.kubernetes.deployment-target=openshift
+
+quarkus.log.level=INFO

--- a/samples/workload-identity-federation-kubernetes/src/main/resources/templates/ChatResource/chatMessage.html
+++ b/samples/workload-identity-federation-kubernetes/src/main/resources/templates/ChatResource/chatMessage.html
@@ -1,0 +1,4 @@
+<div class="message assistant">
+    <div class="message-label">Assistant</div>
+    <div class="message-bubble">{response}</div>
+</div>

--- a/samples/workload-identity-federation-spiffe/README.md
+++ b/samples/workload-identity-federation-spiffe/README.md
@@ -1,0 +1,151 @@
+# Workload Identity Federation with SPIFFE
+
+A Quarkus chat application that authenticates to Anthropic Claude using [Workload Identity Federation](https://docs.anthropic.com/en/docs/build-with-claude/workload-identity-federation) with [SPIFFE Identity Provider](https://docs.anthropic.com/en/docs/build-with-claude/workload-identity-federation/spiffe) JWT-SVIDs.
+
+No API keys are stored or distributed — the workload proves its identity through a SPIFFE-issued JWT token, which is exchanged for a short-lived Anthropic access token.
+
+SPIFFE provides a unified identity layer across clusters and infrastructure boundaries, making it a good fit for multi-cluster or hybrid environments.
+For single-cluster deployments where no additional identity infrastructure is needed, using Kubernetes projected service tokens is a good alternative. See the `workload-identity-federation-kubernetes` sample.
+
+## Prerequisites
+
+- An OpenShift cluster
+- `oc` CLI logged in to the cluster
+- An Anthropic organization with Workload Identity Federation access
+- `envsubst` (used for placeholder substitution in YAML files)
+
+## 1. Deploy SPIRE
+
+This sample uses [Red Hat Zero Trust Workload Identity Manager](https://www.redhat.com/en/technologies/cloud-computing/openshift/zero-trust-workload-identity-manager)(ZTWIM) to deploy SPIRE on OpenShift. 
+
+See the "Configuring an OpenShift environment" section of the [Federated identity across the hybrid cloud using zero trust workload identity manager](https://developers.redhat.com/articles/2026/05/08/federated-identity-across-hybrid-cloud-using-zero-trust-workload-identity) article for more information about deploying ZTWIM.
+
+### Install the ZTWIM operator
+
+```bash
+oc apply -f deploy/ztwim-operator.yml
+```
+
+Wait for the Custom Resource Definitions to be established:
+
+```bash
+oc wait crd/spireservers.operator.openshift.io --for=condition=established --timeout=120s
+```
+
+### Create the ZTWIM instance
+
+Set your OpenShift application domain and apply the ZTWIM instance configuration. This creates the SPIRE Server, SPIRE Agent, SPIRE OIDC Discovery Provider, and SPIFFE CSI Driver (which mounts the SPIRE Workload API socket into application pods so they can request SPIFFE identities):
+
+```bash
+export OPENSHIFT_APPS_DOMAIN=<your-openshift-application-domain>
+envsubst < deploy/ztwim-instance.yml | oc apply -f -
+```
+
+Wait for all components to be ready:
+
+```bash
+oc wait pod -l app.kubernetes.io/name=spire-server -n zero-trust-workload-identity-manager --for=condition=Ready --timeout=120s
+oc wait pod -l app.kubernetes.io/name=spire-agent -n zero-trust-workload-identity-manager --for=condition=Ready --timeout=120s
+```
+
+Verify the OIDC Discovery Provider route:
+
+```bash
+oc get route -n zero-trust-workload-identity-manager
+```
+
+The OIDC Discovery Provider URL will be `https://spire-spiffe-oidc-discovery-provider.<your-openshift-application-domain>`.
+
+### Identify the issuer URL and subject
+
+When configuring Anthropic (next step), you need two values from the SPIFFE token:
+
+- **Issuer URL** (`iss`): the OIDC Discovery Provider URL configured in `deploy/ztwim-instance.yml` as `jwtIssuer`, e.g. `https://spire-spiffe-oidc-discovery-provider.<your-openshift-application-domain>`
+- **Subject** (`sub`): the SPIFFE ID assigned to the workload. It is constructed from the `spiffeIDTemplate` in `deploy/clusterspiffeid.yml`: `spiffe://<trust-domain>/ns/workload-identity-spiffe/sa/workload-identity-federation-spiffe`, where `<trust-domain>` is the `trustDomain` value from `deploy/ztwim-instance.yml` (i.e. your `OPENSHIFT_APPS_DOMAIN`)
+
+You can also verify these values by decoding a token from a running pod:
+
+```bash
+oc exec deployment/workload-identity-federation-spiffe -n workload-identity-spiffe -c app \
+    -- cat /var/run/secrets/tokens/spiffe-jwt-svid | cut -d. -f2 | base64 -d 2>/dev/null | python3 -m json.tool
+```
+
+This will show the JWT payload with `iss` (issuer), `sub` (subject), and `aud` (audience) claims.
+
+## 2. Configure Anthropic
+
+Follow the [Anthropic SPIFFE WIF setup guide](https://docs.anthropic.com/en/docs/build-with-claude/workload-identity-federation/spiffe) to:
+
+1. Register a **federation issuer** using the issuer URL from the previous step (you can use discovery mode)
+2. Create an Anthropic **service account** — this is the identity the workload assumes on the Anthropic side; the access token returned after the token exchange is scoped to it. Its `service_account_id` is included in the OIDC client token exchange request alongside the workload token
+3. Create a **federation rule** matching:
+   - The workload's subject (SPIFFE ID): `spiffe://<trust-domain>/ns/workload-identity-spiffe/sa/workload-identity-federation-spiffe` (where `sa` refers to the Kubernetes service account name)
+   - Audience: `https://api.anthropic.com`
+
+Note the `federation_rule_id`, `organization_id`, and `service_account_id` values — they are needed for the Kubernetes secret in step 5.
+
+## 3. Create the namespace and workload identity
+
+```bash
+oc create namespace workload-identity-spiffe
+oc project workload-identity-spiffe
+oc apply -f deploy/service-account.yml
+```
+
+## 4. Register the SPIFFE ID
+
+```bash
+oc apply -f deploy/clusterspiffeid.yml
+```
+
+This creates a `ClusterSPIFFEID` that tells SPIRE to issue JWT-SVIDs for pods matching the `workload-identity-federation-spiffe` label in the `workload-identity-spiffe` namespace. The `spiffeIDTemplate` in `deploy/clusterspiffeid.yml` defines the SPIFFE ID pattern using the pod's namespace and Kubernetes service account name, for example: `spiffe://<trust-domain>/ns/workload-identity-spiffe/sa/workload-identity-federation-spiffe`.
+
+## 5. Create the Anthropic WIF secret
+
+Edit `deploy/secret.yml` with the values from step 2, then apply:
+
+```bash
+oc apply -f deploy/secret.yml
+```
+
+Or create it directly:
+
+```bash
+oc create secret generic anthropic-wif \
+    --namespace workload-identity-spiffe \
+    --from-literal=ANTHROPIC_FEDERATION_RULE_ID=fdrl_... \
+    --from-literal=ANTHROPIC_ORGANIZATION_ID=... \
+    --from-literal=ANTHROPIC_SERVICE_ACCOUNT_ID=svac_...
+```
+
+## 6. Build and deploy
+
+Build the container image using the OpenShift binary build:
+
+```bash
+mvn package -DskipTests -Dquarkus.container-image.build=true
+```
+
+Deploy the application:
+
+```bash
+oc apply -f deploy/deployment.yml
+oc apply -f deploy/service.yml
+oc apply -f deploy/route.yml
+```
+
+Wait for the pod to be ready:
+
+```bash
+oc wait pod -l app.kubernetes.io/name=workload-identity-federation-spiffe -n workload-identity-spiffe --for=condition=Ready --timeout=120s
+```
+
+## 7. Access the chat UI
+
+Get the route URL:
+
+```bash
+oc get route workload-identity-federation-spiffe -n workload-identity-spiffe -o jsonpath='{.spec.host}'
+```
+
+Open `https://<route-host>/chat.html` in your browser and type a message such as `What is your name?` to verify the application can authenticate and chat with the model.

--- a/samples/workload-identity-federation-spiffe/deploy/clusterspiffeid.yml
+++ b/samples/workload-identity-federation-spiffe/deploy/clusterspiffeid.yml
@@ -1,0 +1,13 @@
+apiVersion: spire.spiffe.io/v1alpha1
+kind: ClusterSPIFFEID
+metadata:
+  name: workload-identity-federation-spiffe
+spec:
+  spiffeIDTemplate: "spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}"
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: workload-identity-federation-spiffe
+  namespaceSelector:
+    matchNames:
+      - workload-identity-spiffe
+  jwtTTL: 5m

--- a/samples/workload-identity-federation-spiffe/deploy/deployment.yml
+++ b/samples/workload-identity-federation-spiffe/deploy/deployment.yml
@@ -1,0 +1,81 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: workload-identity-federation-spiffe
+  namespace: workload-identity-spiffe
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: workload-identity-federation-spiffe
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: workload-identity-federation-spiffe
+    spec:
+      restartPolicy: Always
+      serviceAccountName: workload-identity-federation-spiffe
+      containers:
+        - name: app
+          image: quarkus-langchain4j-sample-workload-identity-federation-spiffe:1.0.0-SNAPSHOT
+          envFrom:
+            - secretRef:
+                name: anthropic-wif
+          volumeMounts:
+            - name: spiffe-token
+              readOnly: true
+              mountPath: /var/run/secrets/tokens
+
+        - name: spiffe-token-refresher
+          image: registry.redhat.io/ubi9/python-311:latest
+          env:
+            - name: SPIFFE_ENDPOINT_SOCKET
+              value: unix:///run/spire/sockets/spire-agent.sock
+            - name: TOKEN_PATH
+              value: /var/run/secrets/tokens/spiffe-jwt-svid
+            - name: TOKEN_AUDIENCE
+              value: https://api.anthropic.com
+          command:
+            - /bin/bash
+            - '-c'
+            - |
+              pip install -q spiffe
+
+              cat << 'SCRIPT' > /opt/app-root/src/refresh-token.py
+              #!/opt/app-root/bin/python
+
+              import time
+              import os
+              from spiffe import JwtSource
+
+              token_path = os.environ["TOKEN_PATH"]
+              audience = os.environ["TOKEN_AUDIENCE"]
+
+              while True:
+                  try:
+                      jwt_svid = JwtSource().fetch_svid(audience={audience})
+                      os.makedirs(os.path.dirname(token_path), exist_ok=True)
+                      with open(token_path, "w") as f:
+                          f.write(jwt_svid.token)
+                  except Exception as e:
+                      print(f"Failed to refresh SPIFFE token: {e}")
+                  time.sleep(60)
+              SCRIPT
+
+              python /opt/app-root/src/refresh-token.py
+          volumeMounts:
+            - name: spiffe-workload-api
+              readOnly: true
+              mountPath: /run/spire/sockets
+            - name: spiffe-token
+              mountPath: /var/run/secrets/tokens
+      volumes:
+        - name: spiffe-workload-api
+          csi:
+            driver: csi.spiffe.io
+            readOnly: true
+        - name: spiffe-token
+          emptyDir:
+            medium: Memory
+  strategy:
+    type: Recreate

--- a/samples/workload-identity-federation-spiffe/deploy/route.yml
+++ b/samples/workload-identity-federation-spiffe/deploy/route.yml
@@ -1,0 +1,13 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: workload-identity-federation-spiffe
+  namespace: workload-identity-spiffe
+spec:
+  to:
+    kind: Service
+    name: workload-identity-federation-spiffe
+  port:
+    targetPort: 8080
+  tls:
+    termination: edge

--- a/samples/workload-identity-federation-spiffe/deploy/secret.yml
+++ b/samples/workload-identity-federation-spiffe/deploy/secret.yml
@@ -1,0 +1,10 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: anthropic-wif
+  namespace: workload-identity-spiffe
+type: Opaque
+stringData:
+  ANTHROPIC_FEDERATION_RULE_ID: <your-federation-rule-id>
+  ANTHROPIC_ORGANIZATION_ID: <your-organization-id>
+  ANTHROPIC_SERVICE_ACCOUNT_ID: <your-service-account-id>

--- a/samples/workload-identity-federation-spiffe/deploy/service-account.yml
+++ b/samples/workload-identity-federation-spiffe/deploy/service-account.yml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: workload-identity-federation-spiffe
+  namespace: workload-identity-spiffe

--- a/samples/workload-identity-federation-spiffe/deploy/service.yml
+++ b/samples/workload-identity-federation-spiffe/deploy/service.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: workload-identity-federation-spiffe
+  namespace: workload-identity-spiffe
+spec:
+  selector:
+    app.kubernetes.io/name: workload-identity-federation-spiffe
+  ports:
+    - port: 8080
+      targetPort: 8080
+      protocol: TCP

--- a/samples/workload-identity-federation-spiffe/deploy/ztwim-instance.yml
+++ b/samples/workload-identity-federation-spiffe/deploy/ztwim-instance.yml
@@ -1,0 +1,51 @@
+apiVersion: operator.openshift.io/v1alpha1
+kind: ZeroTrustWorkloadIdentityManager
+metadata:
+  name: cluster
+spec:
+  clusterName: cluster
+  trustDomain: ${OPENSHIFT_APPS_DOMAIN}
+---
+apiVersion: operator.openshift.io/v1alpha1
+kind: SpireOIDCDiscoveryProvider
+metadata:
+  name: cluster
+  namespace: zero-trust-workload-identity-manager
+spec:
+  jwtIssuer: https://spire-spiffe-oidc-discovery-provider.${OPENSHIFT_APPS_DOMAIN}
+---
+apiVersion: operator.openshift.io/v1alpha1
+kind: SpireServer
+metadata:
+  name: cluster
+  namespace: zero-trust-workload-identity-manager
+spec:
+  jwtIssuer: https://spire-spiffe-oidc-discovery-provider.${OPENSHIFT_APPS_DOMAIN}
+  caSubject:
+    commonName: SPIRE CA
+    country: US
+    organization: SPIRE
+  datastore:
+    databaseType: sqlite3
+    connectionString: /run/spire/data/datastore.sqlite3
+  persistence:
+    accessMode: ReadWriteOnce
+    size: 1Gi
+---
+apiVersion: operator.openshift.io/v1alpha1
+kind: SpireAgent
+metadata:
+  name: cluster
+  namespace: zero-trust-workload-identity-manager
+spec:
+  nodeAttestor:
+    k8sPSATEnabled: "true"
+  workloadAttestors:
+    k8sEnabled: "true"
+---
+apiVersion: operator.openshift.io/v1alpha1
+kind: SpiffeCSIDriver
+metadata:
+  name: cluster
+  namespace: zero-trust-workload-identity-manager
+spec: {}

--- a/samples/workload-identity-federation-spiffe/deploy/ztwim-operator.yml
+++ b/samples/workload-identity-federation-spiffe/deploy/ztwim-operator.yml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: zero-trust-workload-identity-manager
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: zero-trust-workload-identity-manager
+  namespace: zero-trust-workload-identity-manager
+spec: {}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-zero-trust-workload-identity-manager
+  namespace: zero-trust-workload-identity-manager
+spec:
+  channel: stable-v1
+  name: openshift-zero-trust-workload-identity-manager
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic

--- a/samples/workload-identity-federation-spiffe/pom.xml
+++ b/samples/workload-identity-federation-spiffe/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.quarkiverse.langchain4j</groupId>
+    <artifactId>quarkus-langchain4j-sample-workload-identity-federation-spiffe</artifactId>
+    <name>Quarkus LangChain4j - Sample - Workload Identity Federation (SPIFFE)</name>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <properties>
+        <compiler-plugin.version>3.15.0</compiler-plugin.version>
+        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.34.2</quarkus.platform.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
+        <quarkus-langchain4j.version>999-SNAPSHOT</quarkus-langchain4j.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-qute</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-web-dependency-locator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mvnpm</groupId>
+            <artifactId>htmx.org</artifactId>
+            <version>2.0.4</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-openshift</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.langchain4j</groupId>
+            <artifactId>quarkus-langchain4j-anthropic</artifactId>
+            <version>${quarkus-langchain4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.langchain4j</groupId>
+            <artifactId>quarkus-langchain4j-workload-model-auth-provider</artifactId>
+            <version>${quarkus-langchain4j.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire-plugin.version}</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.package.jar.enabled>false</quarkus.package.jar.enabled>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/samples/workload-identity-federation-spiffe/src/main/java/io/quarkiverse/langchain4j/sample/wif/ChatAiService.java
+++ b/samples/workload-identity-federation-spiffe/src/main/java/io/quarkiverse/langchain4j/sample/wif/ChatAiService.java
@@ -1,0 +1,14 @@
+package io.quarkiverse.langchain4j.sample.wif;
+
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@RegisterAiService(chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
+@ApplicationScoped
+public interface ChatAiService {
+
+    @SystemMessage("You are a friendly AI assistant. Answer questions concisely.")
+    String chat(@UserMessage String message);
+}

--- a/samples/workload-identity-federation-spiffe/src/main/java/io/quarkiverse/langchain4j/sample/wif/ChatResource.java
+++ b/samples/workload-identity-federation-spiffe/src/main/java/io/quarkiverse/langchain4j/sample/wif/ChatResource.java
@@ -1,0 +1,27 @@
+package io.quarkiverse.langchain4j.sample.wif;
+
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.TemplateInstance;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/api/chat")
+public class ChatResource {
+
+    @CheckedTemplate
+    public static class Templates {
+        public static native TemplateInstance chatMessage(String response);
+    }
+
+    @Inject
+    ChatAiService aiService;
+
+    @POST
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance chat(@FormParam("message") String message) {
+        String response = aiService.chat(message);
+        return Templates.chatMessage(response);
+    }
+}

--- a/samples/workload-identity-federation-spiffe/src/main/resources/META-INF/resources/chat.html
+++ b/samples/workload-identity-federation-spiffe/src/main/resources/META-INF/resources/chat.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Workload Identity Federation Chat</title>
+    <script src="/_static/htmx.org/dist/htmx.min.js"></script>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            background: #f5f5f5;
+            padding: 20px;
+            height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .container {
+            max-width: 900px;
+            margin: 0 auto;
+            width: 100%;
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+
+        header {
+            background: white;
+            padding: 20px;
+            border-radius: 10px;
+            margin-bottom: 20px;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        h1 {
+            color: #333;
+        }
+
+        .chat-container {
+            background: white;
+            border-radius: 10px;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+        }
+
+        .messages-container {
+            flex: 1;
+            overflow-y: auto;
+            padding: 20px;
+        }
+
+        .message {
+            margin-bottom: 20px;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .message.user {
+            align-items: flex-end;
+        }
+
+        .message.assistant {
+            align-items: flex-start;
+        }
+
+        .message-bubble {
+            max-width: 70%;
+            padding: 12px 16px;
+            border-radius: 12px;
+            word-wrap: break-word;
+            white-space: pre-wrap;
+        }
+
+        .message.user .message-bubble {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+        }
+
+        .message.assistant .message-bubble {
+            background: #f0f0f0;
+            color: #333;
+        }
+
+        .message-label {
+            font-size: 0.85em;
+            color: #666;
+            margin-bottom: 4px;
+            font-weight: 500;
+        }
+
+        .input-container {
+            border-top: 1px solid #e0e0e0;
+            padding: 20px;
+            display: flex;
+            gap: 12px;
+        }
+
+        input {
+            flex: 1;
+            padding: 12px 16px;
+            border: 1px solid #ddd;
+            border-radius: 24px;
+            font-size: 14px;
+            font-family: inherit;
+        }
+
+        input:focus {
+            outline: none;
+            border-color: #667eea;
+        }
+
+        button {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            border: none;
+            padding: 12px 24px;
+            border-radius: 24px;
+            font-size: 14px;
+            font-weight: 500;
+            cursor: pointer;
+            transition: transform 0.2s;
+        }
+
+        button:hover:not(:disabled) {
+            transform: translateY(-2px);
+        }
+
+        button:active:not(:disabled) {
+            transform: translateY(0);
+        }
+
+        button:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
+        .loading {
+            display: flex;
+            gap: 8px;
+            padding: 12px 16px;
+        }
+
+        .loading-dot {
+            width: 8px;
+            height: 8px;
+            background: #667eea;
+            border-radius: 50%;
+            animation: bounce 1.4s infinite ease-in-out both;
+        }
+
+        .loading-dot:nth-child(1) {
+            animation-delay: -0.32s;
+        }
+
+        .loading-dot:nth-child(2) {
+            animation-delay: -0.16s;
+        }
+
+        @keyframes bounce {
+            0%, 80%, 100% {
+                transform: scale(0);
+            }
+            40% {
+                transform: scale(1);
+            }
+        }
+
+        .empty-state {
+            flex: 1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #999;
+            font-size: 1.1em;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Workload Identity Federation Chat</h1>
+        </header>
+
+        <div class="chat-container">
+            <div class="messages-container">
+                <div id="messages">
+                    <div class="empty-state">
+                        Start a conversation by typing a message below
+                    </div>
+                </div>
+                <div id="loading-indicator" class="htmx-indicator message assistant">
+                    <div class="message-label">Assistant</div>
+                    <div class="message-bubble">
+                        <div class="loading">
+                            <div class="loading-dot"></div>
+                            <div class="loading-dot"></div>
+                            <div class="loading-dot"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="input-container">
+                <form id="chat-form"
+                      hx-post="/api/chat"
+                      hx-target="#messages"
+                      hx-swap="beforeend"
+                      hx-indicator="#loading-indicator"
+                      style="display: flex; gap: 12px; flex: 1;">
+                    <input
+                        type="text"
+                        id="messageInput"
+                        name="message"
+                        placeholder="Type your message..."
+                        required
+                        autocomplete="off"
+                    />
+                    <button type="submit">Send</button>
+                </form>
+            </div>
+
+        </div>
+    </div>
+
+    <script>
+        document.body.addEventListener('htmx:beforeRequest', function(evt) {
+            if (evt.detail.target.id === 'messages') {
+                var emptyState = document.querySelector('.empty-state');
+                if (emptyState) {
+                    emptyState.remove();
+                }
+
+                var formData = new FormData(evt.detail.requestConfig.elt);
+                var message = formData.get('message');
+
+                if (message && message.trim()) {
+                    var messagesContainer = document.getElementById('messages');
+                    var userMessageDiv = document.createElement('div');
+                    userMessageDiv.className = 'message user';
+                    userMessageDiv.innerHTML =
+                        '<div class="message-label">You</div>' +
+                        '<div class="message-bubble">' + escapeHtml(message) + '</div>';
+                    messagesContainer.appendChild(userMessageDiv);
+                    messagesContainer.scrollTop = messagesContainer.scrollHeight;
+                }
+            }
+        });
+
+        document.body.addEventListener('htmx:afterSwap', function(evt) {
+            if (evt.detail.target.id === 'messages') {
+                document.getElementById('messageInput').value = '';
+                var messagesContainer = document.getElementById('messages');
+                messagesContainer.scrollTop = messagesContainer.scrollHeight;
+            }
+        });
+
+        function escapeHtml(text) {
+            var div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+
+        window.addEventListener('load', function() {
+            document.getElementById('messageInput').focus();
+        });
+    </script>
+</body>
+</html>

--- a/samples/workload-identity-federation-spiffe/src/main/resources/application.properties
+++ b/samples/workload-identity-federation-spiffe/src/main/resources/application.properties
@@ -1,0 +1,16 @@
+quarkus.langchain4j.anthropic.chat-model.model-name=claude-sonnet-4-6
+quarkus.langchain4j.anthropic.timeout=60s
+
+# Workload Identity Federation
+quarkus.langchain4j.workload-model-auth-provider.token-path=/var/run/secrets/tokens/spiffe-jwt-svid
+
+# OIDC Client - JWT bearer grant to Anthropic
+quarkus.oidc-client.client-id=none
+quarkus.oidc-client.token-path=https://api.anthropic.com/v1/oauth/token
+quarkus.oidc-client.grant.type=jwt
+quarkus.oidc-client.grant-options.jwt.federation_rule_id=${ANTHROPIC_FEDERATION_RULE_ID}
+quarkus.oidc-client.grant-options.jwt.organization_id=${ANTHROPIC_ORGANIZATION_ID}
+quarkus.oidc-client.grant-options.jwt.service_account_id=${ANTHROPIC_SERVICE_ACCOUNT_ID}
+
+
+quarkus.log.level=INFO

--- a/samples/workload-identity-federation-spiffe/src/main/resources/templates/ChatResource/chatMessage.html
+++ b/samples/workload-identity-federation-spiffe/src/main/resources/templates/ChatResource/chatMessage.html
@@ -1,0 +1,4 @@
+<div class="message assistant">
+    <div class="message-label">Assistant</div>
+    <div class="message-bubble">{response}</div>
+</div>


### PR DESCRIPTION
This PR does the following:

*  Introduces a `WorkloadModelAuthProvider` (it copies most of the code done by @michalvavrik in Quarkus to support JWT bearer and Spiffe token loading from the disk for the OIDC client authentication)
* Updates vanilla OpenAI provider to recognize `ModelAuthProvider` - my initial demo idea was to demo it with [OpenAI WIF](https://developers.openai.com/api/docs/guides/workload-identity-federation), but unfortunately it just does not allow to complete the configuration related to service accounts - but vanilla OpenAI should still support `ModelAuthProvider`
* Updates Anthropic provider to recognize `ModelAuthProvider`
* And adds two demo that show how Quarkus LangChain4j payloads can access Anthropic models from Openshift with 1) Spiffe (supported by Red Hat Zero Trust WIF Manager, with the work from Andrew Block @sabre1041 proving of great help) and 2) Kubernetes projected tokens for simpler single cluster setups. 
 
I thought of combining 2 demos into one, but it would make it a more complex demo in terms of varying deployment options - IMHO it should make sense to keep both Spiffe and K8s projected tokens demoed separately. If we were to add only a single demo, we should choose Spiffe as it is very topical and works across clusters.

I used Claude to help me with prepare various deployment files in particular.
I also tried pure Spire deployment with Helm charts but it is very difficult, not worth doing it in the demo.

Besides vanilla OpenAi and Anthropic, azure-openai and gemini providers which already support `ModelAuthProvider` can use it.

Once @michalvavrik introduces a Quarkus extension for accessing Spire agent directly with Spiffe API, we can introduce a Spiffe centric `ModelAuthProvider` and avoid storing Spiffe tokens to the disk, with no need for a sidecar.

MCP Client support is to be added later

- Closes: #2571