### PR TITLE
Fix native compatibility with Quarkus main #2645

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/streaming/BlockingMemoryStoreOnStreamedResponseTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/streaming/BlockingMemoryStoreOnStreamedResponseTest.java
@@ -22,6 +22,7 @@ import dev.langchain4j.service.UserMessage;
 import io.quarkiverse.langchain4j.RegisterAiService;
 import io.quarkus.arc.Arc;
 import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.common.vertx.ContextLocals;
 import io.smallrye.common.vertx.VertxContext;
 import io.smallrye.mutiny.Multi;
 import io.vertx.core.Context;
@@ -63,7 +64,7 @@ public class BlockingMemoryStoreOnStreamedResponseTest {
                 Arc.container().requestContext().activate();
                 var value = UUID.randomUUID().toString();
                 StreamTestUtils.FakeMemoryStore.DC_DATA = value;
-                Vertx.currentContext().putLocal("DC_DATA", value);
+                ContextLocals.put("DC_DATA", value);
                 List<String> list = service.hi("123", "Say hello").collect().asList().await().indefinitely();
                 assertThat(list).containsExactly("Hi!", " ", "World!");
                 Arc.container().requestContext().deactivate();
@@ -76,7 +77,7 @@ public class BlockingMemoryStoreOnStreamedResponseTest {
 
             } finally {
                 Arc.container().requestContext().deactivate();
-                Vertx.currentContext().removeLocal("DC_DATA");
+                ContextLocals.remove("DC_DATA");
 
             }
         }, false);

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/streaming/StreamTestUtils.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/streaming/StreamTestUtils.java
@@ -18,6 +18,7 @@ import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.store.memory.chat.ChatMemoryStore;
 import io.quarkus.arc.Arc;
+import io.smallrye.common.vertx.ContextLocals;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.vertx.core.Vertx;
 
