### PR TITLE
Omit temperature and top-p when they are not configured

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-all-config.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-all-config.adoc
@@ -4344,6 +4344,8 @@ endif::add-copy-button-to-config-props[]
 --
 What sampling temperature to use, with values between 0 and 2. Higher values means the model will take more risks. A value of 0.9 is good for more creative applications, while 0 (argmax sampling) is good for ones with a well-defined answer. It is recommended to alter this or topP, but not both.
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_CHAT_MODEL_TEMPERATURE+++[]
@@ -4353,7 +4355,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_CHAT_MODEL_TEMPERATUR
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++${quarkus.langchain4j.temperature:1.0}+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-top-p]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-top-p[`+++quarkus.langchain4j.azure-openai.chat-model.top-p+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -4365,6 +4367,8 @@ endif::add-copy-button-to-config-props[]
 --
 An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with topP probability mass. 0.1 means only the tokens comprising the top 10% probability mass are considered. It is recommended to alter this or temperature, but not both.
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_CHAT_MODEL_TOP_P+++[]
@@ -4374,7 +4378,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_CHAT_MODEL_TOP_P+++`
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++1.0+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-seed]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-seed[`+++quarkus.langchain4j.azure-openai.chat-model.seed+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -5775,6 +5779,8 @@ endif::add-copy-button-to-config-props[]
 --
 What sampling temperature to use, with values between 0 and 2. Higher values means the model will take more risks. A value of 0.9 is good for more creative applications, while 0 (argmax sampling) is good for ones with a well-defined answer. It is recommended to alter this or topP, but not both.
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__CHAT_MODEL_TEMPERATURE+++[]
@@ -5784,7 +5790,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__CHAT_MOD
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++${quarkus.langchain4j.temperature:1.0}+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-top-p]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-top-p[`+++quarkus.langchain4j.azure-openai."model-name".chat-model.top-p+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -5796,6 +5802,8 @@ endif::add-copy-button-to-config-props[]
 --
 An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with topP probability mass. 0.1 means only the tokens comprising the top 10% probability mass are considered. It is recommended to alter this or temperature, but not both.
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__CHAT_MODEL_TOP_P+++[]
@@ -5805,7 +5813,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__CHAT_MOD
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++1.0+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-seed]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-seed[`+++quarkus.langchain4j.azure-openai."model-name".chat-model.seed+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -20642,6 +20650,8 @@ endif::add-copy-button-to-config-props[]
 --
 What sampling temperature to use, with values between 0 and 2. Higher values means the model will take more risks. A value of 0.9 is good for more creative applications, while 0 (argmax sampling) is good for ones with a well-defined answer. It is recommended to alter this or topP, but not both.
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_TEMPERATURE+++[]
@@ -20651,7 +20661,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_TEMPERATURE+++`
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++${quarkus.langchain4j.temperature:1.0}+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-top-p]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-top-p[`+++quarkus.langchain4j.openai.chat-model.top-p+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -20663,6 +20673,8 @@ endif::add-copy-button-to-config-props[]
 --
 An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with topP probability mass. 0.1 means only the tokens comprising the top 10% probability mass are considered. It is recommended to alter this or temperature, but not both.
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_TOP_P+++[]
@@ -20672,7 +20684,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_TOP_P+++`
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++1.0+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-max-completion-tokens]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-max-completion-tokens[`+++quarkus.langchain4j.openai.chat-model.max-completion-tokens+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -22073,6 +22085,8 @@ endif::add-copy-button-to-config-props[]
 --
 What sampling temperature to use, with values between 0 and 2. Higher values means the model will take more risks. A value of 0.9 is good for more creative applications, while 0 (argmax sampling) is good for ones with a well-defined answer. It is recommended to alter this or topP, but not both.
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_TEMPERATURE+++[]
@@ -22082,7 +22096,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_TEM
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++${quarkus.langchain4j.temperature:1.0}+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-top-p]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-top-p[`+++quarkus.langchain4j.openai."model-name".chat-model.top-p+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -22094,6 +22108,8 @@ endif::add-copy-button-to-config-props[]
 --
 An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with topP probability mass. 0.1 means only the tokens comprising the top 10% probability mass are considered. It is recommended to alter this or temperature, but not both.
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_TOP_P+++[]
@@ -22103,7 +22119,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_TOP
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++1.0+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-max-completion-tokens]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-max-completion-tokens[`+++quarkus.langchain4j.openai."model-name".chat-model.max-completion-tokens+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-all-config.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-all-config.adoc
@@ -12687,6 +12687,8 @@ The temperature is used for sampling during response generation, which occurs wh
 
 Range: 0.0 - 2.0
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GOOGLE_GENAI_CHAT_MODEL_TEMPERATURE+++[]
@@ -12696,7 +12698,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_GOOGLE_GENAI_CHAT_MODEL_TEMPERATUR
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++${quarkus.langchain4j.temperature:1.0}+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-google-genai_quarkus-langchain4j-google-genai-chat-model-max-output-tokens]] [.property-path]##link:#quarkus-langchain4j-google-genai_quarkus-langchain4j-google-genai-chat-model-max-output-tokens[`+++quarkus.langchain4j.google.genai.chat-model.max-output-tokens+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -13217,6 +13219,8 @@ The temperature is used for sampling during response generation, which occurs wh
 
 Range: 0.0 - 2.0
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GOOGLE_GENAI__MODEL_NAME__CHAT_MODEL_TEMPERATURE+++[]
@@ -13226,7 +13230,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_GOOGLE_GENAI__MODEL_NAME__CHAT_MOD
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++${quarkus.langchain4j.temperature:1.0}+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-google-genai_quarkus-langchain4j-google-genai-model-name-chat-model-max-output-tokens]] [.property-path]##link:#quarkus-langchain4j-google-genai_quarkus-langchain4j-google-genai-model-name-chat-model-max-output-tokens[`+++quarkus.langchain4j.google.genai."model-name".chat-model.max-output-tokens+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-azure-openai.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-azure-openai.adoc
@@ -613,6 +613,8 @@ endif::add-copy-button-to-config-props[]
 --
 What sampling temperature to use, with values between 0 and 2. Higher values means the model will take more risks. A value of 0.9 is good for more creative applications, while 0 (argmax sampling) is good for ones with a well-defined answer. It is recommended to alter this or topP, but not both.
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_CHAT_MODEL_TEMPERATURE+++[]
@@ -622,7 +624,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_CHAT_MODEL_TEMPERATUR
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++${quarkus.langchain4j.temperature:1.0}+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-top-p]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-top-p[`+++quarkus.langchain4j.azure-openai.chat-model.top-p+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -634,6 +636,8 @@ endif::add-copy-button-to-config-props[]
 --
 An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with topP probability mass. 0.1 means only the tokens comprising the top 10% probability mass are considered. It is recommended to alter this or temperature, but not both.
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_CHAT_MODEL_TOP_P+++[]
@@ -643,7 +647,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_CHAT_MODEL_TOP_P+++`
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++1.0+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-seed]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-seed[`+++quarkus.langchain4j.azure-openai.chat-model.seed+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -2044,6 +2048,8 @@ endif::add-copy-button-to-config-props[]
 --
 What sampling temperature to use, with values between 0 and 2. Higher values means the model will take more risks. A value of 0.9 is good for more creative applications, while 0 (argmax sampling) is good for ones with a well-defined answer. It is recommended to alter this or topP, but not both.
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__CHAT_MODEL_TEMPERATURE+++[]
@@ -2053,7 +2059,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__CHAT_MOD
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++${quarkus.langchain4j.temperature:1.0}+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-top-p]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-top-p[`+++quarkus.langchain4j.azure-openai."model-name".chat-model.top-p+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -2065,6 +2071,8 @@ endif::add-copy-button-to-config-props[]
 --
 An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with topP probability mass. 0.1 means only the tokens comprising the top 10% probability mass are considered. It is recommended to alter this or temperature, but not both.
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__CHAT_MODEL_TOP_P+++[]
@@ -2074,7 +2082,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__CHAT_MOD
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++1.0+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-seed]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-seed[`+++quarkus.langchain4j.azure-openai."model-name".chat-model.seed+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-azure-openai_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-azure-openai_quarkus.langchain4j.adoc
@@ -613,6 +613,8 @@ endif::add-copy-button-to-config-props[]
 --
 What sampling temperature to use, with values between 0 and 2. Higher values means the model will take more risks. A value of 0.9 is good for more creative applications, while 0 (argmax sampling) is good for ones with a well-defined answer. It is recommended to alter this or topP, but not both.
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_CHAT_MODEL_TEMPERATURE+++[]
@@ -622,7 +624,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_CHAT_MODEL_TEMPERATUR
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++${quarkus.langchain4j.temperature:1.0}+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-top-p]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-top-p[`+++quarkus.langchain4j.azure-openai.chat-model.top-p+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -634,6 +636,8 @@ endif::add-copy-button-to-config-props[]
 --
 An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with topP probability mass. 0.1 means only the tokens comprising the top 10% probability mass are considered. It is recommended to alter this or temperature, but not both.
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_CHAT_MODEL_TOP_P+++[]
@@ -643,7 +647,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_CHAT_MODEL_TOP_P+++`
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++1.0+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-seed]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-seed[`+++quarkus.langchain4j.azure-openai.chat-model.seed+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -2044,6 +2048,8 @@ endif::add-copy-button-to-config-props[]
 --
 What sampling temperature to use, with values between 0 and 2. Higher values means the model will take more risks. A value of 0.9 is good for more creative applications, while 0 (argmax sampling) is good for ones with a well-defined answer. It is recommended to alter this or topP, but not both.
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__CHAT_MODEL_TEMPERATURE+++[]
@@ -2053,7 +2059,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__CHAT_MOD
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++${quarkus.langchain4j.temperature:1.0}+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-top-p]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-top-p[`+++quarkus.langchain4j.azure-openai."model-name".chat-model.top-p+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -2065,6 +2071,8 @@ endif::add-copy-button-to-config-props[]
 --
 An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with topP probability mass. 0.1 means only the tokens comprising the top 10% probability mass are considered. It is recommended to alter this or temperature, but not both.
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__CHAT_MODEL_TOP_P+++[]
@@ -2074,7 +2082,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__CHAT_MOD
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++1.0+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-seed]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-seed[`+++quarkus.langchain4j.azure-openai."model-name".chat-model.seed+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-google-genai.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-google-genai.adoc
@@ -302,6 +302,8 @@ The temperature is used for sampling during response generation, which occurs wh
 
 Range: 0.0 - 2.0
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GOOGLE_GENAI_CHAT_MODEL_TEMPERATURE+++[]
@@ -311,7 +313,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_GOOGLE_GENAI_CHAT_MODEL_TEMPERATUR
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++${quarkus.langchain4j.temperature:1.0}+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-google-genai_quarkus-langchain4j-google-genai-chat-model-max-output-tokens]] [.property-path]##link:#quarkus-langchain4j-google-genai_quarkus-langchain4j-google-genai-chat-model-max-output-tokens[`+++quarkus.langchain4j.google.genai.chat-model.max-output-tokens+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -832,6 +834,8 @@ The temperature is used for sampling during response generation, which occurs wh
 
 Range: 0.0 - 2.0
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GOOGLE_GENAI__MODEL_NAME__CHAT_MODEL_TEMPERATURE+++[]
@@ -841,7 +845,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_GOOGLE_GENAI__MODEL_NAME__CHAT_MOD
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++${quarkus.langchain4j.temperature:1.0}+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-google-genai_quarkus-langchain4j-google-genai-model-name-chat-model-max-output-tokens]] [.property-path]##link:#quarkus-langchain4j-google-genai_quarkus-langchain4j-google-genai-model-name-chat-model-max-output-tokens[`+++quarkus.langchain4j.google.genai."model-name".chat-model.max-output-tokens+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-google-genai_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-google-genai_quarkus.langchain4j.adoc
@@ -302,6 +302,8 @@ The temperature is used for sampling during response generation, which occurs wh
 
 Range: 0.0 - 2.0
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GOOGLE_GENAI_CHAT_MODEL_TEMPERATURE+++[]
@@ -311,7 +313,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_GOOGLE_GENAI_CHAT_MODEL_TEMPERATUR
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++${quarkus.langchain4j.temperature:1.0}+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-google-genai_quarkus-langchain4j-google-genai-chat-model-max-output-tokens]] [.property-path]##link:#quarkus-langchain4j-google-genai_quarkus-langchain4j-google-genai-chat-model-max-output-tokens[`+++quarkus.langchain4j.google.genai.chat-model.max-output-tokens+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -832,6 +834,8 @@ The temperature is used for sampling during response generation, which occurs wh
 
 Range: 0.0 - 2.0
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_GOOGLE_GENAI__MODEL_NAME__CHAT_MODEL_TEMPERATURE+++[]
@@ -841,7 +845,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_GOOGLE_GENAI__MODEL_NAME__CHAT_MOD
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++${quarkus.langchain4j.temperature:1.0}+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-google-genai_quarkus-langchain4j-google-genai-model-name-chat-model-max-output-tokens]] [.property-path]##link:#quarkus-langchain4j-google-genai_quarkus-langchain4j-google-genai-model-name-chat-model-max-output-tokens[`+++quarkus.langchain4j.google.genai."model-name".chat-model.max-output-tokens+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai.adoc
@@ -404,6 +404,8 @@ endif::add-copy-button-to-config-props[]
 --
 What sampling temperature to use, with values between 0 and 2. Higher values means the model will take more risks. A value of 0.9 is good for more creative applications, while 0 (argmax sampling) is good for ones with a well-defined answer. It is recommended to alter this or topP, but not both.
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_TEMPERATURE+++[]
@@ -413,7 +415,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_TEMPERATURE+++`
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++${quarkus.langchain4j.temperature:1.0}+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-top-p]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-top-p[`+++quarkus.langchain4j.openai.chat-model.top-p+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -425,6 +427,8 @@ endif::add-copy-button-to-config-props[]
 --
 An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with topP probability mass. 0.1 means only the tokens comprising the top 10% probability mass are considered. It is recommended to alter this or temperature, but not both.
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_TOP_P+++[]
@@ -434,7 +438,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_TOP_P+++`
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++1.0+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-max-completion-tokens]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-max-completion-tokens[`+++quarkus.langchain4j.openai.chat-model.max-completion-tokens+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -1835,6 +1839,8 @@ endif::add-copy-button-to-config-props[]
 --
 What sampling temperature to use, with values between 0 and 2. Higher values means the model will take more risks. A value of 0.9 is good for more creative applications, while 0 (argmax sampling) is good for ones with a well-defined answer. It is recommended to alter this or topP, but not both.
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_TEMPERATURE+++[]
@@ -1844,7 +1850,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_TEM
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++${quarkus.langchain4j.temperature:1.0}+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-top-p]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-top-p[`+++quarkus.langchain4j.openai."model-name".chat-model.top-p+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -1856,6 +1862,8 @@ endif::add-copy-button-to-config-props[]
 --
 An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with topP probability mass. 0.1 means only the tokens comprising the top 10% probability mass are considered. It is recommended to alter this or temperature, but not both.
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_TOP_P+++[]
@@ -1865,7 +1873,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_TOP
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++1.0+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-max-completion-tokens]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-max-completion-tokens[`+++quarkus.langchain4j.openai."model-name".chat-model.max-completion-tokens+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-openai_quarkus.langchain4j.adoc
@@ -404,6 +404,8 @@ endif::add-copy-button-to-config-props[]
 --
 What sampling temperature to use, with values between 0 and 2. Higher values means the model will take more risks. A value of 0.9 is good for more creative applications, while 0 (argmax sampling) is good for ones with a well-defined answer. It is recommended to alter this or topP, but not both.
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_TEMPERATURE+++[]
@@ -413,7 +415,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_TEMPERATURE+++`
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++${quarkus.langchain4j.temperature:1.0}+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-top-p]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-top-p[`+++quarkus.langchain4j.openai.chat-model.top-p+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -425,6 +427,8 @@ endif::add-copy-button-to-config-props[]
 --
 An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with topP probability mass. 0.1 means only the tokens comprising the top 10% probability mass are considered. It is recommended to alter this or temperature, but not both.
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_TOP_P+++[]
@@ -434,7 +438,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_TOP_P+++`
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++1.0+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-max-completion-tokens]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-chat-model-max-completion-tokens[`+++quarkus.langchain4j.openai.chat-model.max-completion-tokens+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -1835,6 +1839,8 @@ endif::add-copy-button-to-config-props[]
 --
 What sampling temperature to use, with values between 0 and 2. Higher values means the model will take more risks. A value of 0.9 is good for more creative applications, while 0 (argmax sampling) is good for ones with a well-defined answer. It is recommended to alter this or topP, but not both.
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_TEMPERATURE+++[]
@@ -1844,7 +1850,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_TEM
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++${quarkus.langchain4j.temperature:1.0}+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-top-p]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-top-p[`+++quarkus.langchain4j.openai."model-name".chat-model.top-p+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -1856,6 +1862,8 @@ endif::add-copy-button-to-config-props[]
 --
 An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with topP probability mass. 0.1 means only the tokens comprising the top 10% probability mass are considered. It is recommended to alter this or temperature, but not both.
 
+If not set, the parameter is omitted from the request and the model's own default applies.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_TOP_P+++[]
@@ -1865,7 +1873,7 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_OPENAI__MODEL_NAME__CHAT_MODEL_TOP
 endif::add-copy-button-to-env-var[]
 --
 |double
-|`+++1.0+++`
+|`+++the model's default+++`
 
 a| [[quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-max-completion-tokens]] [.property-path]##link:#quarkus-langchain4j-openai_quarkus-langchain4j-openai-model-name-chat-model-max-completion-tokens[`+++quarkus.langchain4j.openai."model-name".chat-model.max-completion-tokens+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/model-providers/google/google-genai/deployment/src/test/java/io/quarkiverse/langchain4j/google/genai/deployment/GoogleGenAiGlobalTemperatureTest.java
+++ b/model-providers/google/google-genai/deployment/src/test/java/io/quarkiverse/langchain4j/google/genai/deployment/GoogleGenAiGlobalTemperatureTest.java
@@ -1,0 +1,56 @@
+package io.quarkiverse.langchain4j.google.genai.deployment;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class GoogleGenAiGlobalTemperatureTest extends WiremockAware {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.temperature", "0.5")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.google.genai.base-url", WiremockAware.wiremockUrlForConfig())
+            .overrideRuntimeConfigKey("quarkus.langchain4j.google.genai.api-key", "dummy");
+
+    @Inject
+    ChatModel chatModel;
+
+    @Test
+    void globalTemperatureIsStillHonored() {
+        wiremock().register(post(urlMatching(".*:generateContent.*"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {
+                                  "candidates": [
+                                    {
+                                      "content": { "role": "model", "parts": [ { "text": "hi" } ] },
+                                      "finishReason": "STOP"
+                                    }
+                                  ],
+                                  "usageMetadata": {
+                                    "promptTokenCount": 1,
+                                    "candidatesTokenCount": 2,
+                                    "totalTokenCount": 3
+                                  }
+                                }
+                                """)));
+
+        chatModel.chat("hello");
+
+        assertThat(new String(requestBodyOfSingleRequest())).contains("\"temperature\"").contains("0.5");
+    }
+}

--- a/model-providers/google/google-genai/deployment/src/test/java/io/quarkiverse/langchain4j/google/genai/deployment/GoogleGenAiSamplingParamsOmittedTest.java
+++ b/model-providers/google/google-genai/deployment/src/test/java/io/quarkiverse/langchain4j/google/genai/deployment/GoogleGenAiSamplingParamsOmittedTest.java
@@ -1,0 +1,60 @@
+package io.quarkiverse.langchain4j.google.genai.deployment;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class GoogleGenAiSamplingParamsOmittedTest extends WiremockAware {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.google.genai.base-url", WiremockAware.wiremockUrlForConfig())
+            .overrideRuntimeConfigKey("quarkus.langchain4j.google.genai.api-key", "dummy");
+
+    @Inject
+    ChatModel chatModel;
+
+    @Test
+    void temperatureIsNotSentWhenUnconfigured() {
+        stubGenerateContent();
+
+        chatModel.chat("hello");
+
+        String requestBody = new String(requestBodyOfSingleRequest());
+        assertThat(requestBody).doesNotContain("\"temperature\"");
+    }
+
+    private void stubGenerateContent() {
+        wiremock().register(post(urlMatching(".*:generateContent.*"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {
+                                  "candidates": [
+                                    {
+                                      "content": { "role": "model", "parts": [ { "text": "hi" } ] },
+                                      "finishReason": "STOP"
+                                    }
+                                  ],
+                                  "usageMetadata": {
+                                    "promptTokenCount": 1,
+                                    "candidatesTokenCount": 2,
+                                    "totalTokenCount": 3
+                                  }
+                                }
+                                """)));
+    }
+}

