### PR TITLE
Add a Dev UI Guardrails page

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/devui/GuardrailInfo.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/devui/GuardrailInfo.java
@@ -1,0 +1,14 @@
+package io.quarkiverse.langchain4j.deployment.devui;
+
+import java.util.List;
+
+/**
+ * Build-time metadata for a single guardrail class, aggregated across everything that uses it.
+ * Powers the Dev UI "Guardrails" page, which is organized by guardrail class.
+ *
+ * @param className the fully qualified guardrail class name
+ * @param kind {@code "Input"}, {@code "Output"}, {@code "Tool input"} or {@code "Tool output"}
+ * @param usedBy the AI services and tool methods applying this guardrail
+ */
+public record GuardrailInfo(String className, String kind, List<GuardrailUsage> usedBy) {
+}

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/devui/GuardrailUsage.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/devui/GuardrailUsage.java
@@ -1,0 +1,19 @@
+package io.quarkiverse.langchain4j.deployment.devui;
+
+import java.util.List;
+
+/**
+ * A single application of a guardrail, either by an AI service or by a tool method.
+ *
+ * @param owner the fully qualified name of the AI service interface or tool class applying the guardrail
+ * @param method the method the guardrail is declared on, or {@code null} when it is declared at the AI service class
+ *        level (and thus applies to every method of the service); tool guardrails are always method-level
+ * @param position the 1-based position of the guardrail in that input/output chain
+ * @param maxRetries the max retries explicitly set on the output guardrail annotation, or {@code null} for input
+ *        guardrails, tool guardrails, and output guardrails that rely on the default/configured value
+ * @param excludedMethods for a class-level guardrail, the methods that declare their own guardrails of the same kind
+ *        and therefore override (and do not run) it; empty otherwise. A method-level annotation overrides the
+ *        class-level one of the same kind rather than adding to it.
+ */
+public record GuardrailUsage(String owner, String method, int position, Integer maxRetries, List<String> excludedMethods) {
+}

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/devui/LangChain4jDevUIProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/devui/LangChain4jDevUIProcessor.java
@@ -1,9 +1,19 @@
 package io.quarkiverse.langchain4j.deployment.devui;
 
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
 
 import io.quarkiverse.langchain4j.deployment.DeclarativeAiServiceBuildItem;
 import io.quarkiverse.langchain4j.deployment.EmbeddingStoreBuildItem;
@@ -18,6 +28,7 @@ import io.quarkiverse.langchain4j.deployment.items.SelectedChatModelProviderBuil
 import io.quarkiverse.langchain4j.runtime.devui.ChatJsonRPCService;
 import io.quarkiverse.langchain4j.runtime.devui.EmbeddingStoreJsonRPCService;
 import io.quarkiverse.langchain4j.runtime.tool.ToolMethodCreateInfo;
