### PR TITLE
Allow to use @Skills annotation also on AiServices methods

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
@@ -614,6 +614,8 @@ public class AiServicesProcessor {
                     skillNames = List.of();
                 }
             }
+            boolean hasMethodLevelSkills = declarativeAiServiceClassInfo.methods().stream()
+                    .anyMatch(m -> m.hasAnnotation(LangChain4jDotNames.SKILLS));
 
             declarativeAiServiceProducer.produce(new DeclarativeAiServiceBuildItem(
                     declarativeAiServiceClassInfo,
@@ -647,7 +649,8 @@ public class AiServicesProcessor {
                     impliedRegisterAiServiceTarget.contains(declarativeAiServiceClassInfo.name()),
                     shouldThrowExceptionOnEventError,
                     chatMemoryFlushStrategySupplierClassDotName,
-                    skillNames));
+                    skillNames,
+                    hasMethodLevelSkills));
 
         }
         toolProviderProducer.produce(new ToolProviderMetaBuildItem(toolProviderInfos));
@@ -1301,14 +1304,14 @@ public class AiServicesProcessor {
                 allToolSearchStrategies.add(toolSearchStrategy);
             }
 
-            if (bi.getSkillNames() != null) {
-                configurator.addInjectionPoint(ClassType.create(LangChain4jDotNames.SKILLS_CONFIGURATOR));
-            }
-
             configurator
                     .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
                             new Type[] { ClassType.create(OutputGuardrail.class) }, null))
                     .done();
+
+            if (bi.getSkillNames() != null || bi.hasMethodLevelSkills()) {
+                unremovableProducer.produce(UnremovableBeanBuildItem.beanTypes(LangChain4jDotNames.SKILLS_CONFIGURATOR));
+            }
 
             syntheticBeanProducer.produce(configurator.done());
         }
@@ -1364,6 +1367,19 @@ public class AiServicesProcessor {
             List<String> names = bi.getSkillNames();
             if (names != null && !names.isEmpty()) {
                 allSkillNames.addAll(names);
+            }
+            if (bi.hasMethodLevelSkills()) {
+                for (MethodInfo method : bi.getServiceClassInfo().methods()) {
+                    AnnotationInstance skillsAnnotation = method.declaredAnnotation(LangChain4jDotNames.SKILLS);
+                    if (skillsAnnotation != null) {
+                        AnnotationValue skillsValue = skillsAnnotation.value();
+                        if (skillsValue != null) {
+                            for (String name : skillsValue.asStringArray()) {
+                                allSkillNames.add(name);
+                            }
+                        }
+                    }
+                }
             }
         }
         if (!allSkillNames.isEmpty()) {
@@ -2126,6 +2142,7 @@ public class AiServicesProcessor {
                                 ToolQualifierProvider.BuildItem::getProvider).toList());
 
         List<String> methodMcpClientNames = gatherMethodMcpClientNames(method);
+        List<String> methodSkillNames = gatherMethodSkillNames(method, skipToolBoxPredicate);
         String accumulatorClassName = AiServicesMethodBuildItem.gatherAccumulator(method);
         String responseAugmenterClassName = AiServicesMethodBuildItem.gatherResponseAugmenter(method);
 
@@ -2149,7 +2166,7 @@ public class AiServicesProcessor {
                 userMessageInfo, memoryIdParamPosition, requiresModeration, methodReturnTypeSignature,
                 overrideChatModelParamPosition, chatRequestParametersParamPosition,
                 metricsTimedInfo, metricsCountedInfo, spanInfo, responseSchemaInfo,
-                methodToolClassInfo, methodMcpClientNames, switchToWorkerThreadForToolExecution,
+                methodToolClassInfo, methodMcpClientNames, methodSkillNames, switchToWorkerThreadForToolExecution,
                 accumulatorClassName, responseAugmenterClassName, gatherInputGuardrails(method),
                 gatherOutputGuardrails(method, methodReturnTypeSignature));
     }
@@ -2822,6 +2839,23 @@ public class AiServicesProcessor {
         }
 
         return Arrays.asList(mcpClientNames);
