### PR TITLE
Handle empty input cases in `EvaluationReport` and `Samples`

### DIFF
--- a/testing/evaluation/evaluation-core/src/main/java/io/quarkiverse/langchain4j/testing/evaluation/EvaluationReport.java
+++ b/testing/evaluation/evaluation-core/src/main/java/io/quarkiverse/langchain4j/testing/evaluation/EvaluationReport.java
@@ -21,11 +21,12 @@ public class EvaluationReport<T> {
     /**
      * Create a new evaluation report and computes the global score.
      *
-     * @param evaluations the evaluations, must not be {@code null}, must not be empty.
+     * @param evaluations the evaluations, must not be {@code null}.
      */
     public EvaluationReport(List<Scorer.EvaluationResult<T>> evaluations) {
         this.evaluations = evaluations;
-        this.score = 100.0 * evaluations.stream().filter(Scorer.EvaluationResult::passed).count() / evaluations.size();
+        this.score = evaluations.isEmpty() ? 0.0
+                : 100.0 * evaluations.stream().filter(Scorer.EvaluationResult::passed).count() / evaluations.size();
     }
 
     /**
@@ -49,9 +50,13 @@ public class EvaluationReport<T> {
      * @return the score for the given tag, between 0.0 and 100.0.
      */
     public double scoreForTag(String tag) {
+        long total = evaluations.stream().filter(e -> e.sample().tags().contains(tag)).count();
+        if (total == 0) {
+            return 0.0;
+        }
         return 100.0 * evaluations.stream().filter(e -> e.sample().tags().contains(tag))
                 .filter(Scorer.EvaluationResult::passed).count()
-                / evaluations.stream().filter(e -> e.sample().tags().contains(tag)).count();
+                / total;
     }
 
     /**

--- a/testing/evaluation/evaluation-core/src/main/java/io/quarkiverse/langchain4j/testing/evaluation/Samples.java
+++ b/testing/evaluation/evaluation-core/src/main/java/io/quarkiverse/langchain4j/testing/evaluation/Samples.java
@@ -3,7 +3,6 @@ package io.quarkiverse.langchain4j.testing.evaluation;
 import java.util.AbstractList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * A list of {@link EvaluationSample} instances.
@@ -18,32 +17,20 @@ public class Samples<T> extends AbstractList<EvaluationSample<T>>
     /**
      * Create a new set of samples.
      *
-     * @param samples the samples, must not be {@code null}, must not be empty.
+     * @param samples the samples, if {@code null} an empty set of samples is created.
      */
     public Samples(List<EvaluationSample<T>> samples) {
-        if (samples == null) {
-            throw new IllegalArgumentException("Samples must not be null");
-        }
-        if (samples.isEmpty()) {
-            throw new IllegalArgumentException("Samples must not be empty");
-        }
-        this.samples = samples;
+        this.samples = (samples != null) ? samples : List.of();
     }
 
     /**
      * Create a new set of samples.
      *
-     * @param samples the samples, must not be {@code null}, must not be empty.
+     * @param samples the samples, if {@code null} an empty set of samples is created.
      */
     @SafeVarargs
     public Samples(EvaluationSample<T>... samples) {
-        if (samples == null) {
-            throw new IllegalArgumentException("Samples must not be null");
-        }
-        if (samples.length == 0) {
-            throw new IllegalArgumentException("Samples must not be empty");
-        }
-        this.samples = List.of(samples);
+        this.samples = (samples != null) ? List.of(samples) : List.of();
     }
 
     /**
@@ -66,26 +53,21 @@ public class Samples<T> extends AbstractList<EvaluationSample<T>>
      * Filter samples by tags.
      * <p>
      * Returns a new Samples instance containing only samples that have at least one of the specified tags.
+     * If no samples match the specified tags, an empty Samples instance is returned.
      * </p>
      *
      * @param tags the tags to filter by
      * @return a new Samples instance with filtered samples
-     * @throws IllegalArgumentException if no samples match the tags
      */
     public Samples<T> filterByTags(String... tags) {
-        if (tags == null || tags.length == 0) {
+        if ((tags == null) || (tags.length == 0)) {
             return this;
         }
 
         List<String> tagList = Arrays.asList(tags);
         List<EvaluationSample<T>> filtered = samples.stream()
                 .filter(sample -> sample.tags().stream().anyMatch(tagList::contains))
-                .collect(Collectors.toList());
-
-        if (filtered.isEmpty()) {
-            throw new IllegalArgumentException(
-                    String.format("No samples found with tags: %s", Arrays.toString(tags)));
-        }
+                .toList();
 
         return new Samples<>(filtered);
     }

--- a/testing/evaluation/evaluation-core/src/test/java/io/quarkiverse/langchain4j/testing/evaluation/EvaluationReportTest.java
+++ b/testing/evaluation/evaluation-core/src/test/java/io/quarkiverse/langchain4j/testing/evaluation/EvaluationReportTest.java
@@ -12,6 +12,14 @@ import org.junit.jupiter.api.Test;
 class EvaluationReportTest {
 
     @Test
+    void globalScoreShouldBeZeroForEmptyEvaluations() {
+        EvaluationReport<String> report = new EvaluationReport<>(List.of());
+
+        assertThat(report.score()).isEqualTo(0.0);
+        assertThat(report.evaluations()).isEmpty();
+    }
+
+    @Test
     void globalScoreShouldBeCorrect() {
         // Create mock evaluations.
         Scorer.EvaluationResult<String> result1 = Scorer.EvaluationResult.fromCompletedEvaluation(

--- a/testing/evaluation/evaluation-core/src/test/java/io/quarkiverse/langchain4j/testing/evaluation/SamplesTest.java
+++ b/testing/evaluation/evaluation-core/src/test/java/io/quarkiverse/langchain4j/testing/evaluation/SamplesTest.java
@@ -50,34 +50,33 @@ class SamplesTest {
         assertThat(samples.get(1)).isEqualTo(sample2);
     }
 
-    @SuppressWarnings("DataFlowIssue")
     @Test
-    void constructorShouldThrowExceptionIfListIsNull() {
-        assertThatThrownBy(() -> new Samples<>((List<EvaluationSample<String>>) null))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Samples must not be null");
+    void constructorShouldCreateEmptySamplesFromNullList() {
+        Samples<String> samples = new Samples<>((List<EvaluationSample<String>>) null);
+
+        assertThat(samples).isEmpty();
     }
 
     @Test
-    void constructorShouldThrowExceptionIfVarargsAreNull() {
-        assertThatThrownBy(() -> new Samples<>((EvaluationSample<String>[]) null))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Samples must not be null");
+    void constructorShouldCreateEmptySamplesFromNullVarargs() {
+        Samples<String> samples = new Samples<>((EvaluationSample<String>[]) null);
+
+        assertThat(samples).isEmpty();
     }
 
     @Test
-    void constructorShouldThrowExceptionIfListIsEmpty() {
-        assertThatThrownBy(() -> new Samples<>(List.of()))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Samples must not be empty");
+    void constructorShouldCreateEmptySamplesFromEmptyList() {
+        Samples<String> samples = new Samples<>(List.of());
+
+        assertThat(samples).isEmpty();
     }
 
     @SuppressWarnings("unchecked")
     @Test
-    void constructorShouldThrowExceptionIfVarargsAreEmpty() {
-        assertThatThrownBy(Samples::new)
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Samples must not be empty");
+    void constructorShouldCreateEmptySamplesFromEmptyVarargs() {
+        Samples<String> samples = new Samples<>();
+
+        assertThat(samples).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
- Update `EvaluationReport` to handle empty evaluation lists gracefully.
- Allow `Samples` to accept `null` or empty input without throwing exceptions.
- Adjust related test cases to verify empty object creation behavior.