@@ -96,7 +97,7 @@ public class StreamTestUtils {
 
         private void checkDuplicatedContext() {
             if (DC_DATA != null) {
-                if (!DC_DATA.equals(Vertx.currentContext().getLocal("DC_DATA"))) {
+                if (!DC_DATA.equals(ContextLocals.get("DC_DATA").orElse(null))) {
                     throw new AssertionError("Expected to be in the same context");
                 }
             }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/ContextLocals.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/ContextLocals.java
@@ -21,7 +21,7 @@ public final class ContextLocals {
         if (current == null) {
             return null;
         }
-        return current.getLocal(Assert.checkNotNullParam("key", key));
+        return io.smallrye.common.vertx.ContextLocals.<T> get(Assert.checkNotNullParam("key", key)).orElse(null);
     }
 
     /**
@@ -38,7 +38,7 @@ public final class ContextLocals {
         if (current == null) {
             return;
         }
-        current.putLocal(
+        io.smallrye.common.vertx.ContextLocals.put(
                 Assert.checkNotNullParam("key", key),
                 Assert.checkNotNullParam("value", value));
     }
@@ -55,7 +55,7 @@ public final class ContextLocals {
         if (current == null) {
             return false;
         }
-        return current.removeLocal(Assert.checkNotNullParam("key", key));
+        return io.smallrye.common.vertx.ContextLocals.remove(Assert.checkNotNullParam("key", key));
     }
 
     public static boolean duplicatedContextActive() {

--- a/model-providers/jaxrs-client/src/main/java/io/quarkiverse/langchain4j/jaxrsclient/JaxRsHttpClient.java
+++ b/model-providers/jaxrs-client/src/main/java/io/quarkiverse/langchain4j/jaxrsclient/JaxRsHttpClient.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.langchain4j.jaxrsclient;
 
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.security.KeyStore;
 import java.util.List;
 import java.util.Optional;
@@ -24,12 +25,14 @@ import dev.langchain4j.http.client.SuccessfulHttpResponse;
 import dev.langchain4j.http.client.sse.ServerSentEventListener;
 import dev.langchain4j.http.client.sse.ServerSentEventParser;
 import io.quarkus.runtime.BlockingOperationControl;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.quarkus.tls.TlsConfiguration;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.vertx.core.net.KeyCertOptions;
 import io.vertx.core.net.SSLOptions;
 import io.vertx.core.net.TrustOptions;
 
+@RegisterForReflection(targets = TlsConfiguration.class)
 public class JaxRsHttpClient implements HttpClient {
 
     private final Client delegate;
@@ -66,7 +69,7 @@ public class JaxRsHttpClient implements HttpClient {
 
                 @Override
                 public SSLOptions getSSLOptions() {
-                    return tlsConfiguration.getSSLOptions();
+                    return getClientSSLOptions(tlsConfiguration);
                 }
 
                 @Override
@@ -100,6 +103,20 @@ public class JaxRsHttpClient implements HttpClient {
 
     public static JaxRsHttpClientBuilder builder() {
         return new JaxRsHttpClientBuilder();
+    }
+
+    private static SSLOptions getClientSSLOptions(TlsConfiguration tlsConfiguration) {
+        try {
+            try {
+                return (SSLOptions) TlsConfiguration.class.getMethod("getClientSSLOptions").invoke(tlsConfiguration);
+            } catch (NoSuchMethodException ignored) {
+                return (SSLOptions) TlsConfiguration.class.getMethod("getSSLOptions").invoke(tlsConfiguration);
+            }
+        } catch (IllegalAccessException | NoSuchMethodException e) {
+            throw new IllegalStateException("Unable to read the TLS client options", e);
+        } catch (InvocationTargetException e) {
+            throw new IllegalStateException("Unable to read the TLS client options", e.getCause());
+        }
     }
 
     @Override

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/OllamaRestApi.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/OllamaRestApi.java
@@ -36,6 +36,7 @@ import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import io.quarkiverse.langchain4j.QuarkusJsonCodecFactory;
 import io.quarkiverse.langchain4j.runtime.CurlRequestLogger;
 import io.quarkus.rest.client.reactive.jackson.ClientObjectMapper;
+import io.smallrye.common.vertx.ContextLocals;
 import io.smallrye.mutiny.Multi;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -106,19 +107,19 @@ public interface OllamaRestApi {
                             // but in pieces (my guess is that it is a Vertx bug).
                             // There is nothing we can do in this case except for returning empty responses and in the meantime buffer the pieces
                             // by storing them in the Vertx Duplicated Context
-                            String existingBuffer = ctx.getLocal("buffer");
+                            String existingBuffer = ContextLocals.<String> get("buffer").orElse(null);
                             if ((existingBuffer != null) && !existingBuffer.isEmpty()) {
                                 if (chunk.endsWith("}")) {
-                                    ctx.putLocal("buffer", "");
+                                    ContextLocals.put("buffer", "");
                                     String entireLine = existingBuffer + chunk;
                                     return QuarkusJsonCodecFactory.SnakeCaseObjectMapperHolder.MAPPER.readValue(entireLine,
                                             ChatResponse.class);
                                 } else {
-                                    ctx.putLocal("buffer", existingBuffer + chunk);
+                                    ContextLocals.put("buffer", existingBuffer + chunk);
                                     return ChatResponse.emptyNotDone();
                                 }
                             } else {
-                                ctx.putLocal("buffer", chunk);
+                                ContextLocals.put("buffer", chunk);
                                 return ChatResponse.emptyNotDone();
                             }
                         }


### PR DESCRIPTION
Fixes #2645.

Quarkus `main` uses Vert.x 5, which removed the object-keyed context-local methods and changed the TLS configuration API. These binary incompatibilities caused native image analysis to fail when using an extension built against Quarkus 3.33.

This change:

- uses SmallRye's context-local compatibility API instead of calling Vert.x directly;
- resolves client SSL options across both TLS configuration APIs;
- registers the TLS configuration methods for reflection in native images;
- updates the affected streaming tests to use the same context-local API.

The public configuration and behaviour remain unchanged.

Tests:

- JAX-RS client tests
- Ollama runtime tests
- `BlockingMemoryStoreOnStreamedResponseTest`
- Core deployment test compilation