### PR TITLE
Report token usage from the Ollama embedding model

### DIFF
--- a/model-providers/ollama/deployment/src/test/java/io/quarkiverse/langchain4j/ollama/deployment/OllamaEmbeddingModelTokenUsageTest.java
+++ b/model-providers/ollama/deployment/src/test/java/io/quarkiverse/langchain4j/ollama/deployment/OllamaEmbeddingModelTokenUsageTest.java
@@ -1,0 +1,116 @@
+package io.quarkiverse.langchain4j.ollama.deployment;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.Response;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OllamaEmbeddingModelTokenUsageTest extends WiremockAware {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.ollama.base-url", WiremockAware.wiremockUrlForConfig())
+            .overrideConfigKey("quarkus.langchain4j.ollama.embedding-model.model-id", "nomic-embed-text")
+            .overrideConfigKey("quarkus.langchain4j.devservices.enabled", "false");
+
+    @Inject
+    EmbeddingModel embeddingModel;
+
+    @Test
+    void shouldReportTokenUsageFromPromptEvalCount() {
+        wiremock().register(
+                post(urlEqualTo("/api/embed"))
+                        .withRequestBody(matchingJsonPath("$.model", equalTo("nomic-embed-text")))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("""
+                                        {
+                                          "model": "nomic-embed-text",
+                                          "embeddings": [[0.1, 0.2, 0.3]],
+                                          "total_duration": 14143917,
+                                          "load_duration": 1019500,
+                                          "prompt_eval_count": 8
+                                        }
+                                        """)));
+
+        Response<Embedding> response = embeddingModel.embed("Hello there");
+
+        assertThat(response.content().vector()).containsExactly(0.1f, 0.2f, 0.3f);
+        assertThat(response.tokenUsage()).isNotNull();
+        assertThat(response.tokenUsage().inputTokenCount()).isEqualTo(8);
+        assertThat(response.tokenUsage().totalTokenCount()).isEqualTo(8);
+    }
+
+    @Test
+    void shouldSumTokenUsageAcrossSegments() {
+        wiremock().register(
+                post(urlEqualTo("/api/embed"))
+                        .withRequestBody(matchingJsonPath("$.input", equalTo("first")))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("""
+                                        {
+                                          "model": "nomic-embed-text",
+                                          "embeddings": [[0.1, 0.2]],
+                                          "prompt_eval_count": 3
+                                        }
+                                        """)));
+        wiremock().register(
+                post(urlEqualTo("/api/embed"))
+                        .withRequestBody(matchingJsonPath("$.input", equalTo("second")))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("""
+                                        {
+                                          "model": "nomic-embed-text",
+                                          "embeddings": [[0.3, 0.4]],
+                                          "prompt_eval_count": 5
+                                        }
+                                        """)));
+
+        Response<List<Embedding>> response = embeddingModel
+                .embedAll(List.of(TextSegment.from("first"), TextSegment.from("second")));
+
+        assertThat(response.content()).hasSize(2);
+        assertThat(response.tokenUsage()).isNotNull();
+        assertThat(response.tokenUsage().inputTokenCount()).isEqualTo(8);
+    }
+
+    @Test
+    void shouldNotFailWhenPromptEvalCountIsAbsent() {
+        wiremock().register(
+                post(urlEqualTo("/api/embed"))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("""
+                                        {
+                                          "model": "nomic-embed-text",
+                                          "embeddings": [[0.1, 0.2, 0.3]]
+                                        }
+                                        """)));
+
+        Response<Embedding> response = embeddingModel.embed("Hello there");
+
+        assertThat(response.content().vector()).containsExactly(0.1f, 0.2f, 0.3f);
+        assertThat(response.tokenUsage()).isNull();
+    }
+}

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/EmbeddingResponse.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/EmbeddingResponse.java
@@ -8,8 +8,11 @@ public class EmbeddingResponse {
 
     private float[][] embeddings;
 
+    private Integer promptEvalCount;
+
     private EmbeddingResponse(Builder builder) {
         embeddings = builder.embeddings;
+        promptEvalCount = builder.promptEvalCount;
     }
 
     public float[][] getEmbeddings() {
@@ -20,15 +23,29 @@ public class EmbeddingResponse {
         this.embeddings = embeddings;
     }
 
+    public Integer getPromptEvalCount() {
+        return promptEvalCount;
+    }
+
+    public void setPromptEvalCount(Integer promptEvalCount) {
+        this.promptEvalCount = promptEvalCount;
+    }
+
     @JsonPOJOBuilder(withPrefix = "")
     public static final class Builder {
         private float[][] embeddings;
+        private Integer promptEvalCount;
 
         private Builder() {
         }
 
         public Builder embeddings(float[][] val) {
             embeddings = val;
+            return this;
+        }
+
+        public Builder promptEvalCount(Integer val) {
+            promptEvalCount = val;
             return this;
         }
 

--- a/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/OllamaEmbeddingModel.java
+++ b/model-providers/ollama/runtime/src/main/java/io/quarkiverse/langchain4j/ollama/OllamaEmbeddingModel.java
@@ -8,6 +8,7 @@ import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.output.TokenUsage;
 
 public class OllamaEmbeddingModel implements EmbeddingModel {
 
@@ -27,8 +28,9 @@ public class OllamaEmbeddingModel implements EmbeddingModel {
     @Override
     public Response<List<Embedding>> embedAll(List<TextSegment> textSegments) {
         List<Embedding> embeddings = new ArrayList<>();
+        TokenUsage tokenUsage = null;
 
-        textSegments.forEach(textSegment -> {
+        for (TextSegment textSegment : textSegments) {
             EmbeddingRequest request = EmbeddingRequest.builder()
                     .model(model)
                     .input(textSegment.text())
@@ -39,9 +41,13 @@ public class OllamaEmbeddingModel implements EmbeddingModel {
             for (float[] embedding : response.getEmbeddings()) {
                 embeddings.add(Embedding.from(embedding));
             }
-        });
 
-        return Response.from(embeddings);
+            if (response.getPromptEvalCount() != null) {
+                tokenUsage = TokenUsage.sum(tokenUsage, new TokenUsage(response.getPromptEvalCount()));
+            }
+        }
+
+        return Response.from(embeddings, tokenUsage);
     }
 
     public static final class Builder {


### PR DESCRIPTION
## Describe your changes

`OllamaEmbeddingModel.embedAll()` always returned `Response.from(embeddings)`, so `tokenUsage()` was `null` for every embedding call. The `/api/embed` response does carry `prompt_eval_count`, but `EmbeddingResponse` never deserialized it.

`EmbeddingResponse` now maps `prompt_eval_count`, and `embedAll()` accumulates it into a `TokenUsage` across the per-segment requests it issues, returning `Response.from(embeddings, tokenUsage)`. The field is optional in the Ollama API (it is absent from the multi-input example in the API docs), so `tokenUsage` stays `null` when the provider does not report it, rather than reporting zero.

Covered by `OllamaEmbeddingModelTokenUsageTest` in `ollama/deployment`, following the existing WireMock test conventions: a single call, accumulation across segments, and the absent-field case.

The issue also asks about HuggingFace. That one is a provider limitation, not something fixable here: the `feature-extraction` endpoint returns a bare array of vectors with no usage metadata, so `HuggingFaceClient.embed()` returns `List<float[]>` and there is no token count to read. Upstream LangChain4j returns no usage there for the same reason.

---

- Closes #2758