### PR TITLE
Increase read-timeout for MCP registry client tests. Re-enable testListServersUpdatedSince

### DIFF
--- a/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/registryclient/McpRegistryClientTest.java
+++ b/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/registryclient/McpRegistryClientTest.java
@@ -9,7 +9,6 @@ import jakarta.inject.Inject;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
@@ -40,6 +39,7 @@ public class McpRegistryClientTest {
                             quarkus.langchain4j.openai.api-key=whatever
                             quarkus.langchain4j.mcp.registry-client.CLIENT1.base-url=https://registry.modelcontextprotocol.io
                             quarkus.langchain4j.mcp.registry-client.CLIENT1.dummyprop=blabla
+                            quarkus.langchain4j.mcp.registry-client.CLIENT1.read-timeout=60s
                             """),
                             "application.properties"));
 
@@ -59,7 +59,6 @@ public class McpRegistryClientTest {
     }
 
     @Test
-    @Disabled("Need to update to a langchain4j version that includes https://github.com/langchain4j/langchain4j/pull/4016")
     public void testListServersUpdatedSince() {
         // NOTE: the DateTimes are evaluated in UTC
         LocalDateTime updatedSince = LocalDateTime.now().minusDays(30);


### PR DESCRIPTION
This should hopefully fix the intermittent MCP registry test failures. The default timeout of 10s just isn't enough sometimes.
Let's also backport this to 1.12, 1.7, 1.2