### PR TITLE
feat(openai): Add support for the OpenAI Responses API

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-all-config.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-all-config.adoc
@@ -19584,6 +19584,29 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-mode]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-mode[`+++quarkus.langchain4j.openai.chat-model.mode+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.mode+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Which OpenAI API the chat model should target.
+
+`chat-completion` (the default) uses the `/v1/chat/completions` endpoint, while `responses` uses the newer `/v1/responses` endpoint. The `responses` mode is required for models that are only available through the Responses API and unlocks Responses-specific settings under `quarkus.langchain4j.openai.chat-model.responses.++*++`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_MODE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_MODE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`chat-completion`, `responses`
+|`+++chat-completion+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-embedding-model-enabled]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-embedding-model-enabled[`+++quarkus.langchain4j.openai.embedding-model.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.openai.embedding-model.enabled+++[]
@@ -20184,6 +20207,321 @@ endif::add-copy-button-to-env-var[]
 --
 |string
 |`+++default+++`
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-store]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-store[`+++quarkus.langchain4j.openai.chat-model.responses.store+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.store+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to store the generated model response for later retrieval via the Responses API.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_STORE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_STORE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-previous-response-id]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-previous-response-id[`+++quarkus.langchain4j.openai.chat-model.responses.previous-response-id+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.previous-response-id+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The unique ID of the previous response to the model, used to create multi-turn conversations.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_PREVIOUS_RESPONSE_ID+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_PREVIOUS_RESPONSE_ID+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-reasoning-summary]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-reasoning-summary[`+++quarkus.langchain4j.openai.chat-model.responses.reasoning-summary+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.reasoning-summary+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+A summary of the reasoning performed by the model, for reasoning models. Supported values are `auto`, `concise`, and `detailed`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_REASONING_SUMMARY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_REASONING_SUMMARY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-max-output-tokens]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-max-output-tokens[`+++quarkus.langchain4j.openai.chat-model.responses.max-output-tokens+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.max-output-tokens+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+An upper bound for the number of tokens that can be generated for a response, including visible output tokens and reasoning tokens.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_MAX_OUTPUT_TOKENS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_MAX_OUTPUT_TOKENS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-max-tool-calls]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-max-tool-calls[`+++quarkus.langchain4j.openai.chat-model.responses.max-tool-calls+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.max-tool-calls+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The maximum number of total calls to built-in tools that can be processed in a response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_MAX_TOOL_CALLS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_MAX_TOOL_CALLS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-parallel-tool-calls]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-parallel-tool-calls[`+++quarkus.langchain4j.openai.chat-model.responses.parallel-tool-calls+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.parallel-tool-calls+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to allow the model to run tool calls in parallel.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_PARALLEL_TOOL_CALLS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_PARALLEL_TOOL_CALLS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-include]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-include[`+++quarkus.langchain4j.openai.chat-model.responses.include+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.include+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Additional output data to include in the model response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_INCLUDE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_INCLUDE+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-truncation]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-truncation[`+++quarkus.langchain4j.openai.chat-model.responses.truncation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.truncation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The truncation strategy to use for the model response. Supported values are `auto` and `disabled`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_TRUNCATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_TRUNCATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-text-verbosity]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-text-verbosity[`+++quarkus.langchain4j.openai.chat-model.responses.text-verbosity+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.text-verbosity+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Constrains the verbosity of the model's response. Supported values are `low`, `medium`, and `high`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_TEXT_VERBOSITY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_TEXT_VERBOSITY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-prompt-cache-key]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-prompt-cache-key[`+++quarkus.langchain4j.openai.chat-model.responses.prompt-cache-key+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.prompt-cache-key+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Used by OpenAI to cache responses for similar requests to optimize your cache hit rates.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_PROMPT_CACHE_KEY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_PROMPT_CACHE_KEY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-prompt-cache-retention]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-prompt-cache-retention[`+++quarkus.langchain4j.openai.chat-model.responses.prompt-cache-retention+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.prompt-cache-retention+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The retention policy for the prompt cache.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_PROMPT_CACHE_RETENTION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_PROMPT_CACHE_RETENTION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-safety-identifier]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-safety-identifier[`+++quarkus.langchain4j.openai.chat-model.responses.safety-identifier+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.safety-identifier+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_SAFETY_IDENTIFIER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_SAFETY_IDENTIFIER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-top-logprobs]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-top-logprobs[`+++quarkus.langchain4j.openai.chat-model.responses.top-logprobs+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.top-logprobs+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The number of most likely tokens to return at each token position, each with an associated log probability.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_TOP_LOGPROBS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_TOP_LOGPROBS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-strict-tools]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-strict-tools[`+++quarkus.langchain4j.openai.chat-model.responses.strict-tools+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.strict-tools+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to enforce strict schema validation on tool/function definitions.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_STRICT_TOOLS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_STRICT_TOOLS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-stream-include-obfuscation]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-stream-include-obfuscation[`+++quarkus.langchain4j.openai.chat-model.responses.stream-include-obfuscation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.stream-include-obfuscation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether obfuscation fields should be included in streaming events. Only applies to the streaming chat model.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_STREAM_INCLUDE_OBFUSCATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_STREAM_INCLUDE_OBFUSCATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-embedding-model-model-name]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-embedding-model-model-name[`+++quarkus.langchain4j.openai.embedding-model.model-name+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -21300,6 +21638,321 @@ endif::add-copy-button-to-env-var[]
 --
 |string
 |`+++default+++`
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-store]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-store[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.store+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.store+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to store the generated model response for later retrieval via the Responses API.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_STORE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_STORE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-previous-response-id]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-previous-response-id[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.previous-response-id+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.previous-response-id+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The unique ID of the previous response to the model, used to create multi-turn conversations.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_PREVIOUS_RESPONSE_ID+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_PREVIOUS_RESPONSE_ID+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-reasoning-summary]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-reasoning-summary[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.reasoning-summary+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.reasoning-summary+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+A summary of the reasoning performed by the model, for reasoning models. Supported values are `auto`, `concise`, and `detailed`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_REASONING_SUMMARY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_REASONING_SUMMARY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-max-output-tokens]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-max-output-tokens[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.max-output-tokens+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.max-output-tokens+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+An upper bound for the number of tokens that can be generated for a response, including visible output tokens and reasoning tokens.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_MAX_OUTPUT_TOKENS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_MAX_OUTPUT_TOKENS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-max-tool-calls]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-max-tool-calls[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.max-tool-calls+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.max-tool-calls+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The maximum number of total calls to built-in tools that can be processed in a response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_MAX_TOOL_CALLS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_MAX_TOOL_CALLS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-parallel-tool-calls]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-parallel-tool-calls[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.parallel-tool-calls+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.parallel-tool-calls+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to allow the model to run tool calls in parallel.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_PARALLEL_TOOL_CALLS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_PARALLEL_TOOL_CALLS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-include]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-include[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.include+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.include+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Additional output data to include in the model response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_INCLUDE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_INCLUDE+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-truncation]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-truncation[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.truncation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.truncation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The truncation strategy to use for the model response. Supported values are `auto` and `disabled`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_TRUNCATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_TRUNCATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-text-verbosity]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-text-verbosity[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.text-verbosity+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.text-verbosity+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Constrains the verbosity of the model's response. Supported values are `low`, `medium`, and `high`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_TEXT_VERBOSITY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_TEXT_VERBOSITY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-prompt-cache-key]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-prompt-cache-key[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.prompt-cache-key+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.prompt-cache-key+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Used by OpenAI to cache responses for similar requests to optimize your cache hit rates.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_PROMPT_CACHE_KEY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_PROMPT_CACHE_KEY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-prompt-cache-retention]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-prompt-cache-retention[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.prompt-cache-retention+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.prompt-cache-retention+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The retention policy for the prompt cache.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_PROMPT_CACHE_RETENTION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_PROMPT_CACHE_RETENTION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-safety-identifier]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-safety-identifier[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.safety-identifier+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.safety-identifier+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_SAFETY_IDENTIFIER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_SAFETY_IDENTIFIER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-top-logprobs]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-top-logprobs[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.top-logprobs+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.top-logprobs+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The number of most likely tokens to return at each token position, each with an associated log probability.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_TOP_LOGPROBS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_TOP_LOGPROBS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-strict-tools]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-strict-tools[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.strict-tools+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.strict-tools+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to enforce strict schema validation on tool/function definitions.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_STRICT_TOOLS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_STRICT_TOOLS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-stream-include-obfuscation]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-stream-include-obfuscation[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.stream-include-obfuscation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.stream-include-obfuscation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether obfuscation fields should be included in streaming events. Only applies to the streaming chat model.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_STREAM_INCLUDE_OBFUSCATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_STREAM_INCLUDE_OBFUSCATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-embedding-model-model-name]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-embedding-model-model-name[`+++quarkus.langchain4j.openai."model-name".embedding-model.model-name+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai.adoc
@@ -28,6 +28,29 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-mode]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-mode[`+++quarkus.langchain4j.openai.chat-model.mode+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.mode+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Which OpenAI API the chat model should target.
+
+`chat-completion` (the default) uses the `/v1/chat/completions` endpoint, while `responses` uses the newer `/v1/responses` endpoint. The `responses` mode is required for models that are only available through the Responses API and unlocks Responses-specific settings under `quarkus.langchain4j.openai.chat-model.responses.++*++`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_MODE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_MODE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`chat-completion`, `responses`
+|`+++chat-completion+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-embedding-model-enabled]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-embedding-model-enabled[`+++quarkus.langchain4j.openai.embedding-model.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.openai.embedding-model.enabled+++[]
@@ -628,6 +651,321 @@ endif::add-copy-button-to-env-var[]
 --
 |string
 |`+++default+++`
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-store]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-store[`+++quarkus.langchain4j.openai.chat-model.responses.store+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.store+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to store the generated model response for later retrieval via the Responses API.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_STORE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_STORE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-previous-response-id]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-previous-response-id[`+++quarkus.langchain4j.openai.chat-model.responses.previous-response-id+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.previous-response-id+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The unique ID of the previous response to the model, used to create multi-turn conversations.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_PREVIOUS_RESPONSE_ID+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_PREVIOUS_RESPONSE_ID+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-reasoning-summary]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-reasoning-summary[`+++quarkus.langchain4j.openai.chat-model.responses.reasoning-summary+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.reasoning-summary+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+A summary of the reasoning performed by the model, for reasoning models. Supported values are `auto`, `concise`, and `detailed`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_REASONING_SUMMARY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_REASONING_SUMMARY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-max-output-tokens]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-max-output-tokens[`+++quarkus.langchain4j.openai.chat-model.responses.max-output-tokens+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.max-output-tokens+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+An upper bound for the number of tokens that can be generated for a response, including visible output tokens and reasoning tokens.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_MAX_OUTPUT_TOKENS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_MAX_OUTPUT_TOKENS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-max-tool-calls]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-max-tool-calls[`+++quarkus.langchain4j.openai.chat-model.responses.max-tool-calls+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.max-tool-calls+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The maximum number of total calls to built-in tools that can be processed in a response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_MAX_TOOL_CALLS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_MAX_TOOL_CALLS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-parallel-tool-calls]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-parallel-tool-calls[`+++quarkus.langchain4j.openai.chat-model.responses.parallel-tool-calls+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.parallel-tool-calls+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to allow the model to run tool calls in parallel.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_PARALLEL_TOOL_CALLS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_PARALLEL_TOOL_CALLS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-include]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-include[`+++quarkus.langchain4j.openai.chat-model.responses.include+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.include+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Additional output data to include in the model response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_INCLUDE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_INCLUDE+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-truncation]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-truncation[`+++quarkus.langchain4j.openai.chat-model.responses.truncation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.truncation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The truncation strategy to use for the model response. Supported values are `auto` and `disabled`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_TRUNCATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_TRUNCATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-text-verbosity]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-text-verbosity[`+++quarkus.langchain4j.openai.chat-model.responses.text-verbosity+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.text-verbosity+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Constrains the verbosity of the model's response. Supported values are `low`, `medium`, and `high`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_TEXT_VERBOSITY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_TEXT_VERBOSITY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-prompt-cache-key]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-prompt-cache-key[`+++quarkus.langchain4j.openai.chat-model.responses.prompt-cache-key+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.prompt-cache-key+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Used by OpenAI to cache responses for similar requests to optimize your cache hit rates.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_PROMPT_CACHE_KEY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_PROMPT_CACHE_KEY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-prompt-cache-retention]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-prompt-cache-retention[`+++quarkus.langchain4j.openai.chat-model.responses.prompt-cache-retention+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.prompt-cache-retention+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The retention policy for the prompt cache.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_PROMPT_CACHE_RETENTION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_PROMPT_CACHE_RETENTION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-safety-identifier]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-safety-identifier[`+++quarkus.langchain4j.openai.chat-model.responses.safety-identifier+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.safety-identifier+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_SAFETY_IDENTIFIER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_SAFETY_IDENTIFIER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-top-logprobs]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-top-logprobs[`+++quarkus.langchain4j.openai.chat-model.responses.top-logprobs+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.top-logprobs+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The number of most likely tokens to return at each token position, each with an associated log probability.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_TOP_LOGPROBS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_TOP_LOGPROBS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-strict-tools]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-strict-tools[`+++quarkus.langchain4j.openai.chat-model.responses.strict-tools+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.strict-tools+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to enforce strict schema validation on tool/function definitions.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_STRICT_TOOLS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_STRICT_TOOLS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-stream-include-obfuscation]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-stream-include-obfuscation[`+++quarkus.langchain4j.openai.chat-model.responses.stream-include-obfuscation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.stream-include-obfuscation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether obfuscation fields should be included in streaming events. Only applies to the streaming chat model.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_STREAM_INCLUDE_OBFUSCATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_STREAM_INCLUDE_OBFUSCATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-embedding-model-model-name]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-embedding-model-model-name[`+++quarkus.langchain4j.openai.embedding-model.model-name+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -1744,6 +2082,321 @@ endif::add-copy-button-to-env-var[]
 --
 |string
 |`+++default+++`
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-store]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-store[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.store+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.store+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to store the generated model response for later retrieval via the Responses API.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_STORE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_STORE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-previous-response-id]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-previous-response-id[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.previous-response-id+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.previous-response-id+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The unique ID of the previous response to the model, used to create multi-turn conversations.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_PREVIOUS_RESPONSE_ID+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_PREVIOUS_RESPONSE_ID+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-reasoning-summary]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-reasoning-summary[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.reasoning-summary+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.reasoning-summary+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+A summary of the reasoning performed by the model, for reasoning models. Supported values are `auto`, `concise`, and `detailed`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_REASONING_SUMMARY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_REASONING_SUMMARY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-max-output-tokens]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-max-output-tokens[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.max-output-tokens+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.max-output-tokens+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+An upper bound for the number of tokens that can be generated for a response, including visible output tokens and reasoning tokens.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_MAX_OUTPUT_TOKENS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_MAX_OUTPUT_TOKENS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-max-tool-calls]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-max-tool-calls[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.max-tool-calls+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.max-tool-calls+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The maximum number of total calls to built-in tools that can be processed in a response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_MAX_TOOL_CALLS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_MAX_TOOL_CALLS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-parallel-tool-calls]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-parallel-tool-calls[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.parallel-tool-calls+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.parallel-tool-calls+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to allow the model to run tool calls in parallel.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_PARALLEL_TOOL_CALLS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_PARALLEL_TOOL_CALLS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-include]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-include[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.include+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.include+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Additional output data to include in the model response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_INCLUDE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_INCLUDE+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-truncation]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-truncation[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.truncation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.truncation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The truncation strategy to use for the model response. Supported values are `auto` and `disabled`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_TRUNCATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_TRUNCATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-text-verbosity]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-text-verbosity[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.text-verbosity+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.text-verbosity+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Constrains the verbosity of the model's response. Supported values are `low`, `medium`, and `high`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_TEXT_VERBOSITY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_TEXT_VERBOSITY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-prompt-cache-key]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-prompt-cache-key[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.prompt-cache-key+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.prompt-cache-key+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Used by OpenAI to cache responses for similar requests to optimize your cache hit rates.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_PROMPT_CACHE_KEY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_PROMPT_CACHE_KEY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-prompt-cache-retention]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-prompt-cache-retention[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.prompt-cache-retention+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.prompt-cache-retention+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The retention policy for the prompt cache.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_PROMPT_CACHE_RETENTION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_PROMPT_CACHE_RETENTION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-safety-identifier]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-safety-identifier[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.safety-identifier+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.safety-identifier+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_SAFETY_IDENTIFIER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_SAFETY_IDENTIFIER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-top-logprobs]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-top-logprobs[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.top-logprobs+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.top-logprobs+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The number of most likely tokens to return at each token position, each with an associated log probability.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_TOP_LOGPROBS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_TOP_LOGPROBS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-strict-tools]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-strict-tools[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.strict-tools+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.strict-tools+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to enforce strict schema validation on tool/function definitions.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_STRICT_TOOLS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_STRICT_TOOLS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-stream-include-obfuscation]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-stream-include-obfuscation[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.stream-include-obfuscation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.stream-include-obfuscation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether obfuscation fields should be included in streaming events. Only applies to the streaming chat model.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_STREAM_INCLUDE_OBFUSCATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_STREAM_INCLUDE_OBFUSCATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-embedding-model-model-name]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-embedding-model-model-name[`+++quarkus.langchain4j.openai."model-name".embedding-model.model-name+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai_quarkus.langchain4j.adoc
@@ -28,6 +28,29 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-mode]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-mode[`+++quarkus.langchain4j.openai.chat-model.mode+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.mode+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Which OpenAI API the chat model should target.
+
+`chat-completion` (the default) uses the `/v1/chat/completions` endpoint, while `responses` uses the newer `/v1/responses` endpoint. The `responses` mode is required for models that are only available through the Responses API and unlocks Responses-specific settings under `quarkus.langchain4j.openai.chat-model.responses.++*++`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_MODE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_MODE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`chat-completion`, `responses`
+|`+++chat-completion+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-embedding-model-enabled]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-embedding-model-enabled[`+++quarkus.langchain4j.openai.embedding-model.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.openai.embedding-model.enabled+++[]
@@ -628,6 +651,321 @@ endif::add-copy-button-to-env-var[]
 --
 |string
 |`+++default+++`
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-store]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-store[`+++quarkus.langchain4j.openai.chat-model.responses.store+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.store+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to store the generated model response for later retrieval via the Responses API.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_STORE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_STORE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-previous-response-id]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-previous-response-id[`+++quarkus.langchain4j.openai.chat-model.responses.previous-response-id+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.previous-response-id+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The unique ID of the previous response to the model, used to create multi-turn conversations.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_PREVIOUS_RESPONSE_ID+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_PREVIOUS_RESPONSE_ID+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-reasoning-summary]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-reasoning-summary[`+++quarkus.langchain4j.openai.chat-model.responses.reasoning-summary+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.reasoning-summary+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+A summary of the reasoning performed by the model, for reasoning models. Supported values are `auto`, `concise`, and `detailed`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_REASONING_SUMMARY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_REASONING_SUMMARY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-max-output-tokens]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-max-output-tokens[`+++quarkus.langchain4j.openai.chat-model.responses.max-output-tokens+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.max-output-tokens+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+An upper bound for the number of tokens that can be generated for a response, including visible output tokens and reasoning tokens.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_MAX_OUTPUT_TOKENS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_MAX_OUTPUT_TOKENS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-max-tool-calls]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-max-tool-calls[`+++quarkus.langchain4j.openai.chat-model.responses.max-tool-calls+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.max-tool-calls+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The maximum number of total calls to built-in tools that can be processed in a response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_MAX_TOOL_CALLS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_MAX_TOOL_CALLS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-parallel-tool-calls]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-parallel-tool-calls[`+++quarkus.langchain4j.openai.chat-model.responses.parallel-tool-calls+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.parallel-tool-calls+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to allow the model to run tool calls in parallel.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_PARALLEL_TOOL_CALLS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_PARALLEL_TOOL_CALLS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-include]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-include[`+++quarkus.langchain4j.openai.chat-model.responses.include+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.include+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Additional output data to include in the model response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_INCLUDE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_INCLUDE+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-truncation]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-truncation[`+++quarkus.langchain4j.openai.chat-model.responses.truncation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.truncation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The truncation strategy to use for the model response. Supported values are `auto` and `disabled`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_TRUNCATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_TRUNCATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-text-verbosity]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-text-verbosity[`+++quarkus.langchain4j.openai.chat-model.responses.text-verbosity+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.text-verbosity+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Constrains the verbosity of the model's response. Supported values are `low`, `medium`, and `high`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_TEXT_VERBOSITY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_TEXT_VERBOSITY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-prompt-cache-key]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-prompt-cache-key[`+++quarkus.langchain4j.openai.chat-model.responses.prompt-cache-key+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.prompt-cache-key+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Used by OpenAI to cache responses for similar requests to optimize your cache hit rates.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_PROMPT_CACHE_KEY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_PROMPT_CACHE_KEY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-prompt-cache-retention]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-prompt-cache-retention[`+++quarkus.langchain4j.openai.chat-model.responses.prompt-cache-retention+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.prompt-cache-retention+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The retention policy for the prompt cache.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_PROMPT_CACHE_RETENTION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_PROMPT_CACHE_RETENTION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-safety-identifier]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-safety-identifier[`+++quarkus.langchain4j.openai.chat-model.responses.safety-identifier+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.safety-identifier+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_SAFETY_IDENTIFIER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_SAFETY_IDENTIFIER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-top-logprobs]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-top-logprobs[`+++quarkus.langchain4j.openai.chat-model.responses.top-logprobs+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.top-logprobs+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The number of most likely tokens to return at each token position, each with an associated log probability.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_TOP_LOGPROBS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_TOP_LOGPROBS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-strict-tools]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-strict-tools[`+++quarkus.langchain4j.openai.chat-model.responses.strict-tools+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.strict-tools+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to enforce strict schema validation on tool/function definitions.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_STRICT_TOOLS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_STRICT_TOOLS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-stream-include-obfuscation]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-responses-stream-include-obfuscation[`+++quarkus.langchain4j.openai.chat-model.responses.stream-include-obfuscation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai.chat-model.responses.stream-include-obfuscation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether obfuscation fields should be included in streaming events. Only applies to the streaming chat model.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_STREAM_INCLUDE_OBFUSCATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_RESPONSES_STREAM_INCLUDE_OBFUSCATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-embedding-model-model-name]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-embedding-model-model-name[`+++quarkus.langchain4j.openai.embedding-model.model-name+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -1744,6 +2082,321 @@ endif::add-copy-button-to-env-var[]
 --
 |string
 |`+++default+++`
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-store]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-store[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.store+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.store+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to store the generated model response for later retrieval via the Responses API.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_STORE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_STORE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-previous-response-id]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-previous-response-id[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.previous-response-id+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.previous-response-id+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The unique ID of the previous response to the model, used to create multi-turn conversations.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_PREVIOUS_RESPONSE_ID+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_PREVIOUS_RESPONSE_ID+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-reasoning-summary]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-reasoning-summary[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.reasoning-summary+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.reasoning-summary+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+A summary of the reasoning performed by the model, for reasoning models. Supported values are `auto`, `concise`, and `detailed`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_REASONING_SUMMARY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_REASONING_SUMMARY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-max-output-tokens]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-max-output-tokens[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.max-output-tokens+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.max-output-tokens+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+An upper bound for the number of tokens that can be generated for a response, including visible output tokens and reasoning tokens.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_MAX_OUTPUT_TOKENS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_MAX_OUTPUT_TOKENS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-max-tool-calls]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-max-tool-calls[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.max-tool-calls+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.max-tool-calls+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The maximum number of total calls to built-in tools that can be processed in a response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_MAX_TOOL_CALLS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_MAX_TOOL_CALLS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-parallel-tool-calls]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-parallel-tool-calls[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.parallel-tool-calls+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.parallel-tool-calls+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to allow the model to run tool calls in parallel.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_PARALLEL_TOOL_CALLS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_PARALLEL_TOOL_CALLS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-include]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-include[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.include+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.include+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Additional output data to include in the model response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_INCLUDE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_INCLUDE+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-truncation]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-truncation[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.truncation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.truncation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The truncation strategy to use for the model response. Supported values are `auto` and `disabled`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_TRUNCATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_TRUNCATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-text-verbosity]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-text-verbosity[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.text-verbosity+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.text-verbosity+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Constrains the verbosity of the model's response. Supported values are `low`, `medium`, and `high`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_TEXT_VERBOSITY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_TEXT_VERBOSITY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-prompt-cache-key]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-prompt-cache-key[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.prompt-cache-key+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.prompt-cache-key+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Used by OpenAI to cache responses for similar requests to optimize your cache hit rates.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_PROMPT_CACHE_KEY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_PROMPT_CACHE_KEY+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-prompt-cache-retention]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-prompt-cache-retention[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.prompt-cache-retention+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.prompt-cache-retention+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The retention policy for the prompt cache.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_PROMPT_CACHE_RETENTION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_PROMPT_CACHE_RETENTION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-safety-identifier]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-safety-identifier[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.safety-identifier+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.safety-identifier+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_SAFETY_IDENTIFIER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_SAFETY_IDENTIFIER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-top-logprobs]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-top-logprobs[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.top-logprobs+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.top-logprobs+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The number of most likely tokens to return at each token position, each with an associated log probability.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_TOP_LOGPROBS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_TOP_LOGPROBS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-strict-tools]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-strict-tools[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.strict-tools+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.strict-tools+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to enforce strict schema validation on tool/function definitions.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_STRICT_TOOLS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_STRICT_TOOLS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-stream-include-obfuscation]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-responses-stream-include-obfuscation[`+++quarkus.langchain4j.openai."model-name".chat-model.responses.stream-include-obfuscation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.openai."model-name".chat-model.responses.stream-include-obfuscation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether obfuscation fields should be included in streaming events. Only applies to the streaming chat model.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_STREAM_INCLUDE_OBFUSCATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_RESPONSES_STREAM_INCLUDE_OBFUSCATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-embedding-model-model-name]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-embedding-model-model-name[`+++quarkus.langchain4j.openai."model-name".embedding-model.model-name+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/openai-chat-model.adoc
+++ b/docs/modules/ROOT/pages/openai-chat-model.adoc
@@ -111,6 +111,42 @@ import jakarta.inject.Inject;
 
 If no model name is specified, the default configuration is used.
 
+== Responses API
+
+By default, the chat model targets OpenAI's `/v1/chat/completions` endpoint. OpenAI also offers the newer
+https://platform.openai.com/docs/api-reference/responses[Responses API] (`/v1/responses`), which is required for models
+that are only exposed through it (for example `gpt-5-pro`, `o1-pro`) and which unlocks Responses-specific settings.
+
+To switch the chat model to the Responses API, set the build-time `mode` property:
+
+[source,properties,subs=attributes+]
+----
+quarkus.langchain4j.openai.chat-model.mode=responses
+quarkus.langchain4j.openai.api-key=sk-...
+quarkus.langchain4j.openai.chat-model.model-name=gpt-5-pro
+----
+
+Both the blocking `ChatModel` and the `StreamingChatModel` are supported in this mode, including tool/function calling and
+structured outputs. The injection points and AI service usage are unchanged — only the underlying API and endpoint differ.
+
+Responses-specific options are configured under `quarkus.langchain4j.openai.chat-model.responses.*`, for example:
+
+[source,properties,subs=attributes+]
+----
+quarkus.langchain4j.openai.chat-model.responses.store=false
+quarkus.langchain4j.openai.chat-model.responses.reasoning-summary=auto
+quarkus.langchain4j.openai.chat-model.responses.max-output-tokens=1024
+----
+
+[NOTE]
+====
+In `responses` mode the model communicates over a Quarkus REST Client-based HTTP client (the same engine used elsewhere,
+so native image and TLS registry configuration continue to work). A few features of the chat-completions path do not apply:
+`quarkus.langchain4j.openai.log-requests-curl` and proxy configuration (`quarkus.langchain4j.openai.proxy-configuration-name`)
+are not honored for Responses traffic. Request/response logging still works via the standard
+`log-requests`/`log-responses` settings.
+====
+
 == Advanced usage
 
 The OpenAI extension internally uses a Quarkus REST Client to make API calls. This client can also be used directly:

--- a/model-providers/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/ChatModelBuildConfig.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/ChatModelBuildConfig.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
 
 @ConfigGroup
 public interface ChatModelBuildConfig {
@@ -13,4 +14,20 @@ public interface ChatModelBuildConfig {
      */
     @ConfigDocDefault("true")
     Optional<Boolean> enabled();
+
+    /**
+     * Which OpenAI API the chat model should target.
+     * <p>
+     * {@code chat-completion} (the default) uses the {@code /v1/chat/completions} endpoint, while {@code responses}
+     * uses the newer {@code /v1/responses} endpoint. The {@code responses} mode is required for models that are only
+     * available through the Responses API and unlocks Responses-specific settings under
+     * {@code quarkus.langchain4j.openai.chat-model.responses.*}.
+     */
+    @WithDefault("chat-completion")
+    Mode mode();
+
+    enum Mode {
+        CHAT_COMPLETION,
+        RESPONSES
+    }
 }

--- a/model-providers/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/OpenAiProcessor.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/main/java/io/quarkiverse/langchain4j/openai/deployment/OpenAiProcessor.java
@@ -24,6 +24,8 @@ import dev.langchain4j.model.openai.OpenAiAudioTranscriptionModel;
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.model.openai.OpenAiEmbeddingModel;
 import dev.langchain4j.model.openai.OpenAiModerationModel;
+import dev.langchain4j.model.openai.OpenAiResponsesChatModel;
+import dev.langchain4j.model.openai.OpenAiResponsesStreamingChatModel;
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
 import dev.langchain4j.model.openai.spi.OpenAiAudioTranscriptionModelBuilderFactory;
 import dev.langchain4j.model.openai.spi.OpenAiChatModelBuilderFactory;
@@ -71,6 +73,10 @@ public class OpenAiProcessor {
             .createSimple(OpenAiChatModel.OpenAiChatModelBuilder.class);
     private static final DotName OPENAI_STREAMING_CHAT_MODEL_BUILDER = DotName
             .createSimple(OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder.class);
+    private static final DotName OPENAI_RESPONSES_CHAT_MODEL_BUILDER = DotName
+            .createSimple(OpenAiResponsesChatModel.Builder.class);
+    private static final DotName OPENAI_RESPONSES_STREAMING_CHAT_MODEL_BUILDER = DotName
+            .createSimple(OpenAiResponsesStreamingChatModel.Builder.class);
     private static final DotName OPENAI_EMBEDDING_MODEL_BUILDER = DotName
             .createSimple(OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder.class);
     private static final DotName OPENAI_MODERATION_MODEL_BUILDER = DotName
@@ -121,40 +127,31 @@ public class OpenAiProcessor {
             List<SelectedModerationModelProviderBuildItem> selectedModeration,
             List<SelectedImageModelProviderBuildItem> selectedImage,
             List<SelectedAudioTranscriptionModelProviderBuildItem> selectedAudioTranscription,
+            LangChain4jOpenAiBuildConfig buildConfig,
             BuildProducer<SyntheticBeanBuildItem> beanProducer) {
+
+        boolean useResponseMode = buildConfig.chatModel().mode() == ChatModelBuildConfig.Mode.RESPONSES;
 
         for (var selected : selectedChatItem) {
             if (PROVIDER.equals(selected.getProvider())) {
                 String configName = selected.getConfigName();
-                var builder = SyntheticBeanBuildItem
-                        .configure(CHAT_MODEL)
-                        .setRuntimeInit()
-                        .defaultBean()
-                        .scope(ApplicationScoped.class)
-                        .addInjectionPoint(Type.create(ProxyConfigurationRegistry.class))
-                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
-                                new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
-                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
-                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
-                                        new Type[] { ClassType.create(OPENAI_CHAT_MODEL_BUILDER) }, null) },
-                                null), ANY)
-                        .createWith(recorder.chatModel(configName));
-                addQualifierIfNecessary(builder, configName);
-                beanProducer.produce(builder.done());
 
-                var streamingBuilder = SyntheticBeanBuildItem
-                        .configure(STREAMING_CHAT_MODEL)
-                        .setRuntimeInit()
-                        .defaultBean()
-                        .scope(ApplicationScoped.class)
-                        .addInjectionPoint(Type.create(ProxyConfigurationRegistry.class))
-                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
-                                new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
-                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
-                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
-                                        new Type[] { ClassType.create(OPENAI_STREAMING_CHAT_MODEL_BUILDER) }, null) },
-                                null), ANY)
-                        .createWith(recorder.streamingChatModel(configName));
+                var chatBuilder = configureChatModelBean(CHAT_MODEL,
+                        useResponseMode ? OPENAI_RESPONSES_CHAT_MODEL_BUILDER : OPENAI_CHAT_MODEL_BUILDER,
+                        useResponseMode);
+                chatBuilder.createWith(useResponseMode
+                        ? recorder.responsesChatModel(configName)
+                        : recorder.chatModel(configName));
+                addQualifierIfNecessary(chatBuilder, configName);
+                beanProducer.produce(chatBuilder.done());
+
+                var streamingBuilder = configureChatModelBean(STREAMING_CHAT_MODEL,
+                        useResponseMode ? OPENAI_RESPONSES_STREAMING_CHAT_MODEL_BUILDER
+                                : OPENAI_STREAMING_CHAT_MODEL_BUILDER,
+                        useResponseMode);
+                streamingBuilder.createWith(useResponseMode
+                        ? recorder.responsesStreamingChatModel(configName)
+                        : recorder.streamingChatModel(configName));
                 addQualifierIfNecessary(streamingBuilder, configName);
                 beanProducer.produce(streamingBuilder.done());
             }
