### PR TITLE
Add direct AI service configuration attributes

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
@@ -446,6 +446,10 @@ public class AiServicesProcessor {
             }
             alreadyHandled.add(declarativeAiServiceClassInfo.name());
 
+            boolean chatMemoryProviderClassIsBean = false;
+            boolean toolProviderClassIsBean = false;
+            boolean toolSearchStrategyClassIsBean = false;
+
             DotName chatLanguageModelSupplierClassDotName = getSupplierDotName(instance.value("chatLanguageModelSupplier"),
                     LangChain4jDotNames.BEAN_CHAT_MODEL_SUPPLIER,
                     supplierDotName -> validateSupplierAndRegister(
@@ -494,7 +498,15 @@ public class AiServicesProcessor {
 
             DotName toolProviderClassName = LangChain4jDotNames.BEAN_IF_EXISTS_TOOL_PROVIDER_SUPPLIER;
             AnnotationValue toolProviderValue = instance.value("toolProviderSupplier");
-            if (toolProviderValue != null) {
+            AnnotationValue configuredToolProvider = instance.value("toolProvider");
+            rejectConflictingConfiguration(declarativeAiServiceClassInfo, toolProviderValue, configuredToolProvider,
+                    "toolProviderSupplier", "toolProvider");
+            if (configuredToolProvider != null) {
+                toolProviderClassName = configuredToolProvider.asClass().name();
+                toolProviderClassIsBean = true;
+                toolProviderInfos.add(new ToolProviderInfo(toolProviderClassName.toString(),
+                        declarativeAiServiceClassInfo.simpleName()));
+            } else if (toolProviderValue != null) {
                 if (LangChain4jDotNames.NO_TOOL_PROVIDER_SUPPLIER.equals(toolProviderValue.asClass().name())) {
                     toolProviderClassName = null;
                 } else {
@@ -508,7 +520,13 @@ public class AiServicesProcessor {
 
             DotName toolSearchStrategyClassName = LangChain4jDotNames.BEAN_IF_EXISTS_TOOL_SEARCH_STRATEGY_SUPPLIER;
             AnnotationValue toolSearchStrategyValue = instance.value("toolSearchStrategySupplier");
-            if (toolSearchStrategyValue != null) {
+            AnnotationValue configuredToolSearchStrategy = instance.value("toolSearchStrategy");
+            rejectConflictingConfiguration(declarativeAiServiceClassInfo, toolSearchStrategyValue,
+                    configuredToolSearchStrategy, "toolSearchStrategySupplier", "toolSearchStrategy");
+            if (configuredToolSearchStrategy != null) {
+                toolSearchStrategyClassName = configuredToolSearchStrategy.asClass().name();
+                toolSearchStrategyClassIsBean = true;
+            } else if (toolSearchStrategyValue != null) {
                 if (LangChain4jDotNames.NO_TOOL_SEARCH_STRATEGY_SUPPLIER.equals(toolSearchStrategyValue.asClass().name())) {
                     toolSearchStrategyClassName = null;
                 } else {
@@ -549,14 +567,43 @@ public class AiServicesProcessor {
             List<ClassInfo> tools = tools(instance, index);
             DotName chatMemoryProviderSupplierClassDotName = chatMemoryProviderSupplierClassDotName(reflectiveClassProducer,
                     unremovableBeanProducer, instance, index);
-            if (!tools.isEmpty() && chatMemoryProviderSupplierClassDotName == null) {
+            chatMemoryProviderClassIsBean = instance.value("chatMemoryProvider") != null;
+            AnnotationValue configuredStore = instance.value("chatMemoryStore");
+            AnnotationValue configuredMaxMessages = instance.value("chatMemoryMaxMessages");
+            if (chatMemoryProviderClassIsBean && (configuredStore != null || configuredMaxMessages != null)) {
+                throw new IllegalArgumentException("AI service '" + declarativeAiServiceClassInfo.name()
+                        + "' cannot combine @RegisterAiService.chatMemoryProvider with chatMemoryStore or "
+                        + "chatMemoryMaxMessages");
+            }
+            DotName chatMemoryStoreClassDotName = null;
+            Integer chatMemoryMaxMessages = null;
+            if (configuredStore != null || configuredMaxMessages != null) {
+                chatMemoryStoreClassDotName = configuredStore != null
+                        ? configuredStore.asClass().name()
+                        : DotName.createSimple(dev.langchain4j.store.memory.chat.ChatMemoryStore.class);
+                chatMemoryMaxMessages = configuredMaxMessages != null ? configuredMaxMessages.asInt() : 10;
+                if (chatMemoryMaxMessages <= 0) {
+                    throw new IllegalArgumentException(
+                            "@RegisterAiService.chatMemoryMaxMessages must be greater than zero, but was: "
+                                    + chatMemoryMaxMessages);
+                }
+                chatMemoryProviderSupplierClassDotName = null;
+            }
+            DotName configuredMemoryIdProviderClassDotName = null;
+            boolean defaultMemoryIdProviderClassIsBean = false;
+            AnnotationValue configuredMemoryIdProvider = instance.value("defaultMemoryIdProvider");
+            if (configuredMemoryIdProvider != null) {
+                configuredMemoryIdProviderClassDotName = configuredMemoryIdProvider.asClass().name();
+                defaultMemoryIdProviderClassIsBean = true;
+            }
+            if (!tools.isEmpty() && chatMemoryProviderSupplierClassDotName == null
+                    && chatMemoryStoreClassDotName == null) {
                 throw new IllegalArgumentException("Tool usage requires chat memory. Offending AiService is '"
                         + declarativeAiServiceClassInfo.name() + "'");
             }
             Integer maxToolCallingRoundTrips = 0;
             AnnotationValue newAnnoValue = instance.value("maxToolCallingRoundTrips");
             AnnotationValue legacyAnnoValue = instance.value("maxSequentialToolInvocations");
-
             if (newAnnoValue != null) {
                 maxToolCallingRoundTrips = newAnnoValue.asInt();
             } else if (legacyAnnoValue != null) {
@@ -592,7 +639,14 @@ public class AiServicesProcessor {
             }
 
             DotName chatMemoryFlushStrategySupplierClassDotName = null;
+            String chatMemoryFlushStrategy = null;
             AnnotationValue chatMemoryFlushStrategySupplierValue = instance.value("chatMemoryFlushStrategySupplier");
+            AnnotationValue configuredFlushStrategy = instance.value("chatMemoryFlushStrategy");
+            rejectConflictingConfiguration(declarativeAiServiceClassInfo, chatMemoryFlushStrategySupplierValue,
+                    configuredFlushStrategy, "chatMemoryFlushStrategySupplier", "chatMemoryFlushStrategy");
+            if (configuredFlushStrategy != null) {
+                chatMemoryFlushStrategy = configuredFlushStrategy.asEnum();
+            }
             if (chatMemoryFlushStrategySupplierValue != null) {
                 DotName supplierDotName = chatMemoryFlushStrategySupplierValue.asClass().name();
                 if (!LangChain4jDotNames.DEFAULT_CHAT_MEMORY_FLUSH_STRATEGY_SUPPLIER.equals(supplierDotName)) {
@@ -633,7 +687,9 @@ public class AiServicesProcessor {
                     moderationModelName,
                     imageModelName,
                     toolProviderClassName,
+                    toolProviderClassIsBean,
                     toolSearchStrategyClassName,
+                    toolSearchStrategyClassIsBean,
                     beanName(declarativeAiServiceClassInfo),
                     toolHallucinationStrategy(instance),
                     classInputGuardrails(declarativeAiServiceClassInfo, index),
@@ -647,6 +703,12 @@ public class AiServicesProcessor {
                     impliedRegisterAiServiceTarget.contains(declarativeAiServiceClassInfo.name()),
                     shouldThrowExceptionOnEventError,
                     chatMemoryFlushStrategySupplierClassDotName,
+                    chatMemoryFlushStrategy,
+                    chatMemoryProviderClassIsBean,
+                    chatMemoryStoreClassDotName,
+                    chatMemoryMaxMessages,
+                    configuredMemoryIdProviderClassDotName,
+                    defaultMemoryIdProviderClassIsBean,
                     skillNames));
 
         }
@@ -757,6 +819,12 @@ public class AiServicesProcessor {
         // the default value depends on whether tools exists or not - if they do, then we require a ChatMemoryProvider bean
         DotName chatMemoryProviderSupplierClassDotName = LangChain4jDotNames.BEAN_CHAT_MEMORY_PROVIDER_SUPPLIER;
         AnnotationValue chatMemoryProviderSupplierValue = instance.value("chatMemoryProviderSupplier");
+        AnnotationValue configuredProvider = instance.value("chatMemoryProvider");
+        rejectConflictingConfiguration(instance.target().asClass(), chatMemoryProviderSupplierValue, configuredProvider,
+                "chatMemoryProviderSupplier", "chatMemoryProvider");
+        if (configuredProvider != null) {
+            return configuredProvider.asClass().name();
+        }
         if (chatMemoryProviderSupplierValue != null) {
             chatMemoryProviderSupplierClassDotName = chatMemoryProviderSupplierValue.asClass().name();
             if (chatMemoryProviderSupplierClassDotName.equals(
@@ -917,6 +985,14 @@ public class AiServicesProcessor {
             return toolHallucinationStrategyInstance.asClass().name();
         }
         return null;
+    }
+
+    private static void rejectConflictingConfiguration(ClassInfo serviceClass, AnnotationValue supplierValue,
+            AnnotationValue beanValue, String supplierName, String beanName) {
+        if (supplierValue != null && beanValue != null) {
+            throw new IllegalArgumentException("AI service '" + serviceClass.name() + "' configures both @RegisterAiService."
+                    + supplierName + " and @RegisterAiService." + beanName + ". Configure only one of them.");
+        }
     }
 
     private DotName getSupplierDotName(
@@ -1083,6 +1159,9 @@ public class AiServicesProcessor {
             String defaultMemoryIdProviderClassName = (bi.getDefaultMemoryIdProviderClassDotName() != null
                     ? bi.getDefaultMemoryIdProviderClassDotName().toString()
                     : null);
+            String chatMemoryStoreClassName = (bi.getChatMemoryStoreClassDotName() != null
+                    ? bi.getChatMemoryStoreClassDotName().toString()
+                    : null);
 
             String chatMemoryFlushStrategySupplierClassName = (bi.getChatMemoryFlushStrategySupplierClassDotName() != null
                     ? bi.getChatMemoryFlushStrategySupplierClassDotName().toString()
@@ -1148,9 +1227,15 @@ public class AiServicesProcessor {
                                     streamingChatLanguageModelSupplierClassName,
                                     toolToQualifierMap,
                                     toolProviderSupplierClassName,
+                                    bi.isToolProviderClassBean(),
                                     toolSearchStrategySupplierClassName,
+                                    bi.isToolSearchStrategyClassBean(),
                                     chatMemoryProviderSupplierClassName,
+                                    bi.isChatMemoryProviderClassBean(),
                                     chatMemoryFlushStrategySupplierClassName,
+                                    bi.getChatMemoryFlushStrategy(),
+                                    chatMemoryStoreClassName,
+                                    bi.getChatMemoryMaxMessages(),
                                     retrievalAugmentorSupplierClassName,
                                     moderationModelSupplierClassName,
                                     imageModelSupplierClassName,
@@ -1173,6 +1258,7 @@ public class AiServicesProcessor {
                                     allowContinuousForcedToolCalling,
                                     bi.isShouldThrowExceptionOnEventError(),
                                     defaultMemoryIdProviderClassName,
+                                    bi.isDefaultMemoryIdProviderClassBean(),
                                     bi.getSkillNames())))
                     .setRuntimeInit()
                     .addQualifier()
@@ -1227,6 +1313,14 @@ public class AiServicesProcessor {
             if (LangChain4jDotNames.BEAN_CHAT_MEMORY_PROVIDER_SUPPLIER.toString().equals(chatMemoryProviderSupplierClassName)) {
                 configurator.addInjectionPoint(ClassType.create(LangChain4jDotNames.CHAT_MEMORY_PROVIDER));
                 needsChatMemoryProviderBean = true;
+            } else if (bi.isChatMemoryProviderClassBean()) {
+                configurator.addInjectionPoint(ClassType.create(bi.getChatMemoryProviderSupplierClassDotName()));
+            }
+            if (bi.getChatMemoryStoreClassDotName() != null) {
+                configurator.addInjectionPoint(ClassType.create(bi.getChatMemoryStoreClassDotName()));
+            }
+            if (bi.isDefaultMemoryIdProviderClassBean()) {
+                configurator.addInjectionPoint(ClassType.create(bi.getDefaultMemoryIdProviderClassDotName()));
             }
 
             if (LangChain4jDotNames.BEAN_IF_EXISTS_RETRIEVAL_AUGMENTOR_SUPPLIER.toString()

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/DeclarativeAiServiceBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/DeclarativeAiServiceBuildItem.java
@@ -18,10 +18,15 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
     private final DotName streamingChatLanguageModelSupplierClassDotName;
     private final List<ClassInfo> toolClassInfos;
     private final DotName toolProviderClassDotName;
+    private final boolean toolProviderClassIsBean;
     private final DotName toolSearchStrategyClassDotName;
+    private final boolean toolSearchStrategyClassIsBean;
     private final DotName toolHallucinationStrategyClassDotName;
 
     private final DotName chatMemoryProviderSupplierClassDotName;
+    private final boolean chatMemoryProviderClassIsBean;
+    private final DotName chatMemoryStoreClassDotName;
+    private final Integer chatMemoryMaxMessages;
     private final DotName retrievalAugmentorSupplierClassDotName;
     private final boolean customRetrievalAugmentorSupplierClassIsABean;
     private final DotName moderationModelSupplierDotName;
@@ -31,6 +36,7 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
     private final DotName systemMessageProviderClassDotName;
     private final DotName cdiScope;
     private DotName defaultMemoryIdProviderClassDotName;
+    private boolean defaultMemoryIdProviderClassIsBean;
     private final String chatModelName;
     private final String moderationModelName;
     private final String imageModelName;
@@ -45,6 +51,7 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
     private final boolean makeDefaultBean;
     private final boolean shouldThrowExceptionOnEventError;
     private final DotName chatMemoryFlushStrategySupplierClassDotName;
+    private final String chatMemoryFlushStrategy;
     private final List<String> skillNames;
 
     public DeclarativeAiServiceBuildItem(
@@ -65,7 +72,9 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
             String moderationModelName,
             String imageModelName,
             DotName toolProviderClassDotName,
+            boolean toolProviderClassIsBean,
             DotName toolSearchStrategyClassDotName,
+            boolean toolSearchStrategyClassIsBean,
             Optional<String> beanName,
             DotName toolHallucinationStrategyClassDotName,
             DeclarativeAiServiceInputGuardrails inputGuardrails,
@@ -77,12 +86,23 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
             boolean allowContinuousForcedToolCalling,
             boolean makeDefaultBean, boolean shouldThrowExceptionOnEventError,
             DotName chatMemoryFlushStrategySupplierClassDotName,
+            String chatMemoryFlushStrategy,
+            boolean chatMemoryProviderClassIsBean,
+            DotName chatMemoryStoreClassDotName,
+            Integer chatMemoryMaxMessages,
+            DotName defaultMemoryIdProviderClassDotName,
+            boolean defaultMemoryIdProviderClassIsBean,
             List<String> skillNames) {
         this.serviceClassInfo = serviceClassInfo;
         this.chatLanguageModelSupplierClassDotName = chatLanguageModelSupplierClassDotName;
         this.streamingChatLanguageModelSupplierClassDotName = streamingChatLanguageModelSupplierClassDotName;
         this.toolClassInfos = toolClassInfos;
         this.chatMemoryProviderSupplierClassDotName = chatMemoryProviderSupplierClassDotName;
+        this.chatMemoryProviderClassIsBean = chatMemoryProviderClassIsBean;
+        this.chatMemoryStoreClassDotName = chatMemoryStoreClassDotName;
+        this.chatMemoryMaxMessages = chatMemoryMaxMessages;
+        this.defaultMemoryIdProviderClassDotName = defaultMemoryIdProviderClassDotName;
+        this.defaultMemoryIdProviderClassIsBean = defaultMemoryIdProviderClassIsBean;
         this.retrievalAugmentorSupplierClassDotName = retrievalAugmentorSupplierClassDotName;
         this.customRetrievalAugmentorSupplierClassIsABean = customRetrievalAugmentorSupplierClassIsABean;
         this.moderationModelSupplierDotName = moderationModelSupplierDotName;
@@ -95,7 +115,9 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
         this.moderationModelName = moderationModelName;
         this.imageModelName = imageModelName;
         this.toolProviderClassDotName = toolProviderClassDotName;
+        this.toolProviderClassIsBean = toolProviderClassIsBean;
         this.toolSearchStrategyClassDotName = toolSearchStrategyClassDotName;
+        this.toolSearchStrategyClassIsBean = toolSearchStrategyClassIsBean;
         this.beanName = beanName;
         this.toolHallucinationStrategyClassDotName = toolHallucinationStrategyClassDotName;
         this.inputGuardrails = inputGuardrails;
@@ -108,6 +130,7 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
         this.makeDefaultBean = makeDefaultBean;
         this.shouldThrowExceptionOnEventError = shouldThrowExceptionOnEventError;
         this.chatMemoryFlushStrategySupplierClassDotName = chatMemoryFlushStrategySupplierClassDotName;
+        this.chatMemoryFlushStrategy = chatMemoryFlushStrategy;
         this.skillNames = skillNames;
     }
 
@@ -179,8 +202,16 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
         return toolProviderClassDotName;
     }
 
+    public boolean isToolProviderClassBean() {
+        return toolProviderClassIsBean;
+    }
+
     public DotName getToolSearchStrategyClassDotName() {
         return toolSearchStrategyClassDotName;
+    }
+
+    public boolean isToolSearchStrategyClassBean() {
+        return toolSearchStrategyClassIsBean;
     }
 
     public Optional<String> getBeanName() {
@@ -252,12 +283,33 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
         return chatMemoryFlushStrategySupplierClassDotName;
     }
 
+    public String getChatMemoryFlushStrategy() {
+        return chatMemoryFlushStrategy;
+    }
+
+    public boolean isChatMemoryProviderClassBean() {
+        return chatMemoryProviderClassIsBean;
+    }
+
+    public DotName getChatMemoryStoreClassDotName() {
+        return chatMemoryStoreClassDotName;
+    }
+
+    public Integer getChatMemoryMaxMessages() {
+        return chatMemoryMaxMessages;
+    }
+
     public DotName getDefaultMemoryIdProviderClassDotName() {
         return defaultMemoryIdProviderClassDotName;
     }
 
     public void setDefaultMemoryIdProviderClassDotName(DotName defaultMemoryIdProviderClassDotName) {
         this.defaultMemoryIdProviderClassDotName = defaultMemoryIdProviderClassDotName;
+        this.defaultMemoryIdProviderClassIsBean = false;
+    }
+
+    public boolean isDefaultMemoryIdProviderClassBean() {
+        return defaultMemoryIdProviderClassIsBean;
     }
 
     /**

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/LangChain4jDotNames.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/LangChain4jDotNames.java
@@ -96,7 +96,6 @@ public class LangChain4jDotNames {
 
     public static final DotName MODEL_NAME = DotName.createSimple(ModelName.class);
     public static final DotName REGISTER_AI_SERVICES = DotName.createSimple(RegisterAiService.class);
-
     static final DotName BEAN_CHAT_MODEL_SUPPLIER = DotName.createSimple(
             RegisterAiService.BeanChatLanguageModelSupplier.class);
 

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/DirectBeanConfigConflictTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/DirectBeanConfigConflictTest.java
@@ -1,0 +1,46 @@
+package io.quarkiverse.langchain4j.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.Supplier;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.service.tool.ToolProvider;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.test.toolresolution.MyCustomToolProvider;
+import io.quarkiverse.langchain4j.test.toolresolution.TestAiSupplier;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DirectBeanConfigConflictTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ConflictingService.class, TestAiSupplier.class, MyCustomToolProvider.class,
+                            ToolProviderSupplier.class))
+            .assertException(error -> assertThat(error)
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining(
+                            "configures both @RegisterAiService.toolProviderSupplier and @RegisterAiService.toolProvider"));
+
+    @RegisterAiService(chatLanguageModelSupplier = TestAiSupplier.class, toolProviderSupplier = ToolProviderSupplier.class, toolProvider = MyCustomToolProvider.class)
+    interface ConflictingService {
+        String chat(String message);
+    }
+
+    public static class ToolProviderSupplier implements Supplier<ToolProvider> {
+        @Override
+        public ToolProvider get() {
+            return null;
+        }
+    }
+
+    @Test
+    void rejectsDuplicateConfiguration() {
+        // Asserted while the test application starts.
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/DirectBeanConfigMissingBeanTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/DirectBeanConfigMissingBeanTest.java
@@ -1,0 +1,42 @@
+package io.quarkiverse.langchain4j.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.test.toolresolution.TestAiSupplier;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DirectBeanConfigMissingBeanTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ConfiguredService.class, NotABean.class, TestAiSupplier.class))
+            .assertException(error -> assertThat(error)
+                    .hasStackTraceContaining("Unsatisfied dependency")
+                    .hasStackTraceContaining(NotABean.class.getName()));
+
+    @RegisterAiService(chatLanguageModelSupplier = TestAiSupplier.class, chatMemoryProvider = NotABean.class)
+    interface ConfiguredService {
+        String chat(String message);
+    }
+
+    public static class NotABean implements ChatMemoryProvider {
+        @Override
+        public ChatMemory get(Object memoryId) {
+            return null;
+        }
+    }
+
+    @Test
+    void rejectsAClassThatIsNotACdiBean() {
+        // Asserted while the test application starts.
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/MemoryConfigInvalidWindowTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/MemoryConfigInvalidWindowTest.java
@@ -1,0 +1,42 @@
+package io.quarkiverse.langchain4j.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.Supplier;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MemoryConfigInvalidWindowTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ConfiguredService.class, ModelSupplier.class))
+            .assertException(error -> assertThat(error)
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("@RegisterAiService.chatMemoryMaxMessages must be greater than zero"));
+
+    @RegisterAiService(chatLanguageModelSupplier = ModelSupplier.class, chatMemoryMaxMessages = 0)
+    interface ConfiguredService {
+        String chat(String message);
+    }
+
+    public static class ModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return null;
+        }
+    }
+
+    @Test
+    void rejectsNonPositiveWindowSize() {
+        // Asserted while the test application starts.
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/MemoryConfigProviderStoreConflictTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/MemoryConfigProviderStoreConflictTest.java
@@ -1,0 +1,69 @@
+package io.quarkiverse.langchain4j.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.store.memory.chat.ChatMemoryStore;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MemoryConfigProviderStoreConflictTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ConfiguredService.class, ModelSupplier.class, MemoryProvider.class, MemoryStore.class))
+            .assertException(error -> assertThat(error)
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("cannot combine @RegisterAiService.chatMemoryProvider with chatMemoryStore"));
+
+    @RegisterAiService(chatLanguageModelSupplier = ModelSupplier.class, chatMemoryProvider = MemoryProvider.class, chatMemoryStore = MemoryStore.class)
+    interface ConfiguredService {
+        String chat(String message);
+    }
+
+    public static class ModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return null;
+        }
+    }
+
+    public static class MemoryProvider implements ChatMemoryProvider {
+        @Override
+        public ChatMemory get(Object memoryId) {
+            return null;
+        }
+    }
+
+    public static class MemoryStore implements ChatMemoryStore {
+        @Override
+        public List<ChatMessage> getMessages(Object memoryId) {
+            return List.of();
+        }
+
+        @Override
+        public void updateMessages(Object memoryId, List<ChatMessage> messages) {
+        }
+
+        @Override
+        public void deleteMessages(Object memoryId) {
+        }
+    }
+
+    @Test
+    void rejectsProviderAndStoreCombination() {
+        // Asserted while the test application starts.
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/MemoryConfigTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/MemoryConfigTest.java
@@ -1,0 +1,151 @@
+package io.quarkiverse.langchain4j.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.store.memory.chat.ChatMemoryStore;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.runtime.aiservice.ChatMemoryFlushStrategy;
+import io.quarkiverse.langchain4j.spi.DefaultMemoryIdProvider;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MemoryConfigTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ConfiguredService.class, DefaultConfigService.class, MemoryProvider.class,
+                            StoreConfiguredService.class, MemoryStore.class, MemoryIdProvider.class, ModelSupplier.class));
+
+    @RegisterAiService(chatLanguageModelSupplier = ModelSupplier.class, chatMemoryProvider = MemoryProvider.class, chatMemoryFlushStrategy = ChatMemoryFlushStrategy.IMMEDIATE)
+    interface ConfiguredService {
+
+        String chat(@UserMessage String message, @MemoryId Object id);
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = ModelSupplier.class)
+    interface DefaultConfigService {
+        String chat(@UserMessage String message, @MemoryId Object id);
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = ModelSupplier.class, chatMemoryStore = MemoryStore.class, chatMemoryMaxMessages = 2, defaultMemoryIdProvider = MemoryIdProvider.class)
+    interface StoreConfiguredService {
+        String chat(@UserMessage String message);
+    }
+
+    @ApplicationScoped
+    public static class MemoryProvider implements ChatMemoryProvider {
+
+        static final AtomicBoolean USED = new AtomicBoolean();
+
+        @Override
+        public dev.langchain4j.memory.ChatMemory get(Object memoryId) {
+            USED.set(true);
+            return MessageWindowChatMemory.withMaxMessages(10);
+        }
+    }
+
+    @ApplicationScoped
+    public static class MemoryStore implements ChatMemoryStore {
+
+        static final Map<Object, List<ChatMessage>> MESSAGES = new ConcurrentHashMap<>();
+
+        @Override
+        public List<ChatMessage> getMessages(Object memoryId) {
+            return new ArrayList<>(MESSAGES.getOrDefault(memoryId, List.of()));
+        }
+
+        @Override
+        public void updateMessages(Object memoryId, List<ChatMessage> messages) {
+            MESSAGES.put(memoryId, new ArrayList<>(messages));
+        }
+
+        @Override
+        public void deleteMessages(Object memoryId) {
+            MESSAGES.remove(memoryId);
+        }
+    }
+
+    @ApplicationScoped
+    public static class MemoryIdProvider implements DefaultMemoryIdProvider {
+
+        static final String MEMORY_ID = "configured-memory-id";
+
+        @Override
+        public Object getMemoryId() {
+            return MEMORY_ID;
+        }
+    }
+
+    public static class ModelSupplier implements Supplier<ChatModel> {
+
+        @Override
+        public ChatModel get() {
+            return new ChatModel() {
+                @Override
+                public ChatResponse doChat(ChatRequest request) {
+                    return ChatResponse.builder().aiMessage(new AiMessage("ok")).build();
+                }
+            };
+        }
+    }
+
+    @Inject
+    ConfiguredService service;
+
+    @Inject
+    DefaultConfigService defaultConfigService;
+
+    @Inject
+    StoreConfiguredService storeConfiguredService;
+
+    @Test
+    @ActivateRequestContext
+    void configuresMemoryUsingBeanClass() {
+        assertEquals("ok", service.chat("hello", 1));
+        assertTrue(MemoryProvider.USED.get());
+    }
+
+    @Test
+    @ActivateRequestContext
+    void preservesDefaultMemoryConfigurationWhenNoAttributesAreSet() {
+        assertEquals("ok", defaultConfigService.chat("hello", 2));
+    }
+
+    @Test
+    @ActivateRequestContext
+    void configuresStoreWindowAndDefaultMemoryIdUsingBeanClasses() {
+        MemoryStore.MESSAGES.clear();
+        storeConfiguredService.chat("one");
+        storeConfiguredService.chat("two");
+        storeConfiguredService.chat("three");
+
+        assertTrue(MemoryStore.MESSAGES.containsKey(MemoryIdProvider.MEMORY_ID));
+        assertEquals(2, MemoryStore.MESSAGES.get(MemoryIdProvider.MEMORY_ID).size());
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolresolution/ToolConfigHallucinationStrategyTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolresolution/ToolConfigHallucinationStrategyTest.java
@@ -1,0 +1,88 @@
+package io.quarkiverse.langchain4j.test.toolresolution;
+
+import static dev.langchain4j.data.message.ChatMessageType.TOOL_EXECUTION_RESULT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ToolConfigHallucinationStrategyTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ConfiguredService.class, HallucinatingModelSupplier.class,
+                            HallucinationStrategy.class));
+
+    @RegisterAiService(chatLanguageModelSupplier = HallucinatingModelSupplier.class, toolHallucinationStrategy = HallucinationStrategy.class)
+    interface ConfiguredService {
+        String chat(@UserMessage String message, @MemoryId Object id);
+    }
+
+    @ApplicationScoped
+    public static class HallucinationStrategy
+            implements Function<ToolExecutionRequest, ToolExecutionResultMessage> {
+        @Override
+        public ToolExecutionResultMessage apply(ToolExecutionRequest request) {
+            return ToolExecutionResultMessage.from(request, "handled hallucinated tool");
+        }
+    }
+
+    public static class HallucinatingModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new ChatModel() {
+                @Override
+                public ChatResponse doChat(ChatRequest request) {
+                    List<ChatMessage> messages = request.messages();
+                    ChatMessage last = messages.get(messages.size() - 1);
+                    if (last.type() == TOOL_EXECUTION_RESULT) {
+                        return ChatResponse.builder()
+                                .aiMessage(new AiMessage(((ToolExecutionResultMessage) last).text()))
+                                .build();
+                    }
+                    ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+                            .id("missing")
+                            .name("missing_tool")
+                            .build();
+                    return ChatResponse.builder()
+                            .aiMessage(AiMessage.from(toolRequest))
+                            .finishReason(FinishReason.TOOL_EXECUTION)
+                            .build();
+                }
+            };
+        }
+    }
+
+    @Inject
+    ConfiguredService service;
+
+    @Test
+    @ActivateRequestContext
+    void configuresHallucinationStrategyUsingBeanClass() {
+        assertEquals("handled hallucinated tool", service.chat("hello", 1));
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolresolution/ToolConfigInvalidLimitTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolresolution/ToolConfigInvalidLimitTest.java
@@ -1,0 +1,32 @@
+package io.quarkiverse.langchain4j.test.toolresolution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ToolConfigInvalidLimitTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ConfiguredService.class, TestAiSupplier.class))
+            .assertException(error -> assertThat(error)
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("maxToolCallsPerResponse must be 0 or greater"));
+
+    @RegisterAiService(chatLanguageModelSupplier = TestAiSupplier.class, maxToolCallsPerResponse = -1)
+    interface ConfiguredService {
+        String chat(String message);
+    }
+
+    @Test
+    void rejectsNegativeLimit() {
+        // Asserted while the test application starts.
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolresolution/ToolConfigProviderTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolresolution/ToolConfigProviderTest.java
@@ -1,0 +1,69 @@
+package io.quarkiverse.langchain4j.test.toolresolution;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ToolConfigProviderTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestAiSupplier.class, TestAiModel.class, ConfiguredService.class,
+                            CombinedConfigService.class, DefaultConfigService.class, MyCustomToolProvider.class,
+                            ToolsClass.class));
+
+    @RegisterAiService(chatLanguageModelSupplier = TestAiSupplier.class, toolProvider = MyCustomToolProvider.class)
+    interface ConfiguredService {
+
+        String chat(@UserMessage String message, @MemoryId Object id);
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = TestAiSupplier.class, toolProvider = MyCustomToolProvider.class, tools = ToolsClass.class)
+    interface CombinedConfigService {
+        String chat(@UserMessage String message, @MemoryId Object id);
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = TestAiSupplier.class)
+    interface DefaultConfigService {
+        String chat(@UserMessage String message, @MemoryId Object id);
+    }
+
+    @Inject
+    ConfiguredService service;
+
+    @Inject
+    CombinedConfigService combinedService;
+
+    @Inject
+    DefaultConfigService defaultConfigService;
+
+    @Test
+    @ActivateRequestContext
+    void configuresProviderUsingBeanClass() {
+        assertEquals("TOOL1", service.chat("hello", 1));
+    }
+
+    @Test
+    @ActivateRequestContext
+    void combinesStaticToolsAndProviderUsingExistingPrecedence() {
+        assertEquals("\"EXPLICIT TOOL\"", combinedService.chat("hello", 2));
+    }
+
+    @Test
+    @ActivateRequestContext
+    void preservesDefaultToolConfigurationWhenNoAttributesAreSet() {
+        assertEquals("TOOL1", defaultConfigService.chat("hello", 3));
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolresolution/ToolConfigRoundTripsTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolresolution/ToolConfigRoundTripsTest.java
@@ -1,0 +1,81 @@
+package io.quarkiverse.langchain4j.test.toolresolution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ToolConfigRoundTripsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+
+    @RegisterAiService(chatLanguageModelSupplier = ModelSupplier.class, tools = Tools.class, maxToolCallingRoundTrips = 3)
+    interface AiService {
+        String chat(String message);
+    }
+
+    public static class ModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new ChatModel() {
+                @Override
+                public ChatResponse doChat(ChatRequest request) {
+                    return ChatResponse.builder()
+                            .aiMessage(AiMessage.from(ToolExecutionRequest.builder()
+                                    .name("dummy")
+                                    .id("dummy")
+                                    .arguments("{}")
+                                    .build()))
+                            .finishReason(FinishReason.TOOL_EXECUTION)
+                            .build();
+                }
+            };
+        }
+    }
+
+    @ApplicationScoped
+    public static class Tools {
+        static volatile int invocations;
+
+        @Tool
+        public String dummy() {
+            invocations++;
+            return "ok";
+        }
+    }
+
+    @Inject
+    AiService aiService;
+
+    @Test
+    @ActivateRequestContext
+    void limitsToolCallingRoundTrips() {
+        Tools.invocations = 0;
+        try {
+            aiService.chat("hello");
+        } catch (RuntimeException expected) {
+            // The model deliberately requests another tool call forever.
+        }
+        assertThat(Tools.invocations).isEqualTo(3);
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolsearch/ToolConfigTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolsearch/ToolConfigTest.java
@@ -1,0 +1,43 @@
+package io.quarkiverse.langchain4j.test.toolsearch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ToolConfigTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ToolSearchModel.class,
+                            ToolSearchModelSupplier.class,
+                            FakeToolSearchStrategy.class,
+                            BookingTools.class,
+                            ConfiguredService.class));
+
+    @RegisterAiService(chatLanguageModelSupplier = ToolSearchModelSupplier.class, tools = BookingTools.class, toolSearchStrategy = FakeToolSearchStrategy.class)
+    interface ConfiguredService {
+
+        String chat(@UserMessage String message, @MemoryId Object id);
+    }
+
+    @Inject
+    ConfiguredService service;
+
+    @Test
+    @ActivateRequestContext
+    void configuresToolsAndSearchStrategyUsingBeanClasses() {
+        assertEquals("REAL_TOOL_RESULT", service.chat("get my booking details", 1));
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/RegisterAiService.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/RegisterAiService.java
@@ -32,6 +32,7 @@ import io.quarkiverse.langchain4j.runtime.aiservice.BaseSystemMessageProvider;
 import io.quarkiverse.langchain4j.runtime.aiservice.ChatMemoryFlushStrategy;
 import io.quarkiverse.langchain4j.runtime.aiservice.SystemMessageProvider;
 import io.quarkiverse.langchain4j.runtime.aiservice.SystemMessageProviderWithContext;
+import io.quarkiverse.langchain4j.spi.DefaultMemoryIdProvider;
 
 /**
  * Used to create LangChain4j's {@link AiServices} in a declarative manner that the application can then use simply by
@@ -47,7 +48,7 @@ import io.quarkiverse.langchain4j.runtime.aiservice.SystemMessageProviderWithCon
  * NOTE: When the application also contains the {@code quarkus-micrometer} extension, metrics are automatically generated
  * for the method invocations.
  * <p>
- * See also {@link ToolBox}, {@link SeedMemory}
+ * See also {@link ToolBox}, {@link SeedMemory}.
  */
 @Retention(RUNTIME)
 @Target(ElementType.TYPE)
@@ -130,6 +131,33 @@ public @interface RegisterAiService {
     Class<? extends Function<ToolExecutionRequest, ToolExecutionResultMessage>> toolHallucinationStrategy() default BeanIfExistsToolHallucinationStrategy.class;
 
     /**
+     * Selects a specific {@link ChatMemoryProvider} CDI bean for this AI service.
+     * This cannot be combined with {@link #chatMemoryProviderSupplier()}, {@link #chatMemoryStore()}, or
+     * {@link #chatMemoryMaxMessages()}.
+     */
+    Class<? extends ChatMemoryProvider> chatMemoryProvider() default ChatMemoryProvider.class;
+
+    /**
+     * Selects the {@link ChatMemoryStore} CDI bean used by the message-window memory for this AI service.
+     */
+    Class<? extends ChatMemoryStore> chatMemoryStore() default ChatMemoryStore.class;
+
+    /**
+     * Maximum messages retained by the message-window memory for this AI service.
+     */
+    int chatMemoryMaxMessages() default 10;
+
+    /**
+     * Selects a {@link DefaultMemoryIdProvider} CDI bean used when an AI-service method has no explicit memory ID.
+     */
+    Class<? extends DefaultMemoryIdProvider> defaultMemoryIdProvider() default DefaultMemoryIdProvider.class;
+
+    /**
+     * Configures when changes to chat memory are persisted.
+     */
+    ChatMemoryFlushStrategy chatMemoryFlushStrategy() default ChatMemoryFlushStrategy.DEFERRED;
+
+    /**
      * Configures the way to obtain the {@link ChatMemoryProvider}.
      * <p>
      * Be default, Quarkus configures a {@link ChatMemoryProvider} bean that uses a {@link InMemoryChatMemoryStore} bean
@@ -197,6 +225,11 @@ public @interface RegisterAiService {
     Class<? extends Supplier<ToolProvider>> toolProviderSupplier() default BeanIfExistsToolProviderSupplier.class;
 
     /**
+     * Selects a specific {@link ToolProvider} CDI bean.
+     */
+    Class<? extends ToolProvider> toolProvider() default ToolProvider.class;
+
+    /**
      * Configures the {@link ToolSearchStrategy} used to let the model discover tools dynamically at inference time
      * instead of exposing the whole tool catalog upfront.
      * <p>
@@ -205,6 +238,11 @@ public @interface RegisterAiService {
      * Use {@link NoToolSearchStrategySupplier} to explicitly opt out even when such a bean is present.
      */
     Class<? extends Supplier<ToolSearchStrategy>> toolSearchStrategySupplier() default BeanIfExistsToolSearchStrategySupplier.class;
+
+    /**
+     * Selects a specific {@link ToolSearchStrategy} CDI bean.
+     */
+    Class<? extends ToolSearchStrategy> toolSearchStrategy() default ToolSearchStrategy.class;
 
     /**
      * By default, after first tool call execution, in subsequent prompts the {@code toolChoice} of

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/AiServicesRecorder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/AiServicesRecorder.java
@@ -19,6 +19,7 @@ import jakarta.enterprise.util.TypeLiteral;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
@@ -30,6 +31,7 @@ import dev.langchain4j.service.tool.ToolExecutionErrorHandler;
 import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.service.tool.search.ToolSearchService;
 import dev.langchain4j.service.tool.search.ToolSearchStrategy;
+import dev.langchain4j.store.memory.chat.ChatMemoryStore;
 import io.quarkiverse.langchain4j.DefaultToolExecutionErrorHandler;
 import io.quarkiverse.langchain4j.ModelName;
 import io.quarkiverse.langchain4j.RegisterAiService;
@@ -142,9 +144,14 @@ public class AiServicesRecorder {
 
                     QuarkusAiServiceContext aiServiceContext = new QuarkusAiServiceContext(serviceClass);
                     if (info.defaultMemoryIdProviderClassName() != null) {
-                        aiServiceContext.defaultMemoryIdProvider = (DefaultMemoryIdProvider) Thread
-                                .currentThread().getContextClassLoader().loadClass(info.defaultMemoryIdProviderClassName())
-                                .getConstructor().newInstance();
+                        Class<?> memoryIdProviderClass = loadClass(info.defaultMemoryIdProviderClassName());
+                        if (info.defaultMemoryIdProviderClassIsBean()) {
+                            aiServiceContext.defaultMemoryIdProvider = (DefaultMemoryIdProvider) creationalContext
+                                    .getInjectedReference(memoryIdProviderClass);
+                        } else {
+                            aiServiceContext.defaultMemoryIdProvider = (DefaultMemoryIdProvider) memoryIdProviderClass
+                                    .getConstructor().newInstance();
+                        }
                     }
 
                     // we don't really care about QuarkusAiServices here, all we care about is that it
@@ -254,7 +261,10 @@ public class AiServicesRecorder {
 
                     // if no explicit tools are provided, check if we should use a tool provider
                     if (info.toolProviderSupplier() != null) {
-                        if (!RegisterAiService.BeanIfExistsToolProviderSupplier.class.getName()
+                        if (info.toolProviderClassIsBean()) {
+                            quarkusAiServices.toolProvider((ToolProvider) creationalContext
+                                    .getInjectedReference(loadClass(info.toolProviderSupplier())));
+                        } else if (!RegisterAiService.BeanIfExistsToolProviderSupplier.class.getName()
                                 .equals(info.toolProviderSupplier())) {
                             // specific provider
                             Class<?> toolProviderClass = loadClass(info.toolProviderSupplier());
@@ -275,7 +285,10 @@ public class AiServicesRecorder {
 
                     if (info.toolSearchStrategySupplier() != null) {
                         ToolSearchStrategy toolSearchStrategy = null;
-                        if (RegisterAiService.BeanIfExistsToolSearchStrategySupplier.class.getName()
+                        if (info.toolSearchStrategyClassIsBean()) {
+                            toolSearchStrategy = (ToolSearchStrategy) creationalContext
+                                    .getInjectedReference(loadClass(info.toolSearchStrategySupplier()));
+                        } else if (RegisterAiService.BeanIfExistsToolSearchStrategySupplier.class.getName()
                                 .equals(info.toolSearchStrategySupplier())) {
                             Instance<ToolSearchStrategy> instance = creationalContext
                                     .getInjectedReference(TOOL_SEARCH_STRATEGY_TYPE_LITERAL);
@@ -294,7 +307,10 @@ public class AiServicesRecorder {
                     }
 
                     if (info.chatMemoryProviderSupplierClassName() != null) {
-                        if (RegisterAiService.BeanChatMemoryProviderSupplier.class.getName()
+                        if (info.chatMemoryProviderClassIsBean()) {
+                            quarkusAiServices.chatMemoryProvider((ChatMemoryProvider) creationalContext
+                                    .getInjectedReference(loadClass(info.chatMemoryProviderSupplierClassName())));
+                        } else if (RegisterAiService.BeanChatMemoryProviderSupplier.class.getName()
                                 .equals(info.chatMemoryProviderSupplierClassName())) {
                             quarkusAiServices.chatMemoryProvider(creationalContext.getInjectedReference(
                                     ChatMemoryProvider.class));
@@ -303,6 +319,14 @@ public class AiServicesRecorder {
                                     info.chatMemoryProviderSupplierClassName());
                             quarkusAiServices.chatMemoryProvider(supplier.get());
                         }
+                    } else if (info.chatMemoryStoreClassName() != null) {
+                        ChatMemoryStore chatMemoryStore = (ChatMemoryStore) creationalContext
+                                .getInjectedReference(loadClass(info.chatMemoryStoreClassName()));
+                        quarkusAiServices.chatMemoryProvider(memoryId -> MessageWindowChatMemory.builder()
+                                .id(memoryId)
+                                .maxMessages(info.chatMemoryMaxMessages())
+                                .chatMemoryStore(chatMemoryStore)
+                                .build());
                     }
 
                     if (info.retrievalAugmentorSupplierClassName() != null) {
@@ -401,6 +425,9 @@ public class AiServicesRecorder {
                         Supplier<? extends ChatMemoryFlushStrategy> supplier = createSupplier(
                                 info.chatMemoryFlushStrategySupplierClassName());
                         quarkusAiServices.chatMemoryFlushStrategy(supplier.get());
+                    } else if (info.chatMemoryFlushStrategy() != null) {
+                        quarkusAiServices.chatMemoryFlushStrategy(
+                                ChatMemoryFlushStrategy.valueOf(info.chatMemoryFlushStrategy()));
                     }
 
                     aiServiceContext.eventListenerRegistrar

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/ChatMemoryFlushStrategy.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/ChatMemoryFlushStrategy.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.langchain4j.runtime.aiservice;
 
+import io.quarkiverse.langchain4j.RegisterAiService;
+
 /**
  * <pre>
  * Controls when messages are flushed (persisted) to the ChatMemoryStore
@@ -18,13 +20,10 @@ package io.quarkiverse.langchain4j.runtime.aiservice;
  *   the current state of the conversation, even if the invocation
  *   eventually fails.
  *
+ * Configure it per AI service with {@link RegisterAiService#chatMemoryFlushStrategy()}.
  * Usage:
  *
- *   &#64;RegisterAiService(
- *       chatMemoryFlushStrategySupplier = MyFlushStrategySupplier.class
- *   )
- *
- * Where MyFlushStrategySupplier implements Supplier&lt;ChatMemoryFlushStrategy&gt;.
+ *   &#64;RegisterAiService(chatMemoryFlushStrategy = ChatMemoryFlushStrategy.IMMEDIATE)
  * </pre>
  */
 public enum ChatMemoryFlushStrategy {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/DeclarativeAiServiceCreateInfo.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/DeclarativeAiServiceCreateInfo.java
@@ -14,9 +14,15 @@ public record DeclarativeAiServiceCreateInfo(
         String streamingChatLanguageModelSupplierClassName,
         Map<String, AnnotationLiteral<?>> toolsClassInfo,
         String toolProviderSupplier,
+        boolean toolProviderClassIsBean,
         String toolSearchStrategySupplier,
+        boolean toolSearchStrategyClassIsBean,
         String chatMemoryProviderSupplierClassName,
+        boolean chatMemoryProviderClassIsBean,
         String chatMemoryFlushStrategySupplierClassName,
+        String chatMemoryFlushStrategy,
+        String chatMemoryStoreClassName,
+        Integer chatMemoryMaxMessages,
         String retrievalAugmentorSupplierClassName,
         String moderationModelSupplierClassName,
         String imageModelSupplierClassName,
@@ -39,5 +45,6 @@ public record DeclarativeAiServiceCreateInfo(
         boolean allowContinuousForcedToolCalling,
         boolean shouldThrowExceptionOnEventError,
         String defaultMemoryIdProviderClassName,
+        boolean defaultMemoryIdProviderClassIsBean,
         List<String> skillNames) {
 }

--- a/docs/modules/ROOT/pages/ai-services.adoc
+++ b/docs/modules/ROOT/pages/ai-services.adoc
@@ -113,6 +113,66 @@ public interface MyAiService {
 }
 ----
 
+=== Memory configuration
+
+Memory can be configured directly on `@RegisterAiService`. Provider, store, and default memory-ID provider classes
+are referenced as CDI beans; no supplier wrappers are required.
+
+[source,java]
+----
+@RegisterAiService(
+    chatMemoryStore = RedisChatMemoryStore.class,
+    chatMemoryMaxMessages = 20,
+    defaultMemoryIdProvider = TenantMemoryIdProvider.class,
+    chatMemoryFlushStrategy = ChatMemoryFlushStrategy.IMMEDIATE
+)
+public interface MyAiService {
+    String chat(@UserMessage String message);
+}
+----
+
+.`@RegisterAiService` memory attributes
+|===
+|Attribute |Description |Default
+
+|`chatMemoryProvider`
+|Concrete `ChatMemoryProvider` CDI bean class used by this service.
+|The same automatically selected provider used by `@RegisterAiService`
+
+|`chatMemoryStore`
+|Concrete `ChatMemoryStore` CDI bean used by the service's message-window memory.
+|The selected `ChatMemoryStore` bean
+
+|`chatMemoryMaxMessages`
+|Maximum number of messages retained by the message-window memory created for `store`.
+|`10`
+
+|`defaultMemoryIdProvider`
+|Concrete `DefaultMemoryIdProvider` CDI bean used when a method has no `@MemoryId` parameter.
+|The existing default memory-ID provider chain
+
+|`chatMemoryFlushStrategy`
+|Controls whether chat-memory changes are persisted after a successful invocation or immediately.
+|`DEFERRED`
+|===
+
+`chatMemoryProvider` is mutually exclusive with `chatMemoryStore` and `chatMemoryMaxMessages`, because a custom provider
+controls its own memory implementation and window. An explicit `@MemoryId` method parameter still takes precedence over
+the configured default memory-ID provider.
+
+For compatibility, `chatMemoryProviderSupplier` and `chatMemoryFlushStrategySupplier` on
+`@RegisterAiService` remain supported. A direct bean attribute and its corresponding supplier attribute cannot both be set.
+
+.Supplier migration
+[source,java]
+----
+// Before
+@RegisterAiService(chatMemoryProviderSupplier = MyMemoryProviderSupplier.class)
+
+// After
+@RegisterAiService(chatMemoryProvider = MyMemoryProvider.class)
+----
+
 === @SystemMessage
 
 The `@SystemMessage` annotation defines initial instructions or context for the LLM interaction.
@@ -568,4 +628,3 @@ Image generate(String prompt);
 * xref:models.adoc[LLM Configuration and Providers]
 * xref:rag.adoc[Retrieval-Augmented Generation (RAG)]
 * xref:function-calling.adoc[Function Calling and Tool Integration]
-

--- a/docs/modules/ROOT/pages/function-calling.adoc
+++ b/docs/modules/ROOT/pages/function-calling.adoc
@@ -55,6 +55,76 @@ interface Assistant {
 
 <1> Provide access to the `stringLength` method from the `Calculator` bean.
 
+Service-wide tools are configured on `@RegisterAiService`. Tool providers and search strategies can be referenced
+directly as CDI beans, without supplier wrappers.
+
+[source,java]
+----
+@RegisterAiService(
+    tools = {BookingTool.class, WeatherTool.class},
+    toolProvider = DynamicToolProvider.class,
+    toolSearchStrategy = SemanticToolSearchStrategy.class,
+    maxToolCallingRoundTrips = 5
+)
+public interface Assistant {
+    String chat(String message);
+}
+----
+
+.`@RegisterAiService` tool attributes
+|===
+|Attribute |Description |Default
+
+|`tools`
+|Tool CDI bean classes available to every method of the service.
+|Empty
+
+|`toolProvider`
+|Concrete `ToolProvider` CDI bean class that provides tools dynamically.
+|The same optional provider lookup used by `@RegisterAiService`
+
+|`toolSearchStrategy`
+|Concrete `ToolSearchStrategy` CDI bean class used for model-driven tool discovery.
+|The same optional strategy lookup used by `@RegisterAiService`
+
+|`toolHallucinationStrategy`
+|CDI bean used when the model requests an unknown tool.
+|The same optional strategy lookup used by `@RegisterAiService`
+
+|`maxToolCallingRoundTrips`
+|Maximum LLM request/response round trips for one service invocation. Zero uses global configuration.
+|`0`
+
+|`maxToolCallsPerResponse`
+|Maximum tool calls in one model response. Zero means unlimited.
+|`0`
+
+|`allowContinuousForcedToolCalling`
+|Keeps the initial forced tool choice after a tool call.
+|`false`
+|===
+
+The supplier-based provider and search-strategy attributes remain supported for compatibility. A direct bean attribute
+and its corresponding supplier attribute cannot both be set.
+
+.Supplier migration
+[source,java]
+----
+// Before
+@RegisterAiService(
+    tools = BookingTool.class,
+    toolProviderSupplier = DynamicToolProviderSupplier.class,
+    toolSearchStrategySupplier = SemanticToolSearchStrategySupplier.class
+)
+
+// After
+@RegisterAiService(
+    tools = BookingTool.class,
+    toolProvider = DynamicToolProvider.class,
+    toolSearchStrategy = SemanticToolSearchStrategy.class
+)
+----
+
 Alternatively, you can use `@RegisterAiService(tools=...)` to provide tools to all the methods from the AI service.
 Here's a simple example:
 


### PR DESCRIPTION
## Summary

Adds direct CDI bean configuration to the existing `@RegisterAiService` annotation, without introducing additional
top-level annotations.

Applications can now select concrete memory and tool infrastructure beans directly instead of creating supplier wrappers.
Existing supplier attributes remain supported for compatibility.

## New `@RegisterAiService` attributes

### Memory

- `chatMemoryProvider`
- `chatMemoryStore`
- `chatMemoryMaxMessages`
- `defaultMemoryIdProvider`
- `chatMemoryFlushStrategy`

When a store or message limit is configured, the extension creates a service-specific `MessageWindowChatMemory` backed
by the selected `ChatMemoryStore`. A configured default memory-ID provider is used only when an invocation has no explicit
memory ID.

### Tools

- `toolProvider`
- `toolSearchStrategy`

Existing attributes continue to configure static tools, hallucination handling, calling limits, and continuous forced
calling:

- `tools`
- `toolHallucinationStrategy`
- `maxToolCallingRoundTrips`
- `maxToolCallsPerResponse`
- `allowContinuousForcedToolCalling`

## CDI integration

Direct class references are resolved as CDI beans through the synthetic AI-service context. This preserves CDI scopes,
lifecycle, interception, and build-time validation. Missing referenced beans fail during augmentation.

## Compatibility

The supplier-based attributes remain supported:

- `chatMemoryProviderSupplier`
- `chatMemoryFlushStrategySupplier`
- `toolProviderSupplier`
- `toolSearchStrategySupplier`

A direct bean attribute and its corresponding supplier attribute cannot both be configured.

Additional validation rejects:

- combining `chatMemoryProvider` with `chatMemoryStore` or `chatMemoryMaxMessages`
- non-positive `chatMemoryMaxMessages`
- negative tool-call limits
- direct references that do not resolve to CDI beans

## Examples

```java
@RegisterAiService(
    chatMemoryStore = RedisChatMemoryStore.class,
    chatMemoryMaxMessages = 20,
    defaultMemoryIdProvider = TenantMemoryIdProvider.class,
    chatMemoryFlushStrategy = ChatMemoryFlushStrategy.IMMEDIATE
)
interface Assistant {
    String chat(@UserMessage String message);
}
```

```java
@RegisterAiService(
    tools = { BookingTool.class, WeatherTool.class },
    toolProvider = DynamicToolProvider.class,
    toolSearchStrategy = SemanticToolSearchStrategy.class,
    maxToolCallingRoundTrips = 5
)
interface Assistant {
    String chat(String message);
}
```

- Closes: #2577