### PR TITLE
Move the MCP extension off LangChain4j's Jackson-typed APIs

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-all-config.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-all-config.adoc
@@ -1319,6 +1319,116 @@ endif::add-copy-button-to-env-var[]
 |`+++empty list+++`
 
 
+h|[.extension-name]##Quarkus LangChain4j - A2A Apicurio Registry - Runtime##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-a2a-apicurio-registry_quarkus-langchain4j-a2a-apicurio-registry-enabled]] [.property-path]##link:#quarkus-langchain4j-a2a-apicurio-registry_quarkus-langchain4j-a2a-apicurio-registry-enabled[`+++quarkus.langchain4j.a2a.apicurio-registry.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.a2a.apicurio-registry.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the Apicurio Registry A2A agent discovery integration is enabled.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_A2A_APICURIO_REGISTRY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_A2A_APICURIO_REGISTRY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a| [[quarkus-langchain4j-a2a-apicurio-registry_quarkus-langchain4j-a2a-apicurio-registry-url]] [.property-path]##link:#quarkus-langchain4j-a2a-apicurio-registry_quarkus-langchain4j-a2a-apicurio-registry-url[`+++quarkus.langchain4j.a2a.apicurio-registry.url+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.a2a.apicurio-registry.url+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The base URL of the Apicurio Registry instance (e.g. http://localhost:8080/apis/registry/v3).
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_A2A_APICURIO_REGISTRY_URL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_A2A_APICURIO_REGISTRY_URL+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-a2a-apicurio-registry_quarkus-langchain4j-a2a-apicurio-registry-auth-token]] [.property-path]##link:#quarkus-langchain4j-a2a-apicurio-registry_quarkus-langchain4j-a2a-apicurio-registry-auth-token[`+++quarkus.langchain4j.a2a.apicurio-registry.auth-token+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.a2a.apicurio-registry.auth-token+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Optional authentication token for the registry.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_A2A_APICURIO_REGISTRY_AUTH_TOKEN+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_A2A_APICURIO_REGISTRY_AUTH_TOKEN+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-a2a-apicurio-registry_quarkus-langchain4j-a2a-apicurio-registry-group-id]] [.property-path]##link:#quarkus-langchain4j-a2a-apicurio-registry_quarkus-langchain4j-a2a-apicurio-registry-group-id[`+++quarkus.langchain4j.a2a.apicurio-registry.group-id+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.a2a.apicurio-registry.group-id+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Group ID to use when publishing and searching agent cards.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_A2A_APICURIO_REGISTRY_GROUP_ID+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_A2A_APICURIO_REGISTRY_GROUP_ID+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++default+++`
+
+a| [[quarkus-langchain4j-a2a-apicurio-registry_quarkus-langchain4j-a2a-apicurio-registry-agent-url]] [.property-path]##link:#quarkus-langchain4j-a2a-apicurio-registry_quarkus-langchain4j-a2a-apicurio-registry-agent-url[`+++quarkus.langchain4j.a2a.apicurio-registry.agent-url+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.a2a.apicurio-registry.agent-url+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The base URL of this application's A2A server endpoint, used when publishing the agent card.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_A2A_APICURIO_REGISTRY_AGENT_URL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_A2A_APICURIO_REGISTRY_AGENT_URL+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+
 h|[.extension-name]##Quarkus LangChain4j - AI Gemini##
 h|Type
 h|Default
