### PR TITLE
Move Guardrails and Function Calling out of the AI Services sub menu

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -40,8 +40,6 @@
 * xref:ai-services.adoc[AI Services]
 ** xref:prompt-and-template.adoc[Prompt and Template]
 ** xref:messages-and-memory.adoc[Messages and Memory]
-** xref:function-calling.adoc[Function Calling]
-** xref:guardrails.adoc[Guardrails]
 ** xref:response-augmenter.adoc[Response Augmenter]
 ** xref:chat-scopes.adoc[Chat Scopes Framework]
 * xref:agentic.adoc[Agentic AI]
@@ -107,7 +105,9 @@
 *** xref:rag-redis.adoc[Redis]
 *** xref:rag-weaviate.adoc[Weaviate]
 
+* xref:function-calling.adoc[Function Calling]
 * xref:mcp.adoc[Model Context Protocol (MCP)]
+* xref:guardrails.adoc[Guardrails]
 * xref:skills.adoc[Skills]
 * xref:dev-ui.adoc[Dev UI]
 * xref:observability.adoc[Observability]


### PR DESCRIPTION
Moving Guardrails and Function Calling under the main Reference menu to be consistent with MCP, RAG and Skills per the discussion in https://github.com/quarkiverse/quarkus-langchain4j/pull/2678 

cc/ @mariofusco @geoand 