@@ -238,6 +235,26 @@ public class OpenAiProcessor {
         }
     }
 
+    private static SyntheticBeanBuildItem.ExtendedBeanConfigurator configureChatModelBean(
+            DotName beanType, DotName builderCustomizerType, boolean useResponseMode) {
+        var configurator = SyntheticBeanBuildItem
+                .configure(beanType)
+                .setRuntimeInit()
+                .defaultBean()
+                .scope(ApplicationScoped.class)
+                .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                        new Type[] { ClassType.create(DotNames.CHAT_MODEL_LISTENER) }, null))
+                .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                        new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                new Type[] { ClassType.create(builderCustomizerType) }, null) },
+                        null), ANY);
+        // Only the chat-completions path flows through QuarkusOpenAiClient, which honors proxy configuration.
+        if (!useResponseMode) {
+            configurator.addInjectionPoint(Type.create(ProxyConfigurationRegistry.class));
+        }
+        return configurator;
+    }
+
     private void addQualifierIfNecessary(SyntheticBeanBuildItem.ExtendedBeanConfigurator builder, String configName) {
         if (!NamedConfigUtil.isDefault(configName)) {
             builder.addQualifier(AnnotationInstance.builder(ModelName.class).add("value", configName).build());
@@ -271,5 +288,8 @@ public class OpenAiProcessor {
         reflectiveClassProducer
                 .produce(ReflectiveClassBuildItem.builder(PropertyNamingStrategies.SnakeCaseStrategy.class).build());
         reflectiveClassProducer.produce(ReflectiveClassBuildItem.builder(OPEN_AI_EMBEDDING_DESERIALIZER).build());
+        reflectiveClassProducer.produce(ReflectiveClassBuildItem
+                .builder(OpenAiResponsesChatModel.class, OpenAiResponsesStreamingChatModel.class)
+                .methods().fields().build());
     }
 }

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/ResponsesChatModelSmokeTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/ResponsesChatModelSmokeTest.java
@@ -1,0 +1,86 @@
+package io.quarkiverse.langchain4j.openai.test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ResponsesChatModelSmokeTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.openai.chat-model.mode", "responses")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "my-key")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.chat-model.responses.store", "false")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.chat-model.responses.max-output-tokens", "100")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    ChatModel chatModel;
+
+    @BeforeEach
+    void reset() {
+        resetRequests();
+    }
+
+    @Test
+    void blockingChatTargetsResponsesEndpoint() throws IOException {
+        stubResponsesEndpoint("Hello from Responses API!");
+
+        String response = chatModel.chat("hello");
+        assertThat(response).isEqualTo("Hello from Responses API!");
+
+        Map<String, Object> requestBody = getRequestAsMap();
+        assertThat(requestBody)
+                .containsEntry("model", "gpt-4o-mini")
+                .containsEntry("store", false)
+                .containsEntry("max_output_tokens", 100)
+                .containsKey("input");
+
+        wiremock().verifyThat(postRequestedFor(urlEqualTo("/v1/responses"))
+                .withHeader("Authorization", equalTo("Bearer my-key")));
+    }
+
+    private void stubResponsesEndpoint(String text) {
+        wiremock().register(post(urlEqualTo("/v1/responses"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(
+                                """
+                                        {
+                                          "id": "resp_123",
+                                          "model": "gpt-4o-mini",
+                                          "status": "completed",
+                                          "output": [
+                                            {
+                                              "type": "message",
+                                              "role": "assistant",
+                                              "content": [ { "type": "output_text", "text": "%s" } ]
+                                            }
+                                          ],
+                                          "usage": { "input_tokens": 1, "output_tokens": 2, "total_tokens": 3 }
+                                        }
+                                        """
+                                        .formatted(text))));
+    }
+}

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/ResponsesStreamingChatModelTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/ResponsesStreamingChatModelTest.java
@@ -1,0 +1,102 @@
+package io.quarkiverse.langchain4j.openai.test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.okForContentType;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ResponsesStreamingChatModelTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.openai.chat-model.mode", "responses")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "my-key")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    StreamingChatModel streamingChatModel;
+
+    @BeforeEach
+    void reset() {
+        resetRequests();
+    }
+
+    @Test
+    void streamingChat() {
+        var eventStream = """
+                data: {"type":"response.output_text.delta","delta":"Hallo"}
+
+                data: {"type":"response.output_text.delta","delta":" Welt"}
+
+                data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt-4o-mini","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Hallo Welt"}]}],"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}}
+
+                data: [DONE]
+                """;
+
+        wiremock().register(post(urlEqualTo("/v1/responses"))
+                .willReturn(okForContentType(MediaType.SERVER_SENT_EVENTS, eventStream)));
+
+        var completeResponse = new AtomicReference<AiMessage>();
+        var error = new AtomicReference<Throwable>();
+        var partialTokens = new StringBuilder();
+        var latch = new CountDownLatch(1);
+        streamingChatModel.chat("Translate to German: Hello world!", new StreamingChatResponseHandler() {
+            @Override
+            public void onPartialResponse(String token) {
+                partialTokens.append(token);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                error.set(t);
+                latch.countDown();
+            }
+
+            @Override
+            public void onCompleteResponse(ChatResponse response) {
+                completeResponse.set(response.aiMessage());
+                latch.countDown();
+            }
+        });
+
+        try {
+            if (!latch.await(1, TimeUnit.MINUTES)) {
+                fail("Streaming did not complete in time");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            fail("Interrupted while waiting for streaming response", e);
+        }
+
+        if (error.get() != null) {
+            fail("Streaming failed: %s".formatted(error.get().getMessage()), error.get());
+        }
+
+        assertThat(partialTokens.toString()).isEqualTo("Hallo Welt");
+        assertThat(completeResponse.get().text()).isEqualTo("Hallo Welt");
+    }
+}

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/ResponsesToolCallTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/ResponsesToolCallTest.java
@@ -1,0 +1,89 @@
+package io.quarkiverse.langchain4j.openai.test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ResponsesToolCallTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.openai.chat-model.mode", "responses")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "my-key")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    ChatModel chatModel;
+
+    @BeforeEach
+    void reset() {
+        resetRequests();
+    }
+
+    @Test
+    void toolCallIsParsed() {
+        wiremock().register(post(urlEqualTo("/v1/responses"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(
+                                """
+                                        {
+                                          "id": "resp_1",
+                                          "model": "gpt-4o-mini",
+                                          "status": "completed",
+                                          "output": [
+                                            {
+                                              "type": "function_call",
+                                              "call_id": "call_1",
+                                              "name": "getWeather",
+                                              "arguments": "{\\"city\\":\\"Paris\\"}"
+                                            }
+                                          ],
+                                          "usage": { "input_tokens": 1, "output_tokens": 2, "total_tokens": 3 }
+                                        }
+                                        """)));
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("What's the weather in Paris?"))
+                .toolSpecifications(ToolSpecification.builder()
+                        .name("getWeather")
+                        .description("Get the weather for a city")
+                        .parameters(JsonObjectSchema.builder()
+                                .addStringProperty("city")
+                                .build())
+                        .build())
+                .build();
+
+        ChatResponse response = chatModel.chat(request);
+
+        assertThat(response.aiMessage().hasToolExecutionRequests()).isTrue();
+        assertThat(response.aiMessage().toolExecutionRequests())
+                .singleElement()
+                .satisfies(toolCall -> {
+                    assertThat(toolCall.name()).isEqualTo("getWeather");
+                    assertThat(toolCall.id()).isEqualTo("call_1");
+                    assertThat(toolCall.arguments()).contains("Paris");
+                });
+    }
+}