@@ -16235,6 +16345,74 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
+
+
+h|[.extension-name]##Quarkus LangChain4j - MCP Apicurio Registry - Runtime##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-mcp-apicurio-registry_quarkus-langchain4j-mcp-apicurio-registry-enabled]] [.property-path]##link:#quarkus-langchain4j-mcp-apicurio-registry_quarkus-langchain4j-mcp-apicurio-registry-enabled[`+++quarkus.langchain4j.mcp.apicurio-registry.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.mcp.apicurio-registry.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the Apicurio Registry MCP integration is enabled.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MCP_APICURIO_REGISTRY_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MCP_APICURIO_REGISTRY_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a| [[quarkus-langchain4j-mcp-apicurio-registry_quarkus-langchain4j-mcp-apicurio-registry-url]] [.property-path]##link:#quarkus-langchain4j-mcp-apicurio-registry_quarkus-langchain4j-mcp-apicurio-registry-url[`+++quarkus.langchain4j.mcp.apicurio-registry.url+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.mcp.apicurio-registry.url+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The base URL of the Apicurio Registry instance (e.g. http://localhost:8080/apis/registry/v3).
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MCP_APICURIO_REGISTRY_URL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MCP_APICURIO_REGISTRY_URL+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|required icon:exclamation-circle[title=Configuration property is required]
+
+a| [[quarkus-langchain4j-mcp-apicurio-registry_quarkus-langchain4j-mcp-apicurio-registry-tool-provider]] [.property-path]##link:#quarkus-langchain4j-mcp-apicurio-registry_quarkus-langchain4j-mcp-apicurio-registry-tool-provider[`+++quarkus.langchain4j.mcp.apicurio-registry.tool-provider+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.mcp.apicurio-registry.tool-provider+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Optional: name of the tool provider to target when the application uses multiple tool providers. If not set, the default tool provider is used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_MCP_APICURIO_REGISTRY_TOOL_PROVIDER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_MCP_APICURIO_REGISTRY_TOOL_PROVIDER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
 
 
 h|[.extension-name]##Quarkus Langchain4j - Memory Store - MongoDB##

--- a/docs/modules/ROOT/pages/mcp.adoc
+++ b/docs/modules/ROOT/pages/mcp.adoc
@@ -714,13 +714,13 @@ import jakarta.enterprise.event.Observes;
 public class McpLogObserver {
 
     public void onGitHubLog(@Observes @McpClientName("github") McpLogMessage logMessage) {
-        System.out.println("GitHub MCP: [" + logMessage.level() + "] " + logMessage.data());
+        System.out.println("GitHub MCP: [" + logMessage.level() + "] " + logMessage.dataAsObject());
         // Custom handling: store in database, trigger alerts, etc.
     }
 
     public void onAnyMcpLog(@Observes McpLogMessage logMessage) {
         // Observe logs from all MCP clients (no @McpClientName qualifier)
-        System.out.println("MCP Log: [" + logMessage.level() + "] " + logMessage.data());
+        System.out.println("MCP Log: [" + logMessage.level() + "] " + logMessage.dataAsObject());
         // Custom handling: store in database, trigger alerts, etc.
     }
 }
