### PR TITLE
Preserve generic tool argument types in generated mappers

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/ToolProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/ToolProcessor.java
@@ -32,6 +32,7 @@ import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.GenericSignature;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.MethodParameterInfo;
@@ -99,6 +100,7 @@ import io.quarkus.deployment.recording.RecorderContext;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.ClassOutput;
 import io.quarkus.gizmo.ClassTransformer;
+import io.quarkus.gizmo.FieldCreator;
 import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
@@ -958,7 +960,14 @@ public class ToolProcessor {
                 FieldDescriptor fieldDescriptor = FieldDescriptor.of(implClassName, parameter.name(),
                         parameter.type().name().toString());
                 fieldDescriptors.add(fieldDescriptor);
-                classCreator.getFieldCreator(fieldDescriptor).setModifiers(Modifier.PUBLIC);
+
+                FieldCreator field = classCreator.getFieldCreator(fieldDescriptor);
+                field.setModifiers(Modifier.PUBLIC);
+
+                String genericSignature = genericFieldSignature(parameter.type());
+                if (genericSignature != null) {
+                    field.setSignature(genericSignature);
+                }
             }
 
             MethodCreator mc = classCreator
@@ -1227,6 +1236,48 @@ public class ToolProcessor {
     private static class ObjectMapperHolder {
         private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
         private static final TypeReference<Map<String, Object>> MAP_TYPE_REF = new TypeReference<>() {
+        };
+    }
+
+    private static String genericFieldSignature(Type type) {
+        if (containsUnresolvedTypeVariable(type)) {
+            throw new IllegalArgumentException("Tool parameter type must not contain unresolved type variables: " + type);
+        }
+        if (!containsParameterizedType(type)) {
+            return null;
+        }
+
+        StringBuilder signature = new StringBuilder();
+        GenericSignature.forType(type, GenericSignature.NO_SUBSTITUTION, signature);
+        return signature.toString();
+    }
+
+    private static boolean containsParameterizedType(Type type) {
+        return switch (type.kind()) {
+            case PARAMETERIZED_TYPE -> true;
+            case ARRAY -> containsParameterizedType(type.asArrayType().constituent());
+            default -> false;
+        };
+    }
+
+    private static boolean containsUnresolvedTypeVariable(Type type) {
+        return switch (type.kind()) {
+            case TYPE_VARIABLE, UNRESOLVED_TYPE_VARIABLE, TYPE_VARIABLE_REFERENCE -> true;
+            case ARRAY -> containsUnresolvedTypeVariable(type.asArrayType().constituent());
+            case PARAMETERIZED_TYPE -> {
+                ParameterizedType parameterizedType = type.asParameterizedType();
+                if (parameterizedType.owner() != null && containsUnresolvedTypeVariable(parameterizedType.owner())) {
+                    yield true;
+                }
+                yield parameterizedType.arguments().stream().anyMatch(ToolProcessor::containsUnresolvedTypeVariable);
+            }
+            case WILDCARD_TYPE -> {
+                Type extendsBound = type.asWildcardType().extendsBound();
+                Type superBound = type.asWildcardType().superBound();
+                yield (extendsBound != null && containsUnresolvedTypeVariable(extendsBound))
+                        || (superBound != null && containsUnresolvedTypeVariable(superBound));
+            }
+            default -> false;
         };
     }
 }

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ToolExecutorTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ToolExecutorTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.fail;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Map;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -41,6 +42,9 @@ class ToolExecutorTest {
         RELEVANCE,
         DATE,
         RATING
+    }
+
+    public record ArgObject(String name, SortBy sortBy) {
     }
 
     private static class DefaultValueTool {
@@ -116,6 +120,27 @@ class ToolExecutorTest {
         @Tool
         int noArgs() {
             return 1;
+        }
+
+        @Tool
+        String listOfEnum(List<SortBy> arg0) {
+            return arg0.get(0).name();
+        }
+
+        @Tool
+        String listOfString(List<String> arg0) {
+            return String.join(",", arg0);
+        }
+
+        @Tool
+        String listOfObject(List<ArgObject> arg0) {
+            ArgObject object = arg0.get(0);
+            return object.name() + ":" + object.sortBy();
+        }
+
+        @Tool
+        String mappedEnum(Map<String, SortBy> arg0) {
+            return arg0.get("first").name();
         }
     }
 
@@ -287,6 +312,25 @@ class ToolExecutorTest {
         String result = toolExecutor.execute(request, null);
 
         assertThat(result).isEqualTo("1");
+    }
+
+    @Test
+    void should_deserialize_generic_tool_arguments() {
+        executeAndAssert("{\"arg0\":[\"DATE\"]}", "listOfEnum", "\"DATE\"");
+
+        executeAndAssert("{\"arg0\":[\"A\",\"B\"]}", "listOfString", "\"A,B\"");
+
+        executeAndAssert("{\"arg0\":[{\"name\":\"ABC\",\"sortBy\":\"DATE\"}]}", "listOfObject", "\"ABC:DATE\"");
+
+        executeAndAssert("{\"arg0\":{\"first\":\"DATE\"}}", "mappedEnum", "\"DATE\"");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "{\"arg0\":[\"INVALID\"]}"
+    })
+    void should_reject_invalid_generic_enum_argument_before_tool_invocation(String arguments) {
+        executeAndExpectFailure(arguments, "listOfEnum");
     }
 
     @Test

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ToolGenericTypeValidationTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ToolGenericTypeValidationTest.java
@@ -1,0 +1,37 @@
+package io.quarkiverse.langchain4j.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Map;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.agent.tool.Tool;
+import io.quarkus.test.QuarkusUnitTest;
+
+class ToolGenericTypeValidationTest {
+
+    static class GenericTool<T> {
+
+        @Tool
+        void update(Map<String, T> values) {
+        }
+    }
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(GenericTool.class))
+            .assertException(t -> assertThat(t)
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Tool parameter type must not contain unresolved type variables"));
+
+    @Test
+    void test() {
+        fail("Should not be called");
+    }
+}


### PR DESCRIPTION
Goal: Preserve concrete generic type metadata on generated tool argument-mapper fields.

This lets Jackson deserialize typed tool arguments correctly, such as `List<MyEnum>`, `List<MyDto>`, and `Map<String, MyEnum>`. 

What is currently happening without these changes is: for a tool argument of `List<SomeEnum>`, the AI Service receives and handles it properly, but the framework loses the typing of `T` in the process and treats it as `List<String>` which then throws when trying to fit it back into the expected argument type of `List<SomeEnum>`.