--- a/model-providers/openai/openai-vanilla/runtime/pom.xml
+++ b/model-providers/openai/openai-vanilla/runtime/pom.xml
@@ -15,6 +15,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.quarkiverse.langchain4j</groupId>
+            <artifactId>quarkus-langchain4j-jaxrs-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-proxy-registry</artifactId>
         </dependency>

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
@@ -8,6 +8,8 @@ import java.net.Proxy.Type;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -15,6 +17,7 @@ import java.util.stream.Collectors;
 
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
 import jakarta.enterprise.util.TypeLiteral;
 
 import org.jboss.logging.Logger;
@@ -25,6 +28,7 @@ import dev.langchain4j.model.chat.DisabledChatModel;
 import dev.langchain4j.model.chat.DisabledStreamingChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.embedding.DisabledEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.image.DisabledImageModel;
@@ -36,8 +40,11 @@ import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
 import dev.langchain4j.model.openai.OpenAiEmbeddingModel;
 import dev.langchain4j.model.openai.OpenAiModerationModel;
+import dev.langchain4j.model.openai.OpenAiResponsesChatModel;
+import dev.langchain4j.model.openai.OpenAiResponsesStreamingChatModel;
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
 import io.quarkiverse.langchain4j.ModelBuilderCustomizer;
