### PR TITLE
fix: generate JSON schema for collection AI service return types

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
@@ -73,6 +73,7 @@ import org.objectweb.asm.tree.analysis.AnalyzerException;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
+import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.guardrail.OutputGuardrail;
 import dev.langchain4j.invocation.InvocationParameters;
 import dev.langchain4j.memory.ChatMemory;
@@ -81,7 +82,6 @@ import dev.langchain4j.model.chat.request.json.JsonSchema;
 import dev.langchain4j.service.IllegalConfigurationException;
 import dev.langchain4j.service.Moderate;
 import dev.langchain4j.service.memory.ChatMemoryAccess;
-import dev.langchain4j.service.output.JsonSchemas;
 import dev.langchain4j.service.output.ServiceOutputParser;
 import dev.langchain4j.service.tool.ToolArgumentsErrorHandler;
 import dev.langchain4j.service.tool.ToolErrorContext;
@@ -2105,11 +2105,24 @@ public class AiServicesProcessor {
         List<MethodParameterInfo> params = method.parameters();
 
         // TODO give user ability to provide custom OutputParser
+        // Prefer ServiceOutputParser.jsonSchema over JsonSchemas.jsonSchemaFrom so collection
+        // return types (List/Set of POJO, String, enum, …) get a proper JSON schema (#943).
+        Optional<JsonSchema> structuredOutputSchema = jsonSchemaFrom(returnType);
         String outputFormatInstructions = "";
-        if (!skipOutputFormatInstructionsPredicate.test(method)) {
-            Optional<JsonSchema> structuredOutputSchema = Optional.empty();
-            if (!returnType.equals(Multi.class)) {
+        if (!skipOutputFormatInstructionsPredicate.test(method) && !returnType.equals(Multi.class)) {
+            try {
                 outputFormatInstructions = SERVICE_OUTPUT_PARSER.outputFormatInstructions(returnType);
+            } catch (RuntimeException e) {
+                // e.g. List/Set of POJO: formatInstructions() is unsupported upstream; JSON schema is.
+                if (structuredOutputSchema.isEmpty()) {
+                    throw illegalConfigurationForMethod(
+                            "AI service method return type '" + returnType
+                                    + "' cannot produce output format instructions or a JSON schema. "
+                                    + "Wrap the collection in a record/POJO (e.g. record Items(List<Item> values) {}) "
+                                    + "or use a supported return type",
+                            method);
+                }
+                outputFormatInstructions = "";
             }
         }
 
@@ -2123,7 +2136,7 @@ public class AiServicesProcessor {
 
         AiServiceMethodCreateInfo.ResponseSchemaInfo responseSchemaInfo = ResponseSchemaInfo.of(generateResponseSchema,
                 systemMessageInfo,
-                userMessageInfo.template(), outputFormatInstructions, jsonSchemaFrom(returnType));
+                userMessageInfo.template(), outputFormatInstructions, structuredOutputSchema);
 
         if (!generateResponseSchema && responseSchemaInfo.isInSystemMessage())
             throw new RuntimeException(
@@ -2231,7 +2244,14 @@ public class AiServicesProcessor {
         if (isMulti(returnType)) {
             return Optional.empty();
         }
-        return JsonSchemas.jsonSchemaFrom(returnType);
+        // ServiceOutputParser supports collections; JsonSchemas.jsonSchemaFrom only handles POJOs.
+        // Some AI-service return types (e.g. agentic AgenticScope) are not schema-mappable — treat
+        // that as "no schema" rather than failing the whole build (#943 must not break agentic/mcp).
+        try {
+            return SERVICE_OUTPUT_PARSER.jsonSchema(returnType);
+        } catch (UnsupportedFeatureException | IllegalArgumentException | IllegalStateException e) {
+            return Optional.empty();
+        }
     }
 
     private boolean detectIfToolExecutionRequiresAWorkerThread(MethodInfo method, List<ToolMethodBuildItem> tools,

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/org/acme/examples/aiservices/CollectionStructuredOutputResponseTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/org/acme/examples/aiservices/CollectionStructuredOutputResponseTest.java
@@ -1,0 +1,85 @@
+package org.acme.examples.aiservices;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.map;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * List/Set AI service return types must produce a real JSON schema (not empty {}), see #943.
+ */
+public class CollectionStructuredOutputResponseTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "whatever")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.chat-model.response-format", "json_schema")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.chat-model.strict-json-schema", "true")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    record FileInfo(String filename, String content) {
+    }
+
+    @RegisterAiService
+    @ApplicationScoped
+    interface FileInfoExtractor {
+
+        @UserMessage("Find data structure mentions in {{it}}")
+        List<FileInfo> generate(String data);
+    }
+
+    @Inject
+    FileInfoExtractor fileInfoExtractor;
+
+    @Test
+    public void testListOfPojo() throws IOException {
+        setChatCompletionMessageContent(
+                "{\\n\\\"values\\\": [{\\n\\\"filename\\\": \\\"a.txt\\\",\\n\\\"content\\\": \\\"hello\\\"\\n}]\\n}");
+
+        List<FileInfo> result = fileInfoExtractor.generate("some input");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).filename()).isEqualTo("a.txt");
+        assertThat(result.get(0).content()).isEqualTo("hello");
+
+        Map<String, Object> requestAsMap = getRequestAsMap();
+        assertThat(requestAsMap).hasEntrySatisfying("response_format", (v) -> {
+            assertThat(v).asInstanceOf(map(String.class, Object.class)).satisfies(responseFormatMap -> {
+                assertThat(responseFormatMap).containsEntry("type", "json_schema");
+                assertThat(responseFormatMap).extracting("json_schema").satisfies(js -> {
+                    assertThat(js).asInstanceOf(map(String.class, Object.class)).satisfies(jsonSchemaMap -> {
+                        assertThat(jsonSchemaMap).containsEntry("name", "List_of_FileInfo");
+                        assertThat(jsonSchemaMap).extracting("schema").asInstanceOf(map(String.class, Object.class))
+                                .satisfies(schema -> {
+                                    assertThat(schema).containsKey("properties");
+                                    assertThat(schema.get("properties")).asInstanceOf(map(String.class, Object.class))
+                                            .containsKey("values");
+                                    assertThat(schema.get("properties")).asInstanceOf(map(String.class, Object.class))
+                                            .extracting("values").asInstanceOf(map(String.class, Object.class))
+                                            .containsEntry("type", "array");
+                                });
+                    });
+                });
+            });
+        });
+    }
+}


