### PR TITLE
Add build-time validations for agentic misconfigurations

### DIFF
--- a/agentic/deployment/src/main/java/io/quarkiverse/langchain4j/agentic/deployment/AgenticProcessor.java
+++ b/agentic/deployment/src/main/java/io/quarkiverse/langchain4j/agentic/deployment/AgenticProcessor.java
@@ -1200,6 +1200,10 @@ public class AgenticProcessor {
         if (subAgentMethods == null) {
             subAgentMethods = classToNonAiAgentMethodsMap.get(subagentName);
         }
+        if (subAgentMethods == null || subAgentMethods.isEmpty()) {
+            throw new IllegalConfigurationException(
+                    "Class '%s' is declared as a sub-agent but does not declare any agent method".formatted(subagentName));
+        }
         if (subAgentMethods.size() != 1) {
             log.warn("Unable to determine agentic method for subagent with type '%s'"
                     .formatted(subagentName));
@@ -1277,6 +1281,149 @@ public class AgenticProcessor {
                 }
             });
         });
+    }
+
+    @BuildStep
+    @Produce(ServiceStartBuildItem.class)
+    public void validateAgentNames(DetectedAiAgentAsMapBuildItem detectedAiAgentAsMapBuildItem,
+            DetectedNonAiAgentAsMapBuildItem detectedNonAiAgentAsMapBuildItem) {
+        Map<DotName, List<MethodInfo>> ifaceToAgentMethodsMap = detectedAiAgentAsMapBuildItem.getIfaceToAgentMethodsMap();
+        Map<DotName, List<MethodInfo>> classToNonAiAgentMethodsMap = detectedNonAiAgentAsMapBuildItem
+                .getClassToNonAiAgentMethodsMap();
+
+        for (var entry : ifaceToAgentMethodsMap.entrySet()) {
+            if (entry.getKey().toString().startsWith(AGENTIC_PACKAGE_PREFIX)) {
+                continue;
+            }
+            for (MethodInfo agenticMethod : entry.getValue()) {
+                for (DotName annotation : AgenticLangChain4jDotNames.AGENT_ANNOTATIONS_WITH_SUB_AGENTS) {
+                    AnnotationInstance instance = agenticMethod.annotation(annotation);
+                    if (instance == null) {
+                        continue;
+                    }
+                    validateSubAgentNames(instance, entry.getKey(), ifaceToAgentMethodsMap, classToNonAiAgentMethodsMap);
+                }
+            }
+        }
+    }
+
+    /**
+     * Explicitly assigned duplicate agent names are rejected. Implicit duplicates (method names) are legal at
+     * runtime, but under a supervisor they reach the planner prompt distinguished only by a positional suffix,
+     * so those get a warning.
+     */
+    private void validateSubAgentNames(AnnotationInstance workflowInstance, DotName rootAgentName,
+            Map<DotName, List<MethodInfo>> ifaceToAgentMethodsMap,
+            Map<DotName, List<MethodInfo>> classToNonAiAgentMethodsMap) {
+        boolean isSupervisor = AgenticLangChain4jDotNames.SUPERVISOR_AGENT.equals(workflowInstance.name());
+        Map<String, DotName> explicitNameToClass = new HashMap<>();
+        Map<String, DotName> effectiveNameToClass = new HashMap<>();
+
+        List<Type> subAgentTypes = new ArrayList<>();
+        AnnotationValue subAgentsValue = workflowInstance.value("subAgents");
+        if (subAgentsValue != null) {
+            subAgentTypes.addAll(List.of(subAgentsValue.asClassArray()));
+        }
+        AnnotationValue subAgentValue = workflowInstance.value("subAgent");
+        if (subAgentValue != null) {
+            subAgentTypes.add(subAgentValue.asClass());
+        }
+
+        for (Type subAgentType : subAgentTypes) {
+            DotName subAgentClassName = subAgentType.name();
+            Optional<MethodInfo> maybeSubAgentMethod = subagentMethod(subAgentClassName, ifaceToAgentMethodsMap,
+                    classToNonAiAgentMethodsMap);
+            if (maybeSubAgentMethod.isEmpty()) {
+                continue;
+            }
+            MethodInfo subAgentMethod = maybeSubAgentMethod.get();
+            for (DotName annotation : AgenticLangChain4jDotNames.ALL_AGENT_ANNOTATIONS) {
+                AnnotationInstance subAgentInstance = subAgentMethod.annotation(annotation);
+                if (subAgentInstance == null) {
+                    continue;
+                }
+                String explicitName = explicitAgentName(subAgentInstance);
+                if (explicitName != null) {
+                    DotName previous = explicitNameToClass.put(explicitName, subAgentClassName);
+                    if (previous != null && !previous.equals(subAgentClassName)) {
+                        throw new IllegalConfigurationException(
+                                "Duplicate agent name '%s' used by both '%s' and '%s' in the agentic system rooted at '%s'"
+                                        .formatted(explicitName, previous, subAgentClassName, rootAgentName));
+                    }
+                }
+                if (isSupervisor) {
+                    String effectiveName = explicitName != null ? explicitName : subAgentMethod.name();
+                    DotName previous = effectiveNameToClass.put(effectiveName, subAgentClassName);
+                    if (previous != null && !previous.equals(subAgentClassName)) {
+                        log.warn(
+                                "Sub-agents '%s' and '%s' of supervisor agent '%s' share the agent name '%s'. The supervisor planner distinguishes them only by a positional suffix, which can degrade planning"
+                                        .formatted(previous, subAgentClassName, rootAgentName, effectiveName));
+                    }
+                }
+                validateSubAgentNames(subAgentInstance, rootAgentName, ifaceToAgentMethodsMap,
+                        classToNonAiAgentMethodsMap);
+                break;
+            }
+        }
+    }
+
+    private static String explicitAgentName(AnnotationInstance agentInstance) {
+        AnnotationValue nameValue = agentInstance.value("name");
+        if (nameValue != null && !nameValue.asString().isBlank()) {
+            return nameValue.asString();
+        }
+        return null;
+    }
+
+    @BuildStep
+    @Produce(ServiceStartBuildItem.class)
+    public void warnAboutSupervisorSubAgentsWithoutDescription(CombinedIndexBuildItem indexBuildItem,
+            DetectedAiAgentAsMapBuildItem detectedAiAgentAsMapBuildItem,
+            DetectedNonAiAgentAsMapBuildItem detectedNonAiAgentAsMapBuildItem) {
+        Map<DotName, List<MethodInfo>> ifaceToAgentMethodsMap = detectedAiAgentAsMapBuildItem.getIfaceToAgentMethodsMap();
+        Map<DotName, List<MethodInfo>> classToNonAiAgentMethodsMap = detectedNonAiAgentAsMapBuildItem
+                .getClassToNonAiAgentMethodsMap();
+
+        indexBuildItem.getIndex().getAnnotations(AgenticLangChain4jDotNames.SUPERVISOR_AGENT).forEach(instance -> {
+            if (instance.target().kind() != AnnotationTarget.Kind.METHOD) {
+                return;
+            }
+            MethodInfo supervisorMethod = instance.target().asMethod();
+            if (supervisorMethod.declaringClass().name().toString().startsWith(AGENTIC_PACKAGE_PREFIX)) {
+                return;
+            }
+            AnnotationValue subAgentsValue = instance.value("subAgents");
+            if (subAgentsValue == null) {
+                return;
+            }
+            for (Type subAgentType : subAgentsValue.asClassArray()) {
+                subagentMethod(subAgentType.name(), ifaceToAgentMethodsMap, classToNonAiAgentMethodsMap)
+                        .ifPresent(subAgentMethod -> {
+                            if (!hasDescription(subAgentMethod)) {
+                                log.warn(
+                                        "Sub-agent '%s' of supervisor agent '%s' has no description. The supervisor planner relies on agent descriptions to decide which agent to invoke"
+                                                .formatted(subAgentType.name(),
+                                                        supervisorMethod.declaringClass().name()));
+                            }
+                        });
+            }
+        });
+    }
+
+    private static boolean hasDescription(MethodInfo agentMethod) {
+        for (DotName annotation : AgenticLangChain4jDotNames.ALL_AGENT_ANNOTATIONS) {
+            AnnotationInstance agentInstance = agentMethod.annotation(annotation);
+            if (agentInstance == null) {
+                continue;
+            }
+            AnnotationValue descriptionValue = agentInstance.value("description");
+            if (descriptionValue != null && !descriptionValue.asString().isBlank()) {
+                return true;
+            }
+            AnnotationValue aliasValue = agentInstance.value("value");
+            return aliasValue != null && !aliasValue.asString().isBlank();
+        }
+        return false;
     }
 
     private static boolean needsResolution(OutputKeyBuildItem outputKeyBuildItem, String parameterName) {

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/validation/DuplicateAgentNamesTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/validation/DuplicateAgentNamesTest.java
@@ -1,0 +1,77 @@
+package io.quarkiverse.langchain4j.agentic.deployment.validation;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.SequenceAgent;
+import dev.langchain4j.service.IllegalConfigurationException;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DuplicateAgentNamesTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "whatever")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"))
+            .assertException(
+                    throwable -> Assertions.assertThat(throwable).isInstanceOf(IllegalConfigurationException.class)
+                            .hasMessageContaining("uplicate agent name")
+                            .hasMessageContaining("writer"));
+
+    @Test
+    public void test() {
+        fail("should never be called");
+    }
+
+    @Singleton
+    public static class StoryCreatorConsumer {
+
+        @Inject
+        StoryCreator storyCreator;
+    }
+
+    public interface StoryCreator {
+
+        @SequenceAgent(outputKey = "story", subAgents = { CreativeWriter.class, AudienceEditor.class })
+        String write(@V("topic") String topic, @V("audience") String audience);
+    }
+
+    public interface CreativeWriter {
+
+        @UserMessage("""
+                You are a creative writer.
+                Generate a draft of a story long no more than 3 sentence around the given topic.
+                Return only the story and nothing else.
+                The topic is {{topic}}.
+                """)
+        @Agent(name = "writer", description = "Generate a story based on the given topic", outputKey = "story-initial")
+        String generateStory(@V("topic") String topic);
+    }
+
+    public interface AudienceEditor {
+
+        @UserMessage("""
+                You are a professional editor.
+                Analyze and rewrite the following story to better align with the target audience of {{audience}}.
+                Return only the story and nothing else.
+                The story is "{{story-initial}}".
+                """)
+        @Agent(name = "writer", description = "Edit a story to better fit a given audience", outputKey = "story")
+        String editStory(@V("story-initial") String story, @V("audience") String audience);
+    }
+}

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/validation/DuplicateSupervisorSubAgentNamesTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/validation/DuplicateSupervisorSubAgentNamesTest.java
@@ -1,0 +1,72 @@
+package io.quarkiverse.langchain4j.agentic.deployment.validation;
+
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.SupervisorAgent;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DuplicateSupervisorSubAgentNamesTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "whatever")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"))
+            .setLogRecordPredicate(DuplicateSupervisorSubAgentNamesTest::isAgenticWarning)
+            .assertLogRecords(DuplicateSupervisorSubAgentNamesTest::assertWarnsAboutSharedAgentName);
+
+    private static boolean isAgenticWarning(LogRecord record) {
+        return record.getLevel().intValue() >= Level.WARNING.intValue()
+                && record.getLoggerName() != null
+                && record.getLoggerName().contains("langchain4j.agentic");
+    }
+
+    private static void assertWarnsAboutSharedAgentName(List<LogRecord> records) {
+        Assertions.assertThat(records).anySatisfy(record -> Assertions.assertThat(record.getMessage())
+                .contains("share the agent name")
+                .contains("editStory"));
+    }
+
+    @Test
+    void test() {
+    }
+
+    public interface AudienceEditor {
+
+        @UserMessage("""
+                Rewrite the following story to better align with the target audience of {{audience}}.
+                The story is "{{story}}".
+                """)
+        @Agent(description = "Edit a story to better fit a given audience", outputKey = "story")
+        String editStory(@V("story") String story, @V("audience") String audience);
+    }
+
+    public interface StyleEditor {
+
+        @UserMessage("""
+                Rewrite the following story to better fit the {{style}} style.
+                The story is "{{story}}".
+                """)
+        @Agent(description = "Edit a story to better fit a given style", outputKey = "story")
+        String editStory(@V("story") String story, @V("style") String style);
+    }
+
+    public interface SupervisorStoryEditor {
+
+        @SupervisorAgent(subAgents = { AudienceEditor.class, StyleEditor.class })
+        String edit(@V("request") String request);
+    }
+}

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/validation/NonAgentSubAgentTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/validation/NonAgentSubAgentTest.java
@@ -1,0 +1,70 @@
+package io.quarkiverse.langchain4j.agentic.deployment.validation;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.SequenceAgent;
+import dev.langchain4j.service.IllegalConfigurationException;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class NonAgentSubAgentTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "whatever")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"))
+            .assertException(
+                    throwable -> Assertions.assertThat(throwable).isInstanceOf(IllegalConfigurationException.class)
+                            .hasMessageContaining("does not declare any agent method")
+                            .hasMessageContaining("NotAnAgent"));
+
+    @Test
+    public void test() {
+        fail("should never be called");
+    }
+
+    @Singleton
+    public static class StoryCreatorConsumer {
+
+        @Inject
+        StoryCreator storyCreator;
+    }
+
+    public interface StoryCreator {
+
+        @SequenceAgent(outputKey = "story", subAgents = { CreativeWriter.class, NotAnAgent.class })
+        String write(@V("topic") String topic);
+    }
+
+    public interface CreativeWriter {
+
+        @UserMessage("""
+                You are a creative writer.
+                Generate a draft of a story long no more than 3 sentence around the given topic.
+                Return only the story and nothing else.
+                The topic is {{topic}}.
+                """)
+        @Agent(description = "Generate a story based on the given topic", outputKey = "story")
+        String generateStory(@V("topic") String topic);
+    }
+
+    public interface NotAnAgent {
+
+        String polish(String story);
+    }
+}

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/validation/SupervisorSubAgentWithoutDescriptionTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/validation/SupervisorSubAgentWithoutDescriptionTest.java
@@ -1,0 +1,75 @@
+package io.quarkiverse.langchain4j.agentic.deployment.validation;
+
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.SupervisorAgent;
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SupervisorSubAgentWithoutDescriptionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "whatever")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"))
+            .setLogRecordPredicate(SupervisorSubAgentWithoutDescriptionTest::isAgenticWarning)
+            .assertLogRecords(SupervisorSubAgentWithoutDescriptionTest::assertWarnsAboutMissingDescription);
+
+    private static boolean isAgenticWarning(LogRecord record) {
+        return record.getLevel().intValue() >= Level.WARNING.intValue()
+                && record.getLoggerName() != null
+                && record.getLoggerName().contains("langchain4j.agentic");
+    }
+
+    private static void assertWarnsAboutMissingDescription(List<LogRecord> records) {
+        Assertions.assertThat(records).anySatisfy(record -> Assertions.assertThat(record.getMessage())
+                .contains("no description")
+                .contains("WithdrawAgent"));
+    }
+
+    @Test
+    void test() {
+    }
+
+    public interface WithdrawAgent {
+        @SystemMessage("""
+                You are a banker that can only withdraw US dollars (USD) from a user account.
+                """)
+        @UserMessage("""
+                Withdraw {{amountInUSD}} USD from {{withdrawUser}}'s account and return the new balance.
+                """)
+        @Agent
+        String withdraw(@V("withdrawUser") String withdrawUser, @V("amountInUSD") Double amountInUSD);
+    }
+
+    public interface CreditAgent {
+        @SystemMessage("""
+                You are a banker that can only credit US dollars (USD) to a user account.
+                """)
+        @UserMessage("""
+                Credit {{amountInUSD}} USD to {{creditUser}}'s account and return the new balance.
+                """)
+        @Agent("A banker that credit USD to an account")
+        String credit(@V("creditUser") String creditUser, @V("amountInUSD") Double amountInUSD);
+    }
+
+    public interface SupervisorBanker {
+
+        @SupervisorAgent(subAgents = { WithdrawAgent.class, CreditAgent.class })
+        String invoke(@V("request") String request);
+    }
+}


### PR DESCRIPTION
## Describe your changes

Adds three cheap build-time checks for agentic systems:

- A `subAgents` entry without any agent method now fails with a configuration error naming the class, instead of an opaque `NullPointerException` in `AgenticProcessor`.
- Two different sub-agents with the same explicit `@Agent(name = ...)` fail the build. Implicit duplicates (shared method names) stay legal, since the documented StoryCreator example relies on them.
- Under a `@SupervisorAgent`, sub-agents sharing an implicit name or missing a `description`/`value` produce a build warning: the planner prompt identifies agents by name and description, so both silently degrade planning.

Each check is covered by a `QuarkusUnitTest` in `agentic/deployment` following the existing `validation/` test conventions.

---

- Closes #2663
- Relates to #1898 