+import io.quarkiverse.langchain4j.jaxrsclient.JaxRsHttpClientBuilder;
 import io.quarkiverse.langchain4j.openai.DisabledAudioTranscriptionModel;
 import io.quarkiverse.langchain4j.openai.QuarkusOpenAiAudioTranscriptionModelBuilderFactory;
 import io.quarkiverse.langchain4j.openai.QuarkusOpenAiChatModelBuilderFactory;
@@ -53,6 +60,7 @@ import io.quarkiverse.langchain4j.openai.runtime.config.EmbeddingModelConfig;
 import io.quarkiverse.langchain4j.openai.runtime.config.ImageModelConfig;
 import io.quarkiverse.langchain4j.openai.runtime.config.LangChain4jOpenAiConfig;
 import io.quarkiverse.langchain4j.openai.runtime.config.ModerationModelConfig;
+import io.quarkiverse.langchain4j.openai.runtime.config.ResponsesChatModelConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.proxy.ProxyConfiguration;
@@ -60,6 +68,8 @@ import io.quarkus.proxy.ProxyConfigurationRegistry;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
+import io.quarkus.tls.TlsConfiguration;
+import io.quarkus.tls.TlsConfigurationRegistry;
 import io.smallrye.config.ConfigValidationException;
 
 @Recorder