--- a/model-providers/google/google-genai/deployment/src/test/java/io/quarkiverse/langchain4j/google/genai/deployment/GoogleGenAiStreamingSamplingParamsOmittedTest.java
+++ b/model-providers/google/google-genai/deployment/src/test/java/io/quarkiverse/langchain4j/google/genai/deployment/GoogleGenAiStreamingSamplingParamsOmittedTest.java
@@ -1,0 +1,70 @@
+package io.quarkiverse.langchain4j.google.genai.deployment;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class GoogleGenAiStreamingSamplingParamsOmittedTest extends WiremockAware {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.google.genai.base-url", WiremockAware.wiremockUrlForConfig())
+            .overrideRuntimeConfigKey("quarkus.langchain4j.google.genai.api-key", "dummy");
+
+    @Inject
+    StreamingChatModel streamingChatModel;
+
+    @Test
+    void temperatureIsNotSentWhenUnconfigured() throws InterruptedException {
+        var eventStream = """
+                data: {"candidates":[{"content":{"role":"model","parts":[{"text":"hi"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":2,"totalTokenCount":3}}
+
+                """;
+        wiremock().register(post(urlMatching(".*:streamGenerateContent.*"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "text/event-stream")
+                        .withBody(eventStream)));
+
+        var latch = new CountDownLatch(1);
+        streamingChatModel.chat("hello", new StreamingChatResponseHandler() {
+            @Override
+            public void onPartialResponse(String token) {
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                latch.countDown();
+            }
+
+            @Override
+            public void onCompleteResponse(ChatResponse response) {
+                latch.countDown();
+            }
+        });
+
+        if (!latch.await(1, TimeUnit.MINUTES)) {
+            fail("Streaming did not complete in time");
+        }
+
+        assertThat(new String(requestBodyOfSingleRequest())).doesNotContain("\"temperature\"");
+    }
+}

