### PR TITLE
Discover named embedding stores configured with runtime properties only

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/NamedConfigDiscovery.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/NamedConfigDiscovery.java
@@ -1,0 +1,97 @@
+package io.quarkiverse.langchain4j.deployment;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import io.smallrye.config.ConfigMappings;
+import io.smallrye.config.ConfigMappings.ConfigClass;
+import io.smallrye.config.NameIterator;
+
+/**
+ * Discovers the keys of a named configuration map, such as the named embedding stores of an extension.
+ * <p>
+ * Extensions declare their named configurations as {@code @WithParentName @WithDefaults Map<String, G>}, which SmallRye
+ * Config only materializes keys for when a configured property structurally matches the config group {@code G}. A
+ * build-time group usually holds a couple of properties at most, so a named entry configured through runtime properties
+ * alone never produces a key, and the corresponding beans are never created.
+ * <p>
+ * This scans the configured property names instead, treating any {@code <prefix>.<name>.<property>} property as a named
+ * entry unless {@code <name>} is a property of the unnamed configuration.
+ */
+public final class NamedConfigDiscovery {
+
+    private NamedConfigDiscovery() {
+    }
+
+    /**
+     * Discovers the named configuration keys from the properties of the current {@code Config}.
+     *
+     * @param configPrefix the config prefix the named configurations live under, without a trailing dot,
+     *        for instance {@code quarkus.langchain4j.pgvector}
+     * @param knownNames the names SmallRye Config already materialized, kept first in the returned set
+     * @param mappingClasses the config mapping roots covering the configuration, across all config phases
+     */
+    public static Set<String> discoverNames(String configPrefix, Set<String> knownNames, Class<?>... mappingClasses) {
+        return discoverNames(ConfigProvider.getConfig().getPropertyNames(), configPrefix, knownNames, mappingClasses);
+    }
+
+    /**
+     * Discovers the named configuration keys from the given property names.
+     */
+    public static Set<String> discoverNames(Iterable<String> propertyNames, String configPrefix, Set<String> knownNames,
+            Class<?>... mappingClasses) {
+        Set<String> unnamedProperties = unnamedPropertyNames(configPrefix, mappingClasses);
+
+        Set<String> names = new LinkedHashSet<>(knownNames);
+        for (String propertyName : propertyNames) {
+            if (!propertyName.startsWith(configPrefix + ".")) {
+                continue;
+            }
+
+            NameIterator name = new NameIterator(propertyName, configPrefix.length());
+            String segment = name.getNextSegment();
+            name.next();
+
+            if (name.hasNext() && !unnamedProperties.contains(withoutIndex(segment))) {
+                names.add(segment);
+            }
+        }
+
+        return names;
+    }
+
+    /**
+     * Collects the first path segment of every property belonging to the unnamed configuration, as opposed to the
+     * {@code <prefix>.*.<property>} ones that belong to a named entry. Letting SmallRye Config expand the mappings
+     * keeps the naming rules ({@code @WithName}, {@code @WithParentName}, nested groups, indexed collections) in one
+     * place instead of reimplementing them here.
+     */
+    private static Set<String> unnamedPropertyNames(String configPrefix, Class<?>... mappingClasses) {
+        Set<String> unnamedProperties = new HashSet<>();
+        for (Class<?> mappingClass : mappingClasses) {
+            for (String path : ConfigMappings.getProperties(ConfigClass.configClass(mappingClass, configPrefix)).keySet()) {
+                if (!path.startsWith(configPrefix + ".")) {
+                    continue;
+                }
+
+                String segment = new NameIterator(path, configPrefix.length()).getNextSegment();
+                if (!"*".equals(segment)) {
+                    unnamedProperties.add(withoutIndex(segment));
+                }
+            }
+        }
+        return unnamedProperties;
+    }
+
+    /**
+     * Strips the collection index off a path segment, so that a configured {@code metadata-indexes[0]} is recognized as
+     * the mapped {@code metadata-indexes[*]} property.
+     */
+    private static String withoutIndex(String segment) {
+        int index = segment.indexOf('[');
+        return index == -1 ? segment : segment.substring(0, index);
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/deployment/NamedConfigDiscoveryTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/deployment/NamedConfigDiscoveryTest.java
@@ -1,0 +1,144 @@
+package io.quarkiverse.langchain4j.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.config.WithDefaults;
+import io.smallrye.config.WithName;
+import io.smallrye.config.WithParentName;
+
+class NamedConfigDiscoveryTest {
+
+    private static final String PREFIX = "quarkus.langchain4j.store";
+
+    interface BuildTimeConfig {
+
+        @WithParentName
+        DefaultStoreBuildTimeConfig defaultConfig();
+
+        @WithParentName
+        @WithDefaults
+        Map<String, NamedStoreBuildTimeConfig> namedConfig();
+
+        DevServicesConfig devservices();
+
+        interface DefaultStoreBuildTimeConfig {
+            boolean defaultStoreEnabled();
+
+            Optional<String> datasource();
+        }
+
+        interface NamedStoreBuildTimeConfig {
+            Optional<String> datasource();
+        }
+
+        interface DevServicesConfig {
+            Optional<String> imageName();
+        }
+    }
+
+    interface RuntimeConfig {
+
+        @WithParentName
+        StoreRuntimeConfig defaultConfig();
+
+        @WithParentName
+        @WithDefaults
+        Map<String, StoreRuntimeConfig> namedConfig();
+
+        interface StoreRuntimeConfig {
+            String table();
+
+            Optional<Integer> dimension();
+
+            @WithName("register-vector-pg-extension")
+            Boolean registerVectorPGExtension();
+
+            MetadataConfig metadata();
+
+            List<MetadataIndexConfig> metadataIndexes();
+
+            interface MetadataConfig {
+                String type();
+            }
+
+            interface MetadataIndexConfig {
+                boolean unique();
+            }
+        }
+    }
+
+    private Set<String> discover(String... propertyNames) {
+        return NamedConfigDiscovery.discoverNames(List.of(propertyNames), PREFIX, Set.of(),
+                BuildTimeConfig.class, RuntimeConfig.class);
+    }
+
+    @Test
+    void discoversStoresConfiguredWithRuntimePropertiesOnly() {
+        assertThat(discover(
+                PREFIX + ".default-store-enabled",
+                PREFIX + ".products.table",
+                PREFIX + ".products.dimension",
+                PREFIX + ".documents.table"))
+                .containsExactlyInAnyOrder("products", "documents");
+    }
+
+    @Test
+    void ignoresUnnamedStoreProperties() {
+        assertThat(discover(
+                PREFIX + ".table",
+                PREFIX + ".dimension",
+                PREFIX + ".datasource",
+                PREFIX + ".default-store-enabled")).isEmpty();
+    }
+
+    @Test
+    void ignoresNestedGroupsOfTheUnnamedStore() {
+        assertThat(discover(
+                PREFIX + ".metadata.type",
+                PREFIX + ".register-vector-pg-extension")).isEmpty();
+    }
+
+    @Test
+    void ignoresIndexedCollectionsOfTheUnnamedStore() {
+        assertThat(discover(PREFIX + ".metadata-indexes[0].unique")).isEmpty();
+    }
+
+    @Test
+    void ignoresRootPropertiesOutsideTheUnnamedStore() {
+        assertThat(discover(PREFIX + ".devservices.image-name")).isEmpty();
+    }
+
+    @Test
+    void ignoresOtherPrefixes() {
+        assertThat(discover(
+                "quarkus.langchain4j.store-other.products.table",
+                "quarkus.datasource.products.username")).isEmpty();
+    }
+
+    @Test
+    void discoversNestedPropertiesOfANamedStore() {
+        assertThat(discover(
+                PREFIX + ".products.metadata.type",
+                PREFIX + ".products.metadata-indexes[0].unique")).containsExactly("products");
+    }
+
+    @Test
+    void unquotesNamedStoreKeys() {
+        assertThat(discover(PREFIX + ".\"my.store\".table")).containsExactly("my.store");
+    }
+
+    @Test
+    void keepsKnownNamesEvenWithoutMatchingProperties() {
+        assertThat(NamedConfigDiscovery.discoverNames(List.of(PREFIX + ".products.table"), PREFIX, Set.of("documents"),
+                BuildTimeConfig.class, RuntimeConfig.class))
+                .containsExactly("documents", "products");
+    }
+
+}

--- a/embedding-stores/chroma/deployment/src/main/java/io/quarkiverse/langchain4j/chroma/deployment/ChromaDevServicesProcessor.java
+++ b/embedding-stores/chroma/deployment/src/main/java/io/quarkiverse/langchain4j/chroma/deployment/ChromaDevServicesProcessor.java
@@ -60,7 +60,7 @@ public class ChromaDevServicesProcessor {
             LoggingSetupBuildItem loggingSetupBuildItem,
             DevServicesConfig devServicesConfig) {
 
-        Set<String> namedStoreNames = chromaBuildConfig.namedConfig().keySet();
+        Set<String> namedStoreNames = ChromaProcessor.discoverStoreNames(chromaBuildConfig);
 
         ChromaDevServiceCfg configuration = getConfiguration(chromaBuildConfig);
 

--- a/embedding-stores/chroma/deployment/src/main/java/io/quarkiverse/langchain4j/chroma/deployment/ChromaProcessor.java
+++ b/embedding-stores/chroma/deployment/src/main/java/io/quarkiverse/langchain4j/chroma/deployment/ChromaProcessor.java
@@ -1,6 +1,6 @@
 package io.quarkiverse.langchain4j.chroma.deployment;
 
-import java.util.Map;
+import java.util.Set;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -13,8 +13,10 @@ import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.chroma.ChromaEmbeddingStore;
 import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkiverse.langchain4j.chroma.runtime.ChromaEmbeddingStoreConfig;
 import io.quarkiverse.langchain4j.chroma.runtime.ChromaRecorder;
 import io.quarkiverse.langchain4j.deployment.EmbeddingStoreBuildItem;
+import io.quarkiverse.langchain4j.deployment.NamedConfigDiscovery;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
@@ -33,6 +35,8 @@ class ChromaProcessor {
     public static final DotName CHROMA_EMBEDDING_STORE = DotName.createSimple(ChromaEmbeddingStore.class);
 
     static final String FEATURE = "langchain4j-chroma";
+
+    static final String CONFIG_PREFIX = "quarkus.langchain4j.chroma";
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -63,10 +67,7 @@ class ChromaProcessor {
             embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
         }
 
-        Map<String, ChromaNamedStoreBuildTimeConfig> namedStores = buildTimeConfig.namedConfig();
-        for (Map.Entry<String, ChromaNamedStoreBuildTimeConfig> entry : namedStores.entrySet()) {
-            String storeName = entry.getKey();
-
+        for (String storeName : discoverStoreNames(buildTimeConfig)) {
             AnnotationInstance storeNameQualifier = AnnotationInstance.builder(EmbeddingStoreName.class)
                     .add("value", storeName)
                     .build();
@@ -86,6 +87,15 @@ class ChromaProcessor {
 
             embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
         }
+    }
+
+    /**
+     * Named stores are only partially materialized by SmallRye Config, since the build-time config group holds a single
+     * property. Discovering them from the configured property names also covers stores configured at runtime only.
+     */
+    static Set<String> discoverStoreNames(ChromaEmbeddingStoreBuildTimeConfig buildTimeConfig) {
+        return NamedConfigDiscovery.discoverNames(CONFIG_PREFIX, buildTimeConfig.namedConfig().keySet(),
+                ChromaEmbeddingStoreBuildTimeConfig.class, ChromaEmbeddingStoreConfig.class);
     }
 
     /**

--- a/embedding-stores/chroma/deployment/src/test/java/io/quarkiverse/langchain4j/chroma/deployment/ChromaNamedStoreWithoutCollectionNameTest.java
+++ b/embedding-stores/chroma/deployment/src/test/java/io/quarkiverse/langchain4j/chroma/deployment/ChromaNamedStoreWithoutCollectionNameTest.java
@@ -1,0 +1,58 @@
+package io.quarkiverse.langchain4j.chroma.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.store.embedding.chroma.ChromaEmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Named stores must be discovered from any configured property, not only from the build-time {@code collection-name} one.
+ */
+public class ChromaNamedStoreWithoutCollectionNameTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.chroma.default-store-enabled", "false")
+            .overrideConfigKey("quarkus.langchain4j.chroma.devservices.enabled", "false")
+            .overrideConfigKey("quarkus.langchain4j.chroma.products.url", "http://localhost:8000")
+            .overrideConfigKey("quarkus.langchain4j.chroma.documents.url", "http://localhost:8000");
+
+    @Inject
+    @EmbeddingStoreName("products")
+    ChromaEmbeddingStore productsEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("documents")
+    ChromaEmbeddingStore documentsEmbeddingStore;
+
+    @Test
+    void testBothNamed() {
+        assertThat(productsEmbeddingStore).isNotNull();
+        assertThat(documentsEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void testNotSame() {
+        assertThat(productsEmbeddingStore).isNotSameAs(documentsEmbeddingStore);
+    }
+
+    /**
+     * {@code devservices} is a root property rather than a store name, so it must not produce a store.
+     */
+    @Test
+    void testDevservicesIsNotAStore() {
+        assertThat(Arc.container()
+                .instance(ChromaEmbeddingStore.class, EmbeddingStoreName.Literal.of("devservices"))
+                .isAvailable()).isFalse();
+    }
+}

--- a/embedding-stores/milvus/deployment/src/main/java/io/quarkiverse/langchain4j/milvus/MilvusProcessor.java
+++ b/embedding-stores/milvus/deployment/src/main/java/io/quarkiverse/langchain4j/milvus/MilvusProcessor.java
@@ -1,6 +1,6 @@
 package io.quarkiverse.langchain4j.milvus;
 
-import java.util.Map;
+import java.util.Set;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -14,7 +14,9 @@ import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.milvus.MilvusEmbeddingStore;
 import io.quarkiverse.langchain4j.EmbeddingStoreName;
 import io.quarkiverse.langchain4j.deployment.EmbeddingStoreBuildItem;
+import io.quarkiverse.langchain4j.deployment.NamedConfigDiscovery;
 import io.quarkiverse.langchain4j.milvus.runtime.MilvusRecorder;
+import io.quarkiverse.langchain4j.milvus.runtime.MilvusRuntimeConfig;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -27,6 +29,8 @@ public class MilvusProcessor {
 
     public static final DotName MILVUS_EMBEDDING_STORE = DotName.createSimple(MilvusEmbeddingStore.class);
     public static final String FEATURE = "langchain4j-milvus";
+
+    static final String CONFIG_PREFIX = "quarkus.langchain4j.milvus";
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -55,9 +59,7 @@ public class MilvusProcessor {
             embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
         }
 
-        Map<String, MilvusNamedStoreBuildTimeConfig> namedStores = buildTimeConfig.namedConfig();
-        for (Map.Entry<String, MilvusNamedStoreBuildTimeConfig> entry : namedStores.entrySet()) {
-            String storeName = entry.getKey();
+        for (String storeName : discoverStoreNames(buildTimeConfig)) {
             AnnotationInstance storeNameQualifier = AnnotationInstance.builder(EmbeddingStoreName.class)
                     .add("value", storeName)
                     .build();
@@ -75,5 +77,14 @@ public class MilvusProcessor {
                     .done());
             embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
         }
+    }
+
+    /**
+     * Named stores are only partially materialized by SmallRye Config, since the build-time config group holds a single
+     * property. Discovering them from the configured property names also covers stores configured at runtime only.
+     */
+    static Set<String> discoverStoreNames(MilvusBuildConfig buildTimeConfig) {
+        return NamedConfigDiscovery.discoverNames(CONFIG_PREFIX, buildTimeConfig.namedConfig().keySet(),
+                MilvusBuildConfig.class, MilvusRuntimeConfig.class);
     }
 }

--- a/embedding-stores/milvus/deployment/src/test/java/io/quarkiverse/langchain4j/milvus/deployment/MilvusNamedStoreWithoutHostTest.java
+++ b/embedding-stores/milvus/deployment/src/test/java/io/quarkiverse/langchain4j/milvus/deployment/MilvusNamedStoreWithoutHostTest.java
@@ -1,0 +1,60 @@
+package io.quarkiverse.langchain4j.milvus.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.store.embedding.milvus.MilvusEmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Named stores must be discovered from any configured property, not only from the build-time {@code host} one.
+ */
+public class MilvusNamedStoreWithoutHostTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.milvus.default-store-enabled", "false")
+            .overrideConfigKey("quarkus.langchain4j.milvus.devservices.enabled", "false")
+            .overrideConfigKey("quarkus.langchain4j.milvus.products.dimension", "1536")
+            .overrideConfigKey("quarkus.langchain4j.milvus.products.collection-name", "product_embeddings")
+            .overrideConfigKey("quarkus.langchain4j.milvus.documents.dimension", "768")
+            .overrideConfigKey("quarkus.langchain4j.milvus.documents.collection-name", "doc_embeddings");
+
+    @Inject
+    @EmbeddingStoreName("products")
+    MilvusEmbeddingStore productsEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("documents")
+    MilvusEmbeddingStore documentsEmbeddingStore;
+
+    @Test
+    void testBothNamed() {
+        assertThat(productsEmbeddingStore).isNotNull();
+        assertThat(documentsEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void testNotSame() {
+        assertThat(productsEmbeddingStore).isNotSameAs(documentsEmbeddingStore);
+    }
+
+    /**
+     * {@code devservices} is a root property rather than a store name, so it must not produce a store.
+     */
+    @Test
+    void testDevservicesIsNotAStore() {
+        assertThat(Arc.container()
+                .instance(MilvusEmbeddingStore.class, EmbeddingStoreName.Literal.of("devservices"))
+                .isAvailable()).isFalse();
+    }
+}

--- a/embedding-stores/neo4j/deployment/src/main/java/io/quarkiverse/langchain4j/neo4j/Neo4jEmbeddingStoreProcessor.java
+++ b/embedding-stores/neo4j/deployment/src/main/java/io/quarkiverse/langchain4j/neo4j/Neo4jEmbeddingStoreProcessor.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.langchain4j.neo4j;
 
 import java.util.Map;
+import java.util.Set;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -15,6 +16,8 @@ import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import io.quarkiverse.langchain4j.EmbeddingStoreName;
 import io.quarkiverse.langchain4j.deployment.EmbeddingStoreBuildItem;
+import io.quarkiverse.langchain4j.deployment.NamedConfigDiscovery;
+import io.quarkiverse.langchain4j.neo4j.runtime.Neo4jEmbeddingStoreConfig;
 import io.quarkiverse.langchain4j.neo4j.runtime.Neo4jEmbeddingStoreRecorder;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
@@ -28,6 +31,7 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 public class Neo4jEmbeddingStoreProcessor {
 
     private static final String FEATURE = "langchain4j-neo4j";
+    private static final String CONFIG_PREFIX = "quarkus.langchain4j.neo4j";
     private static final DotName NEO4J_EMBEDDING_STORE = DotName.createSimple(Neo4jEmbeddingStore.class);
 
     @BuildStep
@@ -64,11 +68,8 @@ public class Neo4jEmbeddingStoreProcessor {
         }
 
         Map<String, Neo4jNamedStoreBuildTimeConfig> namedStores = buildTimeConfig.namedConfig();
-        for (Map.Entry<String, Neo4jNamedStoreBuildTimeConfig> entry : namedStores.entrySet()) {
-            String storeName = entry.getKey();
-            Neo4jNamedStoreBuildTimeConfig storeBuildTimeConfig = entry.getValue();
-
-            if (!storeBuildTimeConfig.enabled()) {
+        for (String storeName : discoverStoreNames(buildTimeConfig)) {
+            if (!namedStores.get(storeName).enabled()) {
                 continue;
             }
 
@@ -93,5 +94,14 @@ public class Neo4jEmbeddingStoreProcessor {
 
             embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
         }
+    }
+
+    /**
+     * Named stores are only partially materialized by SmallRye Config, since the build-time config group holds a couple
+     * of properties. Discovering them from the configured property names also covers stores configured at runtime only.
+     */
+    private static Set<String> discoverStoreNames(Neo4jEmbeddingStoreBuildTimeConfig buildTimeConfig) {
+        return NamedConfigDiscovery.discoverNames(CONFIG_PREFIX, buildTimeConfig.namedConfig().keySet(),
+                Neo4jEmbeddingStoreBuildTimeConfig.class, Neo4jEmbeddingStoreConfig.class);
     }
 }

--- a/embedding-stores/neo4j/deployment/src/test/java/io/quarkiverse/langchain4j/neo4j/Neo4jNamedStoreWithoutDatabaseNameTest.java
+++ b/embedding-stores/neo4j/deployment/src/test/java/io/quarkiverse/langchain4j/neo4j/Neo4jNamedStoreWithoutDatabaseNameTest.java
@@ -1,0 +1,51 @@
+package io.quarkiverse.langchain4j.neo4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Named stores must be discovered from any configured property, not only from the build-time {@code database-name} one.
+ */
+public class Neo4jNamedStoreWithoutDatabaseNameTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.neo4j.default-store-enabled", "false")
+            .overrideConfigKey("quarkus.langchain4j.neo4j.products.dimension", "1536")
+            .overrideConfigKey("quarkus.langchain4j.neo4j.products.label", "Product")
+            .overrideConfigKey("quarkus.langchain4j.neo4j.products.index-name", "product_vector")
+            .overrideConfigKey("quarkus.langchain4j.neo4j.documents.dimension", "768")
+            .overrideConfigKey("quarkus.langchain4j.neo4j.documents.label", "Document")
+            .overrideConfigKey("quarkus.langchain4j.neo4j.documents.index-name", "document_vector");
+
+    @Inject
+    @EmbeddingStoreName("products")
+    EmbeddingStore<TextSegment> productsEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("documents")
+    EmbeddingStore<TextSegment> documentsEmbeddingStore;
+
+    @Test
+    void testBothNamed() {
+        assertThat(productsEmbeddingStore).isNotNull();
+        assertThat(documentsEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void testNotSame() {
+        assertThat(productsEmbeddingStore).isNotSameAs(documentsEmbeddingStore);
+    }
+}

--- a/embedding-stores/oracle/deployment/src/main/java/io/quarkiverse/langchain4j/oracle/deployment/OracleEmbeddingStoreProcessor.java
+++ b/embedding-stores/oracle/deployment/src/main/java/io/quarkiverse/langchain4j/oracle/deployment/OracleEmbeddingStoreProcessor.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.langchain4j.oracle.deployment;
 
 import java.util.Map;
+import java.util.Set;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
@@ -15,7 +16,9 @@ import dev.langchain4j.store.embedding.EmbeddingStore;
 import io.agroal.api.AgroalDataSource;
 import io.quarkiverse.langchain4j.EmbeddingStoreName;
 import io.quarkiverse.langchain4j.deployment.EmbeddingStoreBuildItem;
+import io.quarkiverse.langchain4j.deployment.NamedConfigDiscovery;
 import io.quarkiverse.langchain4j.oracle.QuarkusOracleEmbeddingStore;
+import io.quarkiverse.langchain4j.oracle.runtime.OracleEmbeddingStoreConfig;
 import io.quarkiverse.langchain4j.oracle.runtime.OracleEmbeddingStoreRecorder;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.agroal.DataSource;
@@ -32,6 +35,8 @@ class OracleEmbeddingStoreProcessor {
     private static final DotName QUARKUS_ORACLE_EMBEDDING_STORE = DotName.createSimple(QuarkusOracleEmbeddingStore.class);
 
     private static final String FEATURE = "langchain4j-oracle";
+
+    private static final String CONFIG_PREFIX = "quarkus.langchain4j.oracle";
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -73,9 +78,8 @@ class OracleEmbeddingStoreProcessor {
         }
 
         Map<String, OracleNamedStoreBuildTimeConfig> namedStores = buildTimeConfig.namedConfig();
-        for (Map.Entry<String, OracleNamedStoreBuildTimeConfig> entry : namedStores.entrySet()) {
-            String storeName = entry.getKey();
-            OracleNamedStoreBuildTimeConfig storeBuildTimeConfig = entry.getValue();
+        for (String storeName : discoverStoreNames(buildTimeConfig)) {
+            OracleNamedStoreBuildTimeConfig storeBuildTimeConfig = namedStores.get(storeName);
 
             if (!storeBuildTimeConfig.enabled()) {
                 continue;
@@ -104,6 +108,15 @@ class OracleEmbeddingStoreProcessor {
 
             embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
         }
+    }
+
+    /**
+     * Named stores are only partially materialized by SmallRye Config, since the build-time config group holds a couple
+     * of properties. Discovering them from the configured property names also covers stores configured at runtime only.
+     */
+    private static Set<String> discoverStoreNames(OracleEmbeddingStoreBuildTimeConfig buildTimeConfig) {
+        return NamedConfigDiscovery.discoverNames(CONFIG_PREFIX, buildTimeConfig.namedConfig().keySet(),
+                OracleEmbeddingStoreBuildTimeConfig.class, OracleEmbeddingStoreConfig.class);
     }
 
     private AnnotationInstance resolveDatasourceQualifier(String datasourceName) {

--- a/embedding-stores/oracle/deployment/src/test/java/io/quarkiverse/langchain4j/oracle/test/OracleNamedStoreWithoutDatasourceTest.java
+++ b/embedding-stores/oracle/deployment/src/test/java/io/quarkiverse/langchain4j/oracle/test/OracleNamedStoreWithoutDatasourceTest.java
@@ -1,0 +1,51 @@
+package io.quarkiverse.langchain4j.oracle.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Named stores must be discovered from any configured property, not only from the build-time {@code enabled} and
+ * {@code datasource} ones.
+ */
+public class OracleNamedStoreWithoutDatasourceTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.oracle.default-store-enabled", "false")
+            .overrideConfigKey("quarkus.langchain4j.oracle.products.create-option", "CREATE_OR_REPLACE")
+            .overrideConfigKey("quarkus.langchain4j.oracle.products.table", "product_embeddings")
+            .overrideConfigKey("quarkus.langchain4j.oracle.documents.create-option", "CREATE_OR_REPLACE")
+            .overrideConfigKey("quarkus.langchain4j.oracle.documents.table", "doc_embeddings")
+            .overrideConfigKey("quarkus.class-loading.parent-first-artifacts", "ai.djl.huggingface:tokenizers");
+
+    @Inject
+    @EmbeddingStoreName("products")
+    EmbeddingStore<TextSegment> productsEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("documents")
+    EmbeddingStore<TextSegment> documentsEmbeddingStore;
+
+    @Test
+    void testBothNamed() {
+        assertThat(productsEmbeddingStore).isNotNull();
+        assertThat(documentsEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void testNotSame() {
+        assertThat(productsEmbeddingStore).isNotSameAs(documentsEmbeddingStore);
+    }
+}

--- a/embedding-stores/pgvector/deployment/src/main/java/io/quarkiverse/langchain4j/pgvector/deployment/PgVectorEmbeddingStoreProcessor.java
+++ b/embedding-stores/pgvector/deployment/src/main/java/io/quarkiverse/langchain4j/pgvector/deployment/PgVectorEmbeddingStoreProcessor.java
@@ -20,8 +20,10 @@ import io.agroal.api.AgroalDataSource;
 import io.agroal.api.AgroalPoolInterceptor;
 import io.quarkiverse.langchain4j.EmbeddingStoreName;
 import io.quarkiverse.langchain4j.deployment.EmbeddingStoreBuildItem;
+import io.quarkiverse.langchain4j.deployment.NamedConfigDiscovery;
 import io.quarkiverse.langchain4j.pgvector.PgVectorAgroalPoolInterceptor;
 import io.quarkiverse.langchain4j.pgvector.PgVectorEmbeddingStore;
+import io.quarkiverse.langchain4j.pgvector.runtime.PgVectorEmbeddingStoreConfig;
 import io.quarkiverse.langchain4j.pgvector.runtime.PgVectorEmbeddingStoreRecorder;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.agroal.DataSource;
@@ -41,6 +43,8 @@ class PgVectorEmbeddingStoreProcessor {
     private static final DotName PG_VECTOR_AGROAL_POOL_INTERCEPTOR = DotName.createSimple(PgVectorAgroalPoolInterceptor.class);
 
     private static final String FEATURE = "langchain4j-pgvector";
+
+    private static final String CONFIG_PREFIX = "quarkus.langchain4j.pgvector";
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -63,6 +67,7 @@ class PgVectorEmbeddingStoreProcessor {
 
         String defaultDatasourceName = buildTimeConfig.defaultConfig().datasource().orElse(null);
         AnnotationInstance defaultDatasourceQualifier = resolveDatasourceQualifier(defaultDatasourceName);
+        Set<String> alreadyHandledStoreInterceptors = new HashSet<>();
 
         if (buildTimeConfig.defaultConfig().defaultStoreEnabled()) {
             beanProducer.produce(SyntheticBeanBuildItem
@@ -89,15 +94,14 @@ class PgVectorEmbeddingStoreProcessor {
                     .qualifiers(defaultDatasourceQualifier)
                     .done());
 
+            alreadyHandledStoreInterceptors.add(resolveDatasourceName(defaultDatasourceName));
+
             embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
         }
 
         Map<String, PgVectorNamedStoreBuildTimeConfig> namedStores = buildTimeConfig.namedConfig();
-        Set<String> alreadyHandledStoreInterceptors = new HashSet<>();
-        for (Map.Entry<String, PgVectorNamedStoreBuildTimeConfig> entry : namedStores.entrySet()) {
-            String storeName = entry.getKey();
-            PgVectorNamedStoreBuildTimeConfig storeBuildTimeConfig = entry.getValue();
-            String storeDatasourceName = storeBuildTimeConfig.datasource().orElse(null);
+        for (String storeName : discoverStoreNames(buildTimeConfig)) {
+            String storeDatasourceName = namedStores.get(storeName).datasource().orElse(null);
 
             AnnotationInstance storeNameQualifier = AnnotationInstance.builder(EmbeddingStoreName.class).add("value", storeName)
                     .build();
@@ -118,7 +122,7 @@ class PgVectorEmbeddingStoreProcessor {
                             storeDatasourceQualifier)
                     .done());
 
-            if (!alreadyHandledStoreInterceptors.contains(storeDatasourceName)) {
+            if (alreadyHandledStoreInterceptors.add(resolveDatasourceName(storeDatasourceName))) {
                 beanProducer.produce(SyntheticBeanBuildItem
                         .configure(PG_VECTOR_AGROAL_POOL_INTERCEPTOR)
                         .types(ClassType.create(AGROAL_POOL_INTERCEPTOR))
@@ -129,17 +133,34 @@ class PgVectorEmbeddingStoreProcessor {
                         .qualifiers(storeDatasourceQualifier)
                         .done());
             }
-            alreadyHandledStoreInterceptors.add(storeDatasourceName);
 
             embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
         }
     }
 
+    /**
+     * Named stores are only partially materialized by SmallRye Config, since the build-time config group holds a single
+     * property. Discovering them from the configured property names also covers stores configured at runtime only.
+     */
+    private static Set<String> discoverStoreNames(PgVectorEmbeddingStoreBuildTimeConfig buildTimeConfig) {
+        return NamedConfigDiscovery.discoverNames(CONFIG_PREFIX, buildTimeConfig.namedConfig().keySet(),
+                PgVectorEmbeddingStoreBuildTimeConfig.class, PgVectorEmbeddingStoreConfig.class);
+    }
+
     private AnnotationInstance resolveDatasourceQualifier(String datasourceName) {
-        if (datasourceName != null && !NamedConfigUtil.isDefault(datasourceName)) {
-            return AnnotationInstance.builder(DataSource.class).add("value", datasourceName).build();
+        String resolvedName = resolveDatasourceName(datasourceName);
+        if (NamedConfigUtil.isDefault(resolvedName)) {
+            return AnnotationInstance.builder(Default.class).build();
         }
-        return AnnotationInstance.builder(Default.class).build();
+        return AnnotationInstance.builder(DataSource.class).add("value", resolvedName).build();
+    }
+
+    /**
+     * Normalizes an unset datasource name to {@link NamedConfigUtil#DEFAULT_NAME}, so that stores relying on the
+     * default datasource resolve to a single qualifier regardless of whether {@code datasource} was set explicitly.
+     */
+    private String resolveDatasourceName(String datasourceName) {
+        return datasourceName != null ? datasourceName : NamedConfigUtil.DEFAULT_NAME;
     }
 
     @BuildStep

--- a/embedding-stores/pgvector/deployment/src/test/java/io/quarkiverse/langchain4j/pgvector/test/PgVectorNamedStoreWithoutDatasourceTest.java
+++ b/embedding-stores/pgvector/deployment/src/test/java/io/quarkiverse/langchain4j/pgvector/test/PgVectorNamedStoreWithoutDatasourceTest.java
@@ -1,0 +1,82 @@
+package io.quarkiverse.langchain4j.pgvector.test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Named stores must be discovered from any configured property, not only from the build-time
+ * {@code datasource} one, which defaults to the default datasource.
+ */
+public class PgVectorNamedStoreWithoutDatasourceTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.datasource.db-kind", "postgresql")
+            .overrideConfigKey("quarkus.datasource.devservices.image-name", "pgvector/pgvector:pg16")
+            .overrideConfigKey("quarkus.langchain4j.pgvector.default-store-enabled", "false")
+            .overrideConfigKey("quarkus.langchain4j.pgvector.products.table", "product_embeddings")
+            .overrideConfigKey("quarkus.langchain4j.pgvector.products.dimension", "384")
+            .overrideConfigKey("quarkus.langchain4j.pgvector.documents.table", "doc_embeddings")
+            .overrideConfigKey("quarkus.langchain4j.pgvector.documents.dimension", "768");
+
+    @Inject
+    @EmbeddingStoreName("products")
+    EmbeddingStore<TextSegment> productsEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("documents")
+    EmbeddingStore<TextSegment> documentsEmbeddingStore;
+
+    @Inject
+    javax.sql.DataSource defaultDs;
+
+    @Test
+    void testBothNamed() {
+        Assertions.assertThat(productsEmbeddingStore).isNotNull();
+        Assertions.assertThat(documentsEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void testNotSame() {
+        Assertions.assertThat(productsEmbeddingStore).isNotSameAs(documentsEmbeddingStore);
+    }
+
+    @Test
+    void testProductEmbeddingsTable() throws SQLException {
+        assertTableExists(productsEmbeddingStore, "product_embeddings");
+    }
+
+    @Test
+    void testDocEmbeddingsTable() throws SQLException {
+        assertTableExists(documentsEmbeddingStore, "doc_embeddings");
+    }
+
+    private void assertTableExists(EmbeddingStore<TextSegment> store, String tableName) throws SQLException {
+        store.toString();
+        try (Connection connection = defaultDs.getConnection()) {
+            try (Statement statement = connection.createStatement()) {
+                try (ResultSet rs = statement.executeQuery(
+                        "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = '" + tableName + "')")) {
+                    rs.next();
+                    Assertions.assertThat(rs.getBoolean(1)).isTrue();
+                }
+            }
+        }
+    }
+}

--- a/embedding-stores/pinecone/deployment/src/main/java/io/quarkiverse/langchain4j/pinecone/PineconeProcessor.java
+++ b/embedding-stores/pinecone/deployment/src/main/java/io/quarkiverse/langchain4j/pinecone/PineconeProcessor.java
@@ -1,6 +1,6 @@
 package io.quarkiverse.langchain4j.pinecone;
 
-import java.util.Map;
+import java.util.Set;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -13,6 +13,8 @@ import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import io.quarkiverse.langchain4j.EmbeddingStoreName;
 import io.quarkiverse.langchain4j.deployment.EmbeddingStoreBuildItem;
+import io.quarkiverse.langchain4j.deployment.NamedConfigDiscovery;
+import io.quarkiverse.langchain4j.pinecone.runtime.PineconeConfig;
 import io.quarkiverse.langchain4j.pinecone.runtime.PineconeRecorder;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
@@ -31,6 +33,8 @@ public class PineconeProcessor {
 
     public static final DotName PINECONE_EMBEDDING_STORE = DotName.createSimple(PineconeEmbeddingStore.class);
     private static final String FEATURE = "langchain4j-pinecone";
+
+    private static final String CONFIG_PREFIX = "quarkus.langchain4j.pinecone";
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -59,10 +63,7 @@ public class PineconeProcessor {
             embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
         }
 
-        Map<String, PineconeNamedStoreBuildTimeConfig> namedStores = buildTimeConfig.namedConfig();
-        for (Map.Entry<String, PineconeNamedStoreBuildTimeConfig> entry : namedStores.entrySet()) {
-            String storeName = entry.getKey();
-
+        for (String storeName : discoverStoreNames(buildTimeConfig)) {
             AnnotationInstance storeNameQualifier = AnnotationInstance.builder(EmbeddingStoreName.class)
                     .add("value", storeName)
                     .build();
@@ -80,6 +81,15 @@ public class PineconeProcessor {
                     .done());
             embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
         }
+    }
+
+    /**
+     * Named stores are only partially materialized by SmallRye Config, since the build-time config group holds a single
+     * property. Discovering them from the configured property names also covers stores configured at runtime only.
+     */
+    private static Set<String> discoverStoreNames(PineconeEmbeddingStoreBuildTimeConfig buildTimeConfig) {
+        return NamedConfigDiscovery.discoverNames(CONFIG_PREFIX, buildTimeConfig.namedConfig().keySet(),
+                PineconeEmbeddingStoreBuildTimeConfig.class, PineconeConfig.class);
     }
 
     /**

--- a/embedding-stores/pinecone/deployment/src/test/java/io/quarkiverse/langchain4j/pinecone/test/PineconeNamedStoreWithoutIndexNameTest.java
+++ b/embedding-stores/pinecone/deployment/src/test/java/io/quarkiverse/langchain4j/pinecone/test/PineconeNamedStoreWithoutIndexNameTest.java
@@ -1,0 +1,53 @@
+package io.quarkiverse.langchain4j.pinecone.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Named stores must be discovered from any configured property, not only from the build-time {@code index-name} one.
+ */
+public class PineconeNamedStoreWithoutIndexNameTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.pinecone.default-store-enabled", "false")
+            .overrideConfigKey("quarkus.langchain4j.pinecone.products.api-key", "test-api-key-products")
+            .overrideConfigKey("quarkus.langchain4j.pinecone.products.environment", "gcp-starter")
+            .overrideConfigKey("quarkus.langchain4j.pinecone.products.project-id", "proj123")
+            .overrideConfigKey("quarkus.langchain4j.pinecone.products.dimension", "1536")
+            .overrideConfigKey("quarkus.langchain4j.pinecone.documents.api-key", "test-api-key-docs")
+            .overrideConfigKey("quarkus.langchain4j.pinecone.documents.environment", "us-west1-gcp")
+            .overrideConfigKey("quarkus.langchain4j.pinecone.documents.project-id", "proj456")
+            .overrideConfigKey("quarkus.langchain4j.pinecone.documents.dimension", "768");
+
+    @Inject
+    @EmbeddingStoreName("products")
+    EmbeddingStore<TextSegment> productsEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("documents")
+    EmbeddingStore<TextSegment> documentsEmbeddingStore;
+
+    @Test
+    void testBothNamed() {
+        assertThat(productsEmbeddingStore).isNotNull();
+        assertThat(documentsEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void testNotSame() {
+        assertThat(productsEmbeddingStore).isNotSameAs(documentsEmbeddingStore);
+    }
+}

--- a/embedding-stores/qdrant/deployment/src/test/java/io/quarkiverse/langchain4j/qdrant/QdrantNamedStoreWithoutClientNameTest.java
+++ b/embedding-stores/qdrant/deployment/src/test/java/io/quarkiverse/langchain4j/qdrant/QdrantNamedStoreWithoutClientNameTest.java
@@ -1,0 +1,48 @@
+package io.quarkiverse.langchain4j.qdrant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkiverse.langchain4j.qdrant.runtime.QdrantEmbeddingStore;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Unlike the other embedding stores, every Qdrant store property is a build-time one, so SmallRye Config materializes a
+ * named store key for any of them and no extra discovery is needed. This pins that down: named stores are found without
+ * the {@code client-name} property that the other tests set.
+ */
+public class QdrantNamedStoreWithoutClientNameTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.qdrant.default-store-enabled", "false")
+            .overrideConfigKey("quarkus.langchain4j.qdrant.products.collection-name", "product_embeddings")
+            .overrideConfigKey("quarkus.langchain4j.qdrant.documents.payload-text-key", "content");
+
+    @Inject
+    @EmbeddingStoreName("products")
+    QdrantEmbeddingStore productsEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("documents")
+    QdrantEmbeddingStore documentsEmbeddingStore;
+
+    @Test
+    void testBothNamed() {
+        assertThat(productsEmbeddingStore).isNotNull();
+        assertThat(documentsEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void testNotSame() {
+        assertThat(productsEmbeddingStore).isNotSameAs(documentsEmbeddingStore);
+    }
+}

--- a/embedding-stores/redis/deployment/src/main/java/io/quarkiverse/langchain4j/redis/RedisEmbeddingStoreProcessor.java
+++ b/embedding-stores/redis/deployment/src/main/java/io/quarkiverse/langchain4j/redis/RedisEmbeddingStoreProcessor.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.langchain4j.redis;
 
 import java.util.Map;
+import java.util.Set;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
@@ -14,6 +15,8 @@ import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import io.quarkiverse.langchain4j.EmbeddingStoreName;
 import io.quarkiverse.langchain4j.deployment.EmbeddingStoreBuildItem;
+import io.quarkiverse.langchain4j.deployment.NamedConfigDiscovery;
+import io.quarkiverse.langchain4j.redis.runtime.RedisEmbeddingStoreConfig;
 import io.quarkiverse.langchain4j.redis.runtime.RedisEmbeddingStoreRecorder;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
@@ -33,6 +36,8 @@ public class RedisEmbeddingStoreProcessor {
 
     private static final String FEATURE = "langchain4j-redis";
 
+    private static final String CONFIG_PREFIX = "quarkus.langchain4j.redis";
+
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FEATURE);
@@ -44,8 +49,9 @@ public class RedisEmbeddingStoreProcessor {
         producer.produce(new RequestedRedisClientBuildItem(
                 config.defaultConfig().clientName().orElse(RedisConfig.DEFAULT_CLIENT_NAME)));
 
-        for (Map.Entry<String, RedisNamedStoreBuildTimeConfig> entry : config.namedConfig().entrySet()) {
-            String clientName = entry.getValue().clientName().orElse(null);
+        Map<String, RedisNamedStoreBuildTimeConfig> namedStores = config.namedConfig();
+        for (String storeName : discoverStoreNames(config)) {
+            String clientName = namedStores.get(storeName).clientName().orElse(null);
             if (clientName != null && !NamedConfigUtil.isDefault(clientName)) {
                 producer.produce(new RequestedRedisClientBuildItem(clientName));
             }
@@ -82,10 +88,8 @@ public class RedisEmbeddingStoreProcessor {
         }
 
         Map<String, RedisNamedStoreBuildTimeConfig> namedStores = buildTimeConfig.namedConfig();
-        for (Map.Entry<String, RedisNamedStoreBuildTimeConfig> entry : namedStores.entrySet()) {
-            String storeName = entry.getKey();
-            RedisNamedStoreBuildTimeConfig storeBuildTimeConfig = entry.getValue();
-            String storeClientName = storeBuildTimeConfig.clientName().orElse(null);
+        for (String storeName : discoverStoreNames(buildTimeConfig)) {
+            String storeClientName = namedStores.get(storeName).clientName().orElse(null);
 
             AnnotationInstance storeNameQualifier = AnnotationInstance.builder(EmbeddingStoreName.class)
                     .add("value", storeName)
@@ -109,6 +113,15 @@ public class RedisEmbeddingStoreProcessor {
 
             embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
         }
+    }
+
+    /**
+     * Named stores are only partially materialized by SmallRye Config, since the build-time config group holds a single
+     * property. Discovering them from the configured property names also covers stores configured at runtime only.
+     */
+    private static Set<String> discoverStoreNames(RedisEmbeddingStoreBuildTimeConfig buildTimeConfig) {
+        return NamedConfigDiscovery.discoverNames(CONFIG_PREFIX, buildTimeConfig.namedConfig().keySet(),
+                RedisEmbeddingStoreBuildTimeConfig.class, RedisEmbeddingStoreConfig.class);
     }
 
     private AnnotationInstance resolveRedisClientQualifier(String clientName) {

--- a/embedding-stores/redis/deployment/src/test/java/io/quarkiverse/langchain4j/redis/deployment/RedisNamedStoreWithoutClientNameTest.java
+++ b/embedding-stores/redis/deployment/src/test/java/io/quarkiverse/langchain4j/redis/deployment/RedisNamedStoreWithoutClientNameTest.java
@@ -1,0 +1,48 @@
+package io.quarkiverse.langchain4j.redis.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkiverse.langchain4j.redis.RedisEmbeddingStore;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Named stores must be discovered from any configured property, not only from the build-time {@code client-name} one.
+ */
+public class RedisNamedStoreWithoutClientNameTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.redis.default-store-enabled", "false")
+            .overrideConfigKey("quarkus.langchain4j.redis.products.dimension", "1536")
+            .overrideConfigKey("quarkus.langchain4j.redis.products.index-name", "product_embeddings")
+            .overrideConfigKey("quarkus.langchain4j.redis.documents.dimension", "768")
+            .overrideConfigKey("quarkus.langchain4j.redis.documents.index-name", "doc_embeddings");
+
+    @Inject
+    @EmbeddingStoreName("products")
+    RedisEmbeddingStore productsEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("documents")
+    RedisEmbeddingStore documentsEmbeddingStore;
+
+    @Test
+    void testBothNamed() {
+        assertThat(productsEmbeddingStore).isNotNull();
+        assertThat(documentsEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void testNotSame() {
+        assertThat(productsEmbeddingStore).isNotSameAs(documentsEmbeddingStore);
+    }
+}

--- a/embedding-stores/weaviate/deployment/src/main/java/io/quarkiverse/langchain4j/weaviate/deployment/WeaviateDevServicesProcessor.java
+++ b/embedding-stores/weaviate/deployment/src/main/java/io/quarkiverse/langchain4j/weaviate/deployment/WeaviateDevServicesProcessor.java
@@ -59,7 +59,7 @@ public class WeaviateDevServicesProcessor {
             LoggingSetupBuildItem loggingSetupBuildItem,
             DevServicesConfig devServicesConfig) {
 
-        Set<String> namedStoreNames = weaviateBuildConfig.namedConfig().keySet();
+        Set<String> namedStoreNames = WeaviateProcessor.discoverStoreNames(weaviateBuildConfig);
 
         WeaviateDevServiceCfg configuration = getConfiguration(weaviateBuildConfig);
 

--- a/embedding-stores/weaviate/deployment/src/main/java/io/quarkiverse/langchain4j/weaviate/deployment/WeaviateProcessor.java
+++ b/embedding-stores/weaviate/deployment/src/main/java/io/quarkiverse/langchain4j/weaviate/deployment/WeaviateProcessor.java
@@ -1,6 +1,6 @@
 package io.quarkiverse.langchain4j.weaviate.deployment;
 
-import java.util.Map;
+import java.util.Set;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -14,7 +14,9 @@ import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.weaviate.WeaviateEmbeddingStore;
 import io.quarkiverse.langchain4j.EmbeddingStoreName;
 import io.quarkiverse.langchain4j.deployment.EmbeddingStoreBuildItem;
+import io.quarkiverse.langchain4j.deployment.NamedConfigDiscovery;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
+import io.quarkiverse.langchain4j.weaviate.runtime.WeaviateEmbeddingStoreConfig;
 import io.quarkiverse.langchain4j.weaviate.runtime.WeaviateRecorder;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -30,6 +32,8 @@ class WeaviateProcessor {
     public static final DotName WEAVIATE_CLIENT = DotName.createSimple(WeaviateClient.class);
 
     static final String FEATURE = "langchain4j-weaviate";
+
+    static final String CONFIG_PREFIX = "quarkus.langchain4j.weaviate";
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -70,10 +74,7 @@ class WeaviateProcessor {
             embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
         }
 
-        Map<String, WeaviateNamedStoreBuildTimeConfig> namedStores = buildTimeConfig.namedConfig();
-        for (Map.Entry<String, WeaviateNamedStoreBuildTimeConfig> entry : namedStores.entrySet()) {
-            String storeName = entry.getKey();
-
+        for (String storeName : discoverStoreNames(buildTimeConfig)) {
             AnnotationInstance storeNameQualifier = AnnotationInstance.builder(EmbeddingStoreName.class)
                     .add("value", storeName)
                     .build();
@@ -104,5 +105,14 @@ class WeaviateProcessor {
 
             embeddingStoreProducer.produce(new EmbeddingStoreBuildItem());
         }
+    }
+
+    /**
+     * Named stores are only partially materialized by SmallRye Config, since the build-time config group holds a single
+     * property. Discovering them from the configured property names also covers stores configured at runtime only.
+     */
+    static Set<String> discoverStoreNames(WeaviateEmbeddingStoreBuildTimeConfig buildTimeConfig) {
+        return NamedConfigDiscovery.discoverNames(CONFIG_PREFIX, buildTimeConfig.namedConfig().keySet(),
+                WeaviateEmbeddingStoreBuildTimeConfig.class, WeaviateEmbeddingStoreConfig.class);
     }
 }

--- a/embedding-stores/weaviate/deployment/src/test/java/io/quarkiverse/langchain4j/weaviate/deployment/WeaviateNamedStoreWithoutObjectClassTest.java
+++ b/embedding-stores/weaviate/deployment/src/test/java/io/quarkiverse/langchain4j/weaviate/deployment/WeaviateNamedStoreWithoutObjectClassTest.java
@@ -1,0 +1,60 @@
+package io.quarkiverse.langchain4j.weaviate.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.store.embedding.weaviate.WeaviateEmbeddingStore;
+import io.quarkiverse.langchain4j.EmbeddingStoreName;
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Named stores must be discovered from any configured property, not only from the build-time {@code object-class} one.
+ */
+public class WeaviateNamedStoreWithoutObjectClassTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.weaviate.default-store-enabled", "false")
+            .overrideConfigKey("quarkus.langchain4j.weaviate.devservices.enabled", "false")
+            .overrideConfigKey("quarkus.langchain4j.weaviate.products.host", "localhost")
+            .overrideConfigKey("quarkus.langchain4j.weaviate.products.metadata.keys", "tags")
+            .overrideConfigKey("quarkus.langchain4j.weaviate.documents.host", "localhost")
+            .overrideConfigKey("quarkus.langchain4j.weaviate.documents.metadata.keys", "tags");
+
+    @Inject
+    @EmbeddingStoreName("products")
+    WeaviateEmbeddingStore productsEmbeddingStore;
+
+    @Inject
+    @EmbeddingStoreName("documents")
+    WeaviateEmbeddingStore documentsEmbeddingStore;
+
+    @Test
+    void testBothNamed() {
+        assertThat(productsEmbeddingStore).isNotNull();
+        assertThat(documentsEmbeddingStore).isNotNull();
+    }
+
+    @Test
+    void testNotSame() {
+        assertThat(productsEmbeddingStore).isNotSameAs(documentsEmbeddingStore);
+    }
+
+    /**
+     * {@code devservices} is a root property rather than a store name, so it must not produce a store.
+     */
+    @Test
+    void testDevservicesIsNotAStore() {
+        assertThat(Arc.container()
+                .instance(WeaviateEmbeddingStore.class, EmbeddingStoreName.Literal.of("devservices"))
+                .isAvailable()).isFalse();
+    }
+}


### PR DESCRIPTION
## Describe your changes

Named stores declare their build-time config as `@WithParentName @WithDefaults Map<String, XNamedStoreBuildTimeConfig>`, and SmallRye Config only materializes a map key for properties that structurally match that group. Those groups hold one to three properties, so a store configured through runtime properties alone (`table`, `dimension`, `url`, ...) never produced a key and its beans were never created, failing with `UnsatisfiedResolutionException`.

Reported for pgvector, but it affects every store whose actual settings live in a `@ConfigRoot(RUN_TIME)`: chroma, milvus, neo4j, oracle, pgvector, pinecone, redis and weaviate. Qdrant is the exception, since all of its store properties are build-time ones.

Changes:

- Add `NamedConfigDiscovery` to `core/deployment`. It scans the configured property names and treats `<prefix>.<name>.<property>` as a named store unless `<name>` belongs to the unnamed store. The unnamed property names come from `ConfigMappings.getProperties()`, so `@WithName`, `@WithParentName`, nested groups and indexed collections stay SmallRye's business instead of being reimplemented here.
- Use it in the eight affected processors, and in the chroma and weaviate Dev Services processors so discovered stores also get their URL injected.
- Normalize the pgvector `PgVectorAgroalPoolInterceptor` dedup key. It was keyed on the raw datasource string, where an unset `datasource` (`null`) and an explicit `"<default>"` resolve to the same `@Default` qualifier, which would reintroduce the duplicate bean from #2690 now that discovery works.

Each affected store gets a regression test configuring named stores without the build-time property, verified to fail without the fix. Qdrant gets one too, with no change to `QdrantProcessor`, pinning down that it is not affected. The unit tests on `NamedConfigDiscovery` cover the two cases where a non-store segment could be mistaken for a store name: the root `devservices` property of chroma, milvus and weaviate, and indexed collections such as the documented `quarkus.langchain4j.oracle.metadata-indexes[0].create-option`.

---

- Closes #2754