@@ -72,6 +82,10 @@ public class OpenAiRecorder {
     private static final TypeLiteral<Instance<ModelBuilderCustomizer<OpenAiChatModel.OpenAiChatModelBuilder>>> CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
     };
     private static final TypeLiteral<Instance<ModelBuilderCustomizer<OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder>>> STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<OpenAiResponsesChatModel.Builder>>> RESPONSES_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<OpenAiResponsesStreamingChatModel.Builder>>> RESPONSES_STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
     };
     private static final TypeLiteral<Instance<ModelBuilderCustomizer<OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder>>> EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
     };
@@ -236,6 +250,267 @@ public class OpenAiRecorder {
                     return new DisabledStreamingChatModel();
                 }
             };
+        }
+    }
+
+    public Function<SyntheticCreationalContext<ChatModel>, ChatModel> responsesChatModel(String configName) {
+        LangChain4jOpenAiConfig.OpenAiConfig openAiConfig = correspondingOpenAiConfig(runtimeConfig.getValue(), configName);
+
+        if (openAiConfig.enableIntegration()) {
+            String apiKey = openAiConfig.apiKey();
+            if (DUMMY_KEY.equals(apiKey) && OPENAI_BASE_URL.equals(openAiConfig.baseUrl())) {
+                throw new ConfigValidationException(createApiKeyConfigProblems(configName));
+            }
+            ChatModelConfig chatModelConfig = openAiConfig.chatModel();
+            ResponsesChatModelConfig responsesConfig = chatModelConfig.responses();
+
+            JaxRsHttpClientBuilder httpClientBuilder = new JaxRsHttpClientBuilder();
+            Duration timeout = openAiConfig.timeout().orElse(Duration.ofSeconds(10));
+            httpClientBuilder.connectTimeout(timeout);
+            httpClientBuilder.readTimeout(timeout);
+
+            var builder = OpenAiResponsesChatModel.builder()
+                    .httpClientBuilder(httpClientBuilder)
+                    .baseUrl(normalizeBaseUrl(openAiConfig.baseUrl()))
+                    .apiKey(apiKey)
+                    .modelName(chatModelConfig.modelName())
+                    .logRequests(firstOrDefault(false, chatModelConfig.logRequests(), openAiConfig.logRequests()))
+                    .logResponses(firstOrDefault(false, chatModelConfig.logResponses(), openAiConfig.logResponses()));
+
+            if (openAiConfig.organizationId().isPresent()) {
+                builder.organizationId(openAiConfig.organizationId().get());
+            }
+            if (chatModelConfig.temperature().isPresent()) {
+                builder.temperature(chatModelConfig.temperature().get());
+            }
+            if (chatModelConfig.topP().isPresent()) {
+                builder.topP(chatModelConfig.topP().get());
+            }
+            if (chatModelConfig.serviceTier().isPresent()) {
+                builder.serviceTier(chatModelConfig.serviceTier().get());
+            }
+            if (chatModelConfig.reasoningEffort().isPresent()) {
+                builder.reasoningEffort(chatModelConfig.reasoningEffort().get());
+            }
+            if (chatModelConfig.strictJsonSchema().isPresent()) {
+                builder.strictJsonSchema(chatModelConfig.strictJsonSchema().get());
+            }
+            if (chatModelConfig.responseFormat().isPresent()) {
+                builder.responseFormat(toResponseFormat(chatModelConfig.responseFormat().get()));
+            }
+
+            if (responsesConfig.store().isPresent()) {
+                builder.store(responsesConfig.store().get());
+            }
+            if (responsesConfig.previousResponseId().isPresent()) {
+                builder.previousResponseId(responsesConfig.previousResponseId().get());
+            }
+            if (responsesConfig.reasoningSummary().isPresent()) {
+                builder.reasoningSummary(responsesConfig.reasoningSummary().get());
+            }
+            if (responsesConfig.maxOutputTokens().isPresent()) {
+                builder.maxOutputTokens(responsesConfig.maxOutputTokens().get());
+            }
+            if (responsesConfig.maxToolCalls().isPresent()) {
+                builder.maxToolCalls(responsesConfig.maxToolCalls().get());
+            }
+            if (responsesConfig.parallelToolCalls().isPresent()) {
+                builder.parallelToolCalls(responsesConfig.parallelToolCalls().get());
+            }
+            if (responsesConfig.include().isPresent()) {
+                builder.include(responsesConfig.include().get());
+            }
+            if (responsesConfig.truncation().isPresent()) {
+                builder.truncation(responsesConfig.truncation().get());
+            }
+            if (responsesConfig.textVerbosity().isPresent()) {
+                builder.textVerbosity(responsesConfig.textVerbosity().get());
+            }
+            if (responsesConfig.promptCacheKey().isPresent()) {
+                builder.promptCacheKey(responsesConfig.promptCacheKey().get());
+            }
+            if (responsesConfig.promptCacheRetention().isPresent()) {
+                builder.promptCacheRetention(responsesConfig.promptCacheRetention().get());
+            }
+            if (responsesConfig.safetyIdentifier().isPresent()) {
+                builder.safetyIdentifier(responsesConfig.safetyIdentifier().get());
+            }
+            if (responsesConfig.topLogprobs().isPresent()) {
+                builder.topLogprobs(responsesConfig.topLogprobs().get());
+            }
+            if (responsesConfig.strictTools().isPresent()) {
+                builder.strictTools(responsesConfig.strictTools().get());
+            }
+
+            return new Function<>() {
+                @Override
+                public ChatModel apply(SyntheticCreationalContext<ChatModel> context) {
+                    List<ChatModelListener> listeners = new ArrayList<>();
+                    for (ChatModelListener listener : context.getInjectedReference(CHAT_MODEL_LISTENER_TYPE_LITERAL)) {
+                        listeners.add(listener);
+                    }
+                    builder.listeners(listeners);
+                    resolveTlsConfiguration(openAiConfig, httpClientBuilder);
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(RESPONSES_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
+                    return builder.build();
+                }
+            };
+        } else {
+            return new Function<>() {
+                @Override
+                public ChatModel apply(SyntheticCreationalContext<ChatModel> context) {
+                    return new DisabledChatModel();
+                }
+            };
+        }
+    }
+
+    public Function<SyntheticCreationalContext<StreamingChatModel>, StreamingChatModel> responsesStreamingChatModel(
+            String configName) {
+        LangChain4jOpenAiConfig.OpenAiConfig openAiConfig = correspondingOpenAiConfig(runtimeConfig.getValue(), configName);
+
+        if (openAiConfig.enableIntegration()) {
+            String apiKey = openAiConfig.apiKey();
+            if (DUMMY_KEY.equals(apiKey) && OPENAI_BASE_URL.equals(openAiConfig.baseUrl())) {
+                throw new ConfigValidationException(createApiKeyConfigProblems(configName));
+            }
+            ChatModelConfig chatModelConfig = openAiConfig.chatModel();
+            ResponsesChatModelConfig responsesConfig = chatModelConfig.responses();
+
+            JaxRsHttpClientBuilder httpClientBuilder = new JaxRsHttpClientBuilder();
+            Duration timeout = openAiConfig.timeout().orElse(Duration.ofSeconds(10));
+            httpClientBuilder.connectTimeout(timeout);
+            httpClientBuilder.readTimeout(timeout);
+
+            var builder = OpenAiResponsesStreamingChatModel.builder()
+                    .httpClientBuilder(httpClientBuilder)
+                    .baseUrl(normalizeBaseUrl(openAiConfig.baseUrl()))
+                    .apiKey(apiKey)
+                    .modelName(chatModelConfig.modelName())
+                    .logRequests(firstOrDefault(false, chatModelConfig.logRequests(), openAiConfig.logRequests()))
+                    .logResponses(firstOrDefault(false, chatModelConfig.logResponses(), openAiConfig.logResponses()));
+
+            if (openAiConfig.organizationId().isPresent()) {
+                builder.organizationId(openAiConfig.organizationId().get());
+            }
+            if (chatModelConfig.temperature().isPresent()) {
+                builder.temperature(chatModelConfig.temperature().get());
+            }
+            if (chatModelConfig.topP().isPresent()) {
+                builder.topP(chatModelConfig.topP().get());
+            }
+            if (chatModelConfig.serviceTier().isPresent()) {
+                builder.serviceTier(chatModelConfig.serviceTier().get());
+            }
+            if (chatModelConfig.reasoningEffort().isPresent()) {
+                builder.reasoningEffort(chatModelConfig.reasoningEffort().get());
+            }
+            if (chatModelConfig.strictJsonSchema().isPresent()) {
+                builder.strictJsonSchema(chatModelConfig.strictJsonSchema().get());
+            }
+            if (chatModelConfig.responseFormat().isPresent()) {
+                builder.responseFormat(toResponseFormat(chatModelConfig.responseFormat().get()));
+            }
+
+            if (responsesConfig.store().isPresent()) {
+                builder.store(responsesConfig.store().get());
+            }
+            if (responsesConfig.previousResponseId().isPresent()) {
+                builder.previousResponseId(responsesConfig.previousResponseId().get());
+            }
+            if (responsesConfig.reasoningSummary().isPresent()) {
+                builder.reasoningSummary(responsesConfig.reasoningSummary().get());
+            }
+            if (responsesConfig.maxOutputTokens().isPresent()) {
+                builder.maxOutputTokens(responsesConfig.maxOutputTokens().get());
+            }
+            if (responsesConfig.maxToolCalls().isPresent()) {
+                builder.maxToolCalls(responsesConfig.maxToolCalls().get());
+            }
+            if (responsesConfig.parallelToolCalls().isPresent()) {
+                builder.parallelToolCalls(responsesConfig.parallelToolCalls().get());
+            }
+            if (responsesConfig.include().isPresent()) {
+                builder.include(responsesConfig.include().get());
+            }
+            if (responsesConfig.truncation().isPresent()) {
+                builder.truncation(responsesConfig.truncation().get());
+            }
+            if (responsesConfig.textVerbosity().isPresent()) {
+                builder.textVerbosity(responsesConfig.textVerbosity().get());
+            }
+            if (responsesConfig.promptCacheKey().isPresent()) {
+                builder.promptCacheKey(responsesConfig.promptCacheKey().get());
+            }
+            if (responsesConfig.promptCacheRetention().isPresent()) {
+                builder.promptCacheRetention(responsesConfig.promptCacheRetention().get());
+            }
+            if (responsesConfig.safetyIdentifier().isPresent()) {
+                builder.safetyIdentifier(responsesConfig.safetyIdentifier().get());
+            }
+            if (responsesConfig.topLogprobs().isPresent()) {
+                builder.topLogprobs(responsesConfig.topLogprobs().get());
+            }
+            if (responsesConfig.strictTools().isPresent()) {
+                builder.strictTools(responsesConfig.strictTools().get());
+            }
+            if (responsesConfig.streamIncludeObfuscation().isPresent()) {
+                builder.streamIncludeObfuscation(responsesConfig.streamIncludeObfuscation().get());
+            }
+
+            return new Function<>() {
+                @Override
+                public StreamingChatModel apply(SyntheticCreationalContext<StreamingChatModel> context) {
+                    List<ChatModelListener> listeners = new ArrayList<>();
+                    for (ChatModelListener listener : context.getInjectedReference(CHAT_MODEL_LISTENER_TYPE_LITERAL)) {
+                        listeners.add(listener);
+                    }
+                    builder.listeners(listeners);
+                    resolveTlsConfiguration(openAiConfig, httpClientBuilder);
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(RESPONSES_STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL,
+                                    Any.Literal.INSTANCE),
+                            builder, configName);
+                    return builder.build();
+                }
+            };
+        } else {
+            return new Function<>() {
+                @Override
+                public StreamingChatModel apply(SyntheticCreationalContext<StreamingChatModel> context) {
+                    return new DisabledStreamingChatModel();
+                }
+            };
+        }
+    }
+
+    private static String normalizeBaseUrl(String baseUrl) {
+        if (baseUrl == null) {
+            return null;
+        }
+        // The Responses client appends "/responses" to the base URL, so a trailing slash would produce a double slash.
+        return baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+    }
+
+    private static ResponseFormat toResponseFormat(String responseFormat) {
+        if ("text".equalsIgnoreCase(responseFormat)) {
+            return ResponseFormat.TEXT;
+        }
+        // Everything else (json, json_object, json_schema) maps to JSON structured output
+        return ResponseFormat.JSON;
+    }
+
+    private void resolveTlsConfiguration(LangChain4jOpenAiConfig.OpenAiConfig openAiConfig,
+            JaxRsHttpClientBuilder httpClientBuilder) {
+        Instance<TlsConfigurationRegistry> tlsConfigurationRegistry = CDI.current().select(TlsConfigurationRegistry.class);
+        if (tlsConfigurationRegistry.isResolvable()) {
+            Optional<TlsConfiguration> maybeTlsConfiguration = TlsConfiguration.from(tlsConfigurationRegistry.get(),
+                    openAiConfig.tlsConfigurationName());
+            if (maybeTlsConfiguration.isPresent()) {
+                httpClientBuilder.tlsConfiguration(maybeTlsConfiguration.get());
+            }
         }
     }
 

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/ChatModelConfig.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/ChatModelConfig.java
@@ -121,4 +121,9 @@ public interface ChatModelConfig {
      */
     @ConfigDocDefault("default")
     Optional<String> serviceTier();
+
+    /**
+     * Settings that only apply when {@code quarkus.langchain4j.openai.chat-model.mode} is set to {@code responses}.
+     */
+    ResponsesChatModelConfig responses();
 }

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/ResponsesChatModelConfig.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/ResponsesChatModelConfig.java
@@ -1,0 +1,92 @@
+package io.quarkiverse.langchain4j.openai.runtime.config;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+
+/**
+ * Settings that only apply when {@code quarkus.langchain4j.openai.chat-model.mode} is set to {@code responses},
+ * i.e. when the chat model targets the OpenAI {@code /v1/responses} endpoint.
+ */
+@ConfigGroup
+public interface ResponsesChatModelConfig {
+
+    /**
+     * Whether to store the generated model response for later retrieval via the Responses API.
+     */
+    Optional<Boolean> store();
+
+    /**
+     * The unique ID of the previous response to the model, used to create multi-turn conversations.
+     */
+    Optional<String> previousResponseId();
+
+    /**
+     * A summary of the reasoning performed by the model, for reasoning models.
+     * Supported values are {@code auto}, {@code concise}, and {@code detailed}.
+     */
+    Optional<String> reasoningSummary();
+
+    /**
+     * An upper bound for the number of tokens that can be generated for a response, including visible output tokens
+     * and reasoning tokens.
+     */
+    Optional<Integer> maxOutputTokens();
+
+    /**
+     * The maximum number of total calls to built-in tools that can be processed in a response.
+     */
+    Optional<Integer> maxToolCalls();
+
+    /**
+     * Whether to allow the model to run tool calls in parallel.
+     */
+    Optional<Boolean> parallelToolCalls();
+
+    /**
+     * Additional output data to include in the model response.
+     */
+    Optional<List<String>> include();
+
+    /**
+     * The truncation strategy to use for the model response. Supported values are {@code auto} and {@code disabled}.
+     */
+    Optional<String> truncation();
+
+    /**
+     * Constrains the verbosity of the model's response. Supported values are {@code low}, {@code medium}, and
+     * {@code high}.
+     */
+    Optional<String> textVerbosity();
+
+    /**
+     * Used by OpenAI to cache responses for similar requests to optimize your cache hit rates.
+     */
+    Optional<String> promptCacheKey();
+
+    /**
+     * The retention policy for the prompt cache.
+     */
+    Optional<String> promptCacheRetention();
+
+    /**
+     * A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+     */
+    Optional<String> safetyIdentifier();
+
+    /**
+     * The number of most likely tokens to return at each token position, each with an associated log probability.
+     */
+    Optional<Integer> topLogprobs();
+
+    /**
+     * Whether to enforce strict schema validation on tool/function definitions.
+     */
+    Optional<Boolean> strictTools();
+
+    /**
+     * Whether obfuscation fields should be included in streaming events. Only applies to the streaming chat model.
+     */
+    Optional<Boolean> streamIncludeObfuscation();
+}