--- a/model-providers/google/google-genai/runtime/src/main/java/io/quarkiverse/langchain4j/google/genai/runtime/config/ChatModelConfig.java
+++ b/model-providers/google/google-genai/runtime/src/main/java/io/quarkiverse/langchain4j/google/genai/runtime/config/ChatModelConfig.java
@@ -26,8 +26,11 @@ public interface ChatModelConfig {
      * less open-ended or creative response, while higher temperatures can lead to more diverse or creative results.
      * <p>
      * Range: 0.0 - 2.0
+     * <p>
+     * If not set, the parameter is omitted from the request and the model's own default applies.
      */
-    @WithDefault("${quarkus.langchain4j.temperature:1.0}")
+    @ConfigDocDefault("the model's default")
+    @WithDefault("${quarkus.langchain4j.temperature}")
     Optional<Double> temperature();
 
     /**

--- a/model-providers/openai/azure-openai/deployment/src/test/java/io/quarkiverse/langchain4j/azure/openai/test/AzureOpenAiChatModelExplicitSamplingParamsTest.java
+++ b/model-providers/openai/azure-openai/deployment/src/test/java/io/quarkiverse/langchain4j/azure/openai/test/AzureOpenAiChatModelExplicitSamplingParamsTest.java
@@ -1,0 +1,79 @@
+package io.quarkiverse.langchain4j.azure.openai.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class AzureOpenAiChatModelExplicitSamplingParamsTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.azure-openai.api-key", "whatever")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.azure-openai.chat-model.temperature", "0.3")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.azure-openai.chat-model.top-p", "0.8")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.azure-openai.endpoint",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    ChatModel chatModel;
+
+    @Inject
+    StreamingChatModel streamingChatModel;
+
+    @BeforeEach
+    void reset() {
+        resetRequests();
+    }
+
+    @Test
+    void explicitlyConfiguredValuesAreSent() throws IOException {
+        chatModel.chat("hello");
+
+        Map<String, Object> requestBody = getRequestAsMap();
+        assertThat(requestBody).containsEntry("temperature", 0.3).containsEntry("top_p", 0.8);
+    }
+
+    @Test
+    void streamingModelAlsoSendsThem() throws IOException, InterruptedException {
+        var latch = new CountDownLatch(1);
+        streamingChatModel.chat("hello", new StreamingChatResponseHandler() {
+            @Override
+            public void onPartialResponse(String token) {
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                latch.countDown();
+            }
+
+            @Override
+            public void onCompleteResponse(ChatResponse response) {
+                latch.countDown();
+            }
+        });
+        latch.await(1, TimeUnit.MINUTES);
+
+        Map<String, Object> requestBody = getRequestAsMap();
+        assertThat(requestBody).containsEntry("temperature", 0.3).containsEntry("top_p", 0.8);
+    }
+}

--- a/model-providers/openai/azure-openai/deployment/src/test/java/io/quarkiverse/langchain4j/azure/openai/test/AzureOpenAiChatModelSamplingParamsOmittedTest.java
+++ b/model-providers/openai/azure-openai/deployment/src/test/java/io/quarkiverse/langchain4j/azure/openai/test/AzureOpenAiChatModelSamplingParamsOmittedTest.java
@@ -1,0 +1,39 @@
+package io.quarkiverse.langchain4j.azure.openai.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class AzureOpenAiChatModelSamplingParamsOmittedTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.azure-openai.api-key", "whatever")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.azure-openai.endpoint",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    ChatModel chatModel;
+
+    @Test
+    void temperatureAndTopPAreNotSentWhenUnconfigured() throws IOException {
+        chatModel.chat("hello");
+
+        Map<String, Object> requestBody = getRequestAsMap();
+        assertThat(requestBody).doesNotContainKey("temperature").doesNotContainKey("top_p");
+    }
+}

--- a/model-providers/openai/azure-openai/deployment/src/test/java/io/quarkiverse/langchain4j/azure/openai/test/AzureOpenAiGlobalTemperatureTest.java
+++ b/model-providers/openai/azure-openai/deployment/src/test/java/io/quarkiverse/langchain4j/azure/openai/test/AzureOpenAiGlobalTemperatureTest.java
@@ -1,0 +1,40 @@
+package io.quarkiverse.langchain4j.azure.openai.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class AzureOpenAiGlobalTemperatureTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.temperature", "0.5")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.azure-openai.api-key", "whatever")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.azure-openai.endpoint",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    ChatModel chatModel;
+
+    @Test
+    void globalTemperatureIsStillHonored() throws IOException {
+        chatModel.chat("hello");
+
+        Map<String, Object> requestBody = getRequestAsMap();
+        assertThat(requestBody).containsEntry("temperature", 0.5).doesNotContainKey("top_p");
+    }
+}

--- a/model-providers/openai/azure-openai/deployment/src/test/java/io/quarkiverse/langchain4j/azure/openai/test/AzureOpenAiStreamingChatModelTest.java
+++ b/model-providers/openai/azure-openai/deployment/src/test/java/io/quarkiverse/langchain4j/azure/openai/test/AzureOpenAiStreamingChatModelTest.java
@@ -89,5 +89,8 @@ public class AzureOpenAiStreamingChatModelTest extends WiremockAware {
                 .isNotNull()
                 .isEqualTo("Hallo Welt!");
 
+        assertThat(new String(requestBodyOfSingleRequest()))
+                .doesNotContain("\"temperature\"")
+                .doesNotContain("\"top_p\"");
     }
 }

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/AzureOpenAiChatModel.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/AzureOpenAiChatModel.java
@@ -126,7 +126,7 @@ public class AzureOpenAiChatModel implements ChatModel {
                 .configName(configName)
                 .build();
 
-        this.temperature = getOrDefault(temperature, 0.7);
+        this.temperature = temperature;
         this.seed = seed;
         this.topP = topP;
         this.maxTokens = maxTokens;

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/AzureOpenAiStreamingChatModel.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/AzureOpenAiStreamingChatModel.java
@@ -127,7 +127,7 @@ public class AzureOpenAiStreamingChatModel implements StreamingChatModel {
                 .azureApiKey(apiKey)
                 .configName(configName)
                 .build();
-        this.temperature = getOrDefault(temperature, 0.7);
+        this.temperature = temperature;
         this.topP = topP;
         this.maxTokens = maxTokens;
         this.presencePenalty = presencePenalty;

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/ChatModelConfig.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/ChatModelConfig.java
@@ -59,8 +59,11 @@ public interface ChatModelConfig {
      * A value of 0.9 is good for more creative applications, while 0 (argmax sampling) is good for ones with a well-defined
      * answer.
      * It is recommended to alter this or topP, but not both.
+     * <p>
+     * If not set, the parameter is omitted from the request and the model's own default applies.
      */
-    @WithDefault("${quarkus.langchain4j.temperature:1.0}")
+    @ConfigDocDefault("the model's default")
+    @WithDefault("${quarkus.langchain4j.temperature}")
     Optional<Double> temperature();
 
     /**
@@ -68,8 +71,10 @@ public interface ChatModelConfig {
      * with topP probability mass.
      * 0.1 means only the tokens comprising the top 10% probability mass are considered.
      * It is recommended to alter this or temperature, but not both.
+     * <p>
+     * If not set, the parameter is omitted from the request and the model's own default applies.
      */
-    @WithDefault("1.0")
+    @ConfigDocDefault("the model's default")
     Optional<Double> topP();
 
     /**

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/ChatModelExplicitSamplingParamsTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/ChatModelExplicitSamplingParamsTest.java
@@ -1,0 +1,49 @@
+package io.quarkiverse.langchain4j.openai.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ChatModelExplicitSamplingParamsTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "my-key")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.chat-model.temperature", "0.3")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.chat-model.top-p", "0.8")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    ChatModel chatModel;
+
+    @BeforeEach
+    void reset() {
+        resetRequests();
+    }
+
+    @Test
+    void explicitlyConfiguredValuesAreSent() throws IOException {
+        setChatCompletionMessageContent("whatever");
+
+        chatModel.chat("hello");
+
+        Map<String, Object> requestBody = getRequestAsMap();
+        assertThat(requestBody).containsEntry("temperature", 0.3).containsEntry("top_p", 0.8);
+    }
+}

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/ChatModelGlobalTemperatureTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/ChatModelGlobalTemperatureTest.java
@@ -1,0 +1,48 @@
+package io.quarkiverse.langchain4j.openai.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ChatModelGlobalTemperatureTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.temperature", "0.5")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "my-key")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    ChatModel chatModel;
+
+    @BeforeEach
+    void reset() {
+        resetRequests();
+    }
+
+    @Test
+    void globalTemperatureIsStillHonored() throws IOException {
+        setChatCompletionMessageContent("whatever");
+
+        chatModel.chat("hello");
+
+        Map<String, Object> requestBody = getRequestAsMap();
+        assertThat(requestBody).containsEntry("temperature", 0.5).doesNotContainKey("top_p");
+    }
+}

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/ChatModelSamplingParamsOmittedTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/ChatModelSamplingParamsOmittedTest.java
@@ -1,0 +1,47 @@
+package io.quarkiverse.langchain4j.openai.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ChatModelSamplingParamsOmittedTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "my-key")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    ChatModel chatModel;
+
+    @BeforeEach
+    void reset() {
+        resetRequests();
+    }
+
+    @Test
+    void temperatureAndTopPAreNotSentWhenUnconfigured() throws IOException {
+        setChatCompletionMessageContent("whatever");
+
+        chatModel.chat("hello");
+
+        Map<String, Object> requestBody = getRequestAsMap();
+        assertThat(requestBody).doesNotContainKey("temperature").doesNotContainKey("top_p");
+    }
+}

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/ResponsesChatModelSmokeTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/ResponsesChatModelSmokeTest.java
@@ -55,7 +55,9 @@ public class ResponsesChatModelSmokeTest extends OpenAiBaseTest {
                 .containsEntry("model", "gpt-4o-mini")
                 .containsEntry("store", false)
                 .containsEntry("max_output_tokens", 100)
-                .containsKey("input");
+                .containsKey("input")
+                .doesNotContainKey("temperature")
+                .doesNotContainKey("top_p");
 
         wiremock().verifyThat(postRequestedFor(urlEqualTo("/v1/responses"))
                 .withHeader("Authorization", equalTo("Bearer my-key")));

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/ResponsesExplicitSamplingParamsTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/ResponsesExplicitSamplingParamsTest.java
@@ -1,0 +1,70 @@
+package io.quarkiverse.langchain4j.openai.test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.model.chat.ChatModel;
+import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
+import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ResponsesExplicitSamplingParamsTest extends OpenAiBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.langchain4j.openai.chat-model.mode", "responses")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "my-key")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.chat-model.temperature", "0.3")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.chat-model.top-p", "0.8")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
+                    WiremockAware.wiremockUrlForConfig("/v1"));
+
+    @Inject
+    ChatModel chatModel;
+
+    @BeforeEach
+    void reset() {
+        resetRequests();
+    }
+
+    @Test
+    void explicitlyConfiguredValuesAreSent() throws IOException {
+        wiremock().register(post(urlEqualTo("/v1/responses"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {
+                                  "id": "resp_123",
+                                  "model": "gpt-4o-mini",
+                                  "status": "completed",
+                                  "output": [
+                                    {
+                                      "type": "message",
+                                      "role": "assistant",
+                                      "content": [ { "type": "output_text", "text": "hi" } ]
+                                    }
+                                  ],
+                                  "usage": { "input_tokens": 1, "output_tokens": 2, "total_tokens": 3 }
+                                }
+                                """)));
+
+        chatModel.chat("hello");
+
+        Map<String, Object> requestBody = getRequestAsMap();
+        assertThat(requestBody).containsEntry("temperature", 0.3).containsEntry("top_p", 0.8);
+    }
+}

--- a/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/StreamingChatModelSamplingParamsOmittedTest.java
+++ b/model-providers/openai/openai-vanilla/deployment/src/test/java/io/quarkiverse/langchain4j/openai/test/StreamingChatModelSamplingParamsOmittedTest.java
@@ -6,9 +6,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MediaType;
@@ -19,7 +20,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
@@ -27,12 +27,11 @@ import io.quarkiverse.langchain4j.openai.testing.internal.OpenAiBaseTest;
 import io.quarkiverse.langchain4j.testing.internal.WiremockAware;
 import io.quarkus.test.QuarkusUnitTest;
 
-public class ResponsesStreamingChatModelTest extends OpenAiBaseTest {
+public class StreamingChatModelSamplingParamsOmittedTest extends OpenAiBaseTest {
 
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
-            .overrideConfigKey("quarkus.langchain4j.openai.chat-model.mode", "responses")
             .overrideRuntimeConfigKey("quarkus.langchain4j.openai.api-key", "my-key")
             .overrideRuntimeConfigKey("quarkus.langchain4j.openai.base-url",
                     WiremockAware.wiremockUrlForConfig("/v1"));
@@ -46,61 +45,39 @@ public class ResponsesStreamingChatModelTest extends OpenAiBaseTest {
     }
 
     @Test
-    void streamingChat() {
+    void temperatureAndTopPAreNotSentWhenUnconfigured() throws IOException, InterruptedException {
         var eventStream = """
-                data: {"type":"response.output_text.delta","delta":"Hallo"}
+                data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","content":"Hallo"},"finish_reason":null}]}
 
-                data: {"type":"response.output_text.delta","delta":" Welt"}
-
-                data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt-4o-mini","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Hallo Welt"}]}],"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}}
+                data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gpt-4o-mini","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
 
                 data: [DONE]
                 """;
-
-        wiremock().register(post(urlEqualTo("/v1/responses"))
+        wiremock().register(post(urlEqualTo("/v1/chat/completions"))
                 .willReturn(okForContentType(MediaType.SERVER_SENT_EVENTS, eventStream)));
 
-        var completeResponse = new AtomicReference<AiMessage>();
-        var error = new AtomicReference<Throwable>();
-        var partialTokens = new StringBuilder();
         var latch = new CountDownLatch(1);
-        streamingChatModel.chat("Translate to German: Hello world!", new StreamingChatResponseHandler() {
+        streamingChatModel.chat("hello", new StreamingChatResponseHandler() {
             @Override
             public void onPartialResponse(String token) {
-                partialTokens.append(token);
             }
 
             @Override
-            public void onError(Throwable t) {
-                error.set(t);
+            public void onError(Throwable error) {
                 latch.countDown();
             }
 
             @Override
             public void onCompleteResponse(ChatResponse response) {
-                completeResponse.set(response.aiMessage());
                 latch.countDown();
             }
         });
 
-        try {
-            if (!latch.await(1, TimeUnit.MINUTES)) {
-                fail("Streaming did not complete in time");
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            fail("Interrupted while waiting for streaming response", e);
+        if (!latch.await(1, TimeUnit.MINUTES)) {
+            fail("Streaming did not complete in time");
         }
 
-        if (error.get() != null) {
-            fail("Streaming failed: %s".formatted(error.get().getMessage()), error.get());
-        }
-
-        assertThat(partialTokens.toString()).isEqualTo("Hallo Welt");
-        assertThat(completeResponse.get().text()).isEqualTo("Hallo Welt");
-
-        assertThat(new String(requestBodyOfSingleRequest()))
-                .doesNotContain("\"temperature\"")
-                .doesNotContain("\"top_p\"");
+        Map<String, Object> requestBody = getRequestAsMap();
+        assertThat(requestBody).doesNotContainKey("temperature").doesNotContainKey("top_p");
     }
 }

--- a/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/ChatModelConfig.java
+++ b/model-providers/openai/openai-vanilla/runtime/src/main/java/io/quarkiverse/langchain4j/openai/runtime/config/ChatModelConfig.java
@@ -22,8 +22,11 @@ public interface ChatModelConfig {
      * A value of 0.9 is good for more creative applications, while 0 (argmax sampling) is good for ones with a well-defined
      * answer.
      * It is recommended to alter this or topP, but not both.
+     * <p>
+     * If not set, the parameter is omitted from the request and the model's own default applies.
      */
-    @WithDefault("${quarkus.langchain4j.temperature:1.0}")
+    @ConfigDocDefault("the model's default")
+    @WithDefault("${quarkus.langchain4j.temperature}")
     Optional<Double> temperature();
 
     /**
@@ -31,8 +34,10 @@ public interface ChatModelConfig {
      * with topP probability mass.
      * 0.1 means only the tokens comprising the top 10% probability mass are considered.
      * It is recommended to alter this or temperature, but not both.
+     * <p>
+     * If not set, the parameter is omitted from the request and the model's own default applies.
      */
-    @WithDefault("1.0")
+    @ConfigDocDefault("the model's default")
     Optional<Double> topP();
 
     /**


### PR DESCRIPTION
## Describe your changes

The `@WithDefault` annotations were left in place when `temperature` and `topP` became `Optional` in #2370, so the `Optional` never resolves to empty and `1.0` is always sent. Models that reject these parameters, such as the reasoning models behind the Responses API, fail the request outright.

Azure applied a second hardcoded `0.7` fallback in `AzureOpenAiChatModel` and `AzureOpenAiStreamingChatModel`, which had to go as well for the empty `Optional` to reach the wire. This changes the effective default for anyone building those models directly without setting `temperature`, since `0.7` becomes the provider default. Through Quarkus config nothing changes, because the config always supplied a value before.

`google-genai` carries the same `@WithDefault`, copied when the extension was introduced. Gemini accepts the parameter so it never errored, but it silently overrode the model's own default. `topP` in that same config group is already optional without a default, so `temperature` is now consistent with it. That part is a separate commit and can be dropped independently.

The global `quarkus.langchain4j.temperature` property is unaffected: the default expression is kept, only its literal fallback is dropped.

Each changed path gets a test verified to fail without the fix, covering the blocking, streaming and Responses API models across the three providers. Tests setting the properties explicitly, and through the global property, pin down that those keep reaching the request.

Same direction as #2752 for Anthropic `top_k`.

---

- Closes #2762
