### PR TITLE
Add ability to contribute additional info to tool spans

### DIFF
--- a/core/opentelemetry-tests/src/test/java/io/quarkiverse/langchain4j/opentelemetry/test/ListenersProcessorToolSpanWrapperTest.java
+++ b/core/opentelemetry-tests/src/test/java/io/quarkiverse/langchain4j/opentelemetry/test/ListenersProcessorToolSpanWrapperTest.java
@@ -1,0 +1,182 @@
+package io.quarkiverse.langchain4j.opentelemetry.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.service.tool.ToolExecutionResult;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.quarkiverse.langchain4j.runtime.tool.ToolExecutionErrorContext;
+import io.quarkiverse.langchain4j.runtime.tool.ToolExecutionRequestContext;
+import io.quarkiverse.langchain4j.runtime.tool.ToolExecutionResponseContext;
+import io.quarkiverse.langchain4j.runtime.tool.ToolSpanContributor;
+import io.quarkiverse.langchain4j.runtime.tool.ToolSpanWrapper;
+import io.quarkus.arc.All;
+import io.quarkus.test.QuarkusUnitTest;
+
+class ListenersProcessorToolSpanWrapperTest {
+    @Inject
+    ToolSpanWrapper toolSpanWrapper;
+
+    @Inject
+    @All
+    List<ToolSpanContributor> contributors;
+
+    @Inject
+    InMemorySpanExporter exporter;
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset("""
+                            # Since using a InMemorySpanExporter inside our tests,
+                            # these properties reduce the export timeout and schedule delay from the BatchSpanProcessor
+                            quarkus.otel.bsp.schedule.delay=PT0.001S
+                            quarkus.otel.bsp.max.queue.size=1
+                            quarkus.otel.bsp.max.export.batch.size=1
+                            """), "application.properties")
+                    .addClasses(InMemorySpanExporterProducer.class));
+
+    @BeforeEach
+    void cleanupSpans() {
+        exporter.reset();
+    }
+
+    @Test
+    void shouldCreateSpanOnSuccess() {
+        var ctx = MockedContexts.create();
+
+        toolSpanWrapper.wrap(
+                ctx.requestContext().request(),
+                ctx.requestContext().invocationContext(),
+                (request, invocationContext) -> ctx.responseContext().result(),
+                null);
+
+        await().untilAsserted(() -> assertThat(exporter.getFinishedSpanItems()).hasSize(1));
+        var actualSpan = exporter.getFinishedSpanItems().get(0);
+        assertThat(actualSpan.getName()).isEqualTo("langchain4j.tools.toolName");
+    }
+
+    @Test
+    void shouldCreateAndEndSpanOnFailure() {
+        var ctx = MockedContexts.create();
+
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> toolSpanWrapper.wrap(
+                        ctx.requestContext().request(),
+                        ctx.requestContext().invocationContext(),
+                        (request, invocationContext) -> {
+                            throw (RuntimeException) ctx.errorContext().error();
+                        },
+                        null))
+                .withMessage(ctx.errorContext().error().getMessage());
+
+        await().untilAsserted(() -> assertThat(exporter.getFinishedSpanItems()).hasSize(1));
+        var actualSpan = exporter.getFinishedSpanItems().get(0);
+        assertThat(actualSpan.getName()).isEqualTo("langchain4j.tools.toolName");
+        assertThat(actualSpan.getEvents())
+                .hasSize(1)
+                .first()
+                .extracting("exception")
+                .extracting("message")
+                .isEqualTo("--failed--");
+        verifyFailedSpan(actualSpan);
+    }
+
+    protected void verifyFailedSpan(SpanData actualSpan) {
+        // nothing here
+    }
+
+    public static class InMemorySpanExporterProducer {
+        @ApplicationScoped
+        InMemorySpanExporter exporter() {
+            return InMemorySpanExporter.create();
+        }
+    }
+
+    @ApplicationScoped
+    public static class TestSpanContributor implements ToolSpanContributor {
+        private final MockedContexts contexts = MockedContexts.create();
+
+        @Override
+        public void onRequest(ToolExecutionRequestContext context, Span span) {
+            assertThat(context)
+                    .usingRecursiveComparison()
+                    .ignoringFields("attributes")
+                    .isEqualTo(contexts.requestContext());
+        }
+
+        @Override
+        public void onResponse(ToolExecutionResponseContext context, Span span) {
+            assertThat(context)
+                    .usingRecursiveComparison()
+                    .ignoringFields("requestContext.attributes")
+                    .isEqualTo(contexts.responseContext());
+        }
+
+        @Override
+        public void onError(ToolExecutionErrorContext context, Span span) {
+            assertThat(context).isNotNull();
+
+            assertThat(context.requestContext())
+                    .usingRecursiveComparison()
+                    .ignoringFields("attributes")
+                    .isEqualTo(contexts.errorContext().requestContext());
+
+            assertThat(context.error())
+                    .hasMessage(contexts.errorContext().error().getMessage());
+        }
+    }
+
+    record MockedContexts(
+            ToolExecutionRequestContext requestContext,
+            ToolExecutionResponseContext responseContext,
+            ToolExecutionErrorContext errorContext) {
+
+        static MockedContexts create() {
+            var request = ToolExecutionRequest.builder()
+                    .id("id")
+                    .name("toolName")
+                    .arguments("args")
+                    .build();
+
+            var invocationContext = InvocationContext.builder().build();
+            var response = ToolExecutionResult.builder()
+                    .resultText("result")
+                    .build();
+
+            var requestCtx = ToolExecutionRequestContext.builder()
+                    .request(request)
+                    .invocationContext(invocationContext)
+                    .build();
+
+            var responseCtx = ToolExecutionResponseContext.builder()
+                    .requestContext(requestCtx)
+                    .result(response)
+                    .build();
+
+            var errorCtx = ToolExecutionErrorContext.builder()
+                    .requestContext(requestCtx)
+                    .error(new RuntimeException("--failed--"))
+                    .build();
+
+            return new MockedContexts(requestCtx, responseCtx, errorCtx);
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/DefaultToolExecutionErrorContext.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/DefaultToolExecutionErrorContext.java
@@ -1,0 +1,31 @@
+package io.quarkiverse.langchain4j.runtime.tool;
+
+final class DefaultToolExecutionErrorContext implements ToolExecutionErrorContext {
+    private final ToolExecutionRequestContext requestContext;
+    private final Throwable error;
+
+    DefaultToolExecutionErrorContext(Builder builder) {
+        this.requestContext = builder.requestContext;
+        this.error = builder.error;
+    }
+
+    /**
+     * Retrieves the context of the tool execution request, which provides details
+     * about the request and invocation.
+     */
+    @Override
+    public ToolExecutionRequestContext requestContext() {
+        return requestContext;
+    }
+
+    /**
+     * Retrieves the error associated with the tool execution context.
+     * This method provides information about any error that occurred during the tool's execution.
+     *
+     * @return a {@code Throwable} representing the error, or {@code null} if no error occurred.
+     */
+    @Override
+    public Throwable error() {
+        return this.error;
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/DefaultToolExecutionRequestContext.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/DefaultToolExecutionRequestContext.java
@@ -1,0 +1,50 @@
+package io.quarkiverse.langchain4j.runtime.tool;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.invocation.InvocationContext;
+
+final class DefaultToolExecutionRequestContext implements ToolExecutionRequestContext {
+    private final ToolExecutionRequest request;
+    private final InvocationContext invocationContext;
+    private final Map<Object, Object> attributes = new HashMap<>();
+
+    DefaultToolExecutionRequestContext(Builder builder) {
+        this.request = builder.request;
+        this.invocationContext = builder.invocationContext;
+        this.attributes.putAll(builder.attributes);
+    }
+
+    /**
+     * Retrieves the {@link ToolExecutionRequest} associated with this context.
+     *
+     * @return the tool execution request encapsulated by this context.
+     */
+    @Override
+    public ToolExecutionRequest request() {
+        return request;
+    }
+
+    /**
+     * Retrieves the {@link InvocationContext} associated with this tool execution request context.
+     *
+     * @return the invocation context encapsulated by this tool execution request context.
+     */
+    @Override
+    public InvocationContext invocationContext() {
+        return invocationContext;
+    }
+
+    /**
+     * Retrieves an unmodifiable view of the attributes associated with this context.
+     * The returned map is immutable, ensuring that the attributes cannot be modified externally.
+     *
+     * @return an unmodifiable map containing the attributes of this context.
+     */
+    @Override
+    public Map<Object, Object> attributes() {
+        return Map.copyOf(this.attributes);
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/DefaultToolExecutionResponseContext.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/DefaultToolExecutionResponseContext.java
@@ -1,0 +1,31 @@
+package io.quarkiverse.langchain4j.runtime.tool;
+
+import dev.langchain4j.service.tool.ToolExecutionResult;
+
+final class DefaultToolExecutionResponseContext implements ToolExecutionResponseContext {
+    private final ToolExecutionRequestContext requestContext;
+    private final ToolExecutionResult result;
+
+    DefaultToolExecutionResponseContext(Builder builder) {
+        this.requestContext = builder.requestContext;
+        this.result = builder.result;
+    }
+
+    /**
+     * Retrieves the context of the tool execution request, which provides details
+     * about the request and invocation.
+     */
+    @Override
+    public ToolExecutionRequestContext requestContext() {
+        return requestContext;
+    }
+
+    /**
+     * Retrieves the result of the tool execution, encapsulating details about the
+     * execution outcome such as the response or any errors encountered.
+     */
+    @Override
+    public ToolExecutionResult result() {
+        return result;
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/ToolExecutionErrorContext.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/ToolExecutionErrorContext.java
@@ -1,0 +1,100 @@
+package io.quarkiverse.langchain4j.runtime.tool;
+
+import java.util.Map;
+
+/**
+ * Represents the response context of a tool execution, encapsulating the
+ * associated request context and the resulting execution outcome.
+ */
+public sealed interface ToolExecutionErrorContext permits DefaultToolExecutionErrorContext {
+    /**
+     * Creates and returns a new instance of the {@code Builder} class for constructing
+     * an instance of {@code ToolExecutionErrorContext}.
+     */
+    static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Retrieves the context of the tool execution request, which provides details
+     * about the request and invocation.
+     */
+    ToolExecutionRequestContext requestContext();
+
+    /**
+     * Retrieves the error associated with the tool execution context.
+     * This method provides information about any error that occurred during the tool's execution.
+     *
+     * @return a {@code Throwable} representing the error, or {@code null} if no error occurred.
+     */
+    Throwable error();
+
+    /**
+     * Retrieves a map of attributes associated with the current tool execution request context.
+     * These attributes provide additional metadata or details relevant to the execution context.
+     *
+     * @return an unmodifiable map of attributes for the current request context.
+     */
+    default Map<Object, Object> attributes() {
+        return requestContext().attributes();
+    }
+
+    /**
+     * Creates a new {@code Builder} instance initialized with the current state of this object.
+     * This allows for modifying and regenerating the object while preserving the existing values.
+     */
+    default Builder toBuilder() {
+        return new Builder(this);
+    }
+
+    /**
+     * A builder class for constructing instances of {@code ToolExecutionErrorContext}.
+     * This builder allows for step-by-step construction of a {@code ToolExecutionErrorContext} object
+     * by providing methods to set its component properties.
+     */
+    class Builder {
+        ToolExecutionRequestContext requestContext;
+        Throwable error;
+
+        private Builder() {
+        }
+
+        private Builder(ToolExecutionErrorContext context) {
+            this.requestContext = context.requestContext();
+            this.error = context.error();
+        }
+
+        /**
+         * Sets the {@link DefaultToolExecutionRequestContext} for the builder.
+         *
+         * @param requestContext the {@code ToolExecutionRequestContext} to be set.
+         * @return this {@code Builder} instance for method chaining.
+         */
+        public Builder requestContext(ToolExecutionRequestContext requestContext) {
+            this.requestContext = requestContext;
+            return this;
+        }
+
+        /**
+         * Sets the error associated with the builder.
+         *
+         * @param error the {@code Throwable} representing the error to be set.
+         * @return this {@code Builder} instance for method chaining.
+         */
+        public Builder error(Throwable error) {
+            this.error = error;
+            return this;
+        }
+
+        /**
+         * Constructs and returns an instance of {@code ToolExecutionErrorContext}
+         * using the current state of the builder.
+         *
+         * @return a new {@code ToolExecutionErrorContext} instance
+         *         initialized with the properties set on this builder.
+         */
+        public ToolExecutionErrorContext build() {
+            return new DefaultToolExecutionErrorContext(this);
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/ToolExecutionRequestContext.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/ToolExecutionRequestContext.java
@@ -1,0 +1,169 @@
+package io.quarkiverse.langchain4j.runtime.tool;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.invocation.InvocationContext;
+
+/**
+ * Represents the context for executing a tool within a system. This class encapsulates the request
+ * and invocation context related to a specific tool execution.
+ *
+ * ToolExecutionRequestContext provides a structured approach for handling tool execution information
+ * through immutable instances created using a builder.
+ */
+public sealed interface ToolExecutionRequestContext permits DefaultToolExecutionRequestContext {
+    /**
+     * Creates a new instance of the {@code Builder} for constructing
+     * an immutable {@code ToolExecutionRequestContext}.
+     *
+     * @return a new {@code Builder} instance for constructing a {@code ToolExecutionRequestContext}.
+     */
+    static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Retrieves the {@link ToolExecutionRequest} associated with this context.
+     *
+     * @return the tool execution request encapsulated by this context.
+     */
+    ToolExecutionRequest request();
+
+    /**
+     * Retrieves the {@link InvocationContext} associated with this tool execution request context.
+     *
+     * @return the invocation context encapsulated by this tool execution request context.
+     */
+    InvocationContext invocationContext();
+
+    /**
+     * Retrieves an unmodifiable view of the attributes associated with this context.
+     * The returned map is immutable, ensuring that the attributes cannot be modified externally.
+     *
+     * @return an unmodifiable map containing the attributes of this context.
+     */
+    Map<Object, Object> attributes();
+
+    /**
+     * Creates a {@code Builder} instance initialized with the current state of this
+     * {@code ToolExecutionRequestContext}. This allows for modifications to the existing
+     * immutable context by creating a modified copy.
+     *
+     * @return a {@code Builder} pre-populated with the values from this {@code ToolExecutionRequestContext}.
+     */
+    default Builder toBuilder() {
+        return new Builder(this);
+    }
+
+    /**
+     * A builder class for constructing instances of {@code ToolExecutionRequestContext}.
+     * <p>
+     * The {@code Builder} class enables a step-by-step construction of a {@code ToolExecutionRequestContext},
+     * allowing the customization of the required parameters such as the {@code ToolExecutionRequest} and
+     * {@code InvocationContext}.
+     * <p>
+     * Instances of this builder are obtained through the static {@code builder()} method of
+     * {@code ToolExecutionRequestContext}, or the {@code toBuilder()} method on an existing
+     * {@code ToolExecutionRequestContext} object for modifications.
+     */
+    class Builder {
+        ToolExecutionRequest request;
+        InvocationContext invocationContext;
+        Map<Object, Object> attributes = new HashMap<>();
+
+        private Builder() {
+        }
+
+        private Builder(ToolExecutionRequestContext requestContext) {
+            if (requestContext != null) {
+                this.request = requestContext.request();
+                this.invocationContext = requestContext.invocationContext();
+                this.attributes.putAll(requestContext.attributes());
+            }
+        }
+
+        /**
+         * Sets the {@code ToolExecutionRequest} for the builder.
+         * <p>
+         * This method allows specifying the tool execution request that will be used
+         * when building the {@code ToolExecutionRequestContext}.
+         *
+         * @param request the {@code ToolExecutionRequest} object containing the details
+         *        of the tool execution to be configured in the context
+         * @return the {@code Builder} instance to allow method chaining
+         */
+        public Builder request(ToolExecutionRequest request) {
+            this.request = request;
+            return this;
+        }
+
+        /**
+         * Sets the {@code InvocationContext} for the builder.
+         * <p>
+         * This method allows specifying the invocation context that will be used
+         * when building the {@code ToolExecutionRequestContext}.
+         *
+         * @param invocationContext the {@code InvocationContext} object containing context information
+         *        for the tool execution request
+         * @return the {@code Builder} instance to allow method chaining
+         */
+        public Builder invocationContext(InvocationContext invocationContext) {
+            this.invocationContext = invocationContext;
+            return this;
+        }
+
+        /**
+         * Sets the attributes for the builder.
+         * <p>
+         * This method allows specifying a map of attributes to configure in the builder.
+         * If the provided map is non-null, its entries are added to the builder's attribute map.
+         * Any existing attributes in the builder are cleared before setting the new attributes.
+         *
+         * @param attributes a map containing key-value pairs representing the attributes to be set;
+         *        if {@code null}, the builder's attributes will simply be cleared
+         * @return the {@code Builder} instance to allow method chaining
+         */
+        public Builder attributes(Map<Object, Object> attributes) {
+            this.attributes.clear();
+
+            if (attributes != null) {
+                this.attributes.putAll(attributes);
+            }
+
+            return this;
+        }
+
+        /**
+         * Adds an attribute to the builder's attribute map.
+         * <p>
+         * This method allows specifying a key-value pair to be added as an attribute
+         * to the builder. If the key is non-null, the key-value pair is added to the
+         * builder's attribute map.
+         *
+         * @param key the key of the attribute to be added; must not be null
+         * @param value the value of the attribute to be added
+         * @return the {@code Builder} instance to allow method chaining
+         */
+        public Builder attribute(Object key, Object value) {
+            if (key != null) {
+                this.attributes.put(key, value);
+            }
+
+            return this;
+        }
+
+        /**
+         * Builds and returns an immutable instance of {@code ToolExecutionRequestContext}.
+         * <p>
+         * This method completes the construction process of a {@code ToolExecutionRequestContext},
+         * encapsulating the state configured in this {@code Builder}.
+         *
+         * @return a new {@code ToolExecutionRequestContext} instance with the parameters set in the builder
+         */
+        public ToolExecutionRequestContext build() {
+            return new DefaultToolExecutionRequestContext(this);
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/ToolExecutionResponseContext.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/ToolExecutionResponseContext.java
@@ -1,0 +1,100 @@
+package io.quarkiverse.langchain4j.runtime.tool;
+
+import java.util.Map;
+
+import dev.langchain4j.service.tool.ToolExecutionResult;
+
+/**
+ * Represents the response context of a tool execution, encapsulating the
+ * associated request context and the resulting execution outcome.
+ */
+public sealed interface ToolExecutionResponseContext permits DefaultToolExecutionResponseContext {
+    /**
+     * Creates and returns a new instance of the {@code Builder} class for constructing
+     * an instance of {@code ToolExecutionResponseContext}.
+     */
+    static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Retrieves the context of the tool execution request, which provides details
+     * about the request and invocation.
+     */
+    ToolExecutionRequestContext requestContext();
+
+    /**
+     * Retrieves the result of the tool execution, encapsulating details about the
+     * execution outcome such as the response or any errors encountered.
+     */
+    ToolExecutionResult result();
+
+    /**
+     * Retrieves a map of attributes associated with the current tool execution request context.
+     * These attributes provide additional metadata or details relevant to the execution context.
+     *
+     * @return an unmodifiable map of attributes for the current request context.
+     */
+    default Map<Object, Object> attributes() {
+        return requestContext().attributes();
+    }
+
+    /**
+     * Creates a new {@code Builder} instance initialized with the current state of this object.
+     * This allows for modifying and regenerating the object while preserving the existing values.
+     */
+    default Builder toBuilder() {
+        return new Builder(this);
+    }
+
+    /**
+     * A builder class for constructing instances of {@code ToolExecutionResponseContext}.
+     * This builder allows for step-by-step construction of a {@code ToolExecutionResponseContext} object
+     * by providing methods to set its component properties.
+     */
+    class Builder {
+        ToolExecutionRequestContext requestContext;
+        ToolExecutionResult result;
+
+        private Builder() {
+        }
+
+        private Builder(ToolExecutionResponseContext context) {
+            this.requestContext = context.requestContext();
+            this.result = context.result();
+        }
+
+        /**
+         * Sets the {@link DefaultToolExecutionRequestContext} for the builder.
+         *
+         * @param requestContext the {@code ToolExecutionRequestContext} to be set.
+         * @return this {@code Builder} instance for method chaining.
+         */
+        public Builder requestContext(ToolExecutionRequestContext requestContext) {
+            this.requestContext = requestContext;
+            return this;
+        }
+
+        /**
+         * Sets the {@link ToolExecutionResult} for the builder.
+         *
+         * @param result the {@code ToolExecutionResult} to be assigned to the builder.
+         * @return this {@code Builder} instance for method chaining.
+         */
+        public Builder result(ToolExecutionResult result) {
+            this.result = result;
+            return this;
+        }
+
+        /**
+         * Constructs and returns an instance of {@code ToolExecutionResponseContext}
+         * using the current state of the builder.
+         *
+         * @return a new {@code ToolExecutionResponseContext} instance
+         *         initialized with the properties set on this builder.
+         */
+        public ToolExecutionResponseContext build() {
+            return new DefaultToolExecutionResponseContext(this);
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/ToolSpanContributor.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/ToolSpanContributor.java
@@ -1,0 +1,49 @@
+package io.quarkiverse.langchain4j.runtime.tool;
+
+import io.opentelemetry.api.trace.Span;
+
+/**
+ * Defines a contributor interface for adding behavior to the lifecycle of tool execution spans.
+ *
+ * The ToolSpanContributor interface provides methods for customizing the interaction with spans
+ * during a tool's execution process. Implementations can override default methods to introduce
+ * logic for use cases such as instrumentation, logging, or tracing during request and response events.
+ */
+public interface ToolSpanContributor {
+    /**
+     * Allows for custom data to be added to the span prior to tool execution
+     *
+     * @param context the {@code ToolExecutionRequestContext} containing the details of the tool execution request,
+     *        including the request and invocation context
+     * @param span the {@code Span} representing the tracing span associated with the tool execution request
+     */
+    default void onRequest(ToolExecutionRequestContext context, Span span) {
+
+    }
+
+    /**
+     * Allows for custom data to be added to the span after tool execution
+     *
+     * @param context the {@code ToolExecutionResponseContext} containing details of the
+     *        tool execution response, including the request context and the result
+     *        of the execution
+     * @param span the {@code Span} representing the tracing span associated with the
+     *        tool execution, which can be augmented or annotated
+     */
+    default void onResponse(ToolExecutionResponseContext context, Span span) {
+
+    }
+
+    /**
+     * Allows for custom data to be added to the span if an error occurs during tool execution
+     *
+     * @param context the {@code ToolExecutionErrorContext} containing details about the error
+     *        encountered during the tool's execution, including the request context
+     *        and associated error.
+     * @param span the {@code Span} representing the tracing span associated with the tool's
+     *        execution, which can be augmented or annotated to capture error-specific details.
+     */
+    default void onError(ToolExecutionErrorContext context, Span span) {
+
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/ToolSpanWrapper.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/ToolSpanWrapper.java
@@ -1,10 +1,12 @@
 package io.quarkiverse.langchain4j.runtime.tool;
 
+import java.util.List;
 import java.util.function.BiFunction;
 
 import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.invocation.InvocationContext;
@@ -13,26 +15,36 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
+import io.quarkus.arc.All;
 
 public class ToolSpanWrapper implements QuarkusToolExecutor.Wrapper {
+    private static final Logger LOG = Logger.getLogger(ToolSpanWrapper.class);
+    private static final String OTEL_SCOPE_KEY_NAME = "OTelScope";
+    private static final String OTEL_SPAN_KEY_NAME = "OTelSpan";
+    public static final String OTEL_PARENT_SPAN_KEY_NAME = "OTelParentSpan";
 
     private final Tracer tracer;
     private final boolean includeArguments;
     private final boolean includeResult;
+    private final List<ToolSpanContributor> toolSpanContributors;
 
     @Inject
     public ToolSpanWrapper(Tracer tracer,
             @ConfigProperty(name = "quarkus.langchain4j.tracing.include-tool-arguments") boolean includeArguments,
-            @ConfigProperty(name = "quarkus.langchain4j.tracing.include-tool-result") boolean includeResult) {
+            @ConfigProperty(name = "quarkus.langchain4j.tracing.include-tool-result") boolean includeResult,
+            @All List<ToolSpanContributor> toolSpanContributors) {
 
         this.tracer = tracer;
         this.includeArguments = includeArguments;
         this.includeResult = includeResult;
+        this.toolSpanContributors = toolSpanContributors;
     }
 
     @Override
     public ToolExecutionResult wrap(ToolExecutionRequest toolExecutionRequest, InvocationContext invocationContext,
             BiFunction<ToolExecutionRequest, InvocationContext, ToolExecutionResult> fun, QuarkusToolExecutor executor) {
+
+        var parentSpan = Span.current();
 
         // from https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-spans.md#execute-tool-span
         Span span = tracer.spanBuilder("langchain4j.tools." + toolExecutionRequest.name())
@@ -42,21 +54,85 @@ public class ToolSpanWrapper implements QuarkusToolExecutor.Wrapper {
                 .setAttribute("gen_ai.tool.name", toolExecutionRequest.name())
                 .setAttribute("gen_ai.tool.type", "function")
                 .startSpan();
+
         if (includeArguments) {
             span.setAttribute("gen_ai.tool.call.arguments", toolExecutionRequest.arguments());
         }
-        try (Scope ignored = span.makeCurrent()) {
+
+        var requestContext = ToolExecutionRequestContext.builder()
+                .request(toolExecutionRequest)
+                .invocationContext(invocationContext)
+                .build();
+
+        try (Scope scope = span.makeCurrent()) {
+            requestContext = requestContext.toBuilder()
+                    .attribute(OTEL_PARENT_SPAN_KEY_NAME, parentSpan.getSpanContext().isValid() ? parentSpan : span)
+                    .attribute(OTEL_SCOPE_KEY_NAME, scope)
+                    .attribute(OTEL_SPAN_KEY_NAME, span)
+                    .build();
+            notifyContributorsOnRequest(requestContext, span);
             // TODO Handle async method here.
             var result = fun.apply(toolExecutionRequest, invocationContext);
             if (includeResult && result != null) {
                 span.setAttribute("gen_ai.tool.call.result", result.resultText());
             }
+
+            var responseContext = ToolExecutionResponseContext.builder()
+                    .requestContext(requestContext)
+                    .result(result)
+                    .build();
+
+            notifyContributorsOnResponse(responseContext, span);
+
             return result;
         } catch (Throwable t) {
             span.recordException(t);
+
+            var errorContext = ToolExecutionErrorContext.builder()
+                    .requestContext(requestContext)
+                    .error(t)
+                    .build();
+
+            notifyContributorsOnError(errorContext, span);
+
             throw t;
         } finally {
             span.end();
         }
+    }
+
+    private void notifyContributorsOnRequest(ToolExecutionRequestContext requestContext, Span span) {
+        for (ToolSpanContributor contributor : this.toolSpanContributors) {
+            try {
+                contributor.onRequest(requestContext, span);
+            } catch (Exception ex) {
+                recordLogAndSwallow(span, ex);
+            }
+        }
+    }
+
+    private void notifyContributorsOnResponse(ToolExecutionResponseContext responseContext, Span span) {
+        for (ToolSpanContributor contributor : this.toolSpanContributors) {
+            try {
+                contributor.onResponse(responseContext, span);
+            } catch (Exception ex) {
+                recordLogAndSwallow(span, ex);
+            }
+        }
+    }
+
+    private void notifyContributorsOnError(ToolExecutionErrorContext errorContext, Span span) {
+        for (ToolSpanContributor contributor : this.toolSpanContributors) {
+            try {
+                contributor.onError(errorContext, span);
+            } catch (Exception ex) {
+                recordLogAndSwallow(span, ex);
+            }
+        }
+    }
+
+    private void recordLogAndSwallow(Span span, Exception ex) {
+        span.recordException(ex);
+        LOG.warn("failure on contributor", ex);
     }
 }


### PR DESCRIPTION
This was modeled after `ChatModelSpanContributor`

- Introduced `ToolExecutionRequestContext`, `ToolExecutionResponseContext`, and `ToolExecutionErrorContext` to encapsulate tool execution lifecycle data.
- Added `ToolSpanContributor` interface for customizing span behavior during tool execution.
- Updated `ToolSpanWrapper` to enhance tracing capabilities by notifying contributors on tool request, response, and error events.
- Created unit tests to validate span creation, including successful and failure cases.