### PR TITLE
Replace NoopChatMemory with LocalCommittableChatMemory

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolWithoutMemoryProviderTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ToolWithoutMemoryProviderTest.java
@@ -1,0 +1,113 @@
+package io.quarkiverse.langchain4j.test.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import jakarta.enterprise.context.control.ActivateRequestContext;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.tool.ToolExecutor;
+import dev.langchain4j.service.tool.ToolProviderRequest;
+import dev.langchain4j.service.tool.ToolProviderResult;
+import io.quarkiverse.langchain4j.CreatedAware;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.test.Lists;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests that tool execution works when no ChatMemoryProvider is configured,
+ * using programmatic AiServices.builder() with a ToolProvider. This exercises
+ * the LocalCommittableChatMemory path in determineCommittableChatMemory() and
+ * mirrors the Camel AgentWithoutMemory + ToolProvider flow.
+ */
+public class ToolWithoutMemoryProviderTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyAiService.class, Lists.class));
+
+    @Test
+    @ActivateRequestContext
+    void toolExecutionWorksWithoutMemoryProvider() {
+        MyAiService service = AiServices.builder(MyAiService.class)
+                .chatModel(new MyChatModel())
+                .toolProvider(ToolWithoutMemoryProviderTest::provideTools)
+                .build();
+
+        String result = service.chat("call-tool");
+        assertThat(result).contains("tool-result-123456:");
+    }
+
+    @CreatedAware
+    @RegisterAiService(chatLanguageModelSupplier = MyChatModelSupplier.class, chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
+    public interface MyAiService {
+
+        String chat(@UserMessage String message);
+    }
+
+    static ToolProviderResult provideTools(ToolProviderRequest request) {
+        ToolSpecification spec = ToolSpecification.builder()
+                .name("callTool")
+                .description("Calls a tool")
+                .build();
+        ToolExecutor executor = (req, memoryId) -> "tool-result-123456: " + req.arguments();
+        return ToolProviderResult.builder().add(spec, executor).build();
+    }
+
+    public static class MyChatModelSupplier implements Supplier<ChatModel> {
+        @Override
+        public ChatModel get() {
+            return new MyChatModel();
+        }
+    }
+
+    public static class MyChatModel implements ChatModel {
+
+        @Override
+        public ChatResponse chat(List<ChatMessage> messages) {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            List<ChatMessage> messages = chatRequest.messages();
+            if (messages.size() == 1) {
+                return ChatResponse.builder()
+                        .aiMessage(new AiMessage("", List.of(
+                                ToolExecutionRequest.builder()
+                                        .id("tool-1")
+                                        .name("callTool")
+                                        .arguments("{}")
+                                        .build())))
+                        .tokenUsage(new TokenUsage(0, 0))
+                        .finishReason(FinishReason.TOOL_EXECUTION)
+                        .build();
+            } else if (messages.size() == 3) {
+                ToolExecutionResultMessage toolResult = (ToolExecutionResultMessage) Lists.last(messages);
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.from("response: " + toolResult.text()))
+                        .build();
+            }
+            return ChatResponse.builder().aiMessage(new AiMessage("Unexpected")).build();
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
@@ -342,6 +342,10 @@ public class AiServiceMethodImplementationSupport {
         } else {
             messagesToSend = createMessagesToSendForNoMemory(systemMessage, userMessage, needsMemorySeed, context,
                     methodCreateInfo);
+            // Seed the local memory so the tool-execution loop can read back the conversation history
+            for (ChatMessage msg : messagesToSend) {
+                committableChatMemory.add(msg);
+            }
         }
 
         if (skillsSystemMessage != null) {
@@ -1385,7 +1389,7 @@ public class AiServiceMethodImplementationSupport {
             ChatMemoryFlushStrategy chatMemoryFlushStrategy) {
         CommittableChatMemory committableChatMemory;
         if (chatMemory == null) {
-            committableChatMemory = new NoopChatMemory();
+            committableChatMemory = new LocalCommittableChatMemory();
         } else {
             if (chatMemoryFlushStrategy == ChatMemoryFlushStrategy.IMMEDIATE) {
                 committableChatMemory = new ImmediateFlushChatMemory(chatMemory);

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/LocalCommittableChatMemory.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/LocalCommittableChatMemory.java
@@ -1,0 +1,71 @@
+package io.quarkiverse.langchain4j.runtime.aiservice;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Optional;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+
+/**
+ * A CommittableChatMemory that tracks messages in a local list without
+ * any persistent backing store. Used when no ChatMemoryProvider is
+ * configured, so messages are available within a single invocation
+ * (e.g. for tool-loop retries and guardrail reprompts) but are not
+ * persisted across calls.
+ */
+class LocalCommittableChatMemory implements CommittableChatMemory {
+
+    private final List<ChatMessage> messages = new ArrayList<>();
+
+    @Override
+    public Object id() {
+        return "default";
+    }
+
+    @Override
+    public void add(ChatMessage message) {
+        if (message instanceof SystemMessage) {
+            Optional<SystemMessage> existing = messages.stream()
+                    .filter(m -> m instanceof SystemMessage)
+                    .map(m -> (SystemMessage) m)
+                    .findAny();
+            if (existing.isPresent()) {
+                if (existing.get().equals(message)) {
+                    return;
+                }
+                messages.remove(existing.get());
+            }
+            messages.add(0, message);
+        } else {
+            messages.add(message);
+        }
+    }
+
+    @Override
+    public List<ChatMessage> messages() {
+        return new ArrayList<>(messages);
+    }
+
+    @Override
+    public void clear() {
+        messages.clear();
+    }
+
+    @Override
+    public void replaceLastAiMessage(AiMessage newAiMessage) {
+        ListIterator<ChatMessage> it = messages.listIterator(messages.size());
+        while (it.hasPrevious()) {
+            if (it.previous() instanceof AiMessage) {
+                it.set(newAiMessage);
+                return;
+            }
+        }
+    }
+
+    @Override
+    public void commit() {
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/NoopChatMemory.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/NoopChatMemory.java
@@ -10,6 +10,7 @@ import dev.langchain4j.memory.ChatMemory;
 /**
  * An implementation of {@link ChatMemory} that does nothing.
  * This is useful for simplifying the AiService code.
+ * Kept in main sources because test classes in other modules (core/deployment, mcp/deployment) depend on it.
  */
 public class NoopChatMemory implements CommittableChatMemory {
     @Override


### PR DESCRIPTION
## Summary
- Replace `NoopChatMemory` with `LocalCommittableChatMemory` in `determineCommittableChatMemory()` so that tool-loop retries and guardrail reprompts work when no `ChatMemoryProvider` is configured
- `LocalCommittableChatMemory` tracks messages within a single invocation without persistence
- Seed the local memory with initial messages in the no-memory branch so the tool-execution loop can read back conversation history
- Add `ToolWithoutMemoryProviderTest` exercising the programmatic `AiServices.builder()` + `toolProvider()` path without a `ChatMemoryProvider`

---

- Fixes: https://github.com/quarkiverse/quarkus-langchain4j/issues/2724