### PR TITLE
[1.7] Update to LangChain4j 1.11.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   <properties>
     <quarkus.version>3.27.2</quarkus.version>
     <quarkus.extension-processor.version>${quarkus.version}</quarkus.extension-processor.version>
-    <langchain4j.version>1.11.8</langchain4j.version>
+    <langchain4j.version>1.11.9</langchain4j.version>
     <langchain4j-community.version>1.6.0-beta12</langchain4j-community.version>
     <quarkus-antora.version>3.25.0</quarkus-antora.version>
     <quarkus-poi.version>2.0.4</quarkus-poi.version> <!-- we need to use this version because langchain4j uses POI 5.2.3 instead of 5.2.5 and the substitution needed is different in the two versions -->


### PR DESCRIPTION
The only change is an OpenNLP upgrade that fixes https://app.opencve.io/cve/CVE-2026-63317