### PR TITLE
Fixes #2721: Add ExcludeFromImpliedAiServiceBuildItem

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
@@ -406,6 +406,7 @@ public class AiServicesProcessor {
     public void findDeclarativeServices(CombinedIndexBuildItem indexBuildItem,
             CustomScopeAnnotationsBuildItem customScopes,
             List<AnnotationsImpliesAiServiceBuildItem> annotationsImpliesAiServiceItems,
+            List<ExcludeFromImpliedAiServiceBuildItem> excludedFromImpliedItems,
             BuildProducer<RequestChatModelBeanBuildItem> requestChatModelBeanProducer,
             BuildProducer<RequestModerationModelBeanBuildItem> requestModerationModelBeanProducer,
             BuildProducer<RequestImageModelBeanBuildItem> requestImageModelBeanProducer,
@@ -430,8 +431,12 @@ public class AiServicesProcessor {
         Collection<AnnotationInstance> registerAiServicesInstances = new ArrayList<>(
                 index.getAnnotations(REGISTER_AI_SERVICES));
 
+        Set<DotName> excludedFromImplied = excludedFromImpliedItems.stream()
+                .map(ExcludeFromImpliedAiServiceBuildItem::getClassName)
+                .collect(Collectors.toSet());
+
         Set<AnnotationInstance> impliedRegisterAiServiceInstance = determinedImpliedRegisterAiService(
-                annotationsThatImplyAiService, index);
+                annotationsThatImplyAiService, index, excludedFromImplied);
         Set<DotName> impliedRegisterAiServiceTarget = impliedRegisterAiServiceInstance.stream()
                 .map(ai -> ai.target().asClass().name()).collect(Collectors.toSet());
         registerAiServicesInstances.addAll(impliedRegisterAiServiceInstance);
@@ -669,7 +674,7 @@ public class AiServicesProcessor {
     }
 
     private static Set<AnnotationInstance> determinedImpliedRegisterAiService(Set<DotName> annotationsThatImplyAiService,
-            IndexView index) {
+            IndexView index, Set<DotName> excludedClasses) {
         Set<AnnotationInstance> impliedDefaultRegisterAiService = new HashSet<>();
         for (DotName ann : annotationsThatImplyAiService) {
             index.getAnnotations(ann).forEach(instance -> {
@@ -695,6 +700,9 @@ public class AiServicesProcessor {
                     return;
                 }
                 if (!ci.isInterface()) {
+                    return;
+                }
+                if (excludedClasses.contains(ci.name())) {
                     return;
                 }
                 if (ci.name().toString().startsWith(AGENTIC_PACKAGE_PREFIX)) {

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/ExcludeFromImpliedAiServiceBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/ExcludeFromImpliedAiServiceBuildItem.java
@@ -1,0 +1,32 @@
+package io.quarkiverse.langchain4j.deployment;
+
+import org.jboss.jandex.DotName;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Prevents a specific interface from being auto-registered as an AI service
+ * through the implied registration mechanism (annotations like {@code @UserMessage},
+ * {@code @SystemMessage}, {@code @Moderate}).
+ *
+ * <p>
+ * Other Quarkus extensions can produce this build item to exclude their
+ * library interfaces from implied registration. Interfaces excluded this way
+ * can still be explicitly registered via {@code @RegisterAiService}.
+ */
+public final class ExcludeFromImpliedAiServiceBuildItem extends MultiBuildItem {
+
+    private final DotName className;
+
+    public ExcludeFromImpliedAiServiceBuildItem(DotName className) {
+        this.className = className;
+    }
+
+    public ExcludeFromImpliedAiServiceBuildItem(String className) {
+        this(DotName.createSimple(className));
+    }
+
+    public DotName getClassName() {
+        return className;
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ExcludeFromImpliedAiServiceTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ExcludeFromImpliedAiServiceTest.java
@@ -1,0 +1,81 @@
+package io.quarkiverse.langchain4j.test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.function.Consumer;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.deployment.ExcludeFromImpliedAiServiceBuildItem;
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ExcludeFromImpliedAiServiceTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ImpliedService.class, ExcludedService.class, MyLanguageModel.class))
+            .addBuildChainCustomizer(buildCustomizer());
+
+    protected static Consumer<BuildChainBuilder> buildCustomizer() {
+        return builder -> builder.addBuildStep(new BuildStep() {
+            @Override
+            public void execute(BuildContext context) {
+                context.produce(new ExcludeFromImpliedAiServiceBuildItem(ExcludedService.class.getName()));
+            }
+        })
+                .produces(ExcludeFromImpliedAiServiceBuildItem.class)
+                .build();
+    }
+
+    @Inject
+    Instance<ImpliedService> impliedServiceInstance;
+
+    @Inject
+    Instance<ExcludedService> excludedServiceInstance;
+
+    interface ImpliedService {
+        @UserMessage("Hello {name}")
+        String greet(String name);
+    }
+
+    interface ExcludedService {
+        @UserMessage("Hello {name}")
+        String greet(String name);
+    }
+
+    @Singleton
+    public static class MyLanguageModel implements ChatModel {
+        @Override
+        public ChatResponse doChat(ChatRequest request) {
+            return null;
+        }
+    }
+
+    @Test
+    void impliedServiceIsRegistered() {
+        assertTrue(impliedServiceInstance.isResolvable(),
+                "ImpliedService should be auto-registered as an AI service");
+    }
+
+    @Test
+    void excludedServiceIsNotRegistered() {
+        assertFalse(excludedServiceInstance.isResolvable(),
+                "ExcludedService should not be registered as an AI service");
+    }
+}


### PR DESCRIPTION
Add a build item that allows other extensions to exclude specific interfaces from implied AI service registration.

Fixes: #2721
Reference: https://github.com/apache/camel-quarkus/issues/8836