### PR TITLE
Fix typo in movie similarity search samples

### DIFF
--- a/samples/movie-similarity-search-hibernate/src/main/java/io/quarkiverse/langchain4j/sample/MovieLoader.java
+++ b/samples/movie-similarity-search-hibernate/src/main/java/io/quarkiverse/langchain4j/sample/MovieLoader.java
@@ -50,7 +50,7 @@ public class MovieLoader {
 
     Log.info("Ingesting movies...");
     embeddingStore.addAllEntities(movies);
-    Log.info("Application initalized!");
+    Log.info("Application initialized!");
   }
 
 }

--- a/samples/movie-similarity-search/src/main/java/io/quarkiverse/langchain4j/sample/MovieLoader.java
+++ b/samples/movie-similarity-search/src/main/java/io/quarkiverse/langchain4j/sample/MovieLoader.java
@@ -50,7 +50,7 @@ public class MovieLoader {
 
     Log.info("Ingesting movies...");
     ingester.ingest(docs);
-    Log.info("Application initalized!");
+    Log.info("Application initialized!");
   }
 
   @Transactional


### PR DESCRIPTION
## What changed

Fixed a typo in the startup log message of the `MovieLoader` class in both `movie-similarity-search` and `movie-similarity-search-hibernate` samples: `initalized` → `initialized`.

## Why

The log message `Application initalized!` contains a misspelling. This fixes the spelling so the sample output is correct.

## How verified

Diff inspection of the two affected files. No code logic or API changed — only a log string in sample applications.