### PR TITLE
Cover JSON schema derivation for Result<T> AI service return types

### DIFF
--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/org/acme/examples/aiservices/ResultStructuredOutputResponseTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/org/acme/examples/aiservices/ResultStructuredOutputResponseTest.java
@@ -1,0 +1,74 @@
+package org.acme.examples.aiservices;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.map;
+
+import java.io.IOException;
+import java.time.LocalDate;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.service.Result;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * A {@code Result<T>} return type must advertise the schema of {@code T}, not of the
+ * {@link Result} wrapper, since the output parser unwraps {@code Result} and reads the
+ * response body as {@code T}.
+ */
+public class ResultStructuredOutputResponseTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "whatever")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.chat-model.response-format", "json_schema")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.chat-model.strict-json-schema", "true")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    record Person(String firstName, String lastName, LocalDate birthDate) {
+    }
+
+    @RegisterAiService
+    @ApplicationScoped
+    interface PersonExtractor {
+
+        @UserMessage("Extract information about a person from {{it}}")
+        Result<Person> extractPersonFrom(String text);
+    }
+
+    @Inject
+    PersonExtractor personExtractor;
+
+    @Test
+    public void testResultOfPojo() throws IOException {
+        setChatCompletionMessageContent(
+                // this is supposed to be a string inside a json string hence all the escaping...
+                "{\\n\\\"firstName\\\": \\\"John\\\",\\n\\\"lastName\\\": \\\"Doe\\\",\\n\\\"birthDate\\\": \\\"1968-07-04\\\"\\n}");
+
+        Result<Person> result = personExtractor.extractPersonFrom("some text");
+
+        assertThat(result.content().firstName).isEqualTo("John");
+
+        assertThat(getRequestAsMap()).extracting("response_format")
+                .asInstanceOf(map(String.class, Object.class))
+                .extracting("json_schema").asInstanceOf(map(String.class, Object.class))
+                .satisfies(jsonSchema -> {
+                    assertThat(jsonSchema).containsEntry("name", "Person");
+                    assertThat(jsonSchema).extracting("schema").asInstanceOf(map(String.class, Object.class))
+                            .extracting("properties").asInstanceOf(map(String.class, Object.class))
+                            .containsOnlyKeys("firstName", "lastName", "birthDate");
+                });
+    }
+}


### PR DESCRIPTION
## Describe your changes

A `Result<T>` AI service method must advertise the schema of `T`, not of the `Result` wrapper, because `ServiceOutputParser` unwraps `Result` before parsing the response body. When the two disagree, a model that faithfully follows the advertised schema returns a shape the parser cannot map, and every field of `T` deserialises to null with no exception and nothing in the logs.

This is already correct on `main`, but only as a side effect of `AiServicesProcessor#jsonSchemaFrom` moving from `JsonSchemas.jsonSchemaFrom` to `ServiceOutputParser#jsonSchema` in 23f81d89. Nothing pins it: the only existing `Result` coverage is `Result<String>` in `AiServicesTest`, and `String` short-circuits before the unwrapping, so it produces no schema at all. The `Result<POJO>` path, the one that actually exercises the unwrapping, was never asserted.

The test follows `StructuredOutputResponseTest` and `CollectionStructuredOutputResponseTest` in the same package: a `@RegisterAiService` with `Result<Person>`, OpenAI configured with `response-format=json_schema` and `strict-json-schema=true`, and assertions on the `response_format.json_schema` actually sent over the wire. Reverting that one line to `JsonSchemas.jsonSchemaFrom` makes it fail with `["name"="Result" (expected: "Person")]`.

---

- Relates to #2734
