### PR TITLE
Add a ConversationContext API generalizing the definition of the boundaries of a conversation

### DIFF
--- a/agentic/deployment/pom.xml
+++ b/agentic/deployment/pom.xml
@@ -63,6 +63,17 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+<dependency>
+      <groupId>io.quarkiverse.langchain4j</groupId>
+      <artifactId>quarkus-langchain4j-chat-scopes-deployment</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-test-vertx</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/agentic/deployment/pom.xml
+++ b/agentic/deployment/pom.xml
@@ -63,7 +63,7 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
-<dependency>
+    <dependency>
       <groupId>io.quarkiverse.langchain4j</groupId>
       <artifactId>quarkus-langchain4j-chat-scopes-deployment</artifactId>
       <version>${project.version}</version>

--- a/agentic/deployment/src/main/java/io/quarkiverse/langchain4j/agentic/deployment/AgenticProcessor.java
+++ b/agentic/deployment/src/main/java/io/quarkiverse/langchain4j/agentic/deployment/AgenticProcessor.java
@@ -63,6 +63,7 @@ import io.quarkiverse.langchain4j.deployment.SkipToolBoxProcessingBuildItem;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.deployment.BeanDiscoveryFinishedBuildItem;
+import io.quarkus.arc.deployment.CustomScopeAnnotationsBuildItem;
 import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
 import io.quarkus.arc.deployment.GeneratedBeanGizmoAdaptor;
 import io.quarkus.arc.deployment.InterceptorResolverBuildItem;
@@ -692,6 +693,7 @@ public class AgenticProcessor {
             InterceptorResolverBuildItem interceptorResolverBuildItem,
             BeanDiscoveryFinishedBuildItem beanDiscovery,
             CombinedIndexBuildItem indexBuildItem,
+            CustomScopeAnnotationsBuildItem customScopes,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeanProducer,
             BuildProducer<RequestChatModelBeanBuildItem> requestChatModelBeanProducer,
             BuildProducer<UnremovableBeanBuildItem> unremovableProducer) {
@@ -728,6 +730,7 @@ public class AgenticProcessor {
                 beanConfigurator = SyntheticBeanBuildItem
                         .configure(detectedAiAgentBuildItem.getIface().name());
             }
+
             beanConfigurator
                     .forceApplicationClass()
                     .unremovable()
@@ -736,7 +739,8 @@ public class AgenticProcessor {
                                     new AiAgentCreateInfo(detectedAiAgentBuildItem.getIface().toString(), chatModelInfo,
                                             hasInterceptorBindings, hasMcpToolBox)))
                     .setRuntimeInit()
-                    .scope(ApplicationScoped.class);
+                    .scope(findScope(customScopes, detectedAiAgentBuildItem));
+
             if (hasInterceptorBindings) {
                 beanConfigurator.injectInterceptionProxy();
             }
@@ -782,6 +786,21 @@ public class AgenticProcessor {
         }
 
         requestedChatModelNames.forEach(name -> requestChatModelBeanProducer.produce(new RequestChatModelBeanBuildItem(name)));
