### PR TITLE
Fix missing thinking events for Ollama streaming

### DIFF
--- a/model-providers/ollama/deployment/src/test/java/io/quarkiverse/langchain4j/ollama/deployment/OllamaStreamingChatLanguageModelSmokeTest.java
+++ b/model-providers/ollama/deployment/src/test/java/io/quarkiverse/langchain4j/ollama/deployment/OllamaStreamingChatLanguageModelSmokeTest.java
@@ -26,6 +26,7 @@ import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.service.MemoryId;
 import dev.langchain4j.store.memory.chat.ChatMemoryStore;
 import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.runtime.aiservice.ChatEvent;
 import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
 import io.quarkus.test.QuarkusUnitTest;
 import io.smallrye.mutiny.Multi;
@@ -48,6 +49,8 @@ public class OllamaStreamingChatLanguageModelSmokeTest extends WiremockAware {
     @RegisterAiService
     interface AIServiceWithoutTool {
         Multi<String> streaming(@dev.langchain4j.service.UserMessage String text);
+
+        Multi<ChatEvent> streamingEvents(@dev.langchain4j.service.UserMessage String text);
     }
 
     @Singleton
@@ -96,6 +99,34 @@ public class OllamaStreamingChatLanguageModelSmokeTest extends WiremockAware {
 
         var result = aiServiceWithoutTool.streaming("Hello").collect().asList().await().indefinitely();
         assertEquals(List.of("Hello", "!"), result);
+    }
+
+    @Test
+    void emitsThinkingEvents() {
+        wiremock().register(
+                post(urlEqualTo("/api/chat"))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/x-ndjson")
+                                .withBody(
+                                        """
+                                                {"model":"qwen3:1.7b","created_at":"2024-12-11T15:21:23.422542932Z","message":{"role":"assistant","content":"","thinking":"Let me "},"done":false}
+                                                {"model":"qwen3:1.7b","created_at":"2024-12-11T15:21:23.522542932Z","message":{"role":"assistant","content":"","thinking":"think."},"done":false}
+                                                {"model":"qwen3:1.7b","created_at":"2024-12-11T15:21:23.622542932Z","message":{"role":"assistant","content":"Hello"},"done":false}
+                                                {"model":"qwen3:1.7b","created_at":"2024-12-11T15:21:23.722542932Z","message":{"role":"assistant","content":"!"},"done":false}
+                                                {"model":"qwen3:1.7b","created_at":"2024-12-11T15:21:23.822542932Z","message":{"role":"assistant","content":""},"done_reason":"stop","done":true,"prompt_eval_count":11,"eval_count":10}""")));
+
+        List<ChatEvent> events = aiServiceWithoutTool.streamingEvents("Hello")
+                .collect().asList().await().indefinitely();
+
+        assertEquals(5, events.size());
+        assertEquals("Let me ", ((ChatEvent.PartialThinkingEvent) events.get(0)).getText());
+        assertEquals("think.", ((ChatEvent.PartialThinkingEvent) events.get(1)).getText());
+        assertEquals("Hello", ((ChatEvent.PartialResponseEvent) events.get(2)).getChunk());
+        assertEquals("!", ((ChatEvent.PartialResponseEvent) events.get(3)).getChunk());
+
+        ChatEvent.ChatCompletedEvent completed = (ChatEvent.ChatCompletedEvent) events.get(4);
+        assertEquals("Hello!", completed.getChatResponse().aiMessage().text());
+        assertEquals("Let me think.", completed.getChatResponse().aiMessage().thinking());
     }
 
     @Test

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/ChatResponse.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/ChatResponse.java
@@ -7,7 +7,7 @@ public record ChatResponse(String model, String createdAt, Message message, Bool
 
     public static ChatResponse emptyNotDone() {
         return new ChatResponse(null, null,
-                new Message(Role.ASSISTANT, "", Collections.emptyList(), Collections.emptyList(), null),
+                new Message(Role.ASSISTANT, "", null, Collections.emptyList(), Collections.emptyList(), null),
                 true, null, null);
     }
 }

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/Message.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/Message.java
@@ -8,8 +8,8 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public record Message(Role role, String content, @JsonProperty("tool_calls") List<ToolCall> toolCalls, List<String> images,
-        @JsonIgnore Map<String, Object> additionalFields) {
+public record Message(Role role, String content, String thinking, @JsonProperty("tool_calls") List<ToolCall> toolCalls,
+        List<String> images, @JsonIgnore Map<String, Object> additionalFields) {
 
     @JsonAnyGetter
     public Map<String, Object> getAdditionalFields() {
@@ -23,6 +23,7 @@ public record Message(Role role, String content, @JsonProperty("tool_calls") Lis
     public static class Builder {
         private Role role;
         private String content;
+        private String thinking;
         private List<ToolCall> toolCalls;
         private List<String> images;
         private Map<String, Object> additionalFields;
@@ -34,6 +35,11 @@ public record Message(Role role, String content, @JsonProperty("tool_calls") Lis
 
         public Builder content(String content) {
             this.content = content;
+            return this;
+        }
+
+        public Builder thinking(String thinking) {
+            this.thinking = thinking;
             return this;
         }
 
@@ -54,7 +60,7 @@ public record Message(Role role, String content, @JsonProperty("tool_calls") Lis
         }
 
         public Message build() {
-            return new Message(role, content, toolCalls, images, additionalFields);
+            return new Message(role, content, thinking, toolCalls, images, additionalFields);
         }
     }
 

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/OllamaStreamingChatLanguageModel.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/OllamaStreamingChatLanguageModel.java
@@ -27,6 +27,7 @@ import dev.langchain4j.model.chat.listener.ChatModelRequestContext;
 import dev.langchain4j.model.chat.listener.ChatModelResponseContext;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import dev.langchain4j.model.chat.response.PartialThinking;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.output.TokenUsage;
 import io.smallrye.mutiny.Context;
@@ -41,6 +42,7 @@ public class OllamaStreamingChatLanguageModel implements StreamingChatModel {
     private static final String TOOLS_CONTEXT = "TOOLS";
     private static final String TOKEN_USAGE_CONTEXT = "TOKEN_USAGE";
     private static final String RESPONSE_CONTEXT = "RESPONSE";
+    private static final String THINKING_CONTEXT = "THINKING";
     private static final String MODEL_ID = "MODEL_ID";
     private final OllamaClient client;
     private final String model;
@@ -80,6 +82,7 @@ public class OllamaStreamingChatLanguageModel implements StreamingChatModel {
         Context context = Context.empty();
         context.put(MODEL_ID, "");
         context.put(RESPONSE_CONTEXT, new ArrayList<ChatResponse>());
+        context.put(THINKING_CONTEXT, new ArrayList<String>());
         context.put(TOOLS_CONTEXT, new ArrayList<ToolExecutionRequest>());
 
         dev.langchain4j.model.chat.request.ChatRequest modelListenerRequest = createModelListenerRequest(request, messages,
@@ -118,6 +121,12 @@ public class OllamaStreamingChatLanguageModel implements StreamingChatModel {
                                     if (!response.message().content().isEmpty()) {
                                         ((List<ChatResponse>) context.get(RESPONSE_CONTEXT)).add(response);
                                         handler.onPartialResponse(response.message().content());
+                                    }
+
+                                    String thinking = response.message().thinking();
+                                    if (thinking != null && !thinking.isEmpty()) {
+                                        ((List<String>) context.get(THINKING_CONTEXT)).add(thinking);
+                                        handler.onPartialThinking(new PartialThinking(thinking));
                                     }
 
                                     if (response.done()) {
@@ -166,11 +175,17 @@ public class OllamaStreamingChatLanguageModel implements StreamingChatModel {
                                 TokenUsage tokenUsage = context.contains(TOKEN_USAGE_CONTEXT) ? context.get(TOKEN_USAGE_CONTEXT)
                                         : null;
                                 List<ChatResponse> chatResponses = context.get(RESPONSE_CONTEXT);
+                                List<String> thinkingResponses = context.get(THINKING_CONTEXT);
                                 List<ToolExecutionRequest> toolExecutionRequests = context.get(TOOLS_CONTEXT);
+
+                                String thinkingResponse = String.join("", thinkingResponses);
 
                                 if (!toolExecutionRequests.isEmpty()) {
                                     handler.onCompleteResponse(dev.langchain4j.model.chat.response.ChatResponse.builder()
-                                            .aiMessage(AiMessage.from(toolExecutionRequests))
+                                            .aiMessage(AiMessage.builder()
+                                                    .thinking(thinkingResponse.isEmpty() ? null : thinkingResponse)
+                                                    .toolExecutionRequests(toolExecutionRequests)
+                                                    .build())
                                             .tokenUsage(tokenUsage).build());
                                     return;
                                 }
@@ -180,7 +195,10 @@ public class OllamaStreamingChatLanguageModel implements StreamingChatModel {
                                         .map(Message::content)
                                         .collect(Collectors.joining());
 
-                                AiMessage aiMessage = new AiMessage(stringResponse);
+                                AiMessage aiMessage = AiMessage.builder()
+                                        .text(stringResponse)
+                                        .thinking(thinkingResponse.isEmpty() ? null : thinkingResponse)
+                                        .build();
                                 dev.langchain4j.model.chat.response.ChatResponse aiMessageResponse = dev.langchain4j.model.chat.response.ChatResponse
                                         .builder().aiMessage(aiMessage).tokenUsage(tokenUsage).build();
 


### PR DESCRIPTION
## Description

Fixes missing thinking events when an AI service backed by Ollama returns a `Multi<ChatEvent>`.

Ollama returns reasoning from thinking-capable models in the streamed `message.thinking` field. The custom Ollama streaming implementation did not model this field and only forwarded `message.content`, so thinking chunks were discarded before they could reach the AI service streaming layer.

This change:

- Adds the `thinking` field to the Ollama `Message` response DTO.
- Forwards non-empty thinking chunks through `StreamingChatResponseHandler.onPartialThinking(...)`.
- Accumulates streamed thinking and includes it in the completed `AiMessage`.
- Preserves accumulated thinking when the response contains tool execution requests.
- Adds a WireMock-based regression test covering:
  - ordered `PartialThinkingEvent` emissions;
  - regular `PartialResponseEvent` emissions;
  - accumulated response text in the completed event;
  - accumulated thinking in the completed `AiMessage`.

This makes Ollama consistent with the existing streaming behaviour used by providers such as Anthropic.

- Fixes: #2660