### PR TITLE
Move Agentic AI up one level in the doc

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -44,7 +44,7 @@
 ** xref:guardrails.adoc[Guardrails]
 ** xref:response-augmenter.adoc[Response Augmenter]
 ** xref:chat-scopes.adoc[Chat Scopes Framework]
-** xref:agentic.adoc[Agentic AI]
+* xref:agentic.adoc[Agentic AI]
 * xref:models.adoc[Models]
 ** Chat Models
 *** xref:anthropic-chat-model.adoc[Anthropic (Claude)]


### PR DESCRIPTION
I was talking with @mariofusco  and we think the Agentic module doc is hard to find in the nav menu since it's currently located under the AI Services sub header.  It makes more sense directly under the Reference header. 

@cescoffier @geoand related to this, the rest of the nav items are also inconsistent: Guardrails and Function Calling are under AI Services, but Skills, MCP and RAG are under the main Reference menu item.   Should we move all those items under AI Services, or move them all to the higher level?