@@ -728,9 +728,16 @@ public class McpLogObserver {
 
 The `McpLogMessage` includes:
 
-- `data()`: The log message as a `JsonNode`
 - `level()`: Log level as `McpLogLevel` enum (DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT, EMERGENCY)
 - `logger()`: Logger name from the MCP server
+- `dataAsObject()`: The log payload as an `Object`
+- `dataAsMap()`: The log payload as a `Map<String, Object>`, or `null` if it is not a JSON object
+- `dataAsJson()`: The log payload as JSON text
+
+MCP allows the payload to be any JSON value, so a server may send a plain string just as well as an
+object. `dataAsObject()` therefore returns whatever arrived - most often a `String` or a `Map`. Use
+`dataAsMap()` when you read named fields out of the payload, and `dataAsJson()` when you pass it on
+as JSON.
 
 === Observing MCP Resource Updates
 

--- a/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/McpOverHttpTransportTest.java
+++ b/mcp/deployment/src/test/java/io/quarkiverse/langchain4j/mcp/test/McpOverHttpTransportTest.java
@@ -155,7 +155,7 @@ public class McpOverHttpTransportTest {
         Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> receivedLogMessageForClient1 != null);
         assertThat(receivedLogMessageForClient1.level()).isEqualTo(McpLogLevel.INFO);
         assertThat(receivedLogMessageForClient1.logger()).isEqualTo("mock-mcp");
-        assertThat(receivedLogMessageForClient1.data().get("message").asText()).isEqualTo("This is a log message");
+        assertThat(receivedLogMessageForClient1.dataAsMap()).containsEntry("message", "This is a log message");
 
         // no client named 'client2' actually exists, so just make sure that no CDI event with this qualifier
         // was fired

--- a/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/QuarkusDefaultMcpLogHandler.java
+++ b/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/QuarkusDefaultMcpLogHandler.java
@@ -27,14 +27,14 @@ public class QuarkusDefaultMcpLogHandler implements McpLogMessageHandler {
 
     private void logMessage(McpLogMessage message) {
         if (message.level() == null) {
-            log.warnf("Received MCP log message with unknown level: %s", message.data());
+            log.warnf("Received MCP log message with unknown level: %s", message.dataAsJson());
             return;
         }
         switch (message.level()) {
-            case DEBUG -> log.debugf("MCP logger: %s: %s", message.logger(), message.data());
-            case INFO, NOTICE -> log.infof("MCP logger: %s: %s", message.logger(), message.data());
-            case WARNING -> log.warnf("MCP logger: %s: %s", message.logger(), message.data());
-            case ERROR, CRITICAL, ALERT, EMERGENCY -> log.errorf("MCP logger: %s: %s", message.logger(), message.data());
+            case DEBUG -> log.debugf("MCP logger: %s: %s", message.logger(), message.dataAsJson());
+            case INFO, NOTICE -> log.infof("MCP logger: %s: %s", message.logger(), message.dataAsJson());
+            case WARNING -> log.warnf("MCP logger: %s: %s", message.logger(), message.dataAsJson());
+            case ERROR, CRITICAL, ALERT, EMERGENCY -> log.errorf("MCP logger: %s: %s", message.logger(), message.dataAsJson());
         }
     }
 

--- a/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/http/QuarkusStreamableHttpMcpTransport.java
+++ b/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/http/QuarkusStreamableHttpMcpTransport.java
@@ -107,7 +107,7 @@ public class QuarkusStreamableHttpMcpTransport implements McpTransport {
      * Only used with the legacy MCP protocol (versions up to 2025-11-25).
      */
     @Override
-    public CompletableFuture<JsonNode> initialize(McpInitializeRequest request) {
+    public CompletableFuture<String> sendInitializeRequest(McpInitializeRequest request) {
         this.initializeRequest = request;
         McpCallContext ctx = new McpCallContext(null, request);
         return execute(ctx, false, true)
@@ -150,39 +150,39 @@ public class QuarkusStreamableHttpMcpTransport implements McpTransport {
     }
 
     @Override
-    public CompletableFuture<JsonNode> executeOperationWithResponse(McpClientMessage operation) {
+    public CompletableFuture<String> sendRequest(McpClientMessage operation) {
         McpCallContext context = new McpCallContext(null, operation);
         return execute(context, false, true).subscribeAsCompletionStage();
     }
 
     @Override
-    public CompletableFuture<JsonNode> executeOperationWithResponse(McpCallContext context) {
+    public CompletableFuture<String> sendRequest(McpCallContext context) {
         return execute(context, false, true).subscribeAsCompletionStage();
     }
 
     @Override
-    public void executeOperationWithoutResponse(McpClientMessage operation) {
+    public void sendMessage(McpClientMessage operation) {
         execute(new McpCallContext(null, operation), false, false).subscribe().with(ignored -> {
         });
     }
 
     @Override
-    public void executeOperationWithoutResponse(McpCallContext context) {
+    public void sendMessage(McpCallContext context) {
         execute(context, false, false).subscribe().with(ignored -> {
         });
     }
 
-    private Uni<JsonNode> execute(McpClientMessage operation, boolean isRetry, boolean expectsResponse) {
+    private Uni<String> execute(McpClientMessage operation, boolean isRetry, boolean expectsResponse) {
         return execute(new McpCallContext(null, operation), isRetry, expectsResponse);
     }
 
-    private Uni<JsonNode> execute(McpCallContext context, boolean isRetry, boolean expectsResponse) {
-        CompletableFuture<JsonNode> future = new CompletableFuture<>();
-        Uni<JsonNode> uni = Uni.createFrom().completionStage(future);
+    private Uni<String> execute(McpCallContext context, boolean isRetry, boolean expectsResponse) {
+        CompletableFuture<String> future = new CompletableFuture<>();
+        Uni<String> uni = Uni.createFrom().completionStage(future);
         Long id = context.message().getId();
         McpClientMessage request = context.message();
         if (expectsResponse && id != null) {
-            operationHandler.startOperation(id, future);
+            operationHandler.expectResponse(id, future);
         }
         String body;
         try {
@@ -293,12 +293,11 @@ public class QuarkusStreamableHttpMcpTransport implements McpTransport {
                                         response.result().bodyHandler(bodyBuffer -> {
                                             try {
                                                 String responseString = bodyBuffer.toString();
-                                                JsonNode node = objectMapper.readTree(responseString);
                                                 if (logResponses) {
                                                     log.info("Response: " + responseString);
                                                 }
-                                                operationHandler.handle(node);
-                                            } catch (JsonProcessingException e) {
+                                                operationHandler.onMessage(responseString);
+                                            } catch (RuntimeException e) {
                                                 future.completeExceptionally(e);
                                             }
                                         });
@@ -313,7 +312,7 @@ public class QuarkusStreamableHttpMcpTransport implements McpTransport {
                                                 new IllegalStateException("Cannot retry 404: initializeRequest is null"));
                                         return;
                                     }
-                                    initialize(initReq).thenAccept(node -> {
+                                    sendInitializeRequest(initReq).thenAccept(ignored -> {
                                         execute(request, true, true)
                                                 .subscribeAsCompletionStage()
                                                 .thenAccept(future::complete)
@@ -342,7 +341,7 @@ public class QuarkusStreamableHttpMcpTransport implements McpTransport {
                                                         if (logResponses) {
                                                             log.info("Response: " + responseString);
                                                         }
-                                                        operationHandler.handle(node);
+                                                        operationHandler.onMessage(responseString);
                                                         return;
                                                     }
                                                 } catch (JsonProcessingException ignored) {
@@ -491,10 +490,9 @@ public class QuarkusStreamableHttpMcpTransport implements McpTransport {
                     log.info("Subsidiary SSE event received: " + data);
                 }
                 try {
-                    JsonNode jsonNode = objectMapper.readTree(data);
-                    operationHandler.handle(jsonNode);
-                } catch (JsonProcessingException e) {
-                    log.warn("Failed to parse subsidiary SSE event: " + data, e);
+                    operationHandler.onMessage(data);
+                } catch (RuntimeException e) {
+                    log.warn("Failed to handle subsidiary SSE event: " + data, e);
                 }
             } else if (line.startsWith("id:")) {
                 subsidiaryLastEventId.set(line.substring(3).trim());

--- a/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/http/SseSubscriber.java
+++ b/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/http/SseSubscriber.java
@@ -6,16 +6,11 @@ import java.util.function.Consumer;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.client.SseEvent;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 
 public class SseSubscriber implements Consumer<SseEvent<String>> {
 
     private final McpOperationHandler operationHandler;
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final Logger log = Logger.getLogger(SseSubscriber.class);
     private final boolean logEvents;
     // this will contain the POST url for sending commands to the server
@@ -47,10 +42,9 @@ public class SseSubscriber implements Consumer<SseEvent<String>> {
         }
         if (name.equals("message")) {
             try {
-                JsonNode jsonNode = OBJECT_MAPPER.readTree(data);
-                operationHandler.handle(jsonNode);
-            } catch (JsonProcessingException e) {
-                log.warn("Failed to parse JSON message: {}", data, e);
+                operationHandler.onMessage(data);
+            } catch (RuntimeException e) {
+                log.warn("Failed to handle MCP message: {}", data, e);
             }
         } else if (name.equals("endpoint")) {
             if (initializationFinished.isDone()) {


### PR DESCRIPTION
## Why

LangChain4j's MCP client exposes Jackson's `JsonNode` in the contracts this extension implements:
`McpTransport` returns `CompletableFuture<JsonNode>`, `McpOperationHandler` accepts `JsonNode`, and
`McpLogMessage.data()` returns one. While those are the only options, this extension cannot move to
Jackson 3 without keeping Jackson 2 on the classpath for LangChain4j's sake alone.

LangChain4j 1.20.0 added an alternative for each in https://github.com/langchain4j/langchain4j/pull/6117
and deprecated the Jackson-typed ones for removal. Nothing is removed upstream yet, so the timing is
ours to choose — but the deprecated methods can only be dropped once downstream implementations have
moved, and this extension is the main one.

The upstream counterparts are `sendInitializeRequest`, `sendRequest`, `sendMessage`, `onMessage`,
`expectResponse`, and `dataAsObject()` / `dataAsMap()` / `dataAsJson()`.

`main` is already on LangChain4j 1.20.0, so this PR carries no version bump — it is only the migration.

## What changed

`QuarkusStreamableHttpMcpTransport` implements the new transport methods, `SseSubscriber` hands
messages over as text, and `QuarkusDefaultMcpLogHandler` uses `dataAsJson()`.

Where a response was parsed only to hand LangChain4j a tree that LangChain4j then navigated, the
parse is gone and the response string is passed straight through. `SseSubscriber` loses its
`ObjectMapper` entirely:

```diff
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-                JsonNode jsonNode = OBJECT_MAPPER.readTree(data);
-                operationHandler.handle(jsonNode);
-            } catch (JsonProcessingException e) {
+                operationHandler.onMessage(data);
+            } catch (RuntimeException e) {
```

The transport is a type swap plus the renames:

```diff
-    public CompletableFuture<JsonNode> initialize(McpInitializeRequest request) {
+    public CompletableFuture<String> sendInitializeRequest(McpInitializeRequest request) {
-    public CompletableFuture<JsonNode> executeOperationWithResponse(McpCallContext context) {
+    public CompletableFuture<String> sendRequest(McpCallContext context) {
-    public void executeOperationWithoutResponse(McpCallContext context) {
+    public void sendMessage(McpCallContext context) {
-            operationHandler.startOperation(id, future);
+            operationHandler.expectResponse(id, future);
```

Three `handle(node)` call sites become `onMessage(responseString)`. Two of them dropped their parse;
the third — the branch that only forwards a body when it looks like a JSON-RPC error
(`node.has("error") && node.has("jsonrpc")`) — keeps its `readTree` for that check, since the check
is this extension's own logic rather than something LangChain4j provides.

The `mcp.adoc` log-observer section and the one test that read `McpLogMessage.data()` move to the new
accessors. The log handler uses `dataAsJson()` rather than `dataAsObject()` on purpose: `data()`
returned a `JsonNode`, and logging it went through `JsonNode.toString()`, so `dataAsJson()` is the
one that leaves the emitted log lines byte-for-byte what they were. The documentation sample uses
`dataAsObject()`, which is the nicer one for `println`, since a plain-string payload comes out
unquoted.

Two things that are easy to miss when migrating a transport, both of which bit this one:

- **Deprecated methods on `McpTransport` throw rather than delegate**, because two
  mutually-delegating defaults would recurse. Renaming the overrides is therefore not enough:
  internal callers have to move too, and they keep compiling if they don't. The 404 re-initialize
  path called `initialize(...)` on itself; left alone it threw inside a Vert.x handler and the
  operation timed out rather than failing.
  `McpToolsStreamableHttpLegacyTest.reinitializesSessionWhenMissingFromServer` catches it.
- **Renaming an override removes a public method** from this class. None are kept as deprecated
  delegating overrides: nothing holds `QuarkusStreamableHttpMcpTransport` concretely — the recorder,
  the dynamic-clients sample and the Apicurio module all build it and hand it over as an
  `McpTransport` — so they would guard against a break nobody can hit. LangChain4j does keep them on
  its own `StreamableHttpMcpTransport`, but that is a public API class of a library, held concretely
  by applications. Keeping them here would also mean all of them become compile errors once
  LangChain4j deletes the deprecated methods, forcing a second migration PR for no gain.

Net: 5 files, 36 insertions and 37 deletions. `JsonNode`/`readTree`/`data()` references drop from 13
to 4 in the transport, 4 to 2 in `SseSubscriber` (the remaining two are `SseEvent.data()`,
unrelated), and 5 to 0 in the log handler.

## Nothing Jackson-deprecated left in the repository

LangChain4j 1.20.0 deprecated a Jackson-typed API in several places, not only on the transport. The
whole repository - extensions, tests, samples and documentation - was checked against that list, so
this PR is the last of it rather than the first instalment:

| deprecated in 1.20.0 | used here? |
|---|---|
| `McpTransport.initialize` / `executeOperationWithResponse` / `executeOperationWithoutResponse` | yes - migrated |
| `McpOperationHandler.handle` / `startOperation` | yes - migrated |
| `McpLogMessage.data()` | yes, in the log handler, in one test and in `mcp.adoc` - migrated |
| `McpLogMessage(…, JsonNode)` and `McpLogMessage.fromJson(JsonNode)` | no |
| `McpException.errorData()` and its `JsonNode` constructor | no |
| `McpMeta.getPublisherProvided()` | no |
| `McpToolResultExtractor`, `DefaultMcpToolResultExtractor`, `DefaultMcpClient.Builder.toolResultExtractor` | no |
| `McpProgressNotification.fromJson(JsonNode)` | no |
| `McpJson.deserialize(JsonNode, Class)` | no - and `McpJson` is `@Internal`, so it stays off limits |
| `JsonExtractorOutputGuardrail(ObjectMapper, …)` and `(TypeReference)` | no |

So after this PR, nothing in the repository calls or documents a LangChain4j method that is
deprecated for removal over Jackson, and `-Xlint:removal` on a full build reports none. The Jackson
that remains under `mcp/` is this extension's own, on its own strings - see below.

## Migrating application code

Nothing in your application breaks when this is merged — the old LangChain4j methods still work,
deprecated. But **they are marked for removal upstream** and will go in a release not far off, so the
changes below are worth making now rather than when the compiler forces them.

Four things are reachable from an application using this extension.

**MCP server logs.** This is the one most people will hit, because it is the pattern the
documentation shows: `McpLogMessage` is fired as a CDI event, and `data()` returns Jackson's
`JsonNode`.

```java
public void onGitHubLog(@Observes @McpClientName("github") McpLogMessage logMessage) {
-    System.out.println("GitHub MCP: [" + logMessage.level() + "] " + logMessage.data());
+    System.out.println("GitHub MCP: [" + logMessage.level() + "] " + logMessage.dataAsObject());
}
```

Which replacement to use depends on what you do with the payload:

|  | returns | use when |
|---|---|---|
| `dataAsObject()` | `Object` - a `String`, `Map`, `List` or boxed primitive | you are printing or logging it, or the server sends a plain string. Closest to the old `data().asText()`. |
| `dataAsMap()` | `Map<String, Object>`, or null if the payload is not an object | you read named fields out of it |
| `dataAsJson()` | the payload as JSON text | you forward it somewhere as JSON |

MCP allows a log payload to be any JSON value and a plain string is common, which is why
`dataAsMap()` can return null and `dataAsObject()` exists.

**Tool errors.** If you inject an `McpClient` and call tools yourself, `McpException.errorData()`
returned a `JsonNode`:

```java
catch (McpException e) {
-    JsonNode data = e.errorData();
+    Object data = e.errorDataAsObject();              // any value; JSON-RPC allows a primitive here
+    Map<String, Object> data = e.errorDataAsMap();    // null unless error.data is an object
+    String data = e.errorDataAsJson();                // as JSON text
}
```

**Registry metadata.** If you inject an `McpRegistryClient`:

```java
-Map<String, JsonNode> meta = mcpMeta.getPublisherProvided();
+Map<String, Object> meta = mcpMeta.publisherProvided();
```

**Custom transports.** If you have written your own `McpTransport` rather than using the ones this
extension provides, it needs the same migration this PR applies to
`QuarkusStreamableHttpMcpTransport`: `initialize` becomes `sendInitializeRequest`,
`executeOperationWithResponse` becomes `sendRequest`, `executeOperationWithoutResponse` becomes
`sendMessage`, and the handler's `handle`/`startOperation` become `onMessage`/`expectResponse`. The
new methods carry the message as JSON text instead of a `JsonNode`, so a transport no longer needs a
JSON library.

One trap there, because it does not show up as a compile error: the deprecated methods on
`McpTransport` are defaults that **throw** rather than delegating to the new ones. If your transport
calls its own `initialize(...)` internally, renaming the override is not enough — that call keeps
compiling and then throws at runtime, possibly somewhere the exception is swallowed. Building with
`-Xlint:removal -Werror` finds them.

## What is deliberately left alone

The Jackson still under `mcp/` is this extension's own, on its own strings, and none of it blocks
Jackson 3:

- `QuarkusStreamableHttpMcpTransport` serializes the outgoing `McpClientMessage` with its own
  mapper, then re-reads that body to extract the `Mcp-Method` / `Mcp-Name` headers. A transport has
  to own this: the new API removed Jackson from the **inbound** direction, but outbound it is still
  handed a typed `McpClientMessage` and has to put it on the wire itself, and LangChain4j's own
  `McpJson` is `@Internal`. Worth an upstream follow-up, not something to work around here.
- The JSON-RPC-error shape check described above.
- `McpProcessor` reads the Claude config file at build time.

Serializing the outgoing message is worth a note: it used to be unsafe under Jackson 3 even though
it compiles, because `McpCallToolParams.arguments` was typed as a Jackson 2 `ObjectNode`. A Jackson
3 mapper does not recognise that type, does not throw, and bean-serializes it, so tool arguments
would have gone out as `{"array":false,"bigDecimal":false,…}`. Upstream changed that field to a
plain `Map` in the same release, so every type reachable from `McpClientMessage` is now a plain
value or carries only `jackson-annotations` annotations, and this mapper can become a Jackson 3
mapper whenever this extension moves.

## Compatibility

No breaking changes. Nothing in this extension's public API changes and no configuration changes are
required.

Worth knowing for a later upstream release: `McpLogMessage` is fired to application code as a CDI
event (`@Observes @McpClientName("…") McpLogMessage`). Applications calling `data()` on it are using
a method now deprecated for removal upstream and will eventually need `dataAsObject()` /
`dataAsMap()` / `dataAsJson()`. This PR does not change that type and nothing breaks today.

Two behavioural notes:

- Parsing moves from this extension into LangChain4j, so LangChain4j's parser configuration now
  applies to inbound MCP messages. The mappers replaced here were plain `new ObjectMapper()`
  instances with no customisation, so there is no change in practice.
- A malformed or non-JSON-RPC message used to be caught and logged here. `onMessage` throws on text
  that is not valid JSON and logs-and-returns on valid JSON that is not a JSON-RPC object, which is
  exactly the old split: the response path still fails the pending operation, the two stream readers
  still log and keep reading. The `catch` blocks are now `RuntimeException` rather than
  `JsonProcessingException`, and their wording was adjusted since they no longer only mean "parse
  failure".

## Testing

Green against LangChain4j 1.20.0:

| module | result |
|---|---|
| `mcp/deployment` | 33 (1 skipped, as on `main`) |
| `integration-tests/mcp` | 157 (7 skipped) — real MCP servers over stdio, streamable HTTP and WebSocket |
| `integration-tests/secure-mcp` | 3 |
| `integration-tests/mcp-opentelemetry` | 15 |
| `integration-tests/mcp-conformance` | not run locally (needs Node 24) — left to CI |

The whole reactor also builds clean — 529 modules, `-Dno-format` so `formatter:validate` and
`impsort:check` run rather than reformat — and that build is where the "no Jackson-deprecated API
left" claim above comes from: no `dev.langchain4j` deprecation warning in any module names a
Jackson-typed method.

`mcp/deployment` was also run with the transport unmodified against the same LangChain4j build,
confirming the deprecated path still behaves identically.

Upstream, the same change is covered by 360 integration tests against real MCP servers over stdio,
streamable HTTP, WebSocket and Docker. The subsidiary SSE channel changed here is specific to this
extension and has no upstream equivalent, so it is worth a look from someone who knows that path.

`McpRegistryClientTest` runs against the live registry at `registry.modelcontextprotocol.io` (as its
own TODO notes); it failed once during this work with an upstream HTTP 500 and passed on re-run.
Unrelated to this change, but expect it to be intermittently red.