### PR TITLE
Add `@NoTemplating` to keep `@UserMessage` parameters verbatim

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
@@ -2410,7 +2410,9 @@ public class AiServicesProcessor {
                     .filter(IS_METHOD_PARAMETER_ANNOTATION).findFirst();
             if (userMessageOnMethodParam.isPresent()) {
                 if (DotNames.STRING.equals(userMessageOnMethodParam.get().target().asMethodParameter().type().name())
-                        && !templateParams.isEmpty()) {
+                        && !templateParams.isEmpty()
+                        && !userMessageOnMethodParam.get().target().asMethodParameter()
+                                .hasAnnotation(LangChain4jDotNames.NO_TEMPLATING)) {
                     return AiServiceMethodCreateInfo.UserMessageInfo.fromTemplate(
                             AiServiceMethodCreateInfo.TemplateInfo.fromMethodParam(
                                     Short.valueOf(userMessageOnMethodParam.get().target().asMethodParameter().position())

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/LangChain4jDotNames.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/LangChain4jDotNames.java
@@ -45,6 +45,7 @@ import io.quarkiverse.langchain4j.HandleToolArgumentError;
 import io.quarkiverse.langchain4j.HandleToolExecutionError;
 import io.quarkiverse.langchain4j.ImageUrl;
 import io.quarkiverse.langchain4j.ModelName;
+import io.quarkiverse.langchain4j.NoTemplating;
 import io.quarkiverse.langchain4j.OnThinking;
 import io.quarkiverse.langchain4j.PdfUrl;
 import io.quarkiverse.langchain4j.RegisterAiService;
@@ -93,6 +94,7 @@ public class LangChain4jDotNames {
     static final DotName STRUCTURED_PROMPT_PROCESSOR = DotName.createSimple(StructuredPromptProcessor.class);
     static final DotName DEFAULT_TOOL_EXECUTION_ERROR_HANDLER = DotName.createSimple(DefaultToolExecutionErrorHandler.class);
     public static final DotName V = DotName.createSimple(dev.langchain4j.service.V.class);
+    public static final DotName NO_TEMPLATING = DotName.createSimple(NoTemplating.class);
 
     public static final DotName MODEL_NAME = DotName.createSimple(ModelName.class);
     public static final DotName REGISTER_AI_SERVICES = DotName.createSimple(RegisterAiService.class);

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/UserMessageNoTemplatingTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/UserMessageNoTemplatingTest.java
@@ -1,0 +1,92 @@
+package io.quarkiverse.langchain4j.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.NoTemplating;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * When a {@code @UserMessage} parameter is also annotated with {@link NoTemplating}, its value is sent as-is,
+ * without Qute templating, so literal {@code {...}} sequences are preserved.
+ */
+public class UserMessageNoTemplatingTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(
+                            Assistant.class,
+                            MyChatModelSupplier.class,
+                            MyChatModel.class));
+
+    @Inject
+    Assistant assistant;
+
+    @Test
+    @ActivateRequestContext
+    public void userMessageParameterIsKeptLiteral() {
+        String response = assistant.summarize("Connect to {quarkus.http.host} please", 100);
+        assertThat(response).isEqualTo("Connect to {quarkus.http.host} please");
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
+    interface Assistant {
+        @SystemMessage("Summarize in up to {maximum} tokens.")
+        String summarize(@UserMessage @NoTemplating String text, int maximum);
+    }
+
+    @Singleton
+    public static class MyChatModelSupplier implements Supplier<ChatModel> {
+
+        private MyChatModel myChatModel;
+
+        @PostConstruct
+        public void init() {
+            myChatModel = new MyChatModel();
+        }
+
+        @Override
+        public ChatModel get() {
+            return myChatModel;
+        }
+    }
+
+    public static class MyChatModel implements ChatModel {
+        @Override
+        public ChatResponse chat(List<ChatMessage> messages) {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            String userText = chatRequest.messages().stream()
+                    .filter(dev.langchain4j.data.message.UserMessage.class::isInstance)
+                    .map(dev.langchain4j.data.message.UserMessage.class::cast)
+                    .findFirst()
+                    .map(dev.langchain4j.data.message.UserMessage::singleText)
+                    .orElse("no user message");
+            return ChatResponse.builder().aiMessage(new AiMessage(userText)).build();
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/NoTemplating.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/NoTemplating.java
@@ -1,0 +1,20 @@
+package io.quarkiverse.langchain4j;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Disables Qute templating for a {@code @UserMessage} method parameter, so its value is used verbatim.
+ * <p>
+ * Use it when the parameter value may contain {@code {...}} sequences that must not be interpreted as
+ * template expressions.
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RUNTIME)
+@Documented
+public @interface NoTemplating {
+}

--- a/docs/modules/ROOT/pages/prompt-and-template.adoc
+++ b/docs/modules/ROOT/pages/prompt-and-template.adoc
@@ -67,6 +67,18 @@ Qute supports logic and loops. Here's an advanced example where a follow-up ques
 public String rephrase(List<ChatMessage> chatMessages, @UserMessage String question);
 ----
 
+== Disabling Templating
+
+When a `String` parameter annotated with `@UserMessage` is combined with other template variables, its value is processed as a Qute template. This fails if the value contains `{...}` sequences that are not template expressions (for example user input that happens to include `{some.key}`).
+
+Annotate the parameter with `@NoTemplating` to send its value verbatim:
+
+[source,java]
+----
+@SystemMessage("Summarize in up to {maximum} tokens.")
+String summarize(@UserMessage @NoTemplating String text, int maximum);
+----
+
 == Template Extensions for ChatMessage Lists
 
 To avoid repetitive logic, there are  Qute `TemplateExtension` methods for `List<ChatMessage>`. These simplify formatting historical chat messages.


### PR DESCRIPTION
## Describe your changes

Adds a `@NoTemplating` annotation for `@UserMessage` method parameters. By default, a `String` parameter annotated with `@UserMessage` is processed as a Qute template when the method has other template variables, which fails when the value contains `{...}` sequences that are not template expressions.

Flipping the default so these parameters are never templated would be a breaking change for apps that rely on that interpolation. This takes the non-breaking route instead: `@NoTemplating` opts out per parameter and the default behavior is unchanged.

---

- Closes #2408