+import io.quarkiverse.langchain4j.runtime.tool.guardrails.ToolGuardrailAnnotationLiteral;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -39,6 +50,7 @@ public class LangChain4jDevUIProcessor {
             List<AdditionalDevUiCardBuildItem> additionalDevUiCardBuildItems) {
         CardPageBuildItem card = new CardPageBuildItem();
         addAiServicesPage(card, aiServices);
+        addGuardrailsPage(card, aiServices, toolsMetadataBuildItem);
         if (toolsMetadataBuildItem != null) {
             addToolsPage(card, toolsMetadataBuildItem);
         }
@@ -87,6 +99,133 @@ public class LangChain4jDevUIProcessor {
                 .componentLink("qwc-aiservices.js")
                 .staticLabel(String.valueOf(aiServices.size()))
                 .icon("font-awesome-solid:robot"));
+    }
+
+    private void addGuardrailsPage(CardPageBuildItem card, List<DeclarativeAiServiceBuildItem> aiServices,
+            ToolsMetadataBuildItem toolsMetadataBuildItem) {
+        List<RawGuardrail> raw = new ArrayList<>();
+        for (DeclarativeAiServiceBuildItem aiService : aiServices) {
+            ClassInfo serviceClassInfo = aiService.getServiceClassInfo();
+            String serviceName = serviceClassInfo.name().toString();
+            List<MethodInfo> methods = serviceClassInfo.methods();
+
+            // A method-level annotation overrides the class-level one of the same kind, so a class-level guardrail does
+            // not run on methods that declare their own guardrails of that kind.
+            List<String> inputOverrides = overridingMethods(methods, LangChain4jDotNames.INPUT_GUARDRAILS);
+            List<String> outputOverrides = overridingMethods(methods, LangChain4jDotNames.OUTPUT_GUARDRAILS);
+
+            collectGuardrails(raw, serviceName, null, serviceClassInfo.declaredAnnotation(LangChain4jDotNames.INPUT_GUARDRAILS),
+                    "Input", inputOverrides);
+            collectGuardrails(raw, serviceName, null,
+                    serviceClassInfo.declaredAnnotation(LangChain4jDotNames.OUTPUT_GUARDRAILS),
+                    "Output", outputOverrides);
+
+            for (MethodInfo method : methods) {
+                collectGuardrails(raw, serviceName, method.name(), method.annotation(LangChain4jDotNames.INPUT_GUARDRAILS),
+                        "Input", List.of());
+                collectGuardrails(raw, serviceName, method.name(), method.annotation(LangChain4jDotNames.OUTPUT_GUARDRAILS),
+                        "Output", List.of());
+            }
+        }
+
+        if (toolsMetadataBuildItem != null) {
+            for (Map.Entry<String, List<ToolMethodCreateInfo>> toolClassEntry : toolsMetadataBuildItem.getMetadata()
+                    .entrySet()) {
+                String toolClassName = toolClassEntry.getKey();
+                for (ToolMethodCreateInfo tool : toolClassEntry.getValue()) {
+                    collectToolGuardrails(raw, toolClassName, tool.methodName(), tool.getInputGuardrails(), "Tool input");
+                    collectToolGuardrails(raw, toolClassName, tool.methodName(), tool.getOutputGuardrails(), "Tool output");
+                }
+            }
+        }
+
+        List<GuardrailInfo> infos = buildGuardrailInfos(raw);
+        if (infos.isEmpty()) {
+            return;
+        }
+
+        card.addBuildTimeData("guardrails", infos);
+        card.addPage(Page.webComponentPageBuilder().title("Guardrails")
+                .componentLink("qwc-guardrails.js")
+                .staticLabel(String.valueOf(infos.size()))
+                .icon("font-awesome-solid:shield-halved"));
+    }
+
+    private static List<String> overridingMethods(List<MethodInfo> methods, DotName kind) {
+        return methods.stream()
+                .filter(method -> method.annotation(kind) != null)
+                .map(MethodInfo::name)
+                .distinct()
+                .sorted()
+                .toList();
+    }
+
+    private static void collectGuardrails(List<RawGuardrail> raw, String owner, String method,
+            AnnotationInstance annotation, String kind, List<String> excludedMethods) {
+        if (annotation == null) {
+            return;
+        }
+        Type[] guardrailClasses = annotation.value().asClassArray();
+        Integer maxRetries = null;
+        if ("Output".equals(kind)) {
+            AnnotationValue maxRetriesValue = annotation.value("maxRetries");
+            maxRetries = maxRetriesValue == null ? null : maxRetriesValue.asInt();
+        }
+        for (int i = 0; i < guardrailClasses.length; i++) {
+            raw.add(new RawGuardrail(guardrailClasses[i].name().toString(), kind, owner, method, i + 1, maxRetries,
+                    excludedMethods));
+        }
+    }
+
+    private static void collectToolGuardrails(List<RawGuardrail> raw, String toolClass, String method,
+            ToolGuardrailAnnotationLiteral<?, ?> guardrails, String kind) {
+        if (guardrails == null) {
+            return;
+        }
+        List<String> classNames = guardrails.getClassNames();
+        for (int i = 0; i < classNames.size(); i++) {
+            raw.add(new RawGuardrail(classNames.get(i), kind, toolClass, method, i + 1, null, List.of()));
+        }
+    }
+
+    /**
+     * Inverts the per-owner guardrail declarations into a list keyed by guardrail class, so the Dev UI can show, for
+     * each guardrail, its kind and every AI service or tool method using it, with its position in the chain. Kept
+     * package-private and free of build items/Jandex so it can be unit tested.
+     */
+    static List<GuardrailInfo> buildGuardrailInfos(List<RawGuardrail> raw) {
+        // className -> kind -> usages
+        Map<String, Map<String, List<GuardrailUsage>>> acc = new TreeMap<>();
+        for (RawGuardrail guardrail : raw) {
+            acc.computeIfAbsent(guardrail.guardrailClassName(), k -> new HashMap<>())
+                    .computeIfAbsent(guardrail.kind(), k -> new ArrayList<>())
+                    .add(new GuardrailUsage(guardrail.owner(), guardrail.method(), guardrail.position(),
+                            guardrail.maxRetries(), guardrail.excludedMethods()));
+        }
+
+        Comparator<GuardrailUsage> byOwnerMethodPosition = Comparator.comparing(GuardrailUsage::owner)
+                .thenComparing(usage -> usage.method() == null ? "" : usage.method())
+                .thenComparingInt(GuardrailUsage::position);
+        List<GuardrailInfo> result = new ArrayList<>();
+        for (Map.Entry<String, Map<String, List<GuardrailUsage>>> classEntry : acc.entrySet()) {
+            // Stable, readable order when a guardrail class is used in more than one role.
+            for (String kind : List.of("Input", "Output", "Tool input", "Tool output")) {
+                List<GuardrailUsage> usages = classEntry.getValue().get(kind);
+                if (usages != null) {
+                    usages.sort(byOwnerMethodPosition);
+                    result.add(new GuardrailInfo(classEntry.getKey(), kind, usages));
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * A single guardrail declaration flattened out of the AI service or tool metadata, decoupled from Jandex to keep
+     * {@link #buildGuardrailInfos} testable.
+     */
+    record RawGuardrail(String guardrailClassName, String kind, String owner, String method, int position,
+            Integer maxRetries, List<String> excludedMethods) {
     }
 
     private void addToolsPage(CardPageBuildItem card, ToolsMetadataBuildItem metadataBuildItem) {

--- a/core/deployment/src/main/resources/dev-ui/qwc-guardrails.js
+++ b/core/deployment/src/main/resources/dev-ui/qwc-guardrails.js
@@ -1,0 +1,119 @@
+import {css, html, LitElement} from 'lit';
+import '@vaadin/grid';
+import '@vaadin/grid/vaadin-grid-sort-column.js';
+import {columnBodyRenderer} from '@vaadin/grid/lit.js';
+
+import {guardrails} from 'build-time-data';
+
+/**
+ * Lists the guardrails registered in the application, organized by guardrail class: its kind
+ * (input/output, plus the tool variants), and every AI service or tool method applying it, with
+ * its position in the chain and, for output guardrails, the configured max retries.
+ */
+export class QwcGuardrails extends LitElement {
+
+    static styles = css`
+        :host {
+            height: 100%;
+            display: flex;
+        }
+
+        vaadin-grid {
+            margin-left: 15px;
+            margin-right: 15px;
+            height: 100%;
+        }
+
+        .kind {
+            display: inline-block;
+            padding: 1px 8px;
+            border-radius: var(--lumo-border-radius-s);
+            font-size: var(--lumo-font-size-xs);
+            font-weight: 600;
+            color: var(--lumo-base-color);
+        }
+
+        .kind.input {
+            background-color: var(--lumo-primary-color);
+        }
+
+        .kind.output {
+            background-color: var(--lumo-success-color);
+        }
+
+        .usage {
+            padding: 2px 0;
+            overflow-wrap: anywhere;
+        }
+
+        .scope {
+            color: var(--lumo-secondary-text-color);
+        }
+    `;
+
+    static properties = {
+        "_guardrails": {state: true},
+    }
+
+    constructor() {
+        super();
+        this._guardrails = guardrails;
+    }
+
+    render() {
+        if (this._guardrails && this._guardrails.length > 0) {
+            return this._renderGuardrailsTable();
+        } else {
+            return html`<span>No guardrails found</span>`;
+        }
+    }
+
+    _renderGuardrailsTable() {
+        return html`
+            <vaadin-grid .items="${this._guardrails}" theme="no-border row-stripes wrap-cell-content">
+                <vaadin-grid-sort-column auto-width
+                                         flex-grow="0"
+                                         path="className"
+                                         header="Guardrail">
+                </vaadin-grid-sort-column>
+                <vaadin-grid-sort-column auto-width
+                                         flex-grow="0"
+                                         path="kind"
+                                         header="Type"
+                                         ${columnBodyRenderer(this._kindRenderer, [])}>
+                </vaadin-grid-sort-column>
+                <vaadin-grid-column path="usedBy"
+                                    header="Used by"
+                                    ${columnBodyRenderer(this._usedByRenderer, [])}>
+                </vaadin-grid-column>
+            </vaadin-grid>`;
+    }
+
+    _kindRenderer(guardrail) {
+        const direction = guardrail.kind.toLowerCase().includes('output') ? 'output' : 'input';
+        return html`<span class="kind ${direction}">${guardrail.kind}</span>`;
+    }
+
+    _usedByRenderer(guardrail) {
+        return html`${guardrail.usedBy.map((usage) => html`
+            <div class="usage">
+                <code>${usage.owner}</code>
+                <span class="scope">
+                    &mdash; ${this._scope(usage)} &middot; #${usage.position}${usage.maxRetries != null ? html`, max retries: ${usage.maxRetries}` : ''}
+                </span>
+            </div>`)}`;
+    }
+
+    _scope(usage) {
+        if (usage.method != null) {
+            return html`${usage.method}()`;
+        }
+        if (usage.excludedMethods && usage.excludedMethods.length > 0) {
+            return html`all methods except ${usage.excludedMethods.map((m) => m + '()').join(', ')}`;
+        }
+        return 'all methods';
+    }
+
+}
+
+customElements.define('qwc-guardrails', QwcGuardrails);

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/deployment/devui/GuardrailInfoBuilderTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/deployment/devui/GuardrailInfoBuilderTest.java
@@ -1,0 +1,109 @@
+package io.quarkiverse.langchain4j.deployment.devui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.langchain4j.deployment.devui.LangChain4jDevUIProcessor.RawGuardrail;
+
+class GuardrailInfoBuilderTest {
+
+    @Test
+    void emptyInputProducesEmptyList() {
+        assertThat(LangChain4jDevUIProcessor.buildGuardrailInfos(List.of())).isEmpty();
+    }
+
+    @Test
+    void guardrailSharedBySeveralServicesIsGroupedAndSortedByService() {
+        var infos = LangChain4jDevUIProcessor.buildGuardrailInfos(List.of(
+                new RawGuardrail("com.acme.PiiGuard", "Input", "com.acme.Zeta", null, 1, null, List.of()),
+                new RawGuardrail("com.acme.PiiGuard", "Input", "com.acme.Alpha", null, 1, null, List.of())));
+
+        assertThat(infos).singleElement().satisfies(info -> {
+            assertThat(info.className()).isEqualTo("com.acme.PiiGuard");
+            assertThat(info.kind()).isEqualTo("Input");
+            assertThat(info.usedBy()).extracting(GuardrailUsage::owner)
+                    .containsExactly("com.acme.Alpha", "com.acme.Zeta");
+            assertThat(info.usedBy()).allSatisfy(usage -> {
+                assertThat(usage.position()).isEqualTo(1);
+                assertThat(usage.method()).isNull();
+                assertThat(usage.maxRetries()).isNull();
+            });
+        });
+    }
+
+    @Test
+    void classLevelAndMethodLevelUsagesCoexistAndSortByMethod() {
+        var infos = LangChain4jDevUIProcessor.buildGuardrailInfos(List.of(
+                new RawGuardrail("com.acme.PiiGuard", "Input", "com.acme.Assistant", null, 1, null, List.of()),
+                new RawGuardrail("com.acme.PiiGuard", "Input", "com.acme.Assistant", "chat", 1, null, List.of())));
+
+        assertThat(infos).singleElement().satisfies(info -> assertThat(info.usedBy())
+                .extracting(GuardrailUsage::method)
+                // class-level (null) sorts first, then method-level
+                .containsExactly(null, "chat"));
+    }
+
+    @Test
+    void classLevelGuardrailKeepsTheMethodsThatOverrideItAsExcluded() {
+        var infos = LangChain4jDevUIProcessor.buildGuardrailInfos(List.of(
+                new RawGuardrail("com.acme.PiiGuard", "Input", "com.acme.Assistant", null, 1, null, List.of("chat")),
+                new RawGuardrail("com.acme.OwnGuard", "Input", "com.acme.Assistant", "chat", 1, null, List.of())));
+
+        assertThat(infos).filteredOn(info -> info.className().equals("com.acme.PiiGuard"))
+                .singleElement()
+                .satisfies(info -> assertThat(info.usedBy()).singleElement()
+                        .satisfies(usage -> assertThat(usage.excludedMethods()).containsExactly("chat")));
+    }
+
+    @Test
+    void positionReflectsChainOrderAndOutputCarriesMaxRetries() {
+        var infos = LangChain4jDevUIProcessor.buildGuardrailInfos(List.of(
+                new RawGuardrail("com.acme.FirstOut", "Output", "com.acme.Assistant", "chat", 1, 3, List.of()),
+                new RawGuardrail("com.acme.SecondOut", "Output", "com.acme.Assistant", "chat", 2, 3, List.of())));
+
+        assertThat(infos).extracting(GuardrailInfo::className, GuardrailInfo::kind)
+                .containsExactly(
+                        // TreeMap orders by class name: FirstOut before SecondOut
+                        tuple("com.acme.FirstOut", "Output"),
+                        tuple("com.acme.SecondOut", "Output"));
+
+        assertThat(infos.get(0).usedBy().get(0).position()).isEqualTo(1);
+        assertThat(infos.get(0).usedBy().get(0).maxRetries()).isEqualTo(3);
+        assertThat(infos.get(1).usedBy().get(0).position()).isEqualTo(2);
+    }
+
+    @Test
+    void toolGuardrailsCarryToolClassAndMethodWithNoMaxRetries() {
+        var infos = LangChain4jDevUIProcessor.buildGuardrailInfos(List.of(
+                new RawGuardrail("com.acme.AuthGuard", "Tool input", "com.acme.EmailTools", "sendEmail", 1, null, List.of()),
+                new RawGuardrail("com.acme.PiiFilter", "Tool output", "com.acme.EmailTools", "sendEmail", 1, null, List.of())));
+
+        assertThat(infos).extracting(GuardrailInfo::className, GuardrailInfo::kind)
+                .containsExactly(
+                        tuple("com.acme.AuthGuard", "Tool input"),
+                        tuple("com.acme.PiiFilter", "Tool output"));
+        assertThat(infos).allSatisfy(info -> assertThat(info.usedBy()).singleElement().satisfies(usage -> {
+            assertThat(usage.owner()).isEqualTo("com.acme.EmailTools");
+            assertThat(usage.method()).isEqualTo("sendEmail");
+            assertThat(usage.maxRetries()).isNull();
+        }));
+    }
+
+    @Test
+    void sameGuardrailUsedAsInputAndOutputProducesTwoRowsInputFirst() {
+        var infos = LangChain4jDevUIProcessor.buildGuardrailInfos(List.of(
+                new RawGuardrail("com.acme.DualGuard", "Input", "com.acme.Assistant", null, 1, null, List.of()),
+                new RawGuardrail("com.acme.DualGuard", "Output", "com.acme.Assistant", null, 1, 2, List.of())));
+
+        assertThat(infos).extracting(GuardrailInfo::className, GuardrailInfo::kind)
+                .containsExactly(
+                        tuple("com.acme.DualGuard", "Input"),
+                        tuple("com.acme.DualGuard", "Output"));
+        assertThat(infos.get(0).usedBy().get(0).maxRetries()).isNull();
+        assertThat(infos.get(1).usedBy().get(0).maxRetries()).isEqualTo(2);
+    }
+}

--- a/integration-tests/devui/src/test/java/devui/GuardrailsDevUIBuildTimeDataTest.java
+++ b/integration-tests/devui/src/test/java/devui/GuardrailsDevUIBuildTimeDataTest.java
@@ -1,0 +1,196 @@
+package devui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.guardrail.InputGuardrail;
+import dev.langchain4j.guardrail.InputGuardrailResult;
+import dev.langchain4j.guardrail.OutputGuardrail;
+import dev.langchain4j.guardrail.OutputGuardrailResult;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.guardrail.InputGuardrails;
+import dev.langchain4j.service.guardrail.OutputGuardrails;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrail;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailRequest;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrailResult;
+import io.quarkiverse.langchain4j.guardrails.ToolInputGuardrails;
+import io.quarkiverse.langchain4j.runtime.aiservice.NoopChatMemory;
+import io.quarkus.devui.tests.DevUIBuildTimeDataTest;
+import io.quarkus.test.QuarkusDevModeTest;
+
+/**
+ * Verifies the "guardrails" build-time data that backs the Dev UI Guardrails page: guardrails are grouped by class,
+ * a guardrail shared by several AI services lists all of them, and output guardrails carry their max retries.
+ */
+public class GuardrailsDevUIBuildTimeDataTest extends DevUIBuildTimeDataTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest config = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(FirstService.class, SecondService.class,
+                            PiiInputGuardrail.class, KeywordInputGuardrail.class, ProfanityOutputGuardrail.class,
+                            MyTools.class, AuthToolGuardrail.class,
+                            MyChatModelSupplier.class, MyChatModel.class, MyMemoryProviderSupplier.class));
+
+    public GuardrailsDevUIBuildTimeDataTest() {
+        super("io.quarkiverse.langchain4j.quarkus-langchain4j-core");
+    }
+
+    @Test
+    public void guardrailsBuildTimeDataIsExposed() throws Exception {
+        JsonNode guardrails = getBuildTimeData("guardrails");
+        assertNotNull(guardrails);
+        assertTrue(guardrails.isArray());
+
+        JsonNode pii = findByClassNameAndKind(guardrails, PiiInputGuardrail.class.getName(), "Input");
+        assertNotNull(pii, "shared input guardrail row");
+        assertEquals(2, pii.get("usedBy").size());
+
+        // Class-level guardrails are reported with no specific method, and list the methods that override them.
+        JsonNode piiOnFirst = usageForOwner(pii, FirstService.class.getName());
+        assertTrue(piiOnFirst.get("method").isNull(), "class-level guardrail should have no method");
+        assertEquals("secure", piiOnFirst.get("excludedMethods").get(0).asText(),
+                "the method declaring its own input guardrail overrides the class-level one");
+
+        JsonNode piiOnSecond = usageForOwner(pii, SecondService.class.getName());
+        assertTrue(piiOnSecond.get("method").isNull(), "class-level guardrail should have no method");
+        assertTrue(piiOnSecond.get("excludedMethods").isEmpty(), "no method overrides it on SecondService");
+
+        // The output guardrail is declared on a method, so it is reported against that method.
+        JsonNode profanity = findByClassNameAndKind(guardrails, ProfanityOutputGuardrail.class.getName(), "Output");
+        assertNotNull(profanity, "output guardrail row");
+        JsonNode usage = profanity.get("usedBy").get(0);
+        assertEquals(FirstService.class.getName(), usage.get("owner").asText());
+        assertEquals("chat", usage.get("method").asText());
+        assertEquals(1, usage.get("position").asInt());
+        assertEquals(4, usage.get("maxRetries").asInt());
+
+        JsonNode toolGuardrail = findByClassNameAndKind(guardrails, AuthToolGuardrail.class.getName(), "Tool input");
+        assertNotNull(toolGuardrail, "tool input guardrail row");
+        JsonNode toolUsage = toolGuardrail.get("usedBy").get(0);
+        assertEquals(MyTools.class.getName(), toolUsage.get("owner").asText());
+        assertEquals("sendEmail", toolUsage.get("method").asText());
+        assertTrue(toolUsage.get("maxRetries").isNull(), "tool guardrails carry no max retries");
+    }
+
+    private static JsonNode findByClassNameAndKind(JsonNode guardrails, String className, String kind) {
+        for (JsonNode node : guardrails) {
+            if (className.equals(node.get("className").asText()) && kind.equals(node.get("kind").asText())) {
+                return node;
+            }
+        }
+        return null;
+    }
+
+    private static JsonNode usageForOwner(JsonNode guardrail, String owner) {
+        for (JsonNode usage : guardrail.get("usedBy")) {
+            if (owner.equals(usage.get("owner").asText())) {
+                return usage;
+            }
+        }
+        return null;
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = MyMemoryProviderSupplier.class, tools = MyTools.class)
+    @InputGuardrails(PiiInputGuardrail.class)
+    public interface FirstService {
+        // Output guardrail declared on the method (the common pattern), not on the class
+        @OutputGuardrails(value = ProfanityOutputGuardrail.class, maxRetries = 4)
+        @UserMessage("Say hi")
+        String chat(@MemoryId String mem);
+
+        // Declares its own input guardrail, so it overrides the class-level PiiInputGuardrail.
+        @InputGuardrails(KeywordInputGuardrail.class)
+        @UserMessage("Secure hi")
+        String secure(@MemoryId String mem);
+    }
+
+    @ApplicationScoped
+    public static class MyTools {
+        @Tool("Send an email")
+        @ToolInputGuardrails(AuthToolGuardrail.class)
+        public String sendEmail(String to) {
+            return "sent";
+        }
+    }
+
+    @ApplicationScoped
+    public static class AuthToolGuardrail implements ToolInputGuardrail {
+        @Override
+        public ToolInputGuardrailResult validate(ToolInputGuardrailRequest request) {
+            return ToolInputGuardrailResult.success();
+        }
+    }
+
+    @RegisterAiService(chatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = MyMemoryProviderSupplier.class)
+    @InputGuardrails(PiiInputGuardrail.class)
+    public interface SecondService {
+        @UserMessage("Say hi")
+        String hi(@MemoryId String mem);
+    }
+
+    @ApplicationScoped
+    public static class PiiInputGuardrail implements InputGuardrail {
+        @Override
+        public InputGuardrailResult validate(dev.langchain4j.data.message.UserMessage ignored) {
+            return success();
+        }
+    }
+
+    @ApplicationScoped
+    public static class KeywordInputGuardrail implements InputGuardrail {
+        @Override
+        public InputGuardrailResult validate(dev.langchain4j.data.message.UserMessage ignored) {
+            return success();
+        }
+    }
+
+    @ApplicationScoped
+    public static class ProfanityOutputGuardrail implements OutputGuardrail {
+        @Override
+        public OutputGuardrailResult validate(AiMessage responseFromLLM) {
+            return success();
+        }
+    }
+
+    public static class MyChatModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new MyChatModel();
+        }
+    }
+
+    public static class MyChatModel implements ChatModel {
+        @Override
+        public ChatResponse doChat(ChatRequest request) {
+            return ChatResponse.builder().aiMessage(new AiMessage("Hi!")).build();
+        }
+    }
+
+    public static class MyMemoryProviderSupplier implements Supplier<ChatMemoryProvider> {
+        @Override
+        public ChatMemoryProvider get() {
+            return memoryId -> new NoopChatMemory();
+        }
+    }
+}


### PR DESCRIPTION
## Describe your changes

Adds a "Guardrails" page to the LangChain4j Dev UI card, organized by guardrail class, so you can see where a given guardrail is used without cross-referencing `@InputGuardrails` / `@OutputGuardrails` / `@ToolInputGuardrails` / `@ToolOutputGuardrails` across AI service and tool classes by hand. For each guardrail it shows its kind (input, output, tool input or tool output) and every AI service or tool method applying it, with the guardrail's position in the chain and, for output guardrails, the max retries declared on the annotation.

AI service guardrails are collected at build time from the class- and method-level annotations, so method-level declarations (the common pattern) are picked up, not only class-level ones. Tool guardrails, always declared on the `@Tool` method, are read from the tools metadata that is already resolved at build time. The page is only added when the application has at least one guardrail.

A method-level annotation overrides the class-level one of the same kind, so the page reflects that: a class-level guardrail is shown as "all methods except" the methods that declare their own guardrails of that kind, rather than as a blanket "all methods".

The inversion from per-owner declarations to a per-guardrail view is isolated in a package-private method free of build items and Jandex, unit tested on its own; a `DevUIBuildTimeDataTest` asserts the resulting build-time data in a real dev-mode application.

### Screenshots

<img width="1280" height="577" alt="devui-guardrails" src="https://github.com/user-attachments/assets/66d76062-a9b5-47d1-8eec-b9f2c5b96025" />


---

- Fixes #2698
- Relates to #1898
