### PR TITLE
Fix docs issue 

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -262,6 +262,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.langchain4j</groupId>
+            <artifactId>quarkus-langchain4j-hibernate-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.langchain4j</groupId>
             <artifactId>quarkus-langchain4j-hugging-face-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>


### PR DESCRIPTION
This had failed during release with:

```
Error:  Quarkus Extension Dependency Verification Error
Error:  Deployment artifact io.quarkiverse.langchain4j:quarkus-langchain4j-hibernate-deployment::jar:999-SNAPSHOT was found to be missing dependencies on the Quarkus extension artifacts marked with '-' below:
Error:  -     io.quarkiverse.langchain4j:quarkus-langchain4j-hibernate::jar
Error:  -     io.quarkus:quarkus-arc-deployment::jar
Error:  -         io.quarkus:quarkus-core-deployment::jar
Error:  -     io.quarkiverse.langchain4j:quarkus-langchain4j-core-deployment::jar
Error:  -         io.quarkus:quarkus-qute-deployment::jar
Error:  -         io.quarkus:quarkus-vertx-deployment::jar
Error:  -             io.quarkus:quarkus-netty-deployment::jar
Error:  -             io.quarkus:quarkus-mutiny-deployment::jar
Error:  -                 io.quarkus:quarkus-smallrye-context-propagation-deployment::jar
Error:  -             io.quarkus:quarkus-virtual-threads-deployment::jar
Error:  -     io.quarkus:quarkus-jackson-deployment::jar
Error:  -     io.quarkus:quarkus-agroal-deployment::jar
Error:  -         io.quarkus:quarkus-datasource-deployment::jar
Error:  -             io.quarkus:quarkus-devservices-deployment::jar
Error:  -         io.quarkus:quarkus-narayana-jta-deployment::jar
Error:  -     io.quarkus:quarkus-hibernate-orm-deployment::jar
```