### PR TITLE
Distinguish RAG-augmented context in Dev UI chat

### DIFF
--- a/core/deployment/src/main/resources/dev-ui/qwc-chat.js
+++ b/core/deployment/src/main/resources/dev-ui/qwc-chat.js
@@ -15,6 +15,20 @@ import 'qui-alert';
 import { JsonRpc } from 'jsonrpc';
 import { systemMessages } from 'build-time-data';
 import { dialogHeaderRenderer, dialogRenderer } from '@vaadin/dialog/lit.js';
+import { registerStyles, css as vaadinCss } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+
+// Styles the RAG context box (see ChatMessagePojo#formatRagAugmentedText) as a distinct box in the same bubble
+registerStyles('vaadin-markdown', vaadinCss`
+    ::slotted(.lc4j-rag-context) {
+        margin: var(--lumo-space-s) 0 0 0;
+        padding: var(--lumo-space-xs) var(--lumo-space-m);
+        border-left: 3px solid var(--lumo-primary-color) !important;
+        border-radius: var(--lumo-border-radius-m);
+        background-color: var(--lumo-primary-color-10pct);
+        color: var(--lumo-secondary-text-color);
+        font-size: var(--lumo-font-size-s);
+    }
+`);
 
 export class QwcChat extends LitElement {
 
@@ -169,7 +183,7 @@ export class QwcChat extends LitElement {
     _renderChatView() {
         return html`
             <div class="chatContainer">
-                <vaadin-message-list .items="${this._chatItems}"></vaadin-message-list>
+                <vaadin-message-list .items="${this._chatItems}" markdown></vaadin-message-list>
                 <vaadin-progress-bar class="${this._progressBarClass}" indeterminate></vaadin-progress-bar>
                 <vaadin-message-input @submit="${this._handleSendChat}"></vaadin-message-input>
             </div>

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/devui/ChatJsonRPCService.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/devui/ChatJsonRPCService.java
@@ -4,6 +4,7 @@ import static io.quarkiverse.langchain4j.runtime.LangChain4jUtil.chatMessageToTe
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -137,6 +138,10 @@ public class ChatJsonRPCService {
     private final AtomicReference<ChatMemory> currentMemory = new AtomicReference<>();
     private final AtomicLong currentMemoryId = new AtomicLong();
 
+    // maps a RAG-augmented UserMessage (by identity) to the original text the user typed, so the
+    // Dev UI can later highlight just the retrieved-context part instead of the whole message
+    private final Map<ChatMessage, String> ragOriginalTexts = new IdentityHashMap<>();
+
     public String reset(String systemMessage) {
         if (currentMemory.get() != null) {
             currentMemory.get().clear();
@@ -145,6 +150,7 @@ public class ChatJsonRPCService {
         currentMemoryId.set(memoryId);
         ChatMemory memory = memoryProvider.get(memoryId);
         currentMemory.set(memory);
+        ragOriginalTexts.clear();
         if (systemMessage != null && !systemMessage.isEmpty()) {
             memory.add(new SystemMessage(systemMessage));
         }
@@ -178,7 +184,9 @@ public class ChatJsonRPCService {
                     AugmentationRequest augmentationRequest = new AugmentationRequest(userMessage, metadata);
                     ChatMessage augmentedMessage = retrievalAugmentor.augment(augmentationRequest).chatMessage();
                     memory.add(augmentedMessage);
-                    em.emit(new JsonObject().put("augmentedMessage", chatMessageToText(augmentedMessage)));
+                    ragOriginalTexts.put(augmentedMessage, message);
+                    em.emit(new JsonObject().put("augmentedMessage",
+                            ChatMessagePojo.formatRagAugmentedText(message, chatMessageToText(augmentedMessage))));
                 } else {
                     memory.add(new UserMessage(message));
                 }
@@ -240,6 +248,7 @@ public class ChatJsonRPCService {
                 AugmentationRequest augmentationRequest = new AugmentationRequest(userMessage, metadata);
                 ChatMessage augmentedMessage = retrievalAugmentor.augment(augmentationRequest).chatMessage();
                 memory.add(augmentedMessage);
+                ragOriginalTexts.put(augmentedMessage, message);
             } else {
                 memory.add(new UserMessage(message));
             }
@@ -257,7 +266,7 @@ public class ChatJsonRPCService {
                 toolSpecifications.clear();
                 toolExecutors.clear();
             }
-            List<ChatMessagePojo> response = ChatMessagePojo.listFromMemory(memory);
+            List<ChatMessagePojo> response = ChatMessagePojo.listFromMemory(memory, ragOriginalTexts);
             return new ChatResultPojo(response, null);
         } catch (Throwable t) {
             // restore the memory from the backup

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/devui/json/ChatMessagePojo.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/devui/json/ChatMessagePojo.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.langchain4j.runtime.devui.json;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import dev.langchain4j.data.message.AiMessage;
@@ -34,14 +35,14 @@ public class ChatMessagePojo {
         return toolExecutionResult;
     }
 
-    public static List<ChatMessagePojo> listFromMemory(ChatMemory memory) {
+    public static List<ChatMessagePojo> listFromMemory(ChatMemory memory, Map<ChatMessage, String> ragOriginalTexts) {
         return memory.messages()
                 .stream()
-                .map(ChatMessagePojo::fromMessage)
+                .map(message -> ChatMessagePojo.fromMessage(message, ragOriginalTexts))
                 .collect(Collectors.toList());
     }
 
-    public static ChatMessagePojo fromMessage(ChatMessage message) {
+    public static ChatMessagePojo fromMessage(ChatMessage message, Map<ChatMessage, String> ragOriginalTexts) {
         ChatMessagePojo json = new ChatMessagePojo();
         switch (message.type()) {
             case SYSTEM:
@@ -51,7 +52,9 @@ public class ChatMessagePojo {
             case USER:
                 json.type = MessageType.USER;
                 UserMessage userMessage = (UserMessage) message;
-                json.message = userMessage.hasSingleText() ? userMessage.singleText() : null;
+                String text = userMessage.hasSingleText() ? userMessage.singleText() : null;
+                String originalText = ragOriginalTexts.get(message);
+                json.message = originalText != null && text != null ? formatRagAugmentedText(originalText, text) : text;
                 break;
             case AI:
                 AiMessage aiMessage = (AiMessage) message;
@@ -74,6 +77,62 @@ public class ChatMessagePojo {
                 break;
         }
         return json;
+    }
+
+    /**
+     * Wraps the RAG-inserted part of a user message in a dedicated {@code lc4j-rag-context} box so the Dev UI can
+     * render it distinctly without colliding with regular Markdown blockquotes in other messages. The inserted part
+     * is what remains after removing the common prefix and suffix; if those don't cover the whole original, the
+     * augmentor rewrote it and {@code augmentedText} is returned unchanged.
+     */
+    public static String formatRagAugmentedText(String originalText, String augmentedText) {
+        int prefixLength = commonPrefixLength(originalText, augmentedText);
+        int suffixLength = commonSuffixLength(originalText, augmentedText, prefixLength);
+        if (prefixLength + suffixLength != originalText.length()) {
+            return augmentedText;
+        }
+        String ragContext = augmentedText.substring(prefixLength, augmentedText.length() - suffixLength).strip();
+        if (ragContext.isEmpty()) {
+            return augmentedText;
+        }
+        String box = "<blockquote class=\"lc4j-rag-context\"><strong>Retrieved context</strong><br>"
+                + escapeHtml(ragContext).replace("\n", "<br>") + "</blockquote>";
+        String prefix = originalText.substring(0, prefixLength).strip();
+        String suffix = originalText.substring(originalText.length() - suffixLength).strip();
+        StringBuilder result = new StringBuilder();
+        if (!prefix.isEmpty()) {
+            result.append(prefix).append("\n\n");
+        }
+        result.append(box);
+        if (!suffix.isEmpty()) {
+            result.append("\n\n").append(suffix);
+        }
+        return result.toString();
+    }
+
+    private static String escapeHtml(String text) {
+        return text.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;");
+    }
+
+    private static int commonPrefixLength(String a, String b) {
+        int max = Math.min(a.length(), b.length());
+        int i = 0;
+        while (i < max && a.charAt(i) == b.charAt(i)) {
+            i++;
+        }
+        return i;
+    }
+
+    private static int commonSuffixLength(String a, String b, int prefixLength) {
+        int max = Math.min(a.length(), b.length()) - prefixLength;
+        int i = 0;
+        while (i < max && a.charAt(a.length() - 1 - i) == b.charAt(b.length() - 1 - i)) {
+            i++;
+        }
+        return i;
     }
 
 }

--- a/core/runtime/src/test/java/io/quarkiverse/langchain4j/runtime/devui/json/ChatMessagePojoTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/langchain4j/runtime/devui/json/ChatMessagePojoTest.java
@@ -1,0 +1,72 @@
+package io.quarkiverse.langchain4j.runtime.devui.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class ChatMessagePojoTest {
+
+    @Test
+    void appendedRagContextIsWrappedInContextBox() {
+        String original = "What's the return policy?";
+        String augmented = original + "\n\nAnswer using the following information:\nItems can be returned within 30 days.";
+
+        String result = ChatMessagePojo.formatRagAugmentedText(original, augmented);
+
+        assertEquals(original + "\n\n<blockquote class=\"lc4j-rag-context\"><strong>Retrieved context</strong><br>"
+                + "Answer using the following information:<br>"
+                + "Items can be returned within 30 days.</blockquote>", result);
+    }
+
+    @Test
+    void insertedRagContextInTheMiddleIsWrappedInContextBox() {
+        String original = "hey there";
+        String augmented = original.substring(0, 4) + "\n\nItems can be returned within 30 days.\n\n"
+                + original.substring(4);
+
+        String result = ChatMessagePojo.formatRagAugmentedText(original, augmented);
+
+        assertEquals("hey\n\n<blockquote class=\"lc4j-rag-context\"><strong>Retrieved context</strong><br>"
+                + "Items can be returned within 30 days.</blockquote>\n\nthere", result);
+    }
+
+    @Test
+    void htmlSpecialCharactersInRagContextAreEscaped() {
+        String original = "question";
+        String augmented = original + "\n\nuse <tag> & \"quotes\"";
+
+        String result = ChatMessagePojo.formatRagAugmentedText(original, augmented);
+
+        assertEquals(original + "\n\n<blockquote class=\"lc4j-rag-context\"><strong>Retrieved context</strong><br>"
+                + "use &lt;tag&gt; &amp; &quot;quotes&quot;</blockquote>", result);
+    }
+
+    @Test
+    void partiallyRewrittenMessageIsReturnedUnchanged() {
+        String original = "the cat sat";
+        String augmented = "the dog sat";
+
+        String result = ChatMessagePojo.formatRagAugmentedText(original, augmented);
+
+        assertEquals(augmented, result);
+    }
+
+    @Test
+    void rewrittenMessageIsReturnedUnchanged() {
+        String original = "What's the return policy?";
+        String augmented = "Completely different text produced by a custom RetrievalAugmentor.";
+
+        String result = ChatMessagePojo.formatRagAugmentedText(original, augmented);
+
+        assertEquals(augmented, result);
+    }
+
+    @Test
+    void unmodifiedMessageIsReturnedUnchanged() {
+        String original = "What's the return policy?";
+
+        String result = ChatMessagePojo.formatRagAugmentedText(original, original);
+
+        assertEquals(original, result);
+    }
+}


### PR DESCRIPTION
## Describe your changes

When RAG is enabled in the Dev UI chat, the retrieved context was merged into the user's message with no visual distinction.

The augmented part is now detected by common prefix + suffix against the original message and wrapped in a dedicated `lc4j-rag-context` box, kept in the same bubble but styled apart. If the augmentor rewrote the message instead of only inserting into it, the message is left unchanged.

### Screenshots

<img width="933" height="881" alt="screenshot-2026-07-04_13-33-07" src="https://github.com/user-attachments/assets/7604029a-1800-4703-88c9-a0a54dd095ea" />

<img width="936" height="885" alt="screenshot-2026-07-04_13-31-38" src="https://github.com/user-attachments/assets/551fed39-c863-4ed4-8ae1-8143436e940a" />

---

- Closes #2595