### PR DESCRIPTION
## 🚀 Summary

Adds opt-in support for OpenAI's **Responses API** (`POST /v1/responses`) to the `quarkus-langchain4j-openai` extension, alongside the existing Chat Completions support. This is the first step toward resolving #1952.

Why it matters: some models (like `gpt-5-pro` and `o1-pro`) are only available through the Responses API, and it unlocks Responses-specific capabilities. By default nothing changes - you opt in with a single config property.

## 🧩 How it works

Upstream langchain4j exposes the Responses API as separate `OpenAiResponsesChatModel` / `OpenAiResponsesStreamingChatModel` classes. Unlike the classic `OpenAiChatModel`, these have no builder-factory SPI and use their own internal client, so the existing `QuarkusOpenAiClient` path can't be reused. Instead we feed the upstream models a Quarkus-native `HttpClientBuilder` (`JaxRsHttpClientBuilder` — the same transport Ollama and Gemini use). This keeps traffic on the Quarkus REST Client stack, so native-image, TLS registry, and HTTP-level observability all keep working.

## ✨ What's included

- **Opt-in switch:** `quarkus.langchain4j.openai.chat-model.mode` = `chat-completion` (default) or `responses`. Fully non-breaking.
- **Responses settings** under `quarkus.langchain4j.openai.chat-model.responses.*` — `store`, `previous-response-id`, `reasoning-summary`, `max-output-tokens`, `max-tool-calls`, `parallel-tool-calls`, `include`, `truncation`, `text-verbosity`, `prompt-cache-key`, `prompt-cache-retention`, `safety-identifier`, `top-logprobs`, `strict-tools`, `stream-include-obfuscation`. Shared options (model name, temperature, top-p, response format, service tier, reasoning effort, logging) are reused.
- **Same beans you already use** — `ChatModel` and `StreamingChatModel` inject exactly as before; no new API to learn.
- Blocking + streaming, tool/function calling, and structured output all supported, plus TLS registry, listeners, `ModelBuilderCustomizer`, and native reflection registration.
- Docs added to `openai-chat-model.adoc`.

## 📌 Scope & notes

- Targets `openai-vanilla` only. Azure OpenAI Responses support is a possible follow-up (Azure uses custom model wrappers).
- In `responses` mode, `log-requests-curl` and proxy configuration aren't honored (documented). Standard `log-requests` / `log-responses` still work.

## ✅ Test plan

- [x] Blocking chat hits `/v1/responses` with the correct payload and auth header
- [x] SSE streaming (partial tokens + final response)
- [x] Tool/function call output parsed into a tool execution request
- [x] Existing chat-completion path still passes (no regression)