### PR TITLE
fix: simplify CDI instance selection in SampleLoaderResolver

### DIFF
--- a/testing/evaluation/evaluation-core/src/main/java/io/quarkiverse/langchain4j/testing/evaluation/SampleLoaderResolver.java
+++ b/testing/evaluation/evaluation-core/src/main/java/io/quarkiverse/langchain4j/testing/evaluation/SampleLoaderResolver.java
@@ -6,7 +6,6 @@ import java.util.ServiceLoader;
 
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.CDI;
-import jakarta.enterprise.util.TypeLiteral;
 
 /**
  * Resolver for SampleLoader implementations using a hybrid CDI/ServiceLoader approach.
@@ -197,12 +196,11 @@ public class SampleLoaderResolver {
         List<SampleLoader<?>> loaders = new ArrayList<>();
 
         try {
-            Instance<SampleLoader<?>> instances = CDI.current()
-                    .select(new TypeLiteral<SampleLoader<?>>() {
-                    });
+            Instance instances = CDI.current()
+                    .select(SampleLoader.class);
 
-            for (SampleLoader<?> loader : instances) {
-                loaders.add(loader);
+            for (Object loader : instances) {
+                loaders.add((SampleLoader<?>) loader);
             }
         } catch (Exception e) {
             throw new SampleLoadException("Failed to discover SampleLoaders via CDI", e);

--- a/testing/evaluation/evaluation-junit5/src/test/java/io/quarkiverse/langchain4j/evaluation/junit5/it/QuarkusCustomCdiLoaderIT.java
+++ b/testing/evaluation/evaluation-junit5/src/test/java/io/quarkiverse/langchain4j/evaluation/junit5/it/QuarkusCustomCdiLoaderIT.java
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.quarkiverse.langchain4j.evaluation.junit5.EvaluationExtension;
 import io.quarkiverse.langchain4j.evaluation.junit5.SampleLocation;
+import io.quarkiverse.langchain4j.testing.evaluation.SampleLoader;
 import io.quarkiverse.langchain4j.testing.evaluation.Samples;
+import io.quarkus.arc.Arc;
 import io.quarkus.test.junit.QuarkusTest;
 
 /**
@@ -85,6 +87,17 @@ class QuarkusCustomCdiLoaderIT {
         assertThat(greetings.get(0).name()).isEqualTo("Greeting1");
         assertThat(mathSamples.get(0).name()).isEqualTo("Math1");
         assertThat(yamlSamples.get(0).name()).isEqualTo("QuarkusSample1");
+    }
+
+    @Test
+    void shouldDirectlyVerifyGenericSampleLoaderInCdiContainer() {
+        var beanManager = Arc.container().beanManager();
+        var beans = beanManager.getBeans(SampleLoader.class);
+
+        assertThat(beans)
+                .as("CustomCdiSampleLoader (SampleLoader<String>) should be discoverable as SampleLoader in CDI")
+                .extracting("beanClass")
+                .contains(CustomCdiSampleLoader.class);
     }
 
     @Test


### PR DESCRIPTION
The class does not have a parameterized type; the bean is registered as the concrete class `SampleLoader`. When using `TypeLiteral<SampleLoader<?>>`, CDI looks for `SampleLoader<?>` or a wildcard, whereas in Quarkus Arc, beans are registered with the exact type `SampleLoader<String>`, not a wildcard.

- Closes: #2661 
