### PR TITLE
Fix broken links in sample READMEs

### DIFF
--- a/samples/fraud-detection/README.md
+++ b/samples/fraud-detection/README.md
@@ -18,7 +18,7 @@ The demo is based on fictional random data generated when the application starts
 - 50 transactions
 - For each transaction, a random amount between 1 and 1000 is generated and assigned to a random user. A random city is also assigned to each transaction.
 
-The setup is defined in the [Setup.java](./src/main/java/io/quarkiverse/langchain4j/samples/Setup.java) class.
+The setup is defined in the [Setup.java](./src/main/java/io/quarkiverse/langchain4j/sample/Setup.java) class.
 
 The users and transactions are stored in a PostgreSQL database. When running the demo in dev mode (recommended), the database is automatically created and populated.
 
@@ -26,8 +26,8 @@ The users and transactions are stored in a PostgreSQL database. When running the
 
 To enable fraud detection, we provide the LLM with access to customer and transaction data through two Panache repositories:
 
-- [CustomerRepository.java](./src/main/java/io/quarkiverse/langchain4j/samples/CustomerRepository.java)
-- [TransactionRepository.java](./src/main/java/io/quarkiverse/langchain4j/samples/TransactionRepository.java)
+- [CustomerRepository.java](./src/main/java/io/quarkiverse/langchain4j/sample/CustomerRepository.java)
+- [TransactionRepository.java](./src/main/java/io/quarkiverse/langchain4j/sample/TransactionRepository.java)
 
 The following code snippet demonstrates how to help the LLM access the customer name from the ID:
 

--- a/samples/secure-fraud-detection/README.md
+++ b/samples/secure-fraud-detection/README.md
@@ -13,20 +13,20 @@ You can use system or env properties, see `Running the Demo` section below.
 When the application starts, 5 transactions with random amounts between 1 and 1000 are generated for the registered user.
 A random city is also assigned to each transaction.
 
-The setup is defined in the [Setup.java](./src/main/java/io/quarkiverse/langchain4j/samples/Setup.java) class.
+The setup is defined in the [Setup.java](./src/main/java/io/quarkiverse/langchain4j/sample/Setup.java) class.
 
 The registered user and transactions are stored in a PostgreSQL database. When running the demo in dev mode (recommended), the database is automatically created and populated.
 
 ### Content Retrieval
 
-To enable fraud detection, we provide the LLM with access to the custom [FraudDetectionContentRetriever](./src/main/java/io/quarkiverse/langchain4j/samples/FraudDetectionContentRetriever.java) content retriever.
+To enable fraud detection, we provide the LLM with access to the custom [FraudDetectionContentRetriever](./src/main/java/io/quarkiverse/langchain4j/sample/FraudDetectionContentRetriever.java) content retriever.
 
-`FraudDetectionContentRetriever` is registered by [FraudDetectionRetrievalAugmentor](./src/main/java/io/quarkiverse/langchain4j/samples/FraudDetectionRetrievalAugmentor.java).
+`FraudDetectionContentRetriever` is registered by [FraudDetectionRetrievalAugmentor](./src/main/java/io/quarkiverse/langchain4j/sample/FraudDetectionRetrievalAugmentor.java).
 
 It can only be accessed securely, and it retrieves transaction data for the currently authenticated user through two Panache repositories:
 
-- [CustomerRepository.java](./src/main/java/io/quarkiverse/langchain4j/samples/CustomerRepository.java)
-- [TransactionRepository.java](./src/main/java/io/quarkiverse/langchain4j/samples/TransactionRepository.java)
+- [CustomerRepository.java](./src/main/java/io/quarkiverse/langchain4j/sample/CustomerRepository.java)
+- [TransactionRepository.java](./src/main/java/io/quarkiverse/langchain4j/sample/TransactionRepository.java)
 
 It extracts the authenticated user's name and email from an injected `JsonWebToken` ID token.
 

--- a/samples/secure-sql-chatbot/README.md
+++ b/samples/secure-sql-chatbot/README.md
@@ -13,7 +13,7 @@ You can use system or env properties, see `Running the example` section below.
 
 When the application starts, a registered user, the movie watcher, is allocated a random preferred movie genre .
 
-The setup is defined in the [Setup.java](./src/main/java/io/quarkiverse/langchain4j/samples/chatbot/Setup.java) class.
+The setup is defined in the [Setup.java](./src/main/java/io/quarkiverse/langchain4j/sample/chatbot/Setup.java) class.
 
 The registered movie watchers are stored in a PostgreSQL database. When running the demo in dev mode (recommended), the database is automatically created and populated.
 


### PR DESCRIPTION
## What changed

Fixed 9 broken relative links across 3 sample READMEs. The links referenced `./src/.../samples/` but the actual package directory is `./src/.../sample/` (singular). Clicking these links resulted in 404 on GitHub.

Files affected:
- `samples/fraud-detection/README.md` (3 links)
- `samples/secure-fraud-detection/README.md` (5 links)
- `samples/secure-sql-chatbot/README.md` (1 link)

## Why

Several README links to source files in the fraud-detection and sql-chatbot samples point to a non-existent `samples/` directory, causing 404 errors when browsing the samples on GitHub. The correct package path uses `sample/`.

## How verified

Verified each link target file exists at the corrected `sample/` path. No code or configuration changed — only markdown link paths.