+    }
+
+    private static Class findScope(CustomScopeAnnotationsBuildItem customScopes,
+            DetectedAiAgentBuildItem detectedAiAgentBuildItem) {
+        return customScopes
+                .getScope(detectedAiAgentBuildItem.getIface().annotations())
+                .map(AnnotationInstance::name)
+                .map(scopeDotName -> {
+                    try {
+                        return Class.forName(scopeDotName.toString(), true, Thread.currentThread().getContextClassLoader());
+                    } catch (ClassNotFoundException e) {
+                        throw new RuntimeException("Unable to load scope annotation: " + scopeDotName, e);
+                    }
+                })
+                .orElse((Class) ApplicationScoped.class);
     }
 
     private static boolean isInterceptorBindingAnnotation(AnnotationInstance ann, IndexView index) {

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgenticConversationTrackingTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgenticConversationTrackingTest.java
@@ -396,11 +396,11 @@ public class AgenticConversationTrackingTest extends OpenAiBaseTest {
         private final List<String> ended = new CopyOnWriteArrayList<>();
 
         public void onStarted(@Observes ConversationStarted event) {
-            started.add(event.getConversationId());
+            started.add(event.conversationId());
         }
 
         public void onEnded(@Observes ConversationEnded event) {
-            ended.add(event.getConversationId());
+            ended.add(event.conversationId());
         }
 
         public List<String> started() {

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgenticConversationTrackingTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/AgenticConversationTrackingTest.java
@@ -1,0 +1,419 @@
+package io.quarkiverse.langchain4j.agentic.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agentic.declarative.ActivationCondition;
+import dev.langchain4j.agentic.declarative.ConditionalAgent;
+import dev.langchain4j.agentic.declarative.SequenceAgent;
+import dev.langchain4j.agentic.scope.AgenticScopeAccess;
+import dev.langchain4j.agentic.scope.ResultWithAgenticScope;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.V;
+import io.quarkiverse.langchain4j.agentic.deployment.Agents.CategoryRouter;
+import io.quarkiverse.langchain4j.agentic.deployment.Agents.FixedResponseChatModel;
+import io.quarkiverse.langchain4j.agentic.deployment.Agents.LegalExpert;
+import io.quarkiverse.langchain4j.agentic.deployment.Agents.LegalExpertWithMemory;
+import io.quarkiverse.langchain4j.agentic.deployment.Agents.MedicalExpert;
+import io.quarkiverse.langchain4j.agentic.deployment.Agents.MedicalExpertWithMemory;
+import io.quarkiverse.langchain4j.agentic.deployment.Agents.RequestCategory;
+import io.quarkiverse.langchain4j.agentic.deployment.Agents.TechnicalExpert;
+import io.quarkiverse.langchain4j.agentic.deployment.Agents.TechnicalExpertWithMemory;
+import io.quarkiverse.langchain4j.chatscopes.ChatScope;
+import io.quarkiverse.langchain4j.chatscopes.internal.ChatScopeConversationBridge;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.runtime.conversation.ConversationContext;
+import io.quarkiverse.langchain4j.runtime.conversation.ConversationEnded;
+import io.quarkiverse.langchain4j.runtime.conversation.ConversationStarted;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.vertx.RunOnVertxContext;
+import io.quarkus.test.vertx.UniAsserter;
+import io.smallrye.common.vertx.VertxContext;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+public class AgenticConversationTrackingTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(FixedResponseChatModel.class,
+                            CategoryRouter.class,
+                            MedicalExpert.class,
+                            TechnicalExpert.class,
+                            LegalExpert.class,
+                            MedicalExpertWithMemory.class,
+                            TechnicalExpertWithMemory.class,
+                            LegalExpertWithMemory.class,
+                            RequestCategory.class,
+                            ExpertsAgent.class,
+                            ExpertRouterAgent.class,
+                            ExpertsAgentWithMemory.class,
+                            ExpertRouterAgentWithMemory.class,
+                            ChatScopeConversationBridge.class,
+                            ConversationEventCollector.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "whatever")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    public interface ExpertsAgent {
+
+        @ConditionalAgent(outputKey = "response", subAgents = { MedicalExpert.class, TechnicalExpert.class, LegalExpert.class })
+        String askExpert(@V("request") String request);
+
+        @ActivationCondition(MedicalExpert.class)
+        static boolean activateMedical(@V("category") RequestCategory category) {
+            return category == RequestCategory.MEDICAL;
+        }
+
+        @ActivationCondition(TechnicalExpert.class)
+        static boolean activateTechnical(@V("category") RequestCategory category) {
+            return category == RequestCategory.TECHNICAL;
+        }
+
+        @ActivationCondition(LegalExpert.class)
+        static boolean activateLegal(@V("category") RequestCategory category) {
+            return category == RequestCategory.LEGAL;
+        }
+    }
+
+    public interface ExpertRouterAgent {
+
+        @SequenceAgent(outputKey = "response", subAgents = { CategoryRouter.class, ExpertsAgent.class })
+        ResultWithAgenticScope<String> ask(@V("request") String request);
+    }
+
+    public interface ExpertsAgentWithMemory {
+
+        @ConditionalAgent(outputKey = "response", subAgents = { MedicalExpertWithMemory.class,
+                TechnicalExpertWithMemory.class, LegalExpertWithMemory.class })
+        String askExpert(@V("request") String request);
+
+        @ActivationCondition(MedicalExpertWithMemory.class)
+        static boolean activateMedical(@V("category") RequestCategory category) {
+            return category == RequestCategory.MEDICAL;
+        }
+
+        @ActivationCondition(TechnicalExpertWithMemory.class)
+        static boolean activateTechnical(@V("category") RequestCategory category) {
+            return category == RequestCategory.TECHNICAL;
+        }
+
+        @ActivationCondition(LegalExpertWithMemory.class)
+        static boolean activateLegal(@V("category") RequestCategory category) {
+            return category == RequestCategory.LEGAL;
+        }
+    }
+
+    public interface ExpertRouterAgentWithMemory extends AgenticScopeAccess {
+
+        @SequenceAgent(outputKey = "response", subAgents = { CategoryRouter.class, ExpertsAgentWithMemory.class })
+        String ask(@MemoryId String memoryId, @V("request") String request);
+    }
+
+    @Inject
+    ExpertRouterAgent expertRouterAgent;
+
+    @Inject
+    ExpertRouterAgentWithMemory expertRouterAgentWithMemory;
+
+    @Inject
+    ConversationEventCollector collector;
+
+    @Inject
+    Vertx vertx;
+
+    @BeforeEach
+    void reset() {
+        collector.clear();
+    }
+
+    @Test
+    @RunOnVertxContext(runOnEventLoop = false)
+    void conversationsAreTrackedDuringAgenticWorkflow(UniAsserter asserter) {
+        asserter.execute(() -> {
+            // First conversation — medical question
+            ChatScope.begin();
+            String conv1 = ChatScope.id();
+            assertThat(ConversationContext.isActive()).isTrue();
+            assertThat(ConversationContext.current()).isEqualTo(conv1);
+
+            ResultWithAgenticScope<String> result1 = expertRouterAgent.ask("I broke my leg, what should I do?");
+            assertThat(result1.agenticScope().readState("category")).isEqualTo(RequestCategory.MEDICAL);
+            assertThat(ConversationContext.current()).isEqualTo(conv1);
+
+            ChatScope.end();
+            assertThat(ConversationContext.isActive()).isFalse();
+
+            // Second conversation — technical question
+            ChatScope.begin();
+            String conv2 = ChatScope.id();
+            assertThat(conv2).isNotEqualTo(conv1);
+            assertThat(ConversationContext.current()).isEqualTo(conv2);
+
+            ResultWithAgenticScope<String> result2 = expertRouterAgent.ask("My computer has liquid inside, what should I do?");
+            assertThat(result2.agenticScope().readState("category")).isEqualTo(RequestCategory.TECHNICAL);
+            assertThat(ConversationContext.current()).isEqualTo(conv2);
+
+            ChatScope.end();
+            assertThat(ConversationContext.isActive()).isFalse();
+
+            // Both conversations tracked with correct lifecycle events
+            assertThat(collector.started()).containsExactly(conv1, conv2);
+            assertThat(collector.ended()).containsExactly(conv1, conv2);
+        });
+    }
+
+    @Test
+    @RunOnVertxContext(runOnEventLoop = false)
+    void multiInteractionConversationsAreTrackedWithMemory(UniAsserter asserter) {
+        asserter.execute(() -> {
+            // First conversation — medical then legal follow-up (2 interactions)
+            ChatScope.begin();
+            String conv1 = ChatScope.id();
+
+            String response1 = expertRouterAgentWithMemory.ask(conv1, "I broke my leg, what should I do?");
+            assertThat(expertRouterAgentWithMemory.getAgenticScope(conv1)
+                    .readState("category", RequestCategory.UNKNOWN)).isEqualTo(RequestCategory.MEDICAL);
+            assertThat(ConversationContext.current()).isEqualTo(conv1);
+
+            String legalResponse1 = expertRouterAgentWithMemory.ask(conv1,
+                    "Should I sue my neighbor who caused this damage?");
+            assertThat(expertRouterAgentWithMemory.getAgenticScope(conv1)
+                    .readState("category", RequestCategory.UNKNOWN)).isEqualTo(RequestCategory.LEGAL);
+            assertThat(legalResponse1).containsIgnoringCase("leg").doesNotContain("computer");
+            assertThat(ConversationContext.current()).isEqualTo(conv1);
+
+            ChatScope.end();
+            assertThat(ConversationContext.isActive()).isFalse();
+
+            // Second conversation — technical then legal follow-up (2 interactions)
+            ChatScope.begin();
+            String conv2 = ChatScope.id();
+            assertThat(conv2).isNotEqualTo(conv1);
+
+            String response2 = expertRouterAgentWithMemory.ask(conv2,
+                    "My computer has liquid inside, what should I do?");
+            assertThat(expertRouterAgentWithMemory.getAgenticScope(conv2)
+                    .readState("category", RequestCategory.UNKNOWN)).isEqualTo(RequestCategory.TECHNICAL);
+            assertThat(ConversationContext.current()).isEqualTo(conv2);
+
+            String legalResponse2 = expertRouterAgentWithMemory.ask(conv2,
+                    "Should I sue my neighbor who caused this damage?");
+            assertThat(expertRouterAgentWithMemory.getAgenticScope(conv2)
+                    .readState("category", RequestCategory.UNKNOWN)).isEqualTo(RequestCategory.LEGAL);
+            assertThat(legalResponse2).containsIgnoringCase("computer").doesNotContain("leg");
+            assertThat(ConversationContext.current()).isEqualTo(conv2);
+
+            ChatScope.end();
+            assertThat(ConversationContext.isActive()).isFalse();
+
+            // Both conversations tracked — each had 2 interactions but only 1 begin/end per scope
+            assertThat(collector.started()).containsExactly(conv1, conv2);
+            assertThat(collector.ended()).containsExactly(conv1, conv2);
+
+            assertThat(expertRouterAgentWithMemory.evictAgenticScope(conv1)).isTrue();
+            assertThat(expertRouterAgentWithMemory.evictAgenticScope(conv2)).isTrue();
+            assertThat(expertRouterAgentWithMemory.evictAgenticScope(conv1)).isFalse();
+            assertThat(expertRouterAgentWithMemory.evictAgenticScope(conv2)).isFalse();
+        });
+    }
+
+    @Test
+    @RunOnVertxContext(runOnEventLoop = false)
+    void conversationsAreTrackedWithConversationContext(UniAsserter asserter) {
+        asserter.execute(() -> {
+            // First conversation — medical question
+            ConversationContext.begin("conv-1");
+            assertThat(ConversationContext.isActive()).isTrue();
+            assertThat(ConversationContext.current()).isEqualTo("conv-1");
+
+            ResultWithAgenticScope<String> result1 = expertRouterAgent.ask("I broke my leg, what should I do?");
+            assertThat(result1.agenticScope().readState("category")).isEqualTo(RequestCategory.MEDICAL);
+            assertThat(ConversationContext.current()).isEqualTo("conv-1");
+
+            ConversationContext.end();
+            assertThat(ConversationContext.isActive()).isFalse();
+
+            // Second conversation — technical question
+            ConversationContext.begin("conv-2");
+            assertThat(ConversationContext.current()).isEqualTo("conv-2");
+
+            ResultWithAgenticScope<String> result2 = expertRouterAgent.ask("My computer has liquid inside, what should I do?");
+            assertThat(result2.agenticScope().readState("category")).isEqualTo(RequestCategory.TECHNICAL);
+            assertThat(ConversationContext.current()).isEqualTo("conv-2");
+
+            ConversationContext.end();
+            assertThat(ConversationContext.isActive()).isFalse();
+
+            // Both conversations tracked with correct lifecycle events
+            assertThat(collector.started()).containsExactly("conv-1", "conv-2");
+            assertThat(collector.ended()).containsExactly("conv-1", "conv-2");
+        });
+    }
+
+    @Test
+    @RunOnVertxContext(runOnEventLoop = false)
+    void multiInteractionConversationsAreTrackedWithConversationContext(UniAsserter asserter) {
+        asserter.execute(() -> {
+            // First conversation — medical then legal follow-up (2 interactions)
+            ConversationContext.begin("conv-1");
+
+            String response1 = expertRouterAgentWithMemory.ask("conv-1", "I broke my leg, what should I do?");
+            assertThat(expertRouterAgentWithMemory.getAgenticScope("conv-1")
+                    .readState("category", RequestCategory.UNKNOWN)).isEqualTo(RequestCategory.MEDICAL);
+            assertThat(ConversationContext.current()).isEqualTo("conv-1");
+
+            String legalResponse1 = expertRouterAgentWithMemory.ask("conv-1",
+                    "Should I sue my neighbor who caused this damage?");
+            assertThat(expertRouterAgentWithMemory.getAgenticScope("conv-1")
+                    .readState("category", RequestCategory.UNKNOWN)).isEqualTo(RequestCategory.LEGAL);
+            assertThat(legalResponse1).containsIgnoringCase("leg").doesNotContain("computer");
+            assertThat(ConversationContext.current()).isEqualTo("conv-1");
+
+            ConversationContext.end();
+            assertThat(ConversationContext.isActive()).isFalse();
+
+            // Second conversation — technical then legal follow-up (2 interactions)
+            ConversationContext.begin("conv-2");
+
+            String response2 = expertRouterAgentWithMemory.ask("conv-2",
+                    "My computer has liquid inside, what should I do?");
+            assertThat(expertRouterAgentWithMemory.getAgenticScope("conv-2")
+                    .readState("category", RequestCategory.UNKNOWN)).isEqualTo(RequestCategory.TECHNICAL);
+            assertThat(ConversationContext.current()).isEqualTo("conv-2");
+
+            String legalResponse2 = expertRouterAgentWithMemory.ask("conv-2",
+                    "Should I sue my neighbor who caused this damage?");
+            assertThat(expertRouterAgentWithMemory.getAgenticScope("conv-2")
+                    .readState("category", RequestCategory.UNKNOWN)).isEqualTo(RequestCategory.LEGAL);
+            assertThat(legalResponse2).containsIgnoringCase("computer").doesNotContain("leg");
+            assertThat(ConversationContext.current()).isEqualTo("conv-2");
+
+            ConversationContext.end();
+            assertThat(ConversationContext.isActive()).isFalse();
+
+            // Both conversations tracked — each had 2 interactions but only 1 begin/end per conversation
+            assertThat(collector.started()).containsExactly("conv-1", "conv-2");
+            assertThat(collector.ended()).containsExactly("conv-1", "conv-2");
+
+            assertThat(expertRouterAgentWithMemory.evictAgenticScope("conv-1")).isTrue();
+            assertThat(expertRouterAgentWithMemory.evictAgenticScope("conv-2")).isTrue();
+            assertThat(expertRouterAgentWithMemory.evictAgenticScope("conv-1")).isFalse();
+            assertThat(expertRouterAgentWithMemory.evictAgenticScope("conv-2")).isFalse();
+        });
+    }
+
+    @Test
+    void parallelConversationsAreIsolated() throws Exception {
+        Context dc1 = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+        Context dc2 = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+
+        CompletableFuture<String> future1 = new CompletableFuture<>();
+        CompletableFuture<String> future2 = new CompletableFuture<>();
+
+        dc1.executeBlocking(() -> {
+            ConversationContext.begin("conv-1");
+            assertThat(ConversationContext.current()).isEqualTo("conv-1");
+
+            expertRouterAgentWithMemory.ask("conv-1", "I broke my leg, what should I do?");
+            assertThat(expertRouterAgentWithMemory.getAgenticScope("conv-1")
+                    .readState("category", RequestCategory.UNKNOWN)).isEqualTo(RequestCategory.MEDICAL);
+            assertThat(ConversationContext.current()).isEqualTo("conv-1");
+
+            String legalResponse = expertRouterAgentWithMemory.ask("conv-1",
+                    "Should I sue my neighbor who caused this damage?");
+            assertThat(expertRouterAgentWithMemory.getAgenticScope("conv-1")
+                    .readState("category", RequestCategory.UNKNOWN)).isEqualTo(RequestCategory.LEGAL);
+            assertThat(ConversationContext.current()).isEqualTo("conv-1");
+
+            ConversationContext.end();
+            assertThat(ConversationContext.isActive()).isFalse();
+            return legalResponse;
+        }).onComplete(ar -> {
+            if (ar.failed())
+                future1.completeExceptionally(ar.cause());
+            else
+                future1.complete(ar.result());
+        });
+
+        dc2.executeBlocking(() -> {
+            ConversationContext.begin("conv-2");
+            assertThat(ConversationContext.current()).isEqualTo("conv-2");
+
+            expertRouterAgentWithMemory.ask("conv-2", "My computer has liquid inside, what should I do?");
+            assertThat(expertRouterAgentWithMemory.getAgenticScope("conv-2")
+                    .readState("category", RequestCategory.UNKNOWN)).isEqualTo(RequestCategory.TECHNICAL);
+            assertThat(ConversationContext.current()).isEqualTo("conv-2");
+
+            String legalResponse = expertRouterAgentWithMemory.ask("conv-2",
+                    "Should I sue my neighbor who caused this damage?");
+            assertThat(expertRouterAgentWithMemory.getAgenticScope("conv-2")
+                    .readState("category", RequestCategory.UNKNOWN)).isEqualTo(RequestCategory.LEGAL);
+            assertThat(ConversationContext.current()).isEqualTo("conv-2");
+
+            ConversationContext.end();
+            assertThat(ConversationContext.isActive()).isFalse();
+            return legalResponse;
+        }).onComplete(ar -> {
+            if (ar.failed())
+                future2.completeExceptionally(ar.cause());
+            else
+                future2.complete(ar.result());
+        });
+
+        CompletableFuture.allOf(future1, future2).get(30, TimeUnit.SECONDS);
+
+        // Memory isolation: each conversation's legal follow-up recalls its own prior context
+        assertThat(future1.get()).containsIgnoringCase("leg").doesNotContain("computer");
+        assertThat(future2.get()).containsIgnoringCase("computer").doesNotContain("leg");
+
+        assertThat(collector.started()).containsExactlyInAnyOrder("conv-1", "conv-2");
+        assertThat(collector.ended()).containsExactlyInAnyOrder("conv-1", "conv-2");
+
+        assertThat(expertRouterAgentWithMemory.evictAgenticScope("conv-1")).isTrue();
+        assertThat(expertRouterAgentWithMemory.evictAgenticScope("conv-2")).isTrue();
+    }
+
+    @ApplicationScoped
+    public static class ConversationEventCollector {
+        private final List<String> started = new CopyOnWriteArrayList<>();
+        private final List<String> ended = new CopyOnWriteArrayList<>();
+
+        public void onStarted(@Observes ConversationStarted event) {
+            started.add(event.getConversationId());
+        }
+
+        public void onEnded(@Observes ConversationEnded event) {
+            ended.add(event.getConversationId());
+        }
+
+        public List<String> started() {
+            return started;
+        }
+
+        public List<String> ended() {
+            return ended;
+        }
+
+        public void clear() {
+            started.clear();
+            ended.clear();
+        }
+    }
+}

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/Agents.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/Agents.java
@@ -10,12 +10,14 @@ import org.jboss.logging.Logger;
 
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.ChatMemoryProviderSupplier;
 import dev.langchain4j.agentic.declarative.ChatModelSupplier;
 import dev.langchain4j.agentic.declarative.ExitCondition;
 import dev.langchain4j.agentic.declarative.LoopAgent;
 import dev.langchain4j.agentic.declarative.SequenceAgent;
 import dev.langchain4j.agentic.declarative.SupervisorAgent;
 import dev.langchain4j.agentic.declarative.SupervisorRequest;
+import dev.langchain4j.agentic.scope.AgenticScope;
 import dev.langchain4j.agentic.scope.AgenticScopeAccess;
 import dev.langchain4j.agentic.scope.ResultWithAgenticScope;
 import dev.langchain4j.agentic.supervisor.SupervisorResponseStrategy;
@@ -26,6 +28,8 @@ import dev.langchain4j.guardrail.InputGuardrailRequest;
 import dev.langchain4j.guardrail.InputGuardrailResult;
 import dev.langchain4j.guardrail.OutputGuardrail;
 import dev.langchain4j.guardrail.OutputGuardrailResult;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
@@ -48,6 +52,13 @@ public class Agents {
         @Override
         public ChatResponse doChat(ChatRequest request) {
             return ChatResponse.builder().aiMessage(new AiMessage(response)).build();
+        }
+
+        @Override
+        public String toString() {
+            return "FixedResponseChatModel{" +
+                    "response='" + response + '\'' +
+                    '}';
         }
     }
 
@@ -90,8 +101,18 @@ public class Agents {
         RequestCategory classify(@V("request") String request);
 
         @ChatModelSupplier
-        static ChatModel chatModel() {
-            return new FixedResponseChatModel("MEDICAL");
+        static ChatModel chatModel(AgenticScope scope) {
+            String request = scope.readState("request", "");
+            if (request.contains("leg")) {
+                return new FixedResponseChatModel("MEDICAL");
+            }
+            if (request.contains("sue")) {
+                return new FixedResponseChatModel("LEGAL");
+            }
+            if (request.contains("computer")) {
+                return new FixedResponseChatModel("TECHNICAL");
+            }
+            return new FixedResponseChatModel("UNKNOWN");
         }
     }
 
@@ -129,20 +150,8 @@ public class Agents {
         @ChatModelSupplier
         static ChatModel chatModel() {
             return new FixedResponseChatModel("\"I'm sorry to hear that you've broken your leg." +
-                    "Here are the steps you should take: **Seek Medical Attention");
+                    "Here are the steps you should take: **Seek Legal Attention");
         }
-    }
-
-    public interface MedicalExpertWithMemory {
-
-        @UserMessage("""
-                You are a medical expert.
-                Analyze the following user request under a medical point of view and provide the best possible answer.
-                The user request is {{request}}.
-                """)
-        @Tool("A medical expert")
-        @Agent(description = "A medical expert", outputKey = "response")
-        String medical(@MemoryId String memoryId, @V("request") String request);
     }
 
     public interface LegalExpert {
@@ -155,18 +164,11 @@ public class Agents {
         @Tool("A legal expert")
         @Agent(description = "A legal expert", outputKey = "response")
         String legal(@V("request") String request);
-    }
 
-    public interface LegalExpertWithMemory {
-
-        @UserMessage("""
-                You are a legal expert.
-                Analyze the following user request under a legal point of view and provide the best possible answer.
-                The user request is {{request}}.
-                """)
-        @Tool("A legal expert")
-        @Agent(description = "A legal expert", outputKey = "response")
-        String legal(@MemoryId String memoryId, @V("request") String request);
+        @ChatModelSupplier
+        static ChatModel chatModel() {
+            return new FixedResponseChatModel("**Seek Legal Attention");
+        }
     }
 
     public interface TechnicalExpert {
@@ -179,6 +181,64 @@ public class Agents {
         @Tool("A technical expert")
         @Agent(description = "A technical expert", outputKey = "response")
         String technical(@V("request") String request);
+
+        @ChatModelSupplier
+        static ChatModel chatModel() {
+            return new FixedResponseChatModel("\"I'm sorry to hear that you've broken your computer." +
+                    "Here are the steps you should take: **Seek Technical Assistance");
+        }
+    }
+
+    public interface MedicalExpertWithMemory {
+
+        @UserMessage("""
+                You are a medical expert.
+                Analyze the following user request under a medical point of view and provide the best possible answer.
+                The user request is {{request}}.
+                """)
+        @Agent(description = "A medical expert", outputKey = "response")
+        String medical(@MemoryId String memoryId, @V("request") String request);
+
+        @ChatMemoryProviderSupplier
+        static ChatMemory chatMemory(Object memoryId) {
+            return MessageWindowChatMemory.withMaxMessages(10);
+        }
+
+        @ChatModelSupplier
+        static ChatModel chatModel() {
+            return new FixedResponseChatModel("\"I'm sorry to hear that you've broken your leg." +
+                    "Here are the steps you should take: **Seek Medical Attention");
+        }
+    }
+
+    public interface LegalExpertWithMemory {
+
+        @UserMessage("""
+                You are a legal expert.
+                Analyze the following user request under a legal point of view and provide the best possible answer.
+                The user request is {{request}}.
+                """)
+        @Agent(description = "A legal expert", outputKey = "response")
+        String legal(@MemoryId String memoryId, @V("request") String request);
+
+        @ChatMemoryProviderSupplier
+        static ChatMemory chatMemory(Object memoryId) {
+            return MessageWindowChatMemory.withMaxMessages(10);
+        }
+
+        @ChatModelSupplier
+        static ChatModel chatModel(AgenticScope scope) {
+            String response = scope.readState("response", "");
+            if (response.contains("leg")) {
+                return new FixedResponseChatModel("\"I'm sorry to hear that you've broken your leg." +
+                        "Here are the steps you should take: **Seek Legal Attention");
+            }
+            if (response.contains("computer")) {
+                return new FixedResponseChatModel("\"I'm sorry to hear that you've broken your computer." +
+                        "Here are the steps you should take: **Seek Legal Attention");
+            }
+            return new FixedResponseChatModel("**Seek Legal Attention");
+        }
     }
 
     public interface TechnicalExpertWithMemory {
@@ -188,9 +248,19 @@ public class Agents {
                 Analyze the following user request under a technical point of view and provide the best possible answer.
                 The user request is {{request}}.
                 """)
-        @Tool("A technical expert")
         @Agent(description = "A technical expert", outputKey = "response")
         String technical(@MemoryId String memoryId, @V("request") String request);
+
+        @ChatMemoryProviderSupplier
+        static ChatMemory chatMemory(Object memoryId) {
+            return MessageWindowChatMemory.withMaxMessages(10);
+        }
+
+        @ChatModelSupplier
+        static ChatModel chatModel() {
+            return new FixedResponseChatModel("\"I'm sorry to hear that you've broken your computer." +
+                    "Here are the steps you should take: **Seek Technical Assistance");
+        }
     }
 
     public interface CreativeWriter {

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/ChatScopedAgentMemoryTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/ChatScopedAgentMemoryTest.java
@@ -1,0 +1,146 @@
+package io.quarkiverse.langchain4j.agentic.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.ChatMemoryProviderSupplier;
+import dev.langchain4j.agentic.declarative.ChatModelSupplier;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import dev.langchain4j.store.memory.chat.ChatMemoryStore;
+import io.quarkiverse.langchain4j.chatscopes.ChatScope;
+import io.quarkiverse.langchain4j.chatscopes.ChatScoped;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ChatScopedAgentMemoryTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ChatAgent.class, InMemoryChatMemoryStore.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "whatever")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    public interface ChatAgent {
+
+        @UserMessage("{{message}}")
+        @Agent(description = "A simple chat agent")
+        @ChatScoped
+        String chat(@V("message") String message);
+
+        @ChatMemoryProviderSupplier
+        static ChatMemory chatMemory(Object memoryId) {
+            return MessageWindowChatMemory.builder()
+                    .id(memoryId)
+                    .maxMessages(10)
+                    .chatMemoryStore(Arc.container().select(InMemoryChatMemoryStore.class).get())
+                    .build();
+        }
+
+        @ChatModelSupplier
+        static ChatModel chatModel() {
+            return new ChatModel() {
+                @Override
+                public ChatResponse doChat(ChatRequest request) {
+                    return ChatResponse.builder()
+                            .aiMessage(new AiMessage("echo"))
+                            .build();
+                }
+            };
+        }
+    }
+
+    @ApplicationScoped
+    public static class InMemoryChatMemoryStore implements ChatMemoryStore {
+
+        private final Map<Object, List<ChatMessage>> store = new ConcurrentHashMap<>();
+
+        public Map<Object, List<ChatMessage>> all() {
+            return store;
+        }
+
+        @Override
+        public List<ChatMessage> getMessages(Object memoryId) {
+            return store.computeIfAbsent(memoryId, k -> new ArrayList<>());
+        }
+
+        @Override
+        public void updateMessages(Object memoryId, List<ChatMessage> messages) {
+            store.put(memoryId, messages);
+        }
+
+        @Override
+        public void deleteMessages(Object memoryId) {
+            store.remove(memoryId);
+        }
+    }
+
+    @Inject
+    ChatAgent chatAgent;
+
+    @Inject
+    InMemoryChatMemoryStore memoryStore;
+
+    @BeforeEach
+    void reset() {
+        memoryStore.all().clear();
+    }
+
+    @Test
+    void memoryIdDerivedFromChatScope() {
+        ChatScope.begin();
+        String scopeId = ChatScope.id();
+
+        chatAgent.chat("hello");
+
+        assertThat(memoryStore.all()).hasSize(1);
+        String memoryId = (String) memoryStore.all().keySet().iterator().next();
+        assertThat(memoryId).startsWith(scopeId);
+
+        ChatScope.end();
+    }
+
+    @Test
+    void differentScopesUseDifferentMemoryIds() {
+        ChatScope.begin();
+        String firstScopeId = ChatScope.id();
+        chatAgent.chat("first");
+        String firstMemoryId = (String) memoryStore.all().keySet().iterator().next();
+        ChatScope.end();
+
+        ChatScope.begin();
+        String secondScopeId = ChatScope.id();
+        chatAgent.chat("second");
+        ChatScope.end();
+
+        assertThat(firstScopeId).isNotEqualTo(secondScopeId);
+        assertThat(firstMemoryId).startsWith(firstScopeId);
+        assertThat(memoryStore.all().keySet())
+                .anySatisfy(key -> assertThat((String) key).startsWith(secondScopeId));
+    }
+}

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/ChatScopedAgenticConversationTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/ChatScopedAgenticConversationTest.java
@@ -233,11 +233,11 @@ public class ChatScopedAgenticConversationTest extends OpenAiBaseTest {
         private final List<String> ended = new CopyOnWriteArrayList<>();
 
         public void onStarted(@Observes ConversationStarted event) {
-            started.add(event.getConversationId());
+            started.add(event.conversationId());
         }
 
         public void onEnded(@Observes ConversationEnded event) {
-            ended.add(event.getConversationId());
+            ended.add(event.conversationId());
         }
 
         public List<String> started() {

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/ChatScopedAgenticConversationTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/ChatScopedAgenticConversationTest.java
@@ -1,0 +1,256 @@
+package io.quarkiverse.langchain4j.agentic.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.ActivationCondition;
+import dev.langchain4j.agentic.declarative.ChatMemoryProviderSupplier;
+import dev.langchain4j.agentic.declarative.ChatModelSupplier;
+import dev.langchain4j.agentic.declarative.ConditionalAgent;
+import dev.langchain4j.agentic.declarative.SequenceAgent;
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.agentic.scope.AgenticScopeAccess;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import io.quarkiverse.langchain4j.agentic.deployment.Agents.CategoryRouter;
+import io.quarkiverse.langchain4j.agentic.deployment.Agents.FixedResponseChatModel;
+import io.quarkiverse.langchain4j.agentic.deployment.Agents.RequestCategory;
+import io.quarkiverse.langchain4j.chatscopes.ChatScope;
+import io.quarkiverse.langchain4j.chatscopes.ChatScoped;
+import io.quarkiverse.langchain4j.chatscopes.internal.ChatScopeConversationBridge;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.runtime.conversation.ConversationContext;
+import io.quarkiverse.langchain4j.runtime.conversation.ConversationEnded;
+import io.quarkiverse.langchain4j.runtime.conversation.ConversationStarted;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.vertx.RunOnVertxContext;
+import io.quarkus.test.vertx.UniAsserter;
+
+public class ChatScopedAgenticConversationTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(FixedResponseChatModel.class,
+                            CategoryRouter.class,
+                            RequestCategory.class,
+                            MedicalExpertChatScoped.class,
+                            TechnicalExpertChatScoped.class,
+                            LegalExpertChatScoped.class,
+                            ChatScopedExpertsAgent.class,
+                            ChatScopedExpertRouter.class,
+                            ChatScopeConversationBridge.class,
+                            ConversationEventCollector.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "whatever")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    public interface MedicalExpertChatScoped {
+
+        @UserMessage("""
+                You are a medical expert.
+                Analyze the following user request under a medical point of view and provide the best possible answer.
+                The user request is {{request}}.
+                """)
+        @Agent(description = "A medical expert", outputKey = "response")
+        @ChatScoped
+        String medical(@V("request") String request);
+
+        @ChatMemoryProviderSupplier
+        static ChatMemory chatMemory(Object memoryId) {
+            return MessageWindowChatMemory.withMaxMessages(10);
+        }
+
+        @ChatModelSupplier
+        static ChatModel chatModel() {
+            return new FixedResponseChatModel("\"I'm sorry to hear that you've broken your leg." +
+                    "Here are the steps you should take: **Seek Medical Attention");
+        }
+    }
+
+    public interface LegalExpertChatScoped {
+
+        @UserMessage("""
+                You are a legal expert.
+                Analyze the following user request under a legal point of view and provide the best possible answer.
+                The user request is {{request}}.
+                """)
+        @Agent(description = "A legal expert", outputKey = "response")
+        @ChatScoped
+        String legal(@V("request") String request);
+
+        @ChatMemoryProviderSupplier
+        static ChatMemory chatMemory(Object memoryId) {
+            return MessageWindowChatMemory.withMaxMessages(10);
+        }
+
+        @ChatModelSupplier
+        static ChatModel chatModel(AgenticScope scope) {
+            String response = scope.readState("response", "");
+            if (response.contains("leg")) {
+                return new FixedResponseChatModel("\"I'm sorry to hear that you've broken your leg." +
+                        "Here are the steps you should take: **Seek Legal Attention");
+            }
+            if (response.contains("computer")) {
+                return new FixedResponseChatModel("\"I'm sorry to hear that you've broken your computer." +
+                        "Here are the steps you should take: **Seek Legal Attention");
+            }
+            return new FixedResponseChatModel("**Seek Legal Attention");
+        }
+    }
+
+    public interface TechnicalExpertChatScoped {
+
+        @UserMessage("""
+                You are a technical expert.
+                Analyze the following user request under a technical point of view and provide the best possible answer.
+                The user request is {{request}}.
+                """)
+        @Agent(description = "A technical expert", outputKey = "response")
+        @ChatScoped
+        String technical(@V("request") String request);
+
+        @ChatMemoryProviderSupplier
+        static ChatMemory chatMemory(Object memoryId) {
+            return MessageWindowChatMemory.withMaxMessages(10);
+        }
+
+        @ChatModelSupplier
+        static ChatModel chatModel() {
+            return new FixedResponseChatModel("\"I'm sorry to hear that you've broken your computer." +
+                    "Here are the steps you should take: **Seek Technical Assistance");
+        }
+    }
+
+    public interface ChatScopedExpertsAgent {
+
+        @ConditionalAgent(outputKey = "response", subAgents = { MedicalExpertChatScoped.class,
+                TechnicalExpertChatScoped.class, LegalExpertChatScoped.class })
+        String askExpert(@V("request") String request);
+
+        @ActivationCondition(MedicalExpertChatScoped.class)
+        static boolean activateMedical(@V("category") RequestCategory category) {
+            return category == RequestCategory.MEDICAL;
+        }
+
+        @ActivationCondition(TechnicalExpertChatScoped.class)
+        static boolean activateTechnical(@V("category") RequestCategory category) {
+            return category == RequestCategory.TECHNICAL;
+        }
+
+        @ActivationCondition(LegalExpertChatScoped.class)
+        static boolean activateLegal(@V("category") RequestCategory category) {
+            return category == RequestCategory.LEGAL;
+        }
+    }
+
+    public interface ChatScopedExpertRouter extends AgenticScopeAccess {
+
+        @SequenceAgent(outputKey = "response", subAgents = { CategoryRouter.class, ChatScopedExpertsAgent.class })
+        @ChatScoped
+        String ask(@MemoryId String memoryId, @V("request") String request);
+    }
+
+    @Inject
+    ChatScopedExpertRouter expertRouter;
+
+    @Inject
+    ConversationEventCollector collector;
+
+    @BeforeEach
+    void reset() {
+        collector.clear();
+    }
+
+    @Test
+    @RunOnVertxContext(runOnEventLoop = false)
+    void multiInteractionConversationsWithChatScopedAgent(UniAsserter asserter) {
+        asserter.execute(() -> {
+            // First conversation — medical then legal follow-up (2 interactions)
+            ChatScope.begin();
+            String conv1 = ChatScope.id();
+
+            expertRouter.ask(conv1, "I broke my leg, what should I do?");
+            assertThat(expertRouter.getAgenticScope(conv1)
+                    .readState("category", RequestCategory.UNKNOWN)).isEqualTo(RequestCategory.MEDICAL);
+            assertThat(ConversationContext.current()).isEqualTo(conv1);
+
+            String legalResponse1 = expertRouter.ask(conv1, "Should I sue my neighbor who caused this damage?");
+            assertThat(expertRouter.getAgenticScope(conv1)
+                    .readState("category", RequestCategory.UNKNOWN)).isEqualTo(RequestCategory.LEGAL);
+            assertThat(legalResponse1).containsIgnoringCase("leg").doesNotContain("computer");
+            assertThat(ConversationContext.current()).isEqualTo(conv1);
+
+            ChatScope.end();
+            assertThat(ConversationContext.isActive()).isFalse();
+
+            // Second conversation — technical then legal follow-up (2 interactions)
+            ChatScope.begin();
+            String conv2 = ChatScope.id();
+            assertThat(conv2).isNotEqualTo(conv1);
+
+            expertRouter.ask(conv2, "My computer has liquid inside, what should I do?");
+            assertThat(expertRouter.getAgenticScope(conv2)
+                    .readState("category", RequestCategory.UNKNOWN)).isEqualTo(RequestCategory.TECHNICAL);
+            assertThat(ConversationContext.current()).isEqualTo(conv2);
+
+            String legalResponse2 = expertRouter.ask(conv2, "Should I sue my neighbor who caused this damage?");
+            assertThat(expertRouter.getAgenticScope(conv2)
+                    .readState("category", RequestCategory.UNKNOWN)).isEqualTo(RequestCategory.LEGAL);
+            assertThat(legalResponse2).containsIgnoringCase("computer").doesNotContain("leg");
+            assertThat(ConversationContext.current()).isEqualTo(conv2);
+
+            ChatScope.end();
+            assertThat(ConversationContext.isActive()).isFalse();
+
+            // Both conversations tracked — each had 2 interactions but only 1 begin/end per scope
+            assertThat(collector.started()).containsExactly(conv1, conv2);
+            assertThat(collector.ended()).containsExactly(conv1, conv2);
+        });
+    }
+
+    @ApplicationScoped
+    public static class ConversationEventCollector {
+        private final List<String> started = new CopyOnWriteArrayList<>();
+        private final List<String> ended = new CopyOnWriteArrayList<>();
+
+        public void onStarted(@Observes ConversationStarted event) {
+            started.add(event.getConversationId());
+        }
+
+        public void onEnded(@Observes ConversationEnded event) {
+            ended.add(event.getConversationId());
+        }
+
+        public List<String> started() {
+            return started;
+        }
+
+        public List<String> ended() {
+            return ended;
+        }
+
+        public void clear() {
+            started.clear();
+            ended.clear();
+        }
+    }
+}

--- a/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/WorkflowTest.java
+++ b/agentic/deployment/src/test/java/io/quarkiverse/langchain4j/agentic/deployment/WorkflowTest.java
@@ -22,7 +22,9 @@ import dev.langchain4j.agentic.declarative.ExitCondition;
 import dev.langchain4j.agentic.declarative.LoopAgent;
 import dev.langchain4j.agentic.declarative.SequenceAgent;
 import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.agentic.scope.AgenticScopeAccess;
 import dev.langchain4j.agentic.scope.ResultWithAgenticScope;
+import dev.langchain4j.service.MemoryId;
 import dev.langchain4j.service.V;
 import io.quarkiverse.langchain4j.agentic.deployment.Agents.*;
 import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
@@ -219,5 +221,69 @@ public class WorkflowTest extends OpenAiBaseTest {
         assertThat(story).isNotNull();
         assertThat(violenceInputGuardrail.isInvoked()).isTrue();
         assertThat(lengthOutputGuardrail.isInvoked()).isTrue();
+    }
+
+    public interface ExpertsAgentWithMemory {
+
+        @ConditionalAgent(outputKey = "response", subAgents = { MedicalExpertWithMemory.class, TechnicalExpertWithMemory.class,
+                LegalExpertWithMemory.class
+        })
+        String askExpert(@V("request") String request);
+
+        @ActivationCondition(MedicalExpertWithMemory.class)
+        static boolean activateMedical(@V("category") RequestCategory category) {
+            return category == RequestCategory.MEDICAL;
+        }
+
+        @ActivationCondition(TechnicalExpertWithMemory.class)
+        static boolean activateTechnical(@V("category") RequestCategory category) {
+            return category == RequestCategory.TECHNICAL;
+        }
+
+        @ActivationCondition(LegalExpertWithMemory.class)
+        static boolean activateLegal(@V("category") RequestCategory category) {
+            return category == RequestCategory.LEGAL;
+        }
+    }
+
+    public interface ExpertRouterAgentWithMemory extends AgenticScopeAccess {
+
+        @SequenceAgent(outputKey = "response", subAgents = { CategoryRouter.class, ExpertsAgentWithMemory.class })
+        String ask(@MemoryId String memoryId, @V("request") String request);
+    }
+
+    @Inject
+    ExpertRouterAgentWithMemory expertRouterAgentWithMemory;
+
+    @Test
+    void declarative_memory_tests() {
+        String response1 = expertRouterAgentWithMemory.ask("1", "I broke my leg, what should I do?");
+
+        AgenticScope agenticScope1 = expertRouterAgentWithMemory.getAgenticScope("1");
+        assertThat(agenticScope1.readState("category", RequestCategory.UNKNOWN)).isEqualTo(RequestCategory.MEDICAL);
+
+        String response2 = expertRouterAgentWithMemory.ask("2", "My computer has liquid inside, what should I do?");
+
+        AgenticScope agenticScope2 = expertRouterAgentWithMemory.getAgenticScope("2");
+        assertThat(agenticScope2.readState("category", RequestCategory.UNKNOWN)).isEqualTo(RequestCategory.TECHNICAL);
+
+        String legalResponse1 = expertRouterAgentWithMemory.ask("1", "Should I sue my neighbor who caused this damage?");
+
+        String legalResponse2 = expertRouterAgentWithMemory.ask("2", "Should I sue my neighbor who caused this damage?");
+
+        assertThat(legalResponse1).containsIgnoringCase("leg").doesNotContain("computer");
+        assertThat(legalResponse2).containsIgnoringCase("computer").doesNotContain("leg");
+
+        // It is necessary to read again the agenticScope instances since they were evicted from the in-memory registry
+        // and reloaded from the persistence provider
+        agenticScope1 = expertRouterAgentWithMemory.getAgenticScope("1");
+        assertThat(agenticScope1.readState("category", RequestCategory.UNKNOWN)).isEqualTo(RequestCategory.LEGAL);
+        agenticScope2 = expertRouterAgentWithMemory.getAgenticScope("2");
+        assertThat(agenticScope2.readState("category", RequestCategory.UNKNOWN)).isEqualTo(RequestCategory.LEGAL);
+
+        assertThat(expertRouterAgentWithMemory.evictAgenticScope("1")).isTrue();
+        assertThat(expertRouterAgentWithMemory.evictAgenticScope("2")).isTrue();
+        assertThat(expertRouterAgentWithMemory.evictAgenticScope("1")).isFalse();
+        assertThat(expertRouterAgentWithMemory.evictAgenticScope("2")).isFalse();
     }
 }

--- a/chat-scopes/core/deployment/pom.xml
+++ b/chat-scopes/core/deployment/pom.xml
@@ -58,6 +58,17 @@
             <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-vertx</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/chat-scopes/core/deployment/src/test/java/io/quarkiverse/langchain4j/tests/scopes/chat/ChatScopeConversationBridgeTest.java
+++ b/chat-scopes/core/deployment/src/test/java/io/quarkiverse/langchain4j/tests/scopes/chat/ChatScopeConversationBridgeTest.java
@@ -1,0 +1,161 @@
+package io.quarkiverse.langchain4j.tests.scopes.chat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.langchain4j.chatscopes.ChatScope;
+import io.quarkiverse.langchain4j.chatscopes.internal.ChatScopeConversationBridge;
+import io.quarkiverse.langchain4j.runtime.conversation.ConversationContext;
+import io.quarkiverse.langchain4j.runtime.conversation.ConversationEnded;
+import io.quarkiverse.langchain4j.runtime.conversation.ConversationStarted;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.vertx.RunOnVertxContext;
+import io.quarkus.test.vertx.UniAsserter;
+
+public class ChatScopeConversationBridgeTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ChatScopeConversationBridge.class, ConversationEventCollector.class));
+
+    @Inject
+    ConversationEventCollector collector;
+
+    @BeforeEach
+    void reset() {
+        collector.clear();
+    }
+
+    @Test
+    @RunOnVertxContext
+    void chatScopeBeginActivatesConversation(UniAsserter asserter) {
+        asserter.execute(() -> {
+            ChatScope.begin();
+            String scopeId = ChatScope.id();
+
+            assertThat(ConversationContext.isActive()).isTrue();
+            assertThat(ConversationContext.current()).isEqualTo(scopeId);
+
+            assertThat(collector.started()).hasSize(1);
+            assertThat(collector.started().get(0)).isEqualTo(scopeId);
+
+            ChatScope.end();
+        });
+    }
+
+    @Test
+    @RunOnVertxContext
+    void chatScopeEndDeactivatesConversation(UniAsserter asserter) {
+        asserter.execute(() -> {
+            ChatScope.begin();
+            collector.clear();
+
+            ChatScope.end();
+
+            assertThat(ConversationContext.isActive()).isFalse();
+            assertThat(collector.ended()).hasSize(1);
+        });
+    }
+
+    @Test
+    @RunOnVertxContext
+    void pushDoesNotChangeConversationId(UniAsserter asserter) {
+        asserter.execute(() -> {
+            ChatScope.begin();
+            String topId = ChatScope.id();
+            collector.clear();
+
+            ChatScope.push();
+            String childId = ChatScope.id();
+
+            assertThat(childId).isNotEqualTo(topId);
+            // Conversation ID stays the top scope's ID — push/pop don't affect it
+            assertThat(ConversationContext.current()).isEqualTo(topId);
+
+            // No conversation events fired during push
+            assertThat(collector.started()).isEmpty();
+            assertThat(collector.ended()).isEmpty();
+
+            ChatScope.pop();
+            ChatScope.end();
+        });
+    }
+
+    @Test
+    @RunOnVertxContext
+    void popDoesNotChangeConversationId(UniAsserter asserter) {
+        asserter.execute(() -> {
+            ChatScope.begin();
+            String topId = ChatScope.id();
+            ChatScope.push();
+            collector.clear();
+
+            ChatScope.pop();
+
+            // Conversation ID unchanged throughout
+            assertThat(ConversationContext.current()).isEqualTo(topId);
+
+            // No conversation events fired during pop
+            assertThat(collector.started()).isEmpty();
+            assertThat(collector.ended()).isEmpty();
+
+            ChatScope.end();
+        });
+    }
+
+    @Test
+    @RunOnVertxContext
+    void fullLifecycleEvents(UniAsserter asserter) {
+        asserter.execute(() -> {
+            ChatScope.begin();
+            String topId = ChatScope.id();
+            ChatScope.push();
+            ChatScope.pop();
+            ChatScope.end();
+
+            // Only one start and one end — push/pop don't generate conversation events
+            assertThat(collector.started()).containsExactly(topId);
+            assertThat(collector.ended()).containsExactly(topId);
+        });
+    }
+
+    @ApplicationScoped
+    public static class ConversationEventCollector {
+        private final List<String> started = new ArrayList<>();
+        private final List<String> ended = new ArrayList<>();
+
+        public void onStarted(@Observes ConversationStarted event) {
+            started.add(event.getConversationId());
+        }
+
+        public void onEnded(@Observes ConversationEnded event) {
+            ended.add(event.getConversationId());
+        }
+
+        public List<String> started() {
+            return started;
+        }
+
+        public List<String> ended() {
+            return ended;
+        }
+
+        public void clear() {
+            started.clear();
+            ended.clear();
+        }
+    }
+}

--- a/chat-scopes/core/deployment/src/test/java/io/quarkiverse/langchain4j/tests/scopes/chat/ChatScopeConversationBridgeTest.java
+++ b/chat-scopes/core/deployment/src/test/java/io/quarkiverse/langchain4j/tests/scopes/chat/ChatScopeConversationBridgeTest.java
@@ -138,11 +138,11 @@ public class ChatScopeConversationBridgeTest {
         private final List<String> ended = new ArrayList<>();
 
         public void onStarted(@Observes ConversationStarted event) {
-            started.add(event.getConversationId());
+            started.add(event.conversationId());
         }
 
         public void onEnded(@Observes ConversationEnded event) {
-            ended.add(event.getConversationId());
+            ended.add(event.conversationId());
         }
 
         public List<String> started() {

--- a/chat-scopes/core/runtime/src/main/java/io/quarkiverse/langchain4j/chatscopes/internal/ChatScopeConversationBridge.java
+++ b/chat-scopes/core/runtime/src/main/java/io/quarkiverse/langchain4j/chatscopes/internal/ChatScopeConversationBridge.java
@@ -1,7 +1,9 @@
 package io.quarkiverse.langchain4j.chatscopes.internal;
 
+import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
+import jakarta.interceptor.Interceptor;
 
 import io.quarkiverse.langchain4j.chatscopes.ChatScopeEnded;
 import io.quarkiverse.langchain4j.chatscopes.ChatScopeStarted;
@@ -18,13 +20,13 @@ import io.quarkiverse.langchain4j.runtime.conversation.ConversationContext;
 @ApplicationScoped
 public class ChatScopeConversationBridge {
 
-    void onStarted(@Observes ChatScopeStarted event) {
+    void onStarted(@Observes @Priority(Interceptor.Priority.LIBRARY_BEFORE) ChatScopeStarted event) {
         if (event.scope().parent() == null) {
             ConversationContext.begin(event.scope().getId());
         }
     }
 
-    void onEnded(@Observes ChatScopeEnded event) {
+    void onEnded(@Observes @Priority(Interceptor.Priority.LIBRARY_AFTER) ChatScopeEnded event) {
         if (event.scope().parent() == null) {
             ConversationContext.end();
         }

--- a/chat-scopes/core/runtime/src/main/java/io/quarkiverse/langchain4j/chatscopes/internal/ChatScopeConversationBridge.java
+++ b/chat-scopes/core/runtime/src/main/java/io/quarkiverse/langchain4j/chatscopes/internal/ChatScopeConversationBridge.java
@@ -1,0 +1,32 @@
+package io.quarkiverse.langchain4j.chatscopes.internal;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+import io.quarkiverse.langchain4j.chatscopes.ChatScopeEnded;
+import io.quarkiverse.langchain4j.chatscopes.ChatScopeStarted;
+import io.quarkiverse.langchain4j.runtime.conversation.ConversationContext;
+
+/**
+ * Bridges ChatScope lifecycle events to {@link ConversationContext}, so that the conversation ID
+ * is automatically set on OTel spans when using Chat Scopes.
+ * <p>
+ * Only reacts to top-level scopes (where {@code parent() == null}). Push/pop transitions within
+ * a conversation do not affect the conversation identity — the ID remains that of the top scope
+ * throughout the entire conversation lifecycle.
+ */
+@ApplicationScoped
+public class ChatScopeConversationBridge {
+
+    void onStarted(@Observes ChatScopeStarted event) {
+        if (event.scope().parent() == null) {
+            ConversationContext.begin(event.scope().getId());
+        }
+    }
+
+    void onEnded(@Observes ChatScopeEnded event) {
+        if (event.scope().parent() == null) {
+            ConversationContext.end();
+        }
+    }
+}

--- a/chat-scopes/core/runtime/src/main/java/io/quarkiverse/langchain4j/chatscopes/internal/ChatScopeInjectableContext.java
+++ b/chat-scopes/core/runtime/src/main/java/io/quarkiverse/langchain4j/chatscopes/internal/ChatScopeInjectableContext.java
@@ -15,7 +15,7 @@ public class ChatScopeInjectableContext extends CustomInjectableContext {
 
     @Override
     protected CustomContextState state() {
-        return ChatScopeManagedContext.currentScope.get();
+        return ChatScopeManagedContext.INSTANCE.currentContext();
     }
 
     @Override

--- a/chat-scopes/core/runtime/src/main/java/io/quarkiverse/langchain4j/chatscopes/internal/ChatScopeManagedContext.java
+++ b/chat-scopes/core/runtime/src/main/java/io/quarkiverse/langchain4j/chatscopes/internal/ChatScopeManagedContext.java
@@ -206,11 +206,17 @@ public class ChatScopeManagedContext implements ContextState {
     }
 
     public boolean isActive() {
-        return currentScope.get() != null;
+        return currentContext() != null;
     }
 
     public ChatScopeImpl currentContext() {
-        return currentScope.get();
+        ChatScopeImpl scope = currentScope.get();
+        // On Vert.x duplicated contexts, remove() is a NOOP so a destroyed scope
+        // may linger as a stale reference. Treat it as absent.
+        if (scope != null && scope.destroyed) {
+            return null;
+        }
+        return scope;
     }
 
     public ChatScopeImpl begin() {
@@ -224,7 +230,7 @@ public class ChatScopeManagedContext implements ContextState {
     }
 
     public ChatScopeImpl begin(String route) {
-        if (currentScope.get() != null) {
+        if (currentContext() != null) {
             throw new ContextException("Existing scope already active");
         }
         ChatScopeImpl context = new ChatScopeImpl(route);
@@ -284,7 +290,7 @@ public class ChatScopeManagedContext implements ContextState {
         if (current.isTop()) {
             fireEvent(new ChatScopeDeactivated(current));
             current.destroy();
-            currentScope.set(null);
+            currentScope.remove();
             return;
         }
         ChatScopeImpl parent = current.parent;

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
@@ -1990,8 +1990,14 @@ public class AiServicesProcessor {
                         .map(AiServicesProcessor::classOutputGuardrails)
                         .orElse(null);
 
+                var defaultMemoryIdProviderClassName = aiServiceBuildItem
+                        .map(DeclarativeAiServiceBuildItem::getDefaultMemoryIdProviderClassDotName)
+                        .map(DotName::toString)
+                        .orElse(null);
+
                 perClassMetadata.put(ifaceName,
-                        new AiServiceClassCreateInfo(perMethodMetadata, implClassName, inputGuardrails, outputGuardrails));
+                        new AiServiceClassCreateInfo(perMethodMetadata, implClassName, inputGuardrails, outputGuardrails,
+                                defaultMemoryIdProviderClassName));
                 // make the constructor accessible reflectively since that is how we create the instance
                 reflectiveClassProducer.produce(ReflectiveClassBuildItem.builder(implClassName).build());
             }

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/ListenersProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/ListenersProcessor.java
@@ -2,26 +2,46 @@ package io.quarkiverse.langchain4j.deployment;
 
 import java.util.Optional;
 
+import io.quarkiverse.langchain4j.runtime.conversation.ConversationThreadContextProvider;
+import io.quarkiverse.langchain4j.runtime.listeners.ConversationIdSpanContributor;
 import io.quarkiverse.langchain4j.runtime.listeners.MetricsChatModelListener;
 import io.quarkiverse.langchain4j.runtime.listeners.SpanChatModelListener;
+import io.quarkiverse.langchain4j.runtime.tool.ConversationIdToolSpanContributor;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.ExcludedTypeBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
 import io.quarkus.runtime.metrics.MetricsFactory;
+import io.quarkus.smallrye.context.deployment.spi.ThreadContextProviderBuildItem;
 
 public class ListenersProcessor {
+
+    private static final String CONVERSATION_ID_SPAN_CONTRIBUTOR = ConversationIdSpanContributor.class.getName();
+    private static final String CONVERSATION_ID_TOOL_SPAN_CONTRIBUTOR = ConversationIdToolSpanContributor.class.getName();
 
     @BuildStep
     public void spanListeners(Capabilities capabilities,
             Optional<MetricsCapabilityBuildItem> metricsCapability,
-            BuildProducer<AdditionalBeanBuildItem> additionalBeanProducer) {
+            BuildProducer<AdditionalBeanBuildItem> additionalBeanProducer,
+            BuildProducer<ExcludedTypeBuildItem> excludedTypeProducer) {
         var addOpenTelemetrySpan = capabilities.isPresent(Capability.OPENTELEMETRY_TRACER);
         if (addOpenTelemetrySpan) {
             additionalBeanProducer.produce(
                     AdditionalBeanBuildItem.builder().addBeanClass(SpanChatModelListener.class).setUnremovable().build());
+            additionalBeanProducer.produce(
+                    AdditionalBeanBuildItem.builder()
+                            .addBeanClass(CONVERSATION_ID_SPAN_CONTRIBUTOR)
+                            .setUnremovable().build());
+            additionalBeanProducer.produce(
+                    AdditionalBeanBuildItem.builder()
+                            .addBeanClass(CONVERSATION_ID_TOOL_SPAN_CONTRIBUTOR)
+                            .setUnremovable().build());
+        } else {
+            excludedTypeProducer.produce(new ExcludedTypeBuildItem(CONVERSATION_ID_SPAN_CONTRIBUTOR));
+            excludedTypeProducer.produce(new ExcludedTypeBuildItem(CONVERSATION_ID_TOOL_SPAN_CONTRIBUTOR));
         }
 
         var addMicrometerMetrics = metricsCapability.isPresent()
@@ -30,5 +50,10 @@ public class ListenersProcessor {
             additionalBeanProducer.produce(
                     AdditionalBeanBuildItem.builder().addBeanClass(MetricsChatModelListener.class).setUnremovable().build());
         }
+    }
+
+    @BuildStep
+    public void conversationContextPropagation(BuildProducer<ThreadContextProviderBuildItem> producer) {
+        producer.produce(new ThreadContextProviderBuildItem(ConversationThreadContextProvider.class));
     }
 }

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ListenersProcessorNoOpentelemetryTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ListenersProcessorNoOpentelemetryTest.java
@@ -32,6 +32,6 @@ class ListenersProcessorNoOpentelemetryTest {
     @Test
     void shouldNotHaveSpanChatModelListenerWhenNoOtel() {
         assertThat(spanChatModelListeners).hasSize(1); // The Tracer is active if its on the classpath
-        assertThat(chatModelSpanContributors).hasSize(2); // the prompt and completion ones are always active
+        assertThat(chatModelSpanContributors).hasSize(3); // prompt, completion, and conversation-id contributors
     }
 }

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/conversation/ConversationContextTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/conversation/ConversationContextTest.java
@@ -1,0 +1,139 @@
+package io.quarkiverse.langchain4j.test.conversation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.langchain4j.runtime.conversation.ConversationContext;
+import io.quarkiverse.langchain4j.runtime.conversation.ConversationEnded;
+import io.quarkiverse.langchain4j.runtime.conversation.ConversationStarted;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.vertx.RunOnVertxContext;
+import io.quarkus.test.vertx.UniAsserter;
+
+public class ConversationContextTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(ConversationEventCollector.class));
+
+    @Inject
+    ConversationEventCollector collector;
+
+    @AfterEach
+    void cleanup() {
+        collector.clear();
+    }
+
+    @Test
+    @RunOnVertxContext
+    void beginSetsConversationId(UniAsserter asserter) {
+        asserter.execute(() -> {
+            ConversationContext.begin("conv-123");
+            assertThat(ConversationContext.current()).isEqualTo("conv-123");
+            assertThat(ConversationContext.isActive()).isTrue();
+            ConversationContext.end();
+        });
+    }
+
+    @Test
+    @RunOnVertxContext
+    void endClearsConversationId(UniAsserter asserter) {
+        asserter.execute(() -> {
+            ConversationContext.begin("conv-456");
+            ConversationContext.end();
+            assertThat(ConversationContext.current()).isNull();
+            assertThat(ConversationContext.isActive()).isFalse();
+        });
+    }
+
+    @Test
+    @RunOnVertxContext
+    void endWhenNotActiveIsNoOp(UniAsserter asserter) {
+        asserter.execute(() -> {
+            ConversationContext.end();
+            assertThat(collector.events()).isEmpty();
+        });
+    }
+
+    @Test
+    @RunOnVertxContext(runOnEventLoop = false)
+    void beginAutoEndsPreviousConversation(UniAsserter asserter) {
+        asserter.execute(() -> {
+            ConversationContext.begin("first");
+            assertThat(ConversationContext.current()).isEqualTo("first");
+            assertThat(ConversationContext.isActive()).isTrue();
+            collector.clear();
+
+            ConversationContext.begin("second");
+            assertThat(ConversationContext.current()).isEqualTo("second");
+
+            // The previous conversation was auto-ended before the new one started
+            assertThat(collector.events()).hasSize(2);
+            assertThat(collector.events().get(0)).isInstanceOf(ConversationEnded.class);
+            assertThat(((ConversationEnded) collector.events().get(0)).getConversationId()).isEqualTo("first");
+            assertThat(collector.events().get(1)).isInstanceOf(ConversationStarted.class);
+            assertThat(((ConversationStarted) collector.events().get(1)).getConversationId()).isEqualTo("second");
+
+            ConversationContext.end();
+        });
+    }
+
+    @Test
+    @RunOnVertxContext
+    void firesConversationStartedEvent(UniAsserter asserter) {
+        asserter.execute(() -> {
+            ConversationContext.begin("evt-start");
+            assertThat(collector.events()).hasSize(1);
+            assertThat(collector.events().get(0)).isInstanceOf(ConversationStarted.class);
+            assertThat(((ConversationStarted) collector.events().get(0)).getConversationId()).isEqualTo("evt-start");
+            ConversationContext.end();
+        });
+    }
+
+    @Test
+    @RunOnVertxContext
+    void firesConversationEndedEvent(UniAsserter asserter) {
+        asserter.execute(() -> {
+            ConversationContext.begin("evt-end");
+            collector.clear();
+            ConversationContext.end();
+            assertThat(collector.events()).hasSize(1);
+            assertThat(collector.events().get(0)).isInstanceOf(ConversationEnded.class);
+            assertThat(((ConversationEnded) collector.events().get(0)).getConversationId()).isEqualTo("evt-end");
+        });
+    }
+
+    @ApplicationScoped
+    public static class ConversationEventCollector {
+        private final List<Object> events = new ArrayList<>();
+
+        public void onStarted(@Observes ConversationStarted event) {
+            events.add(event);
+        }
+
+        public void onEnded(@Observes ConversationEnded event) {
+            events.add(event);
+        }
+
+        public List<Object> events() {
+            return events;
+        }
+
+        public void clear() {
+            events.clear();
+        }
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/conversation/ConversationContextTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/conversation/ConversationContextTest.java
@@ -12,6 +12,7 @@ import jakarta.inject.Inject;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -114,6 +115,53 @@ public class ConversationContextTest {
             assertThat(collector.events().get(0)).isInstanceOf(ConversationEnded.class);
             assertThat(((ConversationEnded) collector.events().get(0)).getConversationId()).isEqualTo("evt-end");
         });
+    }
+
+    @Test
+    void beginAndEndWorkWithoutVertxContext() {
+        ConversationContext.begin("no-dc-123");
+        assertThat(ConversationContext.current()).isEqualTo("no-dc-123");
+        assertThat(ConversationContext.isActive()).isTrue();
+
+        ConversationContext.end();
+        assertThat(ConversationContext.current()).isNull();
+        assertThat(ConversationContext.isActive()).isFalse();
+    }
+
+    @Test
+    void firesEventsWithoutVertxContext() {
+        ConversationContext.begin("no-dc-evt");
+        assertThat(collector.events()).hasSize(1);
+        assertThat(collector.events().get(0)).isInstanceOf(ConversationStarted.class);
+        assertThat(((ConversationStarted) collector.events().get(0)).getConversationId()).isEqualTo("no-dc-evt");
+
+        collector.clear();
+        ConversationContext.end();
+        assertThat(collector.events()).hasSize(1);
+        assertThat(collector.events().get(0)).isInstanceOf(ConversationEnded.class);
+        assertThat(((ConversationEnded) collector.events().get(0)).getConversationId()).isEqualTo("no-dc-evt");
+    }
+
+    @Test
+    void beginAutoEndsPreviousWithoutVertxContext() {
+        ConversationContext.begin("first");
+        collector.clear();
+
+        ConversationContext.begin("second");
+        assertThat(ConversationContext.current()).isEqualTo("second");
+
+        assertThat(collector.events()).hasSize(2);
+        assertThat(collector.events().get(0)).isInstanceOf(ConversationEnded.class);
+        assertThat(((ConversationEnded) collector.events().get(0)).getConversationId()).isEqualTo("first");
+        assertThat(collector.events().get(1)).isInstanceOf(ConversationStarted.class);
+        assertThat(((ConversationStarted) collector.events().get(1)).getConversationId()).isEqualTo("second");
+
+        ConversationContext.end();
+    }
+
+    @Test
+    void beginWithNullThrows() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> ConversationContext.begin(null));
     }
 
     @ApplicationScoped

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/conversation/ConversationContextTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/conversation/ConversationContextTest.java
@@ -84,9 +84,9 @@ public class ConversationContextTest {
             // The previous conversation was auto-ended before the new one started
             assertThat(collector.events()).hasSize(2);
             assertThat(collector.events().get(0)).isInstanceOf(ConversationEnded.class);
-            assertThat(((ConversationEnded) collector.events().get(0)).getConversationId()).isEqualTo("first");
+            assertThat(((ConversationEnded) collector.events().get(0)).conversationId()).isEqualTo("first");
             assertThat(collector.events().get(1)).isInstanceOf(ConversationStarted.class);
-            assertThat(((ConversationStarted) collector.events().get(1)).getConversationId()).isEqualTo("second");
+            assertThat(((ConversationStarted) collector.events().get(1)).conversationId()).isEqualTo("second");
 
             ConversationContext.end();
         });
@@ -99,7 +99,7 @@ public class ConversationContextTest {
             ConversationContext.begin("evt-start");
             assertThat(collector.events()).hasSize(1);
             assertThat(collector.events().get(0)).isInstanceOf(ConversationStarted.class);
-            assertThat(((ConversationStarted) collector.events().get(0)).getConversationId()).isEqualTo("evt-start");
+            assertThat(((ConversationStarted) collector.events().get(0)).conversationId()).isEqualTo("evt-start");
             ConversationContext.end();
         });
     }
@@ -113,7 +113,7 @@ public class ConversationContextTest {
             ConversationContext.end();
             assertThat(collector.events()).hasSize(1);
             assertThat(collector.events().get(0)).isInstanceOf(ConversationEnded.class);
-            assertThat(((ConversationEnded) collector.events().get(0)).getConversationId()).isEqualTo("evt-end");
+            assertThat(((ConversationEnded) collector.events().get(0)).conversationId()).isEqualTo("evt-end");
         });
     }
 
@@ -133,13 +133,13 @@ public class ConversationContextTest {
         ConversationContext.begin("no-dc-evt");
         assertThat(collector.events()).hasSize(1);
         assertThat(collector.events().get(0)).isInstanceOf(ConversationStarted.class);
-        assertThat(((ConversationStarted) collector.events().get(0)).getConversationId()).isEqualTo("no-dc-evt");
+        assertThat(((ConversationStarted) collector.events().get(0)).conversationId()).isEqualTo("no-dc-evt");
 
         collector.clear();
         ConversationContext.end();
         assertThat(collector.events()).hasSize(1);
         assertThat(collector.events().get(0)).isInstanceOf(ConversationEnded.class);
-        assertThat(((ConversationEnded) collector.events().get(0)).getConversationId()).isEqualTo("no-dc-evt");
+        assertThat(((ConversationEnded) collector.events().get(0)).conversationId()).isEqualTo("no-dc-evt");
     }
 
     @Test
@@ -152,9 +152,9 @@ public class ConversationContextTest {
 
         assertThat(collector.events()).hasSize(2);
         assertThat(collector.events().get(0)).isInstanceOf(ConversationEnded.class);
-        assertThat(((ConversationEnded) collector.events().get(0)).getConversationId()).isEqualTo("first");
+        assertThat(((ConversationEnded) collector.events().get(0)).conversationId()).isEqualTo("first");
         assertThat(collector.events().get(1)).isInstanceOf(ConversationStarted.class);
-        assertThat(((ConversationStarted) collector.events().get(1)).getConversationId()).isEqualTo("second");
+        assertThat(((ConversationStarted) collector.events().get(1)).conversationId()).isEqualTo("second");
 
         ConversationContext.end();
     }

--- a/core/opentelemetry-tests/pom.xml
+++ b/core/opentelemetry-tests/pom.xml
@@ -52,6 +52,11 @@
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-vertx</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/opentelemetry-tests/src/test/java/io/quarkiverse/langchain4j/opentelemetry/test/ConversationBaggageTest.java
+++ b/core/opentelemetry-tests/src/test/java/io/quarkiverse/langchain4j/opentelemetry/test/ConversationBaggageTest.java
@@ -1,0 +1,121 @@
+package io.quarkiverse.langchain4j.opentelemetry.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.HashMap;
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.chat.listener.ChatModelRequestContext;
+import dev.langchain4j.model.chat.listener.ChatModelResponseContext;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.quarkiverse.langchain4j.runtime.listeners.SpanChatModelListener;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests that incoming OTel Baggage with {@code gen_ai.conversation.id} is picked up
+ * by the span contributor as a fallback when no local conversation is active.
+ */
+class ConversationBaggageTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> {
+                var applicationProperties = """
+                        quarkus.otel.bsp.schedule.delay=PT0.001S
+                        quarkus.otel.bsp.max.queue.size=1
+                        quarkus.otel.bsp.max.export.batch.size=1
+                        """;
+                return ShrinkWrap.create(JavaArchive.class)
+                        .addAsResource(new StringAsset(applicationProperties), "application.properties")
+                        .addClasses(InMemorySpanExporterProducer.class);
+            });
+
+    @Inject
+    InMemorySpanExporter exporter;
+
+    @Inject
+    SpanChatModelListener spanChatModelListener;
+
+    @BeforeEach
+    void resetSpans() {
+        exporter.reset();
+    }
+
+    @Test
+    void incomingBaggageSetsSpanAttribute() {
+        Scope baggageScope = Baggage.builder()
+                .put("gen_ai.conversation.id", "upstream-conv-999")
+                .build()
+                .storeInContext(Context.current())
+                .makeCurrent();
+        try {
+            var attributes = new HashMap<>();
+            var request = ChatRequest.builder().messages(List.of(UserMessage.from("--test--")))
+                    .parameters(DefaultChatRequestParameters.builder().modelName("--mock--")
+                            .temperature(0.0).topP(0.0).build())
+                    .build();
+            var response = ChatResponse.builder().aiMessage(AiMessage.from("--response--")).build();
+            var requestCtx = new ChatModelRequestContext(request, ModelProvider.OTHER, attributes);
+            var responseCtx = new ChatModelResponseContext(response, request, ModelProvider.OTHER, attributes);
+
+            spanChatModelListener.onRequest(requestCtx);
+            spanChatModelListener.onResponse(responseCtx);
+
+            await().untilAsserted(() -> assertThat(exporter.getFinishedSpanItems()).hasSize(1));
+            assertThat(exporter.getFinishedSpanItems().get(0).getAttributes()
+                    .get(AttributeKey.stringKey("gen_ai.conversation.id")))
+                    .isEqualTo("upstream-conv-999");
+        } finally {
+            baggageScope.close();
+        }
+    }
+
+    @Test
+    void noBaggageNoAttribute() {
+        var attributes = new HashMap<>();
+        var request = ChatRequest.builder().messages(List.of(UserMessage.from("--test--")))
+                .parameters(DefaultChatRequestParameters.builder().modelName("--mock--")
+                        .temperature(0.0).topP(0.0).build())
+                .build();
+        var response = ChatResponse.builder().aiMessage(AiMessage.from("--response--")).build();
+        var requestCtx = new ChatModelRequestContext(request, ModelProvider.OTHER, attributes);
+        var responseCtx = new ChatModelResponseContext(response, request, ModelProvider.OTHER, attributes);
+
+        spanChatModelListener.onRequest(requestCtx);
+        spanChatModelListener.onResponse(responseCtx);
+
+        await().untilAsserted(() -> assertThat(exporter.getFinishedSpanItems()).hasSize(1));
+        assertThat(exporter.getFinishedSpanItems().get(0).getAttributes()
+                .get(AttributeKey.stringKey("gen_ai.conversation.id")))
+                .isNull();
+    }
+
+    @ApplicationScoped
+    public static class InMemorySpanExporterProducer {
+        @ApplicationScoped
+        InMemorySpanExporter exporter() {
+            return InMemorySpanExporter.create();
+        }
+    }
+}

--- a/core/opentelemetry-tests/src/test/java/io/quarkiverse/langchain4j/opentelemetry/test/ConversationIdSpanContributorTest.java
+++ b/core/opentelemetry-tests/src/test/java/io/quarkiverse/langchain4j/opentelemetry/test/ConversationIdSpanContributorTest.java
@@ -1,0 +1,67 @@
+package io.quarkiverse.langchain4j.opentelemetry.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.quarkiverse.langchain4j.runtime.conversation.ConversationContext;
+import io.quarkiverse.langchain4j.runtime.listeners.ConversationIdSpanContributor;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.vertx.RunOnVertxContext;
+import io.quarkus.test.vertx.UniAsserter;
+
+class ConversationIdSpanContributorTest extends ListenersProcessorAbstractSpanChatModelListenerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> appWithInMemorySpanExporter());
+
+    @AfterEach
+    void cleanupConversation() {
+        // ConversationContext uses ContextLocals which may not be active here, but end() is safe
+        try {
+            ConversationContext.end();
+        } catch (Exception ignored) {
+        }
+    }
+
+    @Test
+    void shouldHaveConversationIdSpanContributor() {
+        assertThat(contributors).anyMatch(c -> c instanceof ConversationIdSpanContributor);
+    }
+
+    @Test
+    @RunOnVertxContext
+    void shouldSetConversationIdOnSpanWhenActive(UniAsserter asserter) {
+        asserter.execute(() -> {
+            ConversationContext.begin("test-conv-123");
+            var ctx = MockedContexts.create();
+            spanChatModelListener.onRequest(ctx.requestContext());
+            spanChatModelListener.onResponse(ctx.responseContext());
+        });
+        asserter.execute(() -> {
+            await().untilAsserted(() -> assertThat(exporter.getFinishedSpanItems()).hasSize(1));
+            SpanData span = exporter.getFinishedSpanItems().get(0);
+            assertThat(span.getAttributes().get(AttributeKey.stringKey("gen_ai.conversation.id")))
+                    .isEqualTo("test-conv-123");
+            ConversationContext.end();
+        });
+    }
+
+    @Test
+    void shouldNotSetConversationIdWhenNotActive() {
+        var ctx = MockedContexts.create();
+        spanChatModelListener.onRequest(ctx.requestContext());
+        spanChatModelListener.onResponse(ctx.responseContext());
+
+        await().untilAsserted(() -> assertThat(exporter.getFinishedSpanItems()).hasSize(1));
+        SpanData span = exporter.getFinishedSpanItems().get(0);
+        assertThat(span.getAttributes().get(AttributeKey.stringKey("gen_ai.conversation.id")))
+                .isNull();
+    }
+}

--- a/core/opentelemetry-tests/src/test/java/io/quarkiverse/langchain4j/opentelemetry/test/ListenersProcessorOnlySpanChatModelListenerTest.java
+++ b/core/opentelemetry-tests/src/test/java/io/quarkiverse/langchain4j/opentelemetry/test/ListenersProcessorOnlySpanChatModelListenerTest.java
@@ -17,6 +17,6 @@ class ListenersProcessorOnlySpanChatModelListenerTest
     @Test
     void shouldHaveSpanChatModelListenerWithoutContributors() {
         assertThat(spanChatModelListener).isNotNull();
-        assertThat(contributors).hasSize(2);
+        assertThat(contributors).hasSize(3);
     }
 }

--- a/core/opentelemetry-tests/src/test/java/io/quarkiverse/langchain4j/opentelemetry/test/ListenersProcessorSingleChatModelSpanContributorTest.java
+++ b/core/opentelemetry-tests/src/test/java/io/quarkiverse/langchain4j/opentelemetry/test/ListenersProcessorSingleChatModelSpanContributorTest.java
@@ -26,7 +26,7 @@ class ListenersProcessorSingleChatModelSpanContributorTest
     @Test
     void shouldHaveSpanChatModelListenerWitContributor() {
         assertThat(spanChatModelListener).isNotNull();
-        assertThat(contributors).hasSize(3).anyMatch(i -> i instanceof TestChatModelSpanContributor);
+        assertThat(contributors).hasSize(4).anyMatch(i -> i instanceof TestChatModelSpanContributor);
     }
 
     @Override

--- a/core/opentelemetry-tests/src/test/java/io/quarkiverse/langchain4j/opentelemetry/test/ListenersProcessorTwoChatModelSpanContributorsTest.java
+++ b/core/opentelemetry-tests/src/test/java/io/quarkiverse/langchain4j/opentelemetry/test/ListenersProcessorTwoChatModelSpanContributorsTest.java
@@ -50,7 +50,7 @@ class ListenersProcessorTwoChatModelSpanContributorsTest
     void shouldHaveSpanChatModelListenerWitContributor() {
         assertThat(spanChatModelListener).isNotNull();
         assertThat(contributors)
-                .hasSize(4);
+                .hasSize(5);
     }
 
     @Test

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/QuarkusAiServicesFactory.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/QuarkusAiServicesFactory.java
@@ -21,6 +21,7 @@ import io.quarkiverse.langchain4j.runtime.aiservice.QuarkusAiServiceContext;
 import io.quarkiverse.langchain4j.runtime.aiservice.SystemMessageProvider;
 import io.quarkiverse.langchain4j.runtime.aiservice.SystemMessageProviderWithContext;
 import io.quarkiverse.langchain4j.runtime.aiservice.ThinkingHandler;
+import io.quarkiverse.langchain4j.spi.DefaultMemoryIdProvider;
 
 public class QuarkusAiServicesFactory implements AiServicesFactory {
 
@@ -126,9 +127,24 @@ public class QuarkusAiServicesFactory implements AiServicesFactory {
 
             performBasicValidation();
 
+            if (quarkusAiServiceContext().defaultMemoryIdProvider == null
+                    && classCreateInfo.defaultMemoryIdProviderClassName() != null) {
+                try {
+                    quarkusAiServiceContext().defaultMemoryIdProvider = (DefaultMemoryIdProvider) Class
+                            .forName(classCreateInfo.defaultMemoryIdProviderClassName(), true,
+                                    Thread.currentThread().getContextClassLoader())
+                            .getConstructor().newInstance();
+                } catch (Exception e) {
+                    throw new RuntimeException(
+                            "Unable to instantiate DefaultMemoryIdProvider: "
+                                    + classCreateInfo.defaultMemoryIdProviderClassName(),
+                            e);
+                }
+            }
+
             Collection<AiServiceMethodCreateInfo> methodCreateInfos = classCreateInfo.methodMap().values();
             for (var methodCreateInfo : methodCreateInfos) {
-                if (methodCreateInfo.isRequiresModeration() && ((context.moderationModel == null))) {
+                if (methodCreateInfo.isRequiresModeration() && context.moderationModel == null) {
                     throw illegalConfiguration(
                             "The @Moderate annotation is present, but the moderationModel is not set up. " +
                                     "Please ensure a valid moderationModel is configured before using the @Moderate "

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceClassCreateInfo.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceClassCreateInfo.java
@@ -9,7 +9,8 @@ import io.quarkiverse.langchain4j.guardrails.OutputGuardrailsLiteral;
  * @param methodMap the key is a methodId generated at build time
  */
 public record AiServiceClassCreateInfo(Map<String, AiServiceMethodCreateInfo> methodMap, String implClassName,
-        InputGuardrailsLiteral inputGuardrails, OutputGuardrailsLiteral outputGuardrails) {
+        InputGuardrailsLiteral inputGuardrails, OutputGuardrailsLiteral outputGuardrails,
+        String defaultMemoryIdProviderClassName) {
 
     @Override
     public String toString() {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/conversation/ConversationContext.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/conversation/ConversationContext.java
@@ -18,12 +18,6 @@ import io.quarkus.arc.ArcContainer;
  */
 public final class ConversationContext {
 
-    /**
-     * The OpenTelemetry attribute key for the conversation ID, following the
-     * <a href="https://opentelemetry.io/docs/specs/semconv/gen-ai/">GenAI semantic conventions</a>.
-     */
-    public static final String OTEL_ATTRIBUTE = "gen_ai.conversation.id";
-
     static final String CONTEXT_KEY = "langchain4j.conversation.id";
 
     private static final ThreadLocal<String> FALLBACK = new ThreadLocal<>();

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/conversation/ConversationContext.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/conversation/ConversationContext.java
@@ -1,0 +1,93 @@
+package io.quarkiverse.langchain4j.runtime.conversation;
+
+import jakarta.enterprise.event.Event;
+
+import io.quarkiverse.langchain4j.runtime.ContextLocals;
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+
+/**
+ * Manages the current conversation identity for observability purposes.
+ * <p>
+ * The conversation ID is stored in Vert.x duplicated context locals (via {@link ContextLocals}),
+ * which are per-request and safe on event loop threads. When OpenTelemetry is present, the
+ * conversation ID is automatically set as a {@code gen_ai.conversation.id} span attribute.
+ * <p>
+ * When using Chat Scopes, the conversation ID is set automatically via an internal bridge.
+ * For other transports, call {@link #begin(String)} and {@link #end()} explicitly.
+ */
+public final class ConversationContext {
+
+    /**
+     * The OpenTelemetry attribute key for the conversation ID, following the
+     * <a href="https://opentelemetry.io/docs/specs/semconv/gen-ai/">GenAI semantic conventions</a>.
+     */
+    public static final String OTEL_ATTRIBUTE = "gen_ai.conversation.id";
+
+    static final String CONTEXT_KEY = "langchain4j.conversation.id";
+
+    private ConversationContext() {
+    }
+
+    /**
+     * Begins a conversation with the given ID. Sets the conversation ID in the current
+     * context and fires a {@link ConversationStarted} CDI event.
+     * <p>
+     * If a conversation is already active, it is ended first (firing a {@link ConversationEnded}
+     * event for the previous conversation) before starting the new one.
+     *
+     * @param conversationId the conversation identifier
+     */
+    public static void begin(String conversationId) {
+        end();
+        ContextLocals.put(CONTEXT_KEY, conversationId);
+        fireEvent(new ConversationStarted(conversationId));
+    }
+
+    /**
+     * Returns the current conversation ID, or {@code null} if no conversation is active.
+     */
+    public static String current() {
+        return ContextLocals.get(CONTEXT_KEY);
+    }
+
+    /**
+     * Returns {@code true} if a conversation is currently active.
+     */
+    public static boolean isActive() {
+        return current() != null;
+    }
+
+    /**
+     * Ends the current conversation. Clears the conversation ID from the current context
+     * and fires a {@link ConversationEnded} CDI event. Does nothing if no conversation is active.
+     */
+    public static void end() {
+        String id = current();
+        if (id != null) {
+            ContextLocals.remove(CONTEXT_KEY);
+            fireEvent(new ConversationEnded(id));
+        }
+    }
+
+    // Package-private: used by ConversationThreadContextProvider for raw set/clear without events
+    static void set(String conversationId) {
+        if (conversationId != null) {
+            ContextLocals.put(CONTEXT_KEY, conversationId);
+        } else {
+            ContextLocals.remove(CONTEXT_KEY);
+        }
+    }
+
+    static void clear() {
+        ContextLocals.remove(CONTEXT_KEY);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void fireEvent(Object event) {
+        ArcContainer container = Arc.container();
+        if (container != null) {
+            container.instance(Event.class).get().select(event.getClass()).fire(event);
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/conversation/ConversationContext.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/conversation/ConversationContext.java
@@ -26,6 +26,8 @@ public final class ConversationContext {
 
     static final String CONTEXT_KEY = "langchain4j.conversation.id";
 
+    private static final ThreadLocal<String> FALLBACK = new ThreadLocal<>();
+
     private ConversationContext() {
     }
 
@@ -36,11 +38,19 @@ public final class ConversationContext {
      * If a conversation is already active, it is ended first (firing a {@link ConversationEnded}
      * event for the previous conversation) before starting the new one.
      *
-     * @param conversationId the conversation identifier
+     * @param conversationId the conversation identifier (must not be {@code null})
+     * @throws IllegalArgumentException if conversationId is null
      */
     public static void begin(String conversationId) {
+        if (conversationId == null) {
+            throw new IllegalArgumentException("conversationId must not be null");
+        }
         end();
-        ContextLocals.put(CONTEXT_KEY, conversationId);
+        if (ContextLocals.duplicatedContextActive()) {
+            ContextLocals.put(CONTEXT_KEY, conversationId);
+        } else {
+            FALLBACK.set(conversationId);
+        }
         fireEvent(new ConversationStarted(conversationId));
     }
 
@@ -48,7 +58,10 @@ public final class ConversationContext {
      * Returns the current conversation ID, or {@code null} if no conversation is active.
      */
     public static String current() {
-        return ContextLocals.get(CONTEXT_KEY);
+        if (ContextLocals.duplicatedContextActive()) {
+            return ContextLocals.get(CONTEXT_KEY);
+        }
+        return FALLBACK.get();
     }
 
     /**
@@ -65,7 +78,11 @@ public final class ConversationContext {
     public static void end() {
         String id = current();
         if (id != null) {
-            ContextLocals.remove(CONTEXT_KEY);
+            if (ContextLocals.duplicatedContextActive()) {
+                ContextLocals.remove(CONTEXT_KEY);
+            } else {
+                FALLBACK.remove();
+            }
             fireEvent(new ConversationEnded(id));
         }
     }
@@ -73,14 +90,19 @@ public final class ConversationContext {
     // Package-private: used by ConversationThreadContextProvider for raw set/clear without events
     static void set(String conversationId) {
         if (conversationId != null) {
-            ContextLocals.put(CONTEXT_KEY, conversationId);
+            if (ContextLocals.duplicatedContextActive()) {
+                ContextLocals.put(CONTEXT_KEY, conversationId);
+            } else {
+                FALLBACK.set(conversationId);
+            }
         } else {
-            ContextLocals.remove(CONTEXT_KEY);
+            clear();
         }
     }
 
     static void clear() {
         ContextLocals.remove(CONTEXT_KEY);
+        FALLBACK.remove();
     }
 
     @SuppressWarnings("unchecked")

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/conversation/ConversationEnded.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/conversation/ConversationEnded.java
@@ -1,0 +1,17 @@
+package io.quarkiverse.langchain4j.runtime.conversation;
+
+/**
+ * CDI event fired when a conversation ends via {@link ConversationContext#end()}.
+ */
+public class ConversationEnded {
+
+    private final String conversationId;
+
+    public ConversationEnded(String conversationId) {
+        this.conversationId = conversationId;
+    }
+
+    public String getConversationId() {
+        return conversationId;
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/conversation/ConversationEnded.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/conversation/ConversationEnded.java
@@ -3,15 +3,5 @@ package io.quarkiverse.langchain4j.runtime.conversation;
 /**
  * CDI event fired when a conversation ends via {@link ConversationContext#end()}.
  */
-public class ConversationEnded {
-
-    private final String conversationId;
-
-    public ConversationEnded(String conversationId) {
-        this.conversationId = conversationId;
-    }
-
-    public String getConversationId() {
-        return conversationId;
-    }
+public record ConversationEnded(String conversationId) {
 }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/conversation/ConversationSpanHelper.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/conversation/ConversationSpanHelper.java
@@ -1,0 +1,30 @@
+package io.quarkiverse.langchain4j.runtime.conversation;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.trace.Span;
+
+/**
+ * Shared helper for setting the conversation ID on OTel spans.
+ * Only used by span contributors that are registered when OTel is present.
+ */
+public final class ConversationSpanHelper {
+
+    /**
+     * The OpenTelemetry attribute key for the conversation ID, following the
+     * <a href="https://opentelemetry.io/docs/specs/semconv/gen-ai/">GenAI semantic conventions</a>.
+     */
+    public static final String OTEL_ATTRIBUTE = "gen_ai.conversation.id";
+
+    private ConversationSpanHelper() {
+    }
+
+    public static void setConversationId(Span span) {
+        String id = ConversationContext.current();
+        if (id == null) {
+            id = Baggage.current().getEntryValue(OTEL_ATTRIBUTE);
+        }
+        if (id != null) {
+            span.setAttribute(OTEL_ATTRIBUTE, id);
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/conversation/ConversationStarted.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/conversation/ConversationStarted.java
@@ -1,0 +1,17 @@
+package io.quarkiverse.langchain4j.runtime.conversation;
+
+/**
+ * CDI event fired when a conversation begins via {@link ConversationContext#begin(String)}.
+ */
+public class ConversationStarted {
+
+    private final String conversationId;
+
+    public ConversationStarted(String conversationId) {
+        this.conversationId = conversationId;
+    }
+
+    public String getConversationId() {
+        return conversationId;
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/conversation/ConversationStarted.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/conversation/ConversationStarted.java
@@ -3,15 +3,5 @@ package io.quarkiverse.langchain4j.runtime.conversation;
 /**
  * CDI event fired when a conversation begins via {@link ConversationContext#begin(String)}.
  */
-public class ConversationStarted {
-
-    private final String conversationId;
-
-    public ConversationStarted(String conversationId) {
-        this.conversationId = conversationId;
-    }
-
-    public String getConversationId() {
-        return conversationId;
-    }
+public record ConversationStarted(String conversationId) {
 }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/conversation/ConversationThreadContextProvider.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/conversation/ConversationThreadContextProvider.java
@@ -1,0 +1,92 @@
+package io.quarkiverse.langchain4j.runtime.conversation;
+
+import java.util.Map;
+
+import org.eclipse.microprofile.context.spi.ThreadContextController;
+import org.eclipse.microprofile.context.spi.ThreadContextProvider;
+import org.eclipse.microprofile.context.spi.ThreadContextSnapshot;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+
+/**
+ * Propagates the current conversation ID across thread boundaries via MicroProfile Context Propagation.
+ */
+public class ConversationThreadContextProvider implements ThreadContextProvider {
+
+    public static final String THREAD_CONTEXT_TYPE = "CONVERSATION";
+
+    private static final ThreadContextController NOOP_CONTROLLER = () -> {
+    };
+
+    private static final ThreadContextSnapshot NULL_CONTEXT_SNAPSHOT = new NullContextSnapshot();
+
+    @Override
+    public String getThreadContextType() {
+        return THREAD_CONTEXT_TYPE;
+    }
+
+    @Override
+    public ThreadContextSnapshot currentContext(Map<String, String> map) {
+        ArcContainer container = Arc.container();
+        if (container == null) {
+            return null;
+        }
+        String currentId = ConversationContext.current();
+        if (currentId == null) {
+            return NULL_CONTEXT_SNAPSHOT;
+        }
+        return new ContextSnapshot(currentId);
+    }
+
+    @Override
+    public ThreadContextSnapshot clearedContext(Map<String, String> map) {
+        ArcContainer container = Arc.container();
+        if (container == null) {
+            return null;
+        }
+        return NULL_CONTEXT_SNAPSHOT;
+    }
+
+    private static final class NullContextSnapshot implements ThreadContextSnapshot {
+
+        @Override
+        public ThreadContextController begin() {
+            ArcContainer container = Arc.container();
+            if (container == null) {
+                return NOOP_CONTROLLER;
+            }
+            String previous = ConversationContext.current();
+            ConversationContext.clear();
+            if (previous != null) {
+                return () -> ConversationContext.set(previous);
+            }
+            return NOOP_CONTROLLER;
+        }
+    }
+
+    private static final class ContextSnapshot implements ThreadContextSnapshot {
+
+        private final String conversationId;
+
+        ContextSnapshot(String conversationId) {
+            this.conversationId = conversationId;
+        }
+
+        @Override
+        public ThreadContextController begin() {
+            ArcContainer container = Arc.container();
+            if (container == null) {
+                return NOOP_CONTROLLER;
+            }
+            String previous = ConversationContext.current();
+            ConversationContext.set(conversationId);
+            return () -> {
+                ConversationContext.clear();
+                if (previous != null) {
+                    ConversationContext.set(previous);
+                }
+            };
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/listeners/ConversationIdSpanContributor.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/listeners/ConversationIdSpanContributor.java
@@ -1,9 +1,8 @@
 package io.quarkiverse.langchain4j.runtime.listeners;
 
 import dev.langchain4j.model.chat.listener.ChatModelRequestContext;
-import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.trace.Span;
-import io.quarkiverse.langchain4j.runtime.conversation.ConversationContext;
+import io.quarkiverse.langchain4j.runtime.conversation.ConversationSpanHelper;
 
 /**
  * Sets the {@code gen_ai.conversation.id} attribute on LLM call spans when a conversation is active.
@@ -13,12 +12,6 @@ public class ConversationIdSpanContributor implements ChatModelSpanContributor {
 
     @Override
     public void onRequest(ChatModelRequestContext requestContext, Span currentSpan) {
-        String id = ConversationContext.current();
-        if (id == null) {
-            id = Baggage.current().getEntryValue(ConversationContext.OTEL_ATTRIBUTE);
-        }
-        if (id != null) {
-            currentSpan.setAttribute(ConversationContext.OTEL_ATTRIBUTE, id);
-        }
+        ConversationSpanHelper.setConversationId(currentSpan);
     }
 }

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/listeners/ConversationIdSpanContributor.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/listeners/ConversationIdSpanContributor.java
@@ -1,0 +1,24 @@
+package io.quarkiverse.langchain4j.runtime.listeners;
+
+import dev.langchain4j.model.chat.listener.ChatModelRequestContext;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.trace.Span;
+import io.quarkiverse.langchain4j.runtime.conversation.ConversationContext;
+
+/**
+ * Sets the {@code gen_ai.conversation.id} attribute on LLM call spans when a conversation is active.
+ * Falls back to reading from OTel Baggage for cross-service propagation.
+ */
+public class ConversationIdSpanContributor implements ChatModelSpanContributor {
+
+    @Override
+    public void onRequest(ChatModelRequestContext requestContext, Span currentSpan) {
+        String id = ConversationContext.current();
+        if (id == null) {
+            id = Baggage.current().getEntryValue(ConversationContext.OTEL_ATTRIBUTE);
+        }
+        if (id != null) {
+            currentSpan.setAttribute(ConversationContext.OTEL_ATTRIBUTE, id);
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/ConversationIdToolSpanContributor.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/ConversationIdToolSpanContributor.java
@@ -1,0 +1,23 @@
+package io.quarkiverse.langchain4j.runtime.tool;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.trace.Span;
+import io.quarkiverse.langchain4j.runtime.conversation.ConversationContext;
+
+/**
+ * Sets the {@code gen_ai.conversation.id} attribute on tool execution spans when a conversation is active.
+ * Falls back to reading from OTel Baggage for cross-service propagation.
+ */
+public class ConversationIdToolSpanContributor implements ToolSpanContributor {
+
+    @Override
+    public void onRequest(ToolExecutionRequestContext context, Span span) {
+        String id = ConversationContext.current();
+        if (id == null) {
+            id = Baggage.current().getEntryValue(ConversationContext.OTEL_ATTRIBUTE);
+        }
+        if (id != null) {
+            span.setAttribute(ConversationContext.OTEL_ATTRIBUTE, id);
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/ConversationIdToolSpanContributor.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/ConversationIdToolSpanContributor.java
@@ -1,8 +1,7 @@
 package io.quarkiverse.langchain4j.runtime.tool;
 
-import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.trace.Span;
-import io.quarkiverse.langchain4j.runtime.conversation.ConversationContext;
+import io.quarkiverse.langchain4j.runtime.conversation.ConversationSpanHelper;
 
 /**
  * Sets the {@code gen_ai.conversation.id} attribute on tool execution spans when a conversation is active.
@@ -12,12 +11,6 @@ public class ConversationIdToolSpanContributor implements ToolSpanContributor {
 
     @Override
     public void onRequest(ToolExecutionRequestContext context, Span span) {
-        String id = ConversationContext.current();
-        if (id == null) {
-            id = Baggage.current().getEntryValue(ConversationContext.OTEL_ATTRIBUTE);
-        }
-        if (id != null) {
-            span.setAttribute(ConversationContext.OTEL_ATTRIBUTE, id);
-        }
+        ConversationSpanHelper.setConversationId(span);
     }
 }

--- a/docs/modules/ROOT/pages/observability.adoc
+++ b/docs/modules/ROOT/pages/observability.adoc
@@ -205,7 +205,7 @@ import io.quarkiverse.langchain4j.runtime.conversation.ConversationEnded;
 @ApplicationScoped
 public class ConversationObserver {
     void onStarted(@Observes ConversationStarted event) {
-        // event.getConversationId()
+        // event.conversationId()
     }
 
     void onEnded(@Observes ConversationEnded event) {

--- a/docs/modules/ROOT/pages/observability.adoc
+++ b/docs/modules/ROOT/pages/observability.adoc
@@ -167,6 +167,59 @@ public class CustomSpanDataContributor implements ChatModelSpanContributor {
 }
 ----
 
+=== Conversation Boundaries
+
+When `quarkus-opentelemetry` is present, a `gen_ai.conversation.id` attribute is automatically added to LLM call and tool execution spans, following the https://opentelemetry.io/docs/specs/semconv/gen-ai/[OpenTelemetry GenAI semantic conventions]. This attribute groups related AI interactions into a logical conversation, which observability backends like Langfuse use to organize traces and trigger scoring.
+
+==== Automatic with Chat Scopes
+
+When using xref:chat-scopes.adoc[Chat Scopes] (`@ChatScoped`, Chat Routes, or programmatic `ChatScope.begin()`/`end()`), the conversation ID is set on all spans automatically — no additional configuration needed. The conversation ID matches the Chat Scope's ID.
+
+==== Manual usage
+
+For REST endpoints, message listeners, or custom transports that don't use Chat Scopes, set the conversation boundary explicitly:
+
+[source,java]
+----
+import io.quarkiverse.langchain4j.runtime.conversation.ConversationContext;
+
+ConversationContext.begin("my-conversation-id");
+try {
+    // AI calls here get gen_ai.conversation.id on their spans
+} finally {
+    ConversationContext.end();
+}
+----
+
+==== Lifecycle events
+
+`ConversationStarted` and `ConversationEnded` CDI events are fired when a conversation begins and ends. Observe these events to trigger downstream actions, such as Langfuse conversation scoring:
+
+[source,java]
+----
+import io.quarkiverse.langchain4j.runtime.conversation.ConversationStarted;
+import io.quarkiverse.langchain4j.runtime.conversation.ConversationEnded;
+
+@ApplicationScoped
+public class ConversationObserver {
+    void onStarted(@Observes ConversationStarted event) {
+        // event.getConversationId()
+    }
+
+    void onEnded(@Observes ConversationEnded event) {
+        // trigger scoring, cleanup, etc.
+    }
+}
+----
+
+==== Incoming cross-service propagation
+
+When an upstream service sets the `gen_ai.conversation.id` in OTel Baggage (via W3C Baggage headers), the span contributor automatically picks it up as a fallback — even if `ConversationContext.begin()` was not called in the current service. This enables conversation correlation across service boundaries when the upstream service sets the baggage.
+
+==== Async support
+
+The conversation ID propagates across async boundaries when using MicroProfile Context Propagation (`ManagedExecutor`, `@Blocking` / `@NonBlocking` switches). No additional configuration is needed.
+
 === Langfuse
 
 The https://docs.quarkiverse.io/quarkus-langfuse/dev[Quarkus Langfuse] extension provides seamless integration with https://langfuse.com/[Langfuse] for tracing AI operations. When both `quarkus-opentelemetry` and `quarkus-langfuse` are present, all of the necessary OpenTelemetry configuration is handled automatically.

--- a/docs/modules/ROOT/pages/observability.adoc
+++ b/docs/modules/ROOT/pages/observability.adoc
@@ -191,6 +191,8 @@ try {
 }
 ----
 
+`ConversationContext` works both on Vert.x event loop / worker threads and on plain threads (servlet containers, `@Scheduled` methods, message listeners). When using it outside a Vert.x duplicated context, always call `end()` in a `finally` block to prevent the conversation ID from leaking to subsequent requests on pooled threads.
+
 ==== Lifecycle events
 
 `ConversationStarted` and `ConversationEnded` CDI events are fired when a conversation begins and ends. Observe these events to trigger downstream actions, such as Langfuse conversation scoring:


### PR DESCRIPTION
This is a first draft implementation to provide a generic API to define conversation boundaries (as requested in https://github.com/quarkiverse/quarkus-langchain4j/issues/2694 ) and to add `@ChatScoped` support for agentic systems.

**Motivation**

There are two independent but complementary gaps this PR addresses:

1. No standard way to define conversation boundaries for observability. Chat Scopes define a scope for CDI bean lifecycle and memory isolation, but nothing ties them to OpenTelemetry's `gen_ai.conversation.id` semantic convention. Users working outside Chat Scopes (REST endpoints, message listeners, custom transports) have no API at all to mark where a conversation begins and ends.
2. Agentic systems ignore @ChatScoped. The `AgenticProcessor` hardcodes `@ApplicationScoped` for all agent beans, regardless of what scope annotation is on the interface. Additionally, the `defaultMemoryIdProvider`, used by `@ChatScoped` to  eliminate the need for explicit `@MemoryId` on leaf AI services, is never wired for agents because the agent build path creates a fresh `QuarkusAiServiceContext` that bypasses the metadata where the provider class name is stored.

**What this PR introduces**

1. ConversationContext API (core/runtime)

A lightweight, transport-agnostic API for marking conversation boundaries. It stores the conversation ID in Vert.x duplicated context locals (safe for event loops) and fires `ConversationStarted` / `ConversationEnded` CDI events at boundary transitions. A `ConversationThreadContextProvider` propagates the ID across async boundaries via MicroProfile Context Propagation.

This API is independent of Chat Scopes — it works in any context where a Vert.x duplicated context is available or fallback to a `ThreadLocal` when it isn't.

2. ChatScopeConversationBridge (chat-scopes/core/runtime)

An `@ApplicationScoped` CDI observer that bridges Chat Scope lifecycle events (ChatScopeStarted / ChatScopeEnded) to ConversationContext. Only top-level scopes trigger conversation events, while push/pop transitions within a conversation do not affect the conversation identity. This means Chat Scope users get conversation tracking automatically, with zero configuration.

3. ConversationIdSpanContributor (core/runtime, OpenTelemetry)

A `ChatModelSpanContributor` that sets `gen_ai.conversation.id` on LLM call spans when a conversation is active. Falls back to reading from OTel Baggage for cross-service propagation. The `ListenersProcessor` registers it unconditionally when OpenTelemetry is on the classpath, alongside a matching `ConversationIdToolSpanContributor` for tool execution spans.

4. `@ChatScoped` support for agentic agents

Two gaps prevented `@ChatScoped` from working on agent beans:

- Scope was hardcoded. `AgenticProcessor.cdiSupport()` always set `scope(ApplicationScoped.class)`. Now it reads the scope annotation from the interface (via `CustomScopeAnnotationsBuildItem`) and respects it. If no custom scope is present, it defaults to `@ApplicationScoped` as before.
- `defaultMemoryIdProvider` was lost for agents. The implied-AI-service build path correctly stores the provider class name on the `DeclarativeAiServiceBuildItem`, and `ChatScopeProcessor` correctly sets it when the scope is `@ChatScoped`. But when `QuarkusAiServices.build()` runs for agent-created AI services, it looks up `AiServiceClassCreateInfo` from metadata and that record didn't carry the provider class name. The fix adds `defaultMemoryIdProviderClassName` to `AiServiceClassCreateInfo`, populates it at build time from the `DeclarativeAiServiceBuildItem`, and wires it in `QuarkusAiServices.build()` as a fallback when the context's provider is still `null`. For regular AI services, the provider is already set by `AiServicesRecorder.createDeclarativeAiService()` before build() runs, so the null check prevents double-setting.

5. Known limitation: composite agent root still requires `@MemoryId`

The `@ChatScoped` support for automatic memory ID resolution works fully for leaf agents (`@Agent`), which go through `AiServiceMethodImplementationSupport.memoryId()` and its fallback chain that consults `defaultMemoryIdProvider`.

Composite agents use the `PlannerBasedInvocationHandler` from the `langchain4j-agentic` module, which has its own `memoryId()` method that only checks for `@MemoryId` parameter annotations, it has no fallback to a provider. When no `@MemoryId` is present, it creates an ephemeral scope that is not keyed and not retrievable via `getAgenticScope(id)`.

This means the root of a composite agentic system still needs `@MemoryId` on its method signature for the agentic scope key, even when `@ChatScoped`. The sub-agents (leaf agents) work without `@MemoryId` because their memory ID is automatically derived from `ChatScope.id()`. Fixing this requires adding a `defaultMemoryIdSupplier` fallback to `PlannerBasedInvocationHandler` in the `langchain4j-agentic` module and I will send a pull request to the upstream langchain4j to implement this fix.

6. Chat Scope context fixes

While working on the bridge, a stale-scope bug in `ChatScopeManagedContext` was discovered: on Vert.x duplicated contexts, `ContextLocal.remove()` is a no-op, so a destroyed scope could linger as a stale reference. The `currentContext()` method now checks for destroyed scopes and treats them as absent. The top-level `end()` now calls `remove()` instead of `set(null)` for consistency.