### PR TITLE
Always attempt ChatModel discovery

### DIFF
--- a/agentic/runtime/src/main/java/io/quarkiverse/langchain4j/agentic/runtime/AgenticRecorder.java
+++ b/agentic/runtime/src/main/java/io/quarkiverse/langchain4j/agentic/runtime/AgenticRecorder.java
@@ -22,9 +22,7 @@ import dev.langchain4j.agentic.observability.AgentMonitor;
 import dev.langchain4j.agentic.observability.MonitoredAgent;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.service.tool.ToolProvider;
-import io.quarkiverse.langchain4j.ModelName;
 import io.quarkiverse.langchain4j.agentic.runtime.devui.DevAgentMonitorHolder;
-import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ClientProxy;
 import io.quarkus.arc.SyntheticCreationalContext;
@@ -107,19 +105,7 @@ public class AgenticRecorder {
         return new Function<>() {
             @Override
             public Object apply(SyntheticCreationalContext<Object> cdiContext) {
-                ChatModel chatModel;
-                if (info.chatModelInfo() instanceof AiAgentCreateInfo.ChatModelInfo.FromAnnotation
-                        || info.chatModelInfo() instanceof AiAgentCreateInfo.ChatModelInfo.NotNeeded) {
-                    chatModel = null;
-                } else if (info.chatModelInfo() instanceof AiAgentCreateInfo.ChatModelInfo.FromBeanWithName b) {
-                    if (NamedConfigUtil.isDefault(b.name())) {
-                        chatModel = cdiContext.getInjectedReference(ChatModel.class);
-                    } else {
-                        chatModel = cdiContext.getInjectedReference(ChatModel.class, ModelName.Literal.of(b.name()));
-                    }
-                } else {
-                    throw new IllegalStateException("Unknown type: " + info.chatModelInfo().getClass());
-                }
+                ChatModel chatModel = info.chatModelInfo().resolve(cdiContext);
 
                 Class<?> agentClass = loadClassSafe(info);
                 Object agent = AgenticServices.createAgenticSystem(agentClass, chatModel,

--- a/agentic/runtime/src/main/java/io/quarkiverse/langchain4j/agentic/runtime/AiAgentCreateInfo.java
+++ b/agentic/runtime/src/main/java/io/quarkiverse/langchain4j/agentic/runtime/AiAgentCreateInfo.java
@@ -1,18 +1,42 @@
 package io.quarkiverse.langchain4j.agentic.runtime;
 
+import dev.langchain4j.model.chat.ChatModel;
+import io.quarkiverse.langchain4j.ModelName;
+import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.SyntheticCreationalContext;
+
 public record AiAgentCreateInfo(String agentClassName, ChatModelInfo chatModelInfo, boolean hasInterceptorBindings,
         boolean hasMcpToolBox) {
 
     public sealed interface ChatModelInfo
             permits ChatModelInfo.FromAnnotation, ChatModelInfo.FromBeanWithName, ChatModelInfo.NotNeeded {
 
+        ChatModel resolve(SyntheticCreationalContext<?> cdiContext);
+
         final class FromAnnotation implements ChatModelInfo {
+            @Override
+            public ChatModel resolve(SyntheticCreationalContext<?> cdiContext) {
+                return null;
+            }
         }
 
         record FromBeanWithName(String name) implements ChatModelInfo {
+            @Override
+            public ChatModel resolve(SyntheticCreationalContext<?> cdiContext) {
+                if (NamedConfigUtil.isDefault(name)) {
+                    return cdiContext.getInjectedReference(ChatModel.class);
+                }
+                return cdiContext.getInjectedReference(ChatModel.class, ModelName.Literal.of(name));
+            }
         }
 
         final class NotNeeded implements ChatModelInfo {
+            @Override
+            public ChatModel resolve(SyntheticCreationalContext<?> cdiContext) {
+                var handle = Arc.container().instance(ChatModel.class);
+                return handle.isAvailable() ? handle.get() : null;
+            }
         }
     }
 }


### PR DESCRIPTION
I'm sorry but this change https://github.com/quarkiverse/quarkus-langchain4j/pull/2634 caused a regression that I discovered trying to bump the workshop to the new release.

In particular now when a supervisor is a subagent of a sequence (which is exactly the use case that we have in the latest steps of the workshop) the supervisor itself is no longer provided with a ChatModel even if correctly configured.

I would need another release release of the quarkus extension once this pull request will be merged, otherwise I cannot bump the workshop to it. Thank you and sorry again.

/cc @kdubois 