### PR DESCRIPTION
## What was wrong

AI service methods that return `List`/`Set` (for example `List<FileInfo>`) produced an empty structured-output schema. The prompt path could also end up with a useless `{}` format, so the model was not told the real shape of the response. Wrapping the list in a record worked as a workaround.

## Change

`AiServicesProcessor` was building the response schema with `JsonSchemas.jsonSchemaFrom()`, which only supports POJOs. Upstream `ServiceOutputParser.jsonSchema()` already knows how to describe collections (same path as vanilla LangChain4j `DefaultAiServices`).

This switches schema generation to `ServiceOutputParser.jsonSchema()`. For types where prompt format instructions are not available but a JSON schema is (e.g. `List` of a POJO), the build no longer fails with a bare `IllegalStateException`; the schema is kept and used when the model supports structured output. If neither schema nor format instructions can be produced, we fail with a clearer configuration error.

## Test

Added `CollectionStructuredOutputResponseTest` next to the existing structured-output OpenAI test. It checks that a `List<FileInfo>` return type:

- boots successfully
- sends `response_format.json_schema` named `List_of_FileInfo` with a non-empty `values` array schema
- parses a `{"values":[...]}` response

Locally: `./mvnw -pl model-providers/openai/openai-vanilla/deployment -am test -Dtest=StructuredOutputResponseTest,CollectionStructuredOutputResponseTest`

---

- Fixes: #943