+    }
+
+    private List<String> gatherMethodSkillNames(MethodInfo method, Predicate<MethodInfo> skipPredicate) {
+        if (skipPredicate.test(method)) {
+            return null;
+        }
+        AnnotationInstance skillsInstance = method.declaredAnnotation(LangChain4jDotNames.SKILLS);
+        if (skillsInstance == null) {
+            return null;
+        }
+
+        AnnotationValue skillsValue = skillsInstance.value();
+        if (skillsValue != null && skillsValue.asStringArray().length > 0) {
+            return List.of(skillsValue.asStringArray());
+        }
+
+        return List.of();
     }
 
     private DotName determineThinkingHandler(ClassInfo iface, ClassOutput classOutput) {

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/DeclarativeAiServiceBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/DeclarativeAiServiceBuildItem.java
@@ -46,6 +46,7 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
     private final boolean shouldThrowExceptionOnEventError;
     private final DotName chatMemoryFlushStrategySupplierClassDotName;
     private final List<String> skillNames;
+    private final boolean hasMethodLevelSkills;
 
     public DeclarativeAiServiceBuildItem(
             ClassInfo serviceClassInfo,
@@ -77,7 +78,8 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
             boolean allowContinuousForcedToolCalling,
             boolean makeDefaultBean, boolean shouldThrowExceptionOnEventError,
             DotName chatMemoryFlushStrategySupplierClassDotName,
-            List<String> skillNames) {
+            List<String> skillNames,
+            boolean hasMethodLevelSkills) {
         this.serviceClassInfo = serviceClassInfo;
         this.chatLanguageModelSupplierClassDotName = chatLanguageModelSupplierClassDotName;
         this.streamingChatLanguageModelSupplierClassDotName = streamingChatLanguageModelSupplierClassDotName;
@@ -109,6 +111,7 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
         this.shouldThrowExceptionOnEventError = shouldThrowExceptionOnEventError;
         this.chatMemoryFlushStrategySupplierClassDotName = chatMemoryFlushStrategySupplierClassDotName;
         this.skillNames = skillNames;
+        this.hasMethodLevelSkills = hasMethodLevelSkills;
     }
 
     public ClassInfo getServiceClassInfo() {
@@ -266,6 +269,10 @@ public final class DeclarativeAiServiceBuildItem extends MultiBuildItem {
      */
     public List<String> getSkillNames() {
         return skillNames;
+    }
+
+    public boolean hasMethodLevelSkills() {
+        return hasMethodLevelSkills;
     }
 
 }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/AiServicesRecorder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/AiServicesRecorder.java
@@ -8,7 +8,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -16,12 +15,9 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.enterprise.util.TypeLiteral;
 
-import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.memory.chat.ChatMemoryProvider;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
-import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.image.ImageModel;
 import dev.langchain4j.model.moderation.ModerationModel;
 import dev.langchain4j.rag.RetrievalAugmentor;
@@ -406,18 +402,9 @@ public class AiServicesRecorder {
                     aiServiceContext.eventListenerRegistrar
                             .shouldThrowExceptionOnEventError(info.shouldThrowExceptionOnEventError());
 
-                    // @Skills annotation support
+                    // @Skills annotation support — store class-level names for per-method resolution in doImplement0()
                     if (info.skillNames() != null) {
-                        SkillsConfigurator configurator = creationalContext
-                                .getInjectedReference(SkillsConfigurator.class);
-                        if (configurator == null) {
-                            throw new IllegalStateException("@Skills annotation on '" + info.serviceClassName()
-                                    + "' requires the quarkus-langchain4j-skills extension");
-                        }
-                        java.util.List<String> names = info.skillNames();
-                        quarkusAiServices.toolProvider(configurator.createToolProvider(names));
-                        String skillsSystemMsg = configurator.buildSkillsSystemMessage(names);
-                        aiServiceContext.chatRequestTransformer = new SkillsChatRequestTransformer(skillsSystemMsg);
+                        aiServiceContext.classLevelSkillNames = info.skillNames();
                     }
 
                     return aiServiceContext;
@@ -459,29 +446,4 @@ public class AiServicesRecorder {
 
     }
 
-    private static final class SkillsChatRequestTransformer implements BiFunction<ChatRequest, Object, ChatRequest> {
-
-        private final String skillsSystemMsg;
-
-        SkillsChatRequestTransformer(String skillsSystemMsg) {
-            this.skillsSystemMsg = skillsSystemMsg;
-        }
-
-        @Override
-        public ChatRequest apply(ChatRequest request, Object memoryId) {
-            List<ChatMessage> messages = new ArrayList<>(request.messages());
-            boolean appended = false;
-            for (int i = 0; i < messages.size(); i++) {
-                if (messages.get(i) instanceof SystemMessage existing) {
-                    messages.set(i, SystemMessage.from(existing.text() + "\n\n" + skillsSystemMsg));
-                    appended = true;
-                    break;
-                }
-            }
-            if (!appended) {
-                messages.add(0, SystemMessage.from(skillsSystemMsg));
-            }
-            return request.toBuilder().messages(messages).build();
-        }
-    }
 }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodCreateInfo.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodCreateInfo.java
@@ -45,6 +45,7 @@ public final class AiServiceMethodCreateInfo {
     // support @Toolbox
     private final Map<String, AnnotationLiteral<?>> toolClassInfo;
     private final List<String> mcpClientNames;
+    private final List<String> skillNames;
     private final ResponseSchemaInfo responseSchemaInfo;
 
     // support for guardrails
@@ -84,6 +85,7 @@ public final class AiServiceMethodCreateInfo {
             ResponseSchemaInfo responseSchemaInfo,
             Map<String, AnnotationLiteral<?>> toolClassInfo,
             List<String> mcpClientNames,
+            List<String> skillNames,
             boolean switchToWorkerThreadForToolExecution,
             String outputTokenAccumulatorClassName,
             String responseAugmenterClassName,
@@ -111,6 +113,7 @@ public final class AiServiceMethodCreateInfo {
         this.responseSchemaInfo = responseSchemaInfo;
         this.toolClassInfo = toolClassInfo;
         this.mcpClientNames = mcpClientNames;
+        this.skillNames = skillNames;
         this.inputGuardrails = inputGuardrails;
         this.outputGuardrails = outputGuardrails;
         this.outputTokenAccumulatorClassName = outputTokenAccumulatorClassName;
@@ -192,6 +195,10 @@ public final class AiServiceMethodCreateInfo {
 
     public List<String> getMcpClientNames() {
         return mcpClientNames;
+    }
+
+    public List<String> getSkillNames() {
+        return skillNames;
     }
 
     public List<ToolSpecification> getToolSpecifications() {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
@@ -114,6 +114,7 @@ import io.quarkiverse.langchain4j.runtime.QuarkusServiceOutputParser;
 import io.quarkiverse.langchain4j.runtime.ResponseSchemaUtil;
 import io.quarkiverse.langchain4j.runtime.ToolCallsLimitExceededException;
 import io.quarkiverse.langchain4j.runtime.aiservice.GuardrailsSupport.OutputGuardrailStreamingMapper;
+import io.quarkiverse.langchain4j.runtime.skills.SkillsConfigurator;
 import io.quarkiverse.langchain4j.runtime.tool.QuarkusToolExecutor;
 import io.quarkiverse.langchain4j.runtime.types.TypeSignatureParser;
 import io.quarkiverse.langchain4j.runtime.types.TypeUtil;
@@ -287,6 +288,25 @@ public class AiServiceMethodImplementationSupport {
             }
         }
 
+        // @Skills annotation support — resolve per-method or class-level skills
+        List<String> effectiveSkillNames = methodCreateInfo.getSkillNames();
+        if (effectiveSkillNames == null && context instanceof QuarkusAiServiceContext) {
+            effectiveSkillNames = ((QuarkusAiServiceContext) context).classLevelSkillNames;
+        }
+        String skillsSystemMessage = null;
+        if (effectiveSkillNames != null) {
+            SkillsConfigurator configurator = Arc.container().select(SkillsConfigurator.class).get();
+            ToolProviderRequest skillsRequest = new QuarkusToolProviderRequest(invocationContext, userMessage,
+                    methodCreateInfo.getMcpClientNames());
+            ToolProviderResult skillsResult = configurator.createToolProvider(effectiveSkillNames)
+                    .provideTools(skillsRequest);
+            for (ToolSpecification spec : skillsResult.tools().keySet()) {
+                toolSpecifications.add(spec);
+                toolExecutors.put(spec.name(), skillsResult.tools().get(spec));
+            }
+            skillsSystemMessage = configurator.buildSkillsSystemMessage(effectiveSkillNames);
+        }
+
         AugmentationResult augmentationResult = null;
         if (context.retrievalAugmentor != null) {
             Metadata metadata = Metadata.builder()
@@ -322,6 +342,21 @@ public class AiServiceMethodImplementationSupport {
         } else {
             messagesToSend = createMessagesToSendForNoMemory(systemMessage, userMessage, needsMemorySeed, context,
                     methodCreateInfo);
+        }
+
+        if (skillsSystemMessage != null) {
+            boolean appended = false;
+            for (int i = 0; i < messagesToSend.size(); i++) {
+                if (messagesToSend.get(i) instanceof dev.langchain4j.data.message.SystemMessage existing) {
+                    messagesToSend.set(i,
+                            dev.langchain4j.data.message.SystemMessage.from(existing.text() + "\n\n" + skillsSystemMessage));
+                    appended = true;
+                    break;
+                }
+            }
+            if (!appended) {
+                messagesToSend.add(0, dev.langchain4j.data.message.SystemMessage.from(skillsSystemMessage));
+            }
         }
 
         if (TypeUtil.isTokenStream(returnType)) {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceContext.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/QuarkusAiServiceContext.java
@@ -4,6 +4,7 @@ import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import jakarta.enterprise.inject.Any;
@@ -34,6 +35,7 @@ public class QuarkusAiServiceContext extends AiServiceContext {
     public DefaultMemoryIdProvider defaultMemoryIdProvider;
     public ChatMemoryFlushStrategy chatMemoryFlushStrategy = ChatMemoryFlushStrategy.DEFERRED;
     public ToolSearchService toolSearchService;
+    public List<String> classLevelSkillNames;
 
     private boolean hasChatMemoryProvider;
 

--- a/docs/modules/ROOT/pages/skills.adoc
+++ b/docs/modules/ROOT/pages/skills.adoc
@@ -102,6 +102,40 @@ public interface PoemAiService {
 ----
 <1> Only the `poem-writing` skill is available. If the name does not match any loaded skill, the application will fail at startup.
 
+You can also place `@Skills` on individual methods to give each method its own set of skills:
+
+[source,java]
+----
+@RegisterAiService
+public interface TravelService {
+
+    @Skills("adventure-trip")
+    String planAdventure(@UserMessage String request);
+
+    @Skills("family-trip")
+    String planFamilyTrip(@UserMessage String request);
+}
+----
+
+When `@Skills` is present on both the interface and a method, the method-level annotation takes precedence.
+Methods without `@Skills` inherit the class-level skills.
+
+[source,java]
+----
+@RegisterAiService
+@Skills // <1>
+public interface TravelService {
+
+    @Skills("adventure-trip") // <2>
+    String planAdventure(@UserMessage String request);
+
+    String generalChat(@UserMessage String request); // <3>
+}
+----
+<1> Class-level: all skills available by default.
+<2> Method-level overrides: only `adventure-trip` is available here.
+<3> No method-level annotation: inherits all skills from the class.
+
 === With `@Agent`
 
 Place `@Skills` on the `@Agent`-annotated method:
@@ -120,6 +154,41 @@ public interface TripPlannerAgent {
 === Fail-fast validation
 
 If any skill name passed to `@Skills` does not match a loaded skill, the application will fail at startup with a clear error listing the available skill names.
+
+=== Custom `SkillsConfigurator`
+
+The built-in `DefaultSkillsConfigurator` generates an English system message describing the available skills.
+To customize the message (for example, to use a different language), provide your own `SkillsConfigurator` CDI bean.
+It will automatically override the default:
+
+[source,java]
+----
+@ApplicationScoped
+public class MySkillsConfigurator implements SkillsConfigurator {
+
+    @Inject
+    DefaultSkillsConfigurator delegate; // <1>
+
+    @Override
+    public ToolProvider createToolProvider(List<String> skillNames) {
+        return delegate.createToolProvider(skillNames);
+    }
+
+    @Override
+    public String formatAvailableSkills(List<String> skillNames) {
+        return delegate.formatAvailableSkills(skillNames);
+    }
+
+    @Override
+    public String buildSkillsSystemMessage(List<String> skillNames) {
+        return "Hai accesso alle seguenti competenze:\n"
+                + formatAvailableSkills(skillNames)
+                + "\nQuando la richiesta riguarda una di queste competenze, "
+                + "attivala prima con lo strumento `activate_skill`.";
+    }
+}
+----
+<1> You can inject and delegate to the default implementation to reuse its tool provider and formatting logic.
 
 == Using the `SkillsToolProvider`
 

--- a/skills/deployment/src/test/java/io/quarkiverse/langchain4j/skills/deployment/SkillsAiServiceIntegrationTest.java
+++ b/skills/deployment/src/test/java/io/quarkiverse/langchain4j/skills/deployment/SkillsAiServiceIntegrationTest.java
@@ -37,6 +37,8 @@ public class SkillsAiServiceIntegrationTest {
                             FilteredSkillsService.class,
                             SkillsWithSystemMessageService.class,
                             SkillsWithoutSystemMessageService.class,
+                            MethodLevelSkillsService.class,
+                            MethodOverridesClassService.class,
                             CapturingChatModelSupplier.class,
                             CapturingChatModel.class))
             .overrideRuntimeConfigKey("quarkus.langchain4j.skills.directories", SKILLS_DIR.toString());
@@ -93,6 +95,26 @@ public class SkillsAiServiceIntegrationTest {
         String chat(@UserMessage String msg);
     }
 
+    @RegisterAiService(chatLanguageModelSupplier = CapturingChatModelSupplier.class, chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
+    public interface MethodLevelSkillsService {
+        @Skills("foobar-skill")
+        String chatWithFoobar(@UserMessage String msg);
+
+        @Skills("bazqux-skill")
+        String chatWithBazqux(@UserMessage String msg);
+
+        String chatWithoutSkills(@UserMessage String msg);
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = CapturingChatModelSupplier.class, chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
+    @Skills
+    public interface MethodOverridesClassService {
+        @Skills("foobar-skill")
+        String chatWithFoobarOnly(@UserMessage String msg);
+
+        String chatInheritingClassSkills(@UserMessage String msg);
+    }
+
     @Inject
     AllSkillsService allSkillsService;
 
@@ -104,6 +126,12 @@ public class SkillsAiServiceIntegrationTest {
 
     @Inject
     SkillsWithoutSystemMessageService skillsWithoutSystemMessageService;
+
+    @Inject
+    MethodLevelSkillsService methodLevelSkillsService;
+
+    @Inject
+    MethodOverridesClassService methodOverridesClassService;
 
     @Test
     @ActivateRequestContext
@@ -147,6 +175,55 @@ public class SkillsAiServiceIntegrationTest {
         assertThat(response).contains("SYSTEM:");
         assertThat(response).contains("You have access to the following skills");
         assertThat(response).contains("foobar-skill");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void methodLevelSkillsWiresOnlyFoobarSkill() {
+        String response = methodLevelSkillsService.chatWithFoobar("hello");
+        assertThat(response).contains("SYSTEM:");
+        assertThat(response).contains("foobar-skill");
+        assertThat(response).doesNotContain("bazqux-skill");
+        assertThat(response).contains("TOOLS:");
+        assertThat(response).contains("activate_skill,");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void methodLevelSkillsWiresOnlyBazquxSkill() {
+        String response = methodLevelSkillsService.chatWithBazqux("hello");
+        assertThat(response).contains("SYSTEM:");
+        assertThat(response).contains("bazqux-skill");
+        assertThat(response).doesNotContain("foobar-skill");
+        assertThat(response).contains("TOOLS:");
+        assertThat(response).contains("activate_skill,");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void methodWithoutSkillsAnnotationHasNoSkills() {
+        String response = methodLevelSkillsService.chatWithoutSkills("hello");
+        assertThat(response).doesNotContain("foobar-skill");
+        assertThat(response).doesNotContain("bazqux-skill");
+        assertThat(response).doesNotContain("activate_skill");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void methodLevelSkillsOverrideClassLevel() {
+        String response = methodOverridesClassService.chatWithFoobarOnly("hello");
+        assertThat(response).contains("SYSTEM:");
+        assertThat(response).contains("foobar-skill");
+        assertThat(response).doesNotContain("bazqux-skill");
+    }
+
+    @Test
+    @ActivateRequestContext
+    void methodInheritsClassLevelSkillsWhenNoMethodAnnotation() {
+        String response = methodOverridesClassService.chatInheritingClassSkills("hello");
+        assertThat(response).contains("SYSTEM:");
+        assertThat(response).contains("foobar-skill");
+        assertThat(response).contains("bazqux-skill");
     }
 
 }

--- a/skills/deployment/src/test/java/io/quarkiverse/langchain4j/skills/deployment/SkillsChatMemoryTest.java
+++ b/skills/deployment/src/test/java/io/quarkiverse/langchain4j/skills/deployment/SkillsChatMemoryTest.java
@@ -1,0 +1,203 @@
+package io.quarkiverse.langchain4j.skills.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.skills.Skills;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verifies that invoking two AI service methods with different @Skills
+ * in a single conversation (shared chat memory) does not duplicate or
+ * corrupt the skills system message.
+ */
+public class SkillsChatMemoryTest {
+
+    private static final Path SKILLS_DIR = Path.of("src/test/resources/skills").toAbsolutePath();
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(
+                            MethodLevelSkillsWithMemoryService.class,
+                            SkillsWithSystemMessageService.class,
+                            CapturingChatModelSupplier.class,
+                            CapturingChatModel.class,
+                            TestChatMemoryProviderSupplier.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.skills.directories", SKILLS_DIR.toString());
+
+    public static class CapturingChatModel implements ChatModel {
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            StringBuilder sb = new StringBuilder();
+            for (ChatMessage msg : chatRequest.messages()) {
+                if (msg instanceof SystemMessage sysMsg) {
+                    sb.append("SYSTEM:").append(sysMsg.text());
+                }
+            }
+            if (chatRequest.toolSpecifications() != null && !chatRequest.toolSpecifications().isEmpty()) {
+                sb.append("|TOOLS:");
+                chatRequest.toolSpecifications().forEach(t -> sb.append(t.name()).append(","));
+            }
+            return ChatResponse.builder()
+                    .aiMessage(new AiMessage(sb.toString()))
+                    .build();
+        }
+    }
+
+    @Singleton
+    public static class CapturingChatModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new CapturingChatModel();
+        }
+    }
+
+    public static class TestChatMemoryProviderSupplier implements Supplier<ChatMemoryProvider> {
+        @Override
+        public ChatMemoryProvider get() {
+            return new ChatMemoryProvider() {
+                @Override
+                public ChatMemory get(Object memoryId) {
+                    return MessageWindowChatMemory.builder()
+                            .id(memoryId)
+                            .maxMessages(20)
+                            .build();
+                }
+            };
+        }
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = CapturingChatModelSupplier.class, chatMemoryProviderSupplier = TestChatMemoryProviderSupplier.class)
+    public interface MethodLevelSkillsWithMemoryService {
+        @Skills("foobar-skill")
+        String chatWithFoobar(@MemoryId String memoryId, @UserMessage String msg);
+
+        @Skills("bazqux-skill")
+        String chatWithBazqux(@MemoryId String memoryId, @UserMessage String msg);
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = CapturingChatModelSupplier.class, chatMemoryProviderSupplier = TestChatMemoryProviderSupplier.class)
+    public interface SkillsWithSystemMessageService {
+        @Skills("foobar-skill")
+        @dev.langchain4j.service.SystemMessage("You are a travel assistant.")
+        String chatWithFoobar(@MemoryId String memoryId, @UserMessage String msg);
+
+        @Skills("bazqux-skill")
+        @dev.langchain4j.service.SystemMessage("You are a cooking assistant.")
+        String chatWithBazqux(@MemoryId String memoryId, @UserMessage String msg);
+    }
+
+    @Inject
+    MethodLevelSkillsWithMemoryService service;
+
+    @Inject
+    SkillsWithSystemMessageService skillsWithSystemMessageService;
+
+    @Test
+    @ActivateRequestContext
+    void differentMethodSkillsInSameConversationDoNotDuplicate() {
+        String memoryId = "test-conversation";
+
+        // First call — foobar-skill method
+        String response1 = service.chatWithFoobar(memoryId, "hello foobar");
+        assertThat(response1).contains("foobar-skill");
+        assertThat(response1).doesNotContain("bazqux-skill");
+
+        // Second call — bazqux-skill method, same conversation
+        String response2 = service.chatWithBazqux(memoryId, "hello bazqux");
+        assertThat(response2).contains("bazqux-skill");
+        assertThat(response2).doesNotContain("foobar-skill");
+
+        // Verify no duplication: the skills system message should appear exactly once
+        long skillsMentions = countOccurrences(response2, "You have access to the following skills");
+        assertThat(skillsMentions).isEqualTo(1);
+    }
+
+    @Test
+    @ActivateRequestContext
+    void callingTheSameMethodTwiceDoesNotDuplicateSkillsMessage() {
+        String memoryId = "test-same-method";
+
+        String response1 = service.chatWithFoobar(memoryId, "first call");
+        assertThat(response1).contains("foobar-skill");
+
+        String response2 = service.chatWithFoobar(memoryId, "second call");
+        assertThat(response2).contains("foobar-skill");
+
+        long skillsMentions = countOccurrences(response2, "You have access to the following skills");
+        assertThat(skillsMentions).isEqualTo(1);
+    }
+
+    @Test
+    @ActivateRequestContext
+    void skillsAndSystemMessageMergedCorrectly() {
+        String memoryId = "test-skills-sysmsg";
+
+        // First call — foobar-skill + "You are a travel assistant."
+        String response1 = skillsWithSystemMessageService.chatWithFoobar(memoryId, "plan a trip");
+        assertThat(response1).contains("You are a travel assistant.");
+        assertThat(response1).contains("foobar-skill");
+        assertThat(response1).doesNotContain("bazqux-skill");
+        assertThat(response1).doesNotContain("cooking assistant");
+
+        // Second call — bazqux-skill + "You are a cooking assistant.", same conversation
+        String response2 = skillsWithSystemMessageService.chatWithBazqux(memoryId, "make pasta");
+        assertThat(response2).contains("You are a cooking assistant.");
+        assertThat(response2).contains("bazqux-skill");
+        assertThat(response2).doesNotContain("foobar-skill");
+        assertThat(response2).doesNotContain("travel assistant");
+
+        // Verify no duplication of skills preamble
+        assertThat(countOccurrences(response2, "You have access to the following skills")).isEqualTo(1);
+    }
+
+    @Test
+    @ActivateRequestContext
+    void skillsAndSystemMessageNoDuplicationAcrossCalls() {
+        String memoryId = "test-sysmsg-no-dup";
+
+        String response1 = skillsWithSystemMessageService.chatWithFoobar(memoryId, "first call");
+        assertThat(response1).contains("You are a travel assistant.");
+        assertThat(response1).contains("foobar-skill");
+
+        String response2 = skillsWithSystemMessageService.chatWithFoobar(memoryId, "second call");
+        assertThat(response2).contains("You are a travel assistant.");
+        assertThat(response2).contains("foobar-skill");
+        assertThat(countOccurrences(response2, "You have access to the following skills")).isEqualTo(1);
+        assertThat(countOccurrences(response2, "You are a travel assistant.")).isEqualTo(1);
+    }
+
+    private static long countOccurrences(String text, String substring) {
+        int count = 0;
+        int idx = 0;
+        while ((idx = text.indexOf(substring, idx)) != -1) {
+            count++;
+            idx += substring.length();
+        }
+        return count;
+    }
+}

--- a/skills/deployment/src/test/java/io/quarkiverse/langchain4j/skills/deployment/SkillsCustomConfiguratorTest.java
+++ b/skills/deployment/src/test/java/io/quarkiverse/langchain4j/skills/deployment/SkillsCustomConfiguratorTest.java
@@ -1,0 +1,109 @@
+package io.quarkiverse.langchain4j.skills.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.tool.ToolProvider;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.runtime.skills.SkillsConfigurator;
+import io.quarkiverse.langchain4j.skills.Skills;
+import io.quarkiverse.langchain4j.skills.runtime.DefaultSkillsConfigurator;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SkillsCustomConfiguratorTest {
+
+    private static final Path SKILLS_DIR = Path.of("src/test/resources/skills").toAbsolutePath();
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(
+                            CustomConfigurator.class,
+                            SkillsService.class,
+                            CapturingChatModelSupplier.class,
+                            CapturingChatModel.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.skills.directories", SKILLS_DIR.toString());
+
+    public static class CapturingChatModel implements ChatModel {
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            StringBuilder sb = new StringBuilder();
+            for (ChatMessage msg : chatRequest.messages()) {
+                if (msg instanceof SystemMessage sysMsg) {
+                    sb.append("SYSTEM:").append(sysMsg.text());
+                }
+            }
+            return ChatResponse.builder()
+                    .aiMessage(new AiMessage(sb.toString()))
+                    .build();
+        }
+    }
+
+    @Singleton
+    public static class CapturingChatModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new CapturingChatModel();
+        }
+    }
+
+    @ApplicationScoped
+    public static class CustomConfigurator implements SkillsConfigurator {
+
+        @Inject
+        DefaultSkillsConfigurator delegate;
+
+        @Override
+        public ToolProvider createToolProvider(List<String> skillNames) {
+            return delegate.createToolProvider(skillNames);
+        }
+
+        @Override
+        public String formatAvailableSkills(List<String> skillNames) {
+            return delegate.formatAvailableSkills(skillNames);
+        }
+
+        @Override
+        public String buildSkillsSystemMessage(List<String> skillNames) {
+            return "CUSTOM_MESSAGE: " + formatAvailableSkills(skillNames);
+        }
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = CapturingChatModelSupplier.class, chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
+    @Skills
+    public interface SkillsService {
+        String chat(@UserMessage String msg);
+    }
+
+    @Inject
+    SkillsService skillsService;
+
+    @Test
+    @ActivateRequestContext
+    void customConfiguratorOverridesDefault() {
+        String response = skillsService.chat("hello");
+        assertThat(response).contains("CUSTOM_MESSAGE:");
+        assertThat(response).contains("foobar-skill");
+        assertThat(response).doesNotContain("You have access to the following skills");
+    }
+}

--- a/skills/runtime/src/main/java/io/quarkiverse/langchain4j/skills/runtime/DefaultSkillsConfigurator.java
+++ b/skills/runtime/src/main/java/io/quarkiverse/langchain4j/skills/runtime/DefaultSkillsConfigurator.java
@@ -12,7 +12,9 @@ import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.skills.Skill;
 import dev.langchain4j.skills.Skills;
 import io.quarkiverse.langchain4j.runtime.skills.SkillsConfigurator;
+import io.quarkus.arc.DefaultBean;
 
+@DefaultBean
 @ApplicationScoped
 public class DefaultSkillsConfigurator implements SkillsConfigurator {
 


### PR DESCRIPTION
This is a follow up of the work done in this pull request https://github.com/quarkiverse/quarkus-langchain4j/pull/2654

It allows to use `@Skills` annottaion also on `AiServices` methods and also demonstrates how users can provide their own `SkillsConfigurator` implementation without CDI ambiguity.