### PR TITLE
Add AI service conversation resume support

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
@@ -2076,6 +2076,7 @@ public class AiServicesProcessor {
         validateReturnType(method);
 
         boolean requiresModeration = method.hasAnnotation(LangChain4jDotNames.MODERATE);
+        boolean resumeConversation = method.hasAnnotation(LangChain4jDotNames.RESUME_CONVERSATION);
         java.lang.reflect.Type returnType = javaLangReturnType(method);
 
         List<MethodParameterInfo> params = method.parameters();
@@ -2096,6 +2097,11 @@ public class AiServicesProcessor {
         Optional<AiServiceMethodCreateInfo.TemplateInfo> systemMessageInfo = gatherSystemMessageInfo(method, templateParams);
         AiServiceMethodCreateInfo.UserMessageInfo userMessageInfo = gatherUserMessageInfo(method, templateParams,
                 systemMessageInfo, fallbackToDummyUserMessagePredicate, chatRequestParametersParamPosition);
+        if (resumeConversation
+                && (userMessageInfo.template().isPresent() || userMessageInfo.paramPosition().isPresent())) {
+            throw illegalConfigurationForMethod(
+                    "A method annotated with @ResumeConversation must not define a user message", method);
+        }
 
         AiServiceMethodCreateInfo.ResponseSchemaInfo responseSchemaInfo = ResponseSchemaInfo.of(generateResponseSchema,
                 systemMessageInfo,
@@ -2146,7 +2152,7 @@ public class AiServicesProcessor {
 
         return new AiServiceMethodCreateInfo(method.declaringClass().name().toString(), method.name(), parameterInfoList,
                 systemMessageInfo,
-                userMessageInfo, memoryIdParamPosition, requiresModeration, methodReturnTypeSignature,
+                userMessageInfo, memoryIdParamPosition, requiresModeration, resumeConversation, methodReturnTypeSignature,
                 overrideChatModelParamPosition, chatRequestParametersParamPosition,
                 metricsTimedInfo, metricsCountedInfo, spanInfo, responseSchemaInfo,
                 methodToolClassInfo, methodMcpClientNames, switchToWorkerThreadForToolExecution,

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/LangChain4jDotNames.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/LangChain4jDotNames.java
@@ -48,6 +48,7 @@ import io.quarkiverse.langchain4j.ModelName;
 import io.quarkiverse.langchain4j.OnThinking;
 import io.quarkiverse.langchain4j.PdfUrl;
 import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.ResumeConversation;
 import io.quarkiverse.langchain4j.SeedMemory;
 import io.quarkiverse.langchain4j.VideoUrl;
 import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrail;
@@ -96,6 +97,7 @@ public class LangChain4jDotNames {
 
     public static final DotName MODEL_NAME = DotName.createSimple(ModelName.class);
     public static final DotName REGISTER_AI_SERVICES = DotName.createSimple(RegisterAiService.class);
+    static final DotName RESUME_CONVERSATION = DotName.createSimple(ResumeConversation.class);
 
     static final DotName BEAN_CHAT_MODEL_SUPPLIER = DotName.createSimple(
             RegisterAiService.BeanChatLanguageModelSupplier.class);

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ResumeConversationTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ResumeConversationTest.java
@@ -66,7 +66,7 @@ class ResumeConversationTest {
                 ToolExecutionResultMessage.from(toolRequest, "approved"));
         TestChatMemoryStore.MESSAGES.put(memoryId, new ArrayList<>(suspendedConversation));
 
-        assertThat(assistant.resume(memoryId)).isEqualTo("Continuing after approval");
+        assertThat(assistant.resume(memoryId)).isEqualTo("Conversation continued");
 
         assertThat(TestChatModel.lastRequest.messages()).containsExactlyElementsOf(suspendedConversation);
         assertThat(TestChatModel.lastRequest.messages()).filteredOn(UserMessage.class::isInstance).hasSize(1);
@@ -75,17 +75,27 @@ class ResumeConversationTest {
                         suspendedConversation.get(0),
                         suspendedConversation.get(1),
                         suspendedConversation.get(2),
-                        AiMessage.from("Continuing after approval")));
+                        AiMessage.from("Conversation continued")));
     }
 
     @Test
     @ActivateRequestContext
-    void rejectsConversationThatIsNotWaitingForAToolResult() {
-        String memoryId = "active-conversation";
-        TestChatMemoryStore.MESSAGES.put(memoryId, new ArrayList<>(List.of(UserMessage.from("Hello"))));
+    void resumesFromGeneralConversationHistory() {
+        String memoryId = "general-conversation";
+        List<ChatMessage> conversation = List.of(
+                UserMessage.from("Summarize our discussion"),
+                AiMessage.from("We discussed deployment options."));
+        TestChatMemoryStore.MESSAGES.put(memoryId, new ArrayList<>(conversation));
 
-        assertThatThrownBy(() -> assistant.resume(memoryId))
-                .hasMessageContaining("last chat memory message is a ToolExecutionResultMessage");
+        assertThat(assistant.resume(memoryId)).isEqualTo("Conversation continued");
+        assertThat(TestChatModel.lastRequest.messages()).containsExactlyElementsOf(conversation);
+    }
+
+    @Test
+    @ActivateRequestContext
+    void rejectsEmptyConversation() {
+        assertThatThrownBy(() -> assistant.resume("empty-conversation"))
+                .hasMessageContaining("Cannot resume a conversation with empty chat memory");
     }
 
     @RegisterAiService(chatLanguageModelSupplier = TestChatModelSupplier.class, chatMemoryProviderSupplier = TestChatMemoryProviderSupplier.class)
@@ -143,7 +153,7 @@ class ResumeConversationTest {
         public ChatResponse doChat(ChatRequest chatRequest) {
             lastRequest = chatRequest;
             return ChatResponse.builder()
-                    .aiMessage(AiMessage.from("Continuing after approval"))
+                    .aiMessage(AiMessage.from("Conversation continued"))
                     .build();
         }
     }

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ResumeConversationTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ResumeConversationTest.java
@@ -1,0 +1,150 @@
+package io.quarkiverse.langchain4j.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.store.memory.chat.ChatMemoryStore;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.ResumeConversation;
+import io.quarkus.test.QuarkusUnitTest;
+
+class ResumeConversationTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(Assistant.class, TestChatMemoryStore.class, TestChatMemoryProviderSupplier.class,
+                            TestChatModel.class, TestChatModelSupplier.class));
+
+    @Inject
+    Assistant assistant;
+
+    @BeforeEach
+    void reset() {
+        TestChatMemoryStore.MESSAGES.clear();
+        TestChatModel.lastRequest = null;
+    }
+
+    @Test
+    @ActivateRequestContext
+    void resumesFromToolResultWithoutAddingUserMessage() {
+        String memoryId = "conversation";
+        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+                .id("approval-1")
+                .name("requestApproval")
+                .arguments("{}")
+                .build();
+        List<ChatMessage> suspendedConversation = List.of(
+                UserMessage.from("Delete the deployment"),
+                AiMessage.from(toolRequest),
+                ToolExecutionResultMessage.from(toolRequest, "approved"));
+        TestChatMemoryStore.MESSAGES.put(memoryId, new ArrayList<>(suspendedConversation));
+
+        assertThat(assistant.resume(memoryId)).isEqualTo("Continuing after approval");
+
+        assertThat(TestChatModel.lastRequest.messages()).containsExactlyElementsOf(suspendedConversation);
+        assertThat(TestChatModel.lastRequest.messages()).filteredOn(UserMessage.class::isInstance).hasSize(1);
+        assertThat(TestChatMemoryStore.MESSAGES.get(memoryId))
+                .containsExactlyElementsOf(List.of(
+                        suspendedConversation.get(0),
+                        suspendedConversation.get(1),
+                        suspendedConversation.get(2),
+                        AiMessage.from("Continuing after approval")));
+    }
+
+    @Test
+    @ActivateRequestContext
+    void rejectsConversationThatIsNotWaitingForAToolResult() {
+        String memoryId = "active-conversation";
+        TestChatMemoryStore.MESSAGES.put(memoryId, new ArrayList<>(List.of(UserMessage.from("Hello"))));
+
+        assertThatThrownBy(() -> assistant.resume(memoryId))
+                .hasMessageContaining("last chat memory message is a ToolExecutionResultMessage");
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = TestChatModelSupplier.class, chatMemoryProviderSupplier = TestChatMemoryProviderSupplier.class)
+    interface Assistant {
+
+        @ResumeConversation
+        String resume(@MemoryId String memoryId);
+    }
+
+    public static class TestChatMemoryStore implements ChatMemoryStore {
+
+        static final Map<Object, List<ChatMessage>> MESSAGES = new ConcurrentHashMap<>();
+
+        @Override
+        public List<ChatMessage> getMessages(Object memoryId) {
+            return new ArrayList<>(MESSAGES.getOrDefault(memoryId, List.of()));
+        }
+
+        @Override
+        public void updateMessages(Object memoryId, List<ChatMessage> messages) {
+            MESSAGES.put(memoryId, new ArrayList<>(messages));
+        }
+
+        @Override
+        public void deleteMessages(Object memoryId) {
+            MESSAGES.remove(memoryId);
+        }
+    }
+
+    public static class TestChatMemoryProviderSupplier implements Supplier<ChatMemoryProvider> {
+
+        @Override
+        public ChatMemoryProvider get() {
+            return memoryId -> MessageWindowChatMemory.builder()
+                    .id(memoryId)
+                    .maxMessages(20)
+                    .chatMemoryStore(new TestChatMemoryStore())
+                    .build();
+        }
+    }
+
+    public static class TestChatModelSupplier implements Supplier<ChatModel> {
+
+        @Override
+        public ChatModel get() {
+            return new TestChatModel();
+        }
+    }
+
+    public static class TestChatModel implements ChatModel {
+
+        static ChatRequest lastRequest;
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            lastRequest = chatRequest;
+            return ChatResponse.builder()
+                    .aiMessage(AiMessage.from("Continuing after approval"))
+                    .build();
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/ResumeConversation.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/ResumeConversation.java
@@ -1,0 +1,16 @@
+package io.quarkiverse.langchain4j;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Marks an AI Service method that continues a conversation from the messages
+ * already present in chat memory, without adding a new user message.
+ */
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface ResumeConversation {
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/ResumeConversation.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/ResumeConversation.java
@@ -9,6 +9,10 @@ import java.lang.annotation.Target;
 /**
  * Marks an AI Service method that continues a conversation from the messages
  * already present in chat memory, without adding a new user message.
+ * <p>
+ * The chat memory must contain at least one message. The caller is responsible
+ * for ensuring that the stored message sequence is accepted by the configured
+ * model provider.
  */
 @Retention(RUNTIME)
 @Target(METHOD)

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodCreateInfo.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodCreateInfo.java
@@ -35,6 +35,7 @@ public final class AiServiceMethodCreateInfo {
     private final UserMessageInfo userMessageInfo;
     private final Optional<Integer> memoryIdParamPosition;
     private final boolean requiresModeration;
+    private final boolean resumeConversation;
     private final String returnTypeSignature; // transient so bytecode recording ignores it
     private final Optional<Integer> overrideChatModelParamPosition;
     private final Optional<Integer> chatRequestParametersParamPosition;
@@ -75,6 +76,7 @@ public final class AiServiceMethodCreateInfo {
             UserMessageInfo userMessageInfo,
             Optional<Integer> memoryIdParamPosition,
             boolean requiresModeration,
+            boolean resumeConversation,
             String returnTypeSignature,
             Optional<Integer> overrideChatModelParamPosition,
             Optional<Integer> chatRequestParametersParamPosition,
@@ -96,6 +98,7 @@ public final class AiServiceMethodCreateInfo {
         this.userMessageInfo = userMessageInfo;
         this.memoryIdParamPosition = memoryIdParamPosition;
         this.requiresModeration = requiresModeration;
+        this.resumeConversation = resumeConversation;
         this.returnTypeSignature = returnTypeSignature;
         this.overrideChatModelParamPosition = overrideChatModelParamPosition;
         this.chatRequestParametersParamPosition = chatRequestParametersParamPosition;
@@ -152,6 +155,10 @@ public final class AiServiceMethodCreateInfo {
 
     public boolean isRequiresModeration() {
         return requiresModeration;
+    }
+
+    public boolean isResumeConversation() {
+        return resumeConversation;
     }
 
     public String getReturnTypeSignature() {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
@@ -944,10 +944,6 @@ public class AiServiceMethodImplementationSupport {
         if (messages.isEmpty()) {
             throw illegalConfiguration("Cannot resume a conversation with empty chat memory");
         }
-        if (!(messages.get(messages.size() - 1) instanceof ToolExecutionResultMessage)) {
-            throw illegalConfiguration(
-                    "Cannot resume a conversation unless the last chat memory message is a ToolExecutionResultMessage");
-        }
         return messages;
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
@@ -288,7 +288,7 @@ public class AiServiceMethodImplementationSupport {
         }
 
         AugmentationResult augmentationResult = null;
-        if (context.retrievalAugmentor != null) {
+        if (!methodCreateInfo.isResumeConversation() && context.retrievalAugmentor != null) {
             Metadata metadata = Metadata.builder()
                     .chatMessage(userMessage)
                     .chatMemory(committableChatMemory.messages())
@@ -311,11 +311,20 @@ public class AiServiceMethodImplementationSupport {
                 .aiServiceListenerRegistrar(context.eventListenerRegistrar)
                 .build();
 
-        userMessage = GuardrailsSupport.executeInputGuardrails(guardrailService, userMessage, methodCreateInfo,
-                guardrailParams);
+        if (!methodCreateInfo.isResumeConversation()) {
+            userMessage = GuardrailsSupport.executeInputGuardrails(guardrailService, userMessage, methodCreateInfo,
+                    guardrailParams);
+        }
 
         List<ChatMessage> messagesToSend;
-        if (context.hasChatMemory()) {
+        if (methodCreateInfo.isResumeConversation()) {
+            if (!context.hasChatMemory()) {
+                throw illegalConfiguration(
+                        "AI Service method '%s' is annotated with @ResumeConversation but no chat memory is configured",
+                        methodCreateInfo.getMethodName());
+            }
+            messagesToSend = createMessagesToSendForResume(systemMessage, committableChatMemory);
+        } else if (context.hasChatMemory()) {
             messagesToSend = createMessagesToSendForExistingMemory(systemMessage, userMessage, committableChatMemory,
                     needsMemorySeed,
                     context, methodCreateInfo);
@@ -923,6 +932,23 @@ public class AiServiceMethodImplementationSupport {
 
         chatMemory.add(userMessage);
         return chatMemory.messages();
+    }
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    private static List<ChatMessage> createMessagesToSendForResume(Optional<SystemMessage> systemMessage,
+            CommittableChatMemory chatMemory) {
+        if (systemMessage.isPresent()) {
+            chatMemory.add(systemMessage.get());
+        }
+        List<ChatMessage> messages = chatMemory.messages();
+        if (messages.isEmpty()) {
+            throw illegalConfiguration("Cannot resume a conversation with empty chat memory");
+        }
+        if (!(messages.get(messages.size() - 1) instanceof ToolExecutionResultMessage)) {
+            throw illegalConfiguration(
+                    "Cannot resume a conversation unless the last chat memory message is a ToolExecutionResultMessage");
+        }
+        return messages;
     }
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")


### PR DESCRIPTION
## Summary

This PR adds `@ResumeConversation` for declarative AI Services, allowing an existing conversation to continue from persisted chat memory without adding a synthetic `UserMessage`.

```java
@RegisterAiService
interface Assistant {

    String chat(@MemoryId String conversationId, @UserMessage String message);

    @ResumeConversation
    String resume(@MemoryId String conversationId);
}
```

Calling `resume(conversationId)` loads the messages already associated with that memory ID and submits them to the model through the normal AI Service execution path.

## Why

Applications can receive or persist conversation messages outside a regular user-prompt invocation. A human-in-the-loop tool response is one example, but the requirement is more general: continue an existing conversation without recording or displaying a user message that was never entered by the user.

Using the low-level `ChatModel` API can submit the messages directly, but it bypasses the declarative AI Service abstraction and requires the application to reproduce its orchestration behavior.

This is separate from LangChain4j's agentic suspension and resume support. That feature operates on agentic workflows and `AgenticScope`; this PR supports applications using plain declarative AI Services and `ChatMemory`, without requiring the agentic module.

## Behavior

A method annotated with `@ResumeConversation`:

- loads the existing messages from the configured chat memory;
- does not create, append, or send a synthetic user message;
- supports both tool-result histories and other model-compatible message sequences;
- continues through the normal model and tool-calling loop;
- preserves output parsing, output guardrails, observability, response augmentation, and memory commits;
- skips retrieval augmentation and input guardrails because there is no new user input.

The conversation must contain at least one message. The caller remains responsible for providing a message sequence accepted by the configured model/provider.

At build time, a resume method is rejected if it also defines a user message.


- Closes: #2677.