### PR TITLE
Improve error message for missing OpenAI API key configuration

### DIFF
--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/OpenAiRecorder.java
@@ -823,9 +823,12 @@ public class OpenAiRecorder {
     }
 
     private ConfigValidationException.Problem createConfigProblem(String key, String configName) {
+        String propertyPath = "quarkus.langchain4j.openai"
+                + (NamedConfigUtil.isDefault(configName) ? "." : ("." + configName + ".")) + key;
         return new ConfigValidationException.Problem(String.format(
-                "SRCFG00014: The config property quarkus.langchain4j.openai%s%s is required but it could not be found in any config source",
-                NamedConfigUtil.isDefault(configName) ? "." : ("." + configName + "."), key));
+                "SRCFG00014: The config property %s is required but it could not be found in any config source. "
+                        + "Please configure it in application.properties or pass it as a system property: -D%s=<value>",
+                propertyPath, propertyPath));
     }
 
     public void cleanUp(ShutdownContext shutdown) {


### PR DESCRIPTION
## What changed

Improved the error message in `OpenAiRecorder.createConfigProblem()` to provide actionable guidance when the OpenAI API key is not configured.

## Why

Issue #2750 reports that setting the API key via the `QUARKUS_LANGCHAIN4J_OPENAI_API_KEY` environment variable does not work, and the resulting error message does not tell the user how to fix the problem.

The improved message now suggests setting the key in `application.properties` or via the `-Dquarkus.langchain4j.openai.api-key=<value>` system property.

**Before:**
```
SRCFG00014: The config property quarkus.langchain4j.openai.api-key is required but it could not be found in any config source
```

**After:**
```
SRCFG00014: The config property quarkus.langchain4j.openai.api-key is required but it could not be found in any config source. Please configure it in application.properties or pass it as a system property: -Dquarkus.langchain4j.openai.api-key=<value>
```

This change is scoped to the OpenAI module. The same pattern exists in other recorders (Anthropic, Cohere, VertexAi, etc.) and can be improved in follow-up PRs.

## How verified

No existing tests assert on the exact error message text. The `OpenAiInvalidMaxRetriesTest` tests the separate `createMaxRetriesConfigProblems` method, which is not affected by this change.

Relates to #2750