### PR TITLE
feat: Add create-collections flag to Qdrant Dev Services

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-all-config.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-all-config.adoc
@@ -25371,6 +25371,27 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++qdrant+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-devservices-create-collections]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-devservices-create-collections[`+++quarkus.langchain4j.qdrant.devservices.create-collections+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.qdrant.devservices.create-collections+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to automatically create Qdrant collections for all configured named stores when Dev Services starts. Requires the collection vector-params to be configured.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_QDRANT_DEVSERVICES_CREATE_COLLECTIONS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_QDRANT_DEVSERVICES_CREATE_COLLECTIONS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-devservices-collection-vector-params-distance]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-devservices-collection-vector-params-distance[`+++quarkus.langchain4j.qdrant.devservices.collection.vector-params.distance+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.qdrant.devservices.collection.vector-params.distance+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-qdrant.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-qdrant.adoc
@@ -133,6 +133,27 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++qdrant+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-devservices-create-collections]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-devservices-create-collections[`+++quarkus.langchain4j.qdrant.devservices.create-collections+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.qdrant.devservices.create-collections+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to automatically create Qdrant collections for all configured named stores when Dev Services starts. Requires the collection vector-params to be configured.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_QDRANT_DEVSERVICES_CREATE_COLLECTIONS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_QDRANT_DEVSERVICES_CREATE_COLLECTIONS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-devservices-collection-vector-params-distance]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-devservices-collection-vector-params-distance[`+++quarkus.langchain4j.qdrant.devservices.collection.vector-params.distance+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.qdrant.devservices.collection.vector-params.distance+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-qdrant_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-qdrant_quarkus.langchain4j.adoc
@@ -133,6 +133,27 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++qdrant+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-devservices-create-collections]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-devservices-create-collections[`+++quarkus.langchain4j.qdrant.devservices.create-collections+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.qdrant.devservices.create-collections+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to automatically create Qdrant collections for all configured named stores when Dev Services starts. Requires the collection vector-params to be configured.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_QDRANT_DEVSERVICES_CREATE_COLLECTIONS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_QDRANT_DEVSERVICES_CREATE_COLLECTIONS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-devservices-collection-vector-params-distance]] [.property-path]##link:#quarkus-langchain4j-qdrant_quarkus-langchain4j-qdrant-devservices-collection-vector-params-distance[`+++quarkus.langchain4j.qdrant.devservices.collection.vector-params.distance+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.qdrant.devservices.collection.vector-params.distance+++[]

--- a/embedding-stores/qdrant/deployment/src/main/java/io/quarkiverse/langchain4j/qdrant/QdrantDevServiceCfg.java
+++ b/embedding-stores/qdrant/deployment/src/main/java/io/quarkiverse/langchain4j/qdrant/QdrantDevServiceCfg.java
@@ -1,12 +1,22 @@
 package io.quarkiverse.langchain4j.qdrant;
 
+import java.util.Map;
 import java.util.OptionalInt;
 
+/**
+ * @param namedStoreCollectionNames maps store name to resolved collection name for all named stores.
+ *        This replaces the previous {@code Set<String>} of store names so that the record's
+ *        {@code equals()} detects collection-name renames during hot-reload, triggering a
+ *        container restart. A simpler {@code Set<String>} of keys would suffice for host/port
+ *        propagation but would miss renames, leaving stale collections in the running container.
+ */
 record QdrantDevServiceCfg(
         boolean devServicesEnabled,
         OptionalInt fixedPort,
         String imageName,
         String serviceName,
         boolean shared,
-        QdrantVectorCfg vectorCfg) {
+        QdrantVectorCfg vectorCfg,
+        boolean createCollections,
+        Map<String, String> namedStoreCollectionNames) {
 }

--- a/embedding-stores/qdrant/deployment/src/main/java/io/quarkiverse/langchain4j/qdrant/QdrantDevServicesProcessor.java
+++ b/embedding-stores/qdrant/deployment/src/main/java/io/quarkiverse/langchain4j/qdrant/QdrantDevServicesProcessor.java
@@ -8,13 +8,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Supplier;
 
 import org.jboss.logging.Logger;
 
 import io.qdrant.client.QdrantClient;
 import io.qdrant.client.QdrantGrpcClient;
+import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -48,8 +48,6 @@ public class QdrantDevServicesProcessor {
             List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
             LoggingSetupBuildItem loggingSetupBuildItem,
             DevServicesConfig devServicesConfig) {
-
-        Set<String> namedStoreNames = qdrantBuildConfig.namedConfig().keySet();
 
         List<DevServicesResultBuildItem> result = new ArrayList<>();
         QdrantDevServiceCfg configuration = getConfiguration(qdrantBuildConfig);
@@ -85,8 +83,7 @@ public class QdrantDevServicesProcessor {
                     configuration,
                     launchMode,
                     devServicesConfig.timeout(),
-                    !devServicesSharedNetworkBuildItem.isEmpty(),
-                    namedStoreNames);
+                    !devServicesSharedNetworkBuildItem.isEmpty());
 
             if (newDevService != null) {
                 devService = newDevService;
@@ -141,8 +138,7 @@ public class QdrantDevServicesProcessor {
             QdrantDevServiceCfg config,
             LaunchModeBuildItem launchMode,
             Optional<Duration> timeout,
-            boolean useSharedNetwork,
-            Set<String> namedStoreNames) {
+            boolean useSharedNetwork) {
 
         if (!dockerStatusBuildItem.isDockerAvailable()) {
             LOG.warn("Docker isn't working, please configure the Qdrant server location.");
@@ -162,26 +158,38 @@ public class QdrantDevServicesProcessor {
 
             if (config.vectorCfg() != null) {
                 try (QdrantClient client = client(container)) {
-                    client
-                            .createCollectionAsync(
-                                    config.serviceName(),
-                                    io.qdrant.client.grpc.Collections.VectorParams.newBuilder()
-                                            .setDistance(config.vectorCfg().distance())
-                                            .setSize(config.vectorCfg().size())
-                                            .build())
-                            .get();
+                    var vectorParams = io.qdrant.client.grpc.Collections.VectorParams.newBuilder()
+                            .setDistance(config.vectorCfg().distance())
+                            .setSize(config.vectorCfg().size())
+                            .build();
+
+                    client.createCollectionAsync(config.serviceName(), vectorParams).get();
+
+                    if (config.createCollections()) {
+                        for (var entry : config.namedStoreCollectionNames().entrySet()) {
+                            var collectionName = entry.getValue();
+                            if (!collectionName.equals(config.serviceName())) {
+                                client.createCollectionAsync(collectionName, vectorParams).get();
+                                LOG.debugf("Created Qdrant collection '%s' for named store '%s'",
+                                        collectionName, entry.getKey());
+                            }
+                        }
+                    }
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }
+            } else if (config.createCollections() && !config.namedStoreCollectionNames().isEmpty()) {
+                LOG.warn("Cannot create collections for named stores: "
+                        + "vector parameters (quarkus.langchain4j.qdrant.devservices.collection.vector-params) "
+                        + "are not configured.");
             }
 
             return getRunningQdrantDevService(
-                    config.serviceName(),
+                    config,
                     container.getContainerId(),
                     container::close,
                     container.getHost(),
-                    container.getPort(),
-                    namedStoreNames);
+                    container.getPort());
         };
 
         return QdrantDevServices.LOCATOR
@@ -190,30 +198,35 @@ public class QdrantDevServicesProcessor {
                         config.shared(),
                         launchMode.getLaunchMode())
                 .map(containerAddress -> getRunningQdrantDevService(
-                        config.serviceName(),
+                        config,
                         containerAddress.getId(),
                         null,
                         containerAddress.getHost(),
-                        containerAddress.getPort(),
-                        namedStoreNames))
+                        containerAddress.getPort()))
                 .orElseGet(defaultQdrantSupplier);
     }
 
     private DevServicesResultBuildItem.RunningDevService getRunningQdrantDevService(
-            String serviceName,
+            QdrantDevServiceCfg config,
             String containerId,
             Closeable closeable,
             String host,
-            int port,
-            Set<String> namedStoreNames) {
+            int port) {
 
         Map<String, String> configMap = new HashMap<>();
-        configMap.put("quarkus.langchain4j.qdrant.collection.name", serviceName);
+        configMap.put("quarkus.langchain4j.qdrant.collection.name", config.serviceName());
         configMap.put("quarkus.langchain4j.qdrant.host", host);
         configMap.put("quarkus.langchain4j.qdrant.port", String.valueOf(port));
-        for (String namedStore : namedStoreNames) {
-            configMap.put("quarkus.langchain4j.qdrant." + namedStore + ".host", host);
-            configMap.put("quarkus.langchain4j.qdrant." + namedStore + ".port", String.valueOf(port));
+
+        for (var entry : config.namedStoreCollectionNames().entrySet()) {
+            var storeName = entry.getKey();
+            configMap.put("quarkus.langchain4j.qdrant." + storeName + ".host", host);
+            configMap.put("quarkus.langchain4j.qdrant." + storeName + ".port", String.valueOf(port));
+
+            if (config.createCollections()) {
+                configMap.put("quarkus.langchain4j.qdrant." + storeName + ".collection.name",
+                        entry.getValue());
+            }
         }
 
         return new DevServicesResultBuildItem.RunningDevService(
@@ -224,6 +237,17 @@ public class QdrantDevServicesProcessor {
     }
 
     private QdrantDevServiceCfg getConfiguration(QdrantEmbeddingStoreBuildTimeConfig cfg) {
+        Map<String, String> namedStoreCollectionNames = new HashMap<>();
+
+        for (var entry : cfg.namedConfig().entrySet()) {
+            var storeName = entry.getKey();
+            var collectionName = entry.getValue().collectionName()
+                    .filter(name -> !NamedConfigUtil.isDefault(name))
+                    .orElse(storeName);
+
+            namedStoreCollectionNames.put(storeName, collectionName);
+        }
+
         return new QdrantDevServiceCfg(
                 cfg.devservices().enabled(),
                 cfg.devservices().port(),
@@ -237,7 +261,9 @@ public class QdrantDevServicesProcessor {
 
                             return new QdrantVectorCfg(distance, c.vectorParams().size());
                         })
-                        .orElse(null));
+                        .orElse(null),
+                cfg.devservices().createCollections(),
+                namedStoreCollectionNames);
     }
 
     private QdrantClient client(QdrantContainer container) {

--- a/embedding-stores/qdrant/deployment/src/main/java/io/quarkiverse/langchain4j/qdrant/QdrantEmbeddingStoreBuildTimeConfig.java
+++ b/embedding-stores/qdrant/deployment/src/main/java/io/quarkiverse/langchain4j/qdrant/QdrantEmbeddingStoreBuildTimeConfig.java
@@ -84,6 +84,13 @@ public interface QdrantEmbeddingStoreBuildTimeConfig {
         String serviceName();
 
         /**
+         * Whether to automatically create Qdrant collections for all configured named stores
+         * when Dev Services starts. Requires the collection vector-params to be configured.
+         */
+        @WithDefault("false")
+        boolean createCollections();
+
+        /**
          * The Qdrant collection configuration.
          */
         Optional<CollectionConfig> collection();

--- a/embedding-stores/qdrant/deployment/src/test/java/io/quarkiverse/langchain4j/qdrant/QdrantCreateCollectionsDisabledTest.java
+++ b/embedding-stores/qdrant/deployment/src/test/java/io/quarkiverse/langchain4j/qdrant/QdrantCreateCollectionsDisabledTest.java
@@ -1,0 +1,59 @@
+package io.quarkiverse.langchain4j.qdrant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.qdrant.QdrantEmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verifies that when {@code create-collections} is not enabled (default),
+ * named store collections are NOT auto-created, so adding embeddings to them fails.
+ */
+public class QdrantCreateCollectionsDisabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.qdrant.devservices.service-name", "test_default")
+            .overrideConfigKey("quarkus.langchain4j.qdrant.devservices.collection.vector-params.distance", "Cosine")
+            .overrideConfigKey("quarkus.langchain4j.qdrant.devservices.collection.vector-params.size", "384")
+            .overrideConfigKey("quarkus.langchain4j.qdrant.products.collection-name", "product_embeddings");
+
+    @Inject
+    QdrantEmbeddingStore defaultEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("products")
+    QdrantEmbeddingStore productsEmbeddingStore;
+
+    @Test
+    void defaultStoreWorksBecauseCollectionIsCreated() {
+        var id = defaultEmbeddingStore.add(createEmbedding(), TextSegment.from("test default"));
+        assertThat(id).isNotNull();
+    }
+
+    @Test
+    void namedStoreFailsBecauseCollectionWasNotCreated() {
+        assertThatThrownBy(() -> productsEmbeddingStore.add(createEmbedding(), TextSegment.from("test products")))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    private static Embedding createEmbedding() {
+        var vector = new float[384];
+        for (int i = 0; i < vector.length; i++) {
+            vector[i] = i * 0.001f;
+        }
+        return new Embedding(vector);
+    }
+}

--- a/embedding-stores/qdrant/deployment/src/test/java/io/quarkiverse/langchain4j/qdrant/QdrantCreateCollectionsTest.java
+++ b/embedding-stores/qdrant/deployment/src/test/java/io/quarkiverse/langchain4j/qdrant/QdrantCreateCollectionsTest.java
@@ -1,0 +1,76 @@
+package io.quarkiverse.langchain4j.qdrant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.qdrant.QdrantEmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class QdrantCreateCollectionsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.qdrant.devservices.service-name", "test_default")
+            .overrideConfigKey("quarkus.langchain4j.qdrant.devservices.collection.vector-params.distance", "Cosine")
+            .overrideConfigKey("quarkus.langchain4j.qdrant.devservices.collection.vector-params.size", "384")
+            .overrideConfigKey("quarkus.langchain4j.qdrant.devservices.create-collections", "true")
+            .overrideConfigKey("quarkus.langchain4j.qdrant.products.collection-name", "product_embeddings")
+            .overrideConfigKey("quarkus.langchain4j.qdrant.documents.collection-name", "documents");
+
+    @Inject
+    QdrantEmbeddingStore defaultEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("products")
+    QdrantEmbeddingStore productsEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("documents")
+    QdrantEmbeddingStore documentsEmbeddingStore;
+
+    @Test
+    void defaultStoreIsFunctional() {
+        var id = defaultEmbeddingStore.add(createEmbedding(), TextSegment.from("test default"));
+        assertThat(id).isNotNull();
+    }
+
+    @Test
+    void namedStoreWithExplicitCollectionNameIsFunctional() {
+        var id = productsEmbeddingStore.add(createEmbedding(), TextSegment.from("test products"));
+        assertThat(id).isNotNull();
+    }
+
+    @Test
+    void namedStoreWithStoreNameAsCollectionNameIsFunctional() {
+        var id = documentsEmbeddingStore.add(createEmbedding(), TextSegment.from("test documents"));
+        assertThat(id).isNotNull();
+    }
+
+    @Test
+    void storesAreDistinct() {
+        assertThat(defaultEmbeddingStore)
+                .isNotSameAs(productsEmbeddingStore)
+                .isNotSameAs(documentsEmbeddingStore);
+
+        assertThat(productsEmbeddingStore)
+                .isNotSameAs(documentsEmbeddingStore);
+    }
+
+    private static Embedding createEmbedding() {
+        var vector = new float[384];
+        for (int i = 0; i < vector.length; i++) {
+            vector[i] = i * 0.001f;
+        }
+        return new Embedding(vector);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a `quarkus.langchain4j.qdrant.devservices.create-collections` config property (default: `false`) that automatically creates Qdrant collections for all configured named stores during Dev Services startup
- When enabled, uses the same vector-params (distance, size) configured for the default collection to create each named store's collection
- Propagates the resolved collection name into each named store's runtime config, so users don't need to separately configure both `collection-name` (build-time) and `collection.name` (runtime)

### Design note: `Map<String, String>` vs `Set<String>` in `QdrantDevServiceCfg`

The previous `Set<String>` of named store keys (passed as a method parameter) has been replaced with a `Map<String, String>` of store name → resolved collection name stored in the `QdrantDevServiceCfg` record. This is intentional: the record's `equals()` is used for hot-reload change detection, and a `Set<String>` of keys would not detect collection-name renames — leaving stale collections in the running container. A reviewer may reasonably prefer the simpler `Set<String>` approach if hot-reload detection of collection-name renames is considered unnecessary.