### PR TITLE
Add streaming cancellation, gateway models, inline moderation and native image support in watsonx

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -59,6 +59,7 @@
 *** xref:podman.adoc[Podman AI Lab]
 ** Image Models
 *** xref:azure-openai-image-model.adoc[Azure OpenAI]
+*** xref:watsonx-image-model.adoc[IBM watsonx.ai]
 *** xref:openai-image-model.adoc[OpenAI]
 ** Embedding Models
 *** xref:azure-openai-embedding-model.adoc[Azure OpenAI]
@@ -73,6 +74,7 @@
 ** Moderation Models
 *** xref:mistral-moderation-model.adoc[Mistral AI]
 *** xref:openai-moderation-model.adoc[OpenAI]
+*** xref:watsonx-moderation-model.adoc[IBM watsonx.ai]
 ** Audio Transcription Models
 *** xref:azure-openai-audio-transcription-model.adoc[Azure OpenAI]
 *** xref:openai-audio-transcription-model.adoc[OpenAI]

--- a/docs/modules/ROOT/pages/includes/quarkus-all-config.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-all-config.adoc
@@ -28492,6 +28492,27 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-enabled]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-enabled[`+++quarkus.langchain4j.watsonx.gateway-image-model.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the gateway image model should be enabled.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-scoring-model-enabled]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-scoring-model-enabled[`+++quarkus.langchain4j.watsonx.scoring-model.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.watsonx.scoring-model.enabled+++[]
@@ -30092,6 +30113,176 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++ibm/granite-4-h-small+++`
 
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-hap-input]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-hap-input[`+++quarkus.langchain4j.watsonx.chat-model.moderations.hap.input+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.moderations.hap.input+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enables HAP detection on the input text, using the given threshold score.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_HAP_INPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_HAP_INPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-hap-output]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-hap-output[`+++quarkus.langchain4j.watsonx.chat-model.moderations.hap.output+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.moderations.hap.output+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enables HAP detection on the output text, using the given threshold score.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_HAP_OUTPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_HAP_OUTPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-hap-mask]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-hap-mask[`+++quarkus.langchain4j.watsonx.chat-model.moderations.hap.mask+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.moderations.hap.mask+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the detected entity value is removed from the text instead of being returned.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_HAP_MASK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_HAP_MASK+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-pii-input]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-pii-input[`+++quarkus.langchain4j.watsonx.chat-model.moderations.pii.input+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.moderations.pii.input+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether PII detection is applied to the input text.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_PII_INPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_PII_INPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-pii-output]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-pii-output[`+++quarkus.langchain4j.watsonx.chat-model.moderations.pii.output+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.moderations.pii.output+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether PII detection is applied to the output text.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_PII_OUTPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_PII_OUTPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-pii-mask]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-pii-mask[`+++quarkus.langchain4j.watsonx.chat-model.moderations.pii.mask+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.moderations.pii.mask+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the detected entity value is removed from the text instead of being returned.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_PII_MASK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_PII_MASK+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-granite-guardian-input]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-granite-guardian-input[`+++quarkus.langchain4j.watsonx.chat-model.moderations.granite-guardian.input+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.moderations.granite-guardian.input+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enables Granite Guardian detection on the input text, using the given threshold score.
+
+Granite Guardian is only applied to the input text.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_GRANITE_GUARDIAN_INPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_GRANITE_GUARDIAN_INPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-granite-guardian-mask]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-granite-guardian-mask[`+++quarkus.langchain4j.watsonx.chat-model.moderations.granite-guardian.mask+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.moderations.granite-guardian.mask+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the detected entity value is removed from the text instead of being returned.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_GRANITE_GUARDIAN_MASK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_GRANITE_GUARDIAN_MASK+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-deployment-chat-model-tool-choice]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-deployment-chat-model-tool-choice[`+++quarkus.langchain4j.watsonx.deployment-chat-model.tool-choice+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.watsonx.deployment-chat-model.tool-choice+++[]
@@ -31361,31 +31552,6 @@ endif::add-copy-button-to-env-var[]
 |Map<String,String>
 |
 
-a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-embedding-model-model-name]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-embedding-model-model-name[`+++quarkus.langchain4j.watsonx.embedding-model.model-name+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.watsonx.embedding-model.model-name+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Specifies the ID of the model to be used.
-
-A list of all available models is provided in the IBM watsonx.ai documentation at the link:https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models-embed.html?context=wx&audience=wdp#ibm-provided[this link].
-
-To use a model, locate the `API model ID` column in the table and copy the corresponding model ID.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_EMBEDDING_MODEL_MODEL_NAME+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_EMBEDDING_MODEL_MODEL_NAME+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++ibm/granite-embedding-278m-multilingual+++`
-
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-embedding-model-log-requests]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-embedding-model-log-requests[`+++quarkus.langchain4j.watsonx.embedding-model.log-requests+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.watsonx.embedding-model.log-requests+++[]
@@ -31444,6 +31610,477 @@ Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_EM
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_EMBEDDING_MODEL_LOG_REQUESTS_CURL+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-embedding-model-model-name]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-embedding-model-model-name[`+++quarkus.langchain4j.watsonx.embedding-model.model-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.embedding-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Specifies the ID of the model to be used.
+
+A list of all available models is provided in the IBM watsonx.ai documentation at the link:https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models-embed.html?context=wx&audience=wdp#ibm-provided[this link].
+
+To use a model, locate the `API model ID` column in the table and copy the corresponding model ID.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_EMBEDDING_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_EMBEDDING_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++ibm/granite-embedding-278m-multilingual+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-log-requests]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-log-requests[`+++quarkus.langchain4j.watsonx.gateway-embedding-model.log-requests+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-embedding-model.log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether embedding model requests should be logged.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-log-responses]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-log-responses[`+++quarkus.langchain4j.watsonx.gateway-embedding-model.log-responses+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-embedding-model.log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether embedding model responses should be logged.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-log-requests-curl]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-log-requests-curl[`+++quarkus.langchain4j.watsonx.gateway-embedding-model.log-requests-curl+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-embedding-model.log-requests-curl+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the watsonx.ai client should log requests as cURL commands.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_LOG_REQUESTS_CURL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_LOG_REQUESTS_CURL+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-model-name]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-model-name[`+++quarkus.langchain4j.watsonx.gateway-embedding-model.model-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-embedding-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The identifier of the model to use, as configured in the Model Gateway (for example `openai/text-embedding-3-small`).
+
+Setting this property routes all embedding requests to the Model Gateway.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-dimensions]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-dimensions[`+++quarkus.langchain4j.watsonx.gateway-embedding-model.dimensions+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-embedding-model.dimensions+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The number of dimensions of the returned embeddings.
+
+Only the models that support it accept this value.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_DIMENSIONS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_DIMENSIONS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-encoding-format]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-encoding-format[`+++quarkus.langchain4j.watsonx.gateway-embedding-model.encoding-format+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-embedding-model.encoding-format+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The wire format used to return the embeddings.
+
+Both formats produce the same vectors, `base64` is decoded for you.
+
+*Allowable values:* `++[++float, base64++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_ENCODING_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_ENCODING_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`float`, `base64`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-user]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-user[`+++quarkus.langchain4j.watsonx.gateway-embedding-model.user+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-embedding-model.user+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+A stable identifier of the end user issuing the request, used by the backing provider to detect and prevent abuse.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_USER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-model-name]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-model-name[`+++quarkus.langchain4j.watsonx.gateway-image-model.model-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The identifier of the model to use, as configured in the Model Gateway.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-background]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-background[`+++quarkus.langchain4j.watsonx.gateway-image-model.background+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.background+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The background of the generated images.
+
+Transparency requires an output format that supports it, so `png` or `webp`.
+
+*Allowable values:* `++[++transparent, opaque, auto++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_BACKGROUND+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_BACKGROUND+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`transparent`, `opaque`, `auto`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-moderation]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-moderation[`+++quarkus.langchain4j.watsonx.gateway-image-model.moderation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.moderation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+How strictly the generated images are filtered, `low` being the least restrictive.
+
+*Allowable values:* `++[++low, auto++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_MODERATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_MODERATION+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`low`, `auto`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-output-compression]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-output-compression[`+++quarkus.langchain4j.watsonx.gateway-image-model.output-compression+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.output-compression+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The compression level of the generated images, from `0` to `100`.
+
+Only the `jpeg` and `webp` output formats accept it.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_OUTPUT_COMPRESSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_OUTPUT_COMPRESSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-output-format]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-output-format[`+++quarkus.langchain4j.watsonx.gateway-image-model.output-format+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.output-format+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The file format of the generated images.
+
+*Allowable values:* `++[++png, jpeg, webp, auto++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_OUTPUT_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_OUTPUT_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`png`, `jpeg`, `webp`, `auto`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-quality]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-quality[`+++quarkus.langchain4j.watsonx.gateway-image-model.quality+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.quality+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The quality of the generated images.
+
+*Allowable values:* `++[++auto, high, medium, low, hd, standard++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_QUALITY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_QUALITY+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`auto`, `high`, `medium`, `low`, `hd`, `standard`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-response-format]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-response-format[`+++quarkus.langchain4j.watsonx.gateway-image-model.response-format+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.response-format+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+How the generated images are returned, as a link with `url` or as Base64 data with `b64_json`.
+
+Only the models that support it accept this value.
+
+*Allowable values:* `++[++url, b64_json++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_RESPONSE_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_RESPONSE_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`url`, `b64-json`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-size]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-size[`+++quarkus.langchain4j.watsonx.gateway-image-model.size+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The dimensions of the generated images, for example `1024x1024`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-style]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-style[`+++quarkus.langchain4j.watsonx.gateway-image-model.style+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.style+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The visual style of the generated images.
+
+*Allowable values:* `++[++vivid, natural++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_STYLE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_STYLE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`vivid`, `natural`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-user]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-user[`+++quarkus.langchain4j.watsonx.gateway-image-model.user+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.user+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+A stable identifier of the end user issuing the request, used by the backing provider to detect and prevent abuse.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_USER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-log-requests]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-log-requests[`+++quarkus.langchain4j.watsonx.gateway-image-model.log-requests+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether image model requests should be logged.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-log-responses]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-log-responses[`+++quarkus.langchain4j.watsonx.gateway-image-model.log-responses+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether image model responses should be logged.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-log-requests-curl]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-log-requests-curl[`+++quarkus.langchain4j.watsonx.gateway-image-model.log-requests-curl+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.log-requests-curl+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the watsonx.ai client should log requests as cURL commands.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_LOG_REQUESTS_CURL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_LOG_REQUESTS_CURL+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
@@ -33442,6 +34079,176 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++ibm/granite-4-h-small+++`
 
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-hap-input]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-hap-input[`+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.hap.input+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.hap.input+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enables HAP detection on the input text, using the given threshold score.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_HAP_INPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_HAP_INPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-hap-output]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-hap-output[`+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.hap.output+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.hap.output+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enables HAP detection on the output text, using the given threshold score.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_HAP_OUTPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_HAP_OUTPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-hap-mask]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-hap-mask[`+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.hap.mask+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.hap.mask+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the detected entity value is removed from the text instead of being returned.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_HAP_MASK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_HAP_MASK+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-pii-input]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-pii-input[`+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.pii.input+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.pii.input+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether PII detection is applied to the input text.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_PII_INPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_PII_INPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-pii-output]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-pii-output[`+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.pii.output+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.pii.output+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether PII detection is applied to the output text.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_PII_OUTPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_PII_OUTPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-pii-mask]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-pii-mask[`+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.pii.mask+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.pii.mask+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the detected entity value is removed from the text instead of being returned.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_PII_MASK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_PII_MASK+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-granite-guardian-input]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-granite-guardian-input[`+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.granite-guardian.input+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.granite-guardian.input+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enables Granite Guardian detection on the input text, using the given threshold score.
+
+Granite Guardian is only applied to the input text.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_GRANITE_GUARDIAN_INPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_GRANITE_GUARDIAN_INPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-granite-guardian-mask]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-granite-guardian-mask[`+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.granite-guardian.mask+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.granite-guardian.mask+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the detected entity value is removed from the text instead of being returned.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_GRANITE_GUARDIAN_MASK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_GRANITE_GUARDIAN_MASK+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-deployment-chat-model-tool-choice]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-deployment-chat-model-tool-choice[`+++quarkus.langchain4j.watsonx."model-name".deployment-chat-model.tool-choice+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".deployment-chat-model.tool-choice+++[]
@@ -34711,31 +35518,6 @@ endif::add-copy-button-to-env-var[]
 |Map<String,String>
 |
 
-a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-embedding-model-model-name]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-embedding-model-model-name[`+++quarkus.langchain4j.watsonx."model-name".embedding-model.model-name+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".embedding-model.model-name+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Specifies the ID of the model to be used.
-
-A list of all available models is provided in the IBM watsonx.ai documentation at the link:https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models-embed.html?context=wx&audience=wdp#ibm-provided[this link].
-
-To use a model, locate the `API model ID` column in the table and copy the corresponding model ID.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__EMBEDDING_MODEL_MODEL_NAME+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__EMBEDDING_MODEL_MODEL_NAME+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++ibm/granite-embedding-278m-multilingual+++`
-
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-embedding-model-log-requests]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-embedding-model-log-requests[`+++quarkus.langchain4j.watsonx."model-name".embedding-model.log-requests+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".embedding-model.log-requests+++[]
@@ -34794,6 +35576,477 @@ Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__M
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__EMBEDDING_MODEL_LOG_REQUESTS_CURL+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-embedding-model-model-name]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-embedding-model-model-name[`+++quarkus.langchain4j.watsonx."model-name".embedding-model.model-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".embedding-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Specifies the ID of the model to be used.
+
+A list of all available models is provided in the IBM watsonx.ai documentation at the link:https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models-embed.html?context=wx&audience=wdp#ibm-provided[this link].
+
+To use a model, locate the `API model ID` column in the table and copy the corresponding model ID.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__EMBEDDING_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__EMBEDDING_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++ibm/granite-embedding-278m-multilingual+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-log-requests]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-log-requests[`+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.log-requests+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether embedding model requests should be logged.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-log-responses]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-log-responses[`+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.log-responses+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether embedding model responses should be logged.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-log-requests-curl]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-log-requests-curl[`+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.log-requests-curl+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.log-requests-curl+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the watsonx.ai client should log requests as cURL commands.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_LOG_REQUESTS_CURL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_LOG_REQUESTS_CURL+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-model-name]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-model-name[`+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.model-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The identifier of the model to use, as configured in the Model Gateway (for example `openai/text-embedding-3-small`).
+
+Setting this property routes all embedding requests to the Model Gateway.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-dimensions]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-dimensions[`+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.dimensions+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.dimensions+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The number of dimensions of the returned embeddings.
+
+Only the models that support it accept this value.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_DIMENSIONS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_DIMENSIONS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-encoding-format]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-encoding-format[`+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.encoding-format+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.encoding-format+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The wire format used to return the embeddings.
+
+Both formats produce the same vectors, `base64` is decoded for you.
+
+*Allowable values:* `++[++float, base64++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_ENCODING_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_ENCODING_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`float`, `base64`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-user]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-user[`+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.user+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.user+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+A stable identifier of the end user issuing the request, used by the backing provider to detect and prevent abuse.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_USER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-model-name]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-model-name[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.model-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The identifier of the model to use, as configured in the Model Gateway.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-background]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-background[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.background+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.background+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The background of the generated images.
+
+Transparency requires an output format that supports it, so `png` or `webp`.
+
+*Allowable values:* `++[++transparent, opaque, auto++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_BACKGROUND+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_BACKGROUND+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`transparent`, `opaque`, `auto`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-moderation]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-moderation[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.moderation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.moderation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+How strictly the generated images are filtered, `low` being the least restrictive.
+
+*Allowable values:* `++[++low, auto++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_MODERATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_MODERATION+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`low`, `auto`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-output-compression]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-output-compression[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.output-compression+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.output-compression+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The compression level of the generated images, from `0` to `100`.
+
+Only the `jpeg` and `webp` output formats accept it.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_OUTPUT_COMPRESSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_OUTPUT_COMPRESSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-output-format]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-output-format[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.output-format+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.output-format+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The file format of the generated images.
+
+*Allowable values:* `++[++png, jpeg, webp, auto++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_OUTPUT_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_OUTPUT_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`png`, `jpeg`, `webp`, `auto`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-quality]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-quality[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.quality+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.quality+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The quality of the generated images.
+
+*Allowable values:* `++[++auto, high, medium, low, hd, standard++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_QUALITY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_QUALITY+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`auto`, `high`, `medium`, `low`, `hd`, `standard`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-response-format]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-response-format[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.response-format+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.response-format+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+How the generated images are returned, as a link with `url` or as Base64 data with `b64_json`.
+
+Only the models that support it accept this value.
+
+*Allowable values:* `++[++url, b64_json++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_RESPONSE_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_RESPONSE_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`url`, `b64-json`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-size]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-size[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.size+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The dimensions of the generated images, for example `1024x1024`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-style]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-style[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.style+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.style+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The visual style of the generated images.
+
+*Allowable values:* `++[++vivid, natural++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_STYLE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_STYLE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`vivid`, `natural`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-user]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-user[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.user+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.user+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+A stable identifier of the end user issuing the request, used by the backing provider to detect and prevent abuse.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_USER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-log-requests]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-log-requests[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.log-requests+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether image model requests should be logged.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-log-responses]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-log-responses[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.log-responses+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether image model responses should be logged.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-log-requests-curl]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-log-requests-curl[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.log-requests-curl+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.log-requests-curl+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the watsonx.ai client should log requests as cURL commands.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_LOG_REQUESTS_CURL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_LOG_REQUESTS_CURL+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-watsonx.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-watsonx.adoc
@@ -49,6 +49,27 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-enabled]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-enabled[`+++quarkus.langchain4j.watsonx.gateway-image-model.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the gateway image model should be enabled.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-scoring-model-enabled]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-scoring-model-enabled[`+++quarkus.langchain4j.watsonx.scoring-model.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.watsonx.scoring-model.enabled+++[]
@@ -1649,6 +1670,176 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++ibm/granite-4-h-small+++`
 
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-hap-input]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-hap-input[`+++quarkus.langchain4j.watsonx.chat-model.moderations.hap.input+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.moderations.hap.input+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enables HAP detection on the input text, using the given threshold score.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_HAP_INPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_HAP_INPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-hap-output]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-hap-output[`+++quarkus.langchain4j.watsonx.chat-model.moderations.hap.output+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.moderations.hap.output+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enables HAP detection on the output text, using the given threshold score.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_HAP_OUTPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_HAP_OUTPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-hap-mask]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-hap-mask[`+++quarkus.langchain4j.watsonx.chat-model.moderations.hap.mask+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.moderations.hap.mask+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the detected entity value is removed from the text instead of being returned.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_HAP_MASK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_HAP_MASK+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-pii-input]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-pii-input[`+++quarkus.langchain4j.watsonx.chat-model.moderations.pii.input+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.moderations.pii.input+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether PII detection is applied to the input text.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_PII_INPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_PII_INPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-pii-output]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-pii-output[`+++quarkus.langchain4j.watsonx.chat-model.moderations.pii.output+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.moderations.pii.output+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether PII detection is applied to the output text.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_PII_OUTPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_PII_OUTPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-pii-mask]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-pii-mask[`+++quarkus.langchain4j.watsonx.chat-model.moderations.pii.mask+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.moderations.pii.mask+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the detected entity value is removed from the text instead of being returned.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_PII_MASK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_PII_MASK+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-granite-guardian-input]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-granite-guardian-input[`+++quarkus.langchain4j.watsonx.chat-model.moderations.granite-guardian.input+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.moderations.granite-guardian.input+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enables Granite Guardian detection on the input text, using the given threshold score.
+
+Granite Guardian is only applied to the input text.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_GRANITE_GUARDIAN_INPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_GRANITE_GUARDIAN_INPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-granite-guardian-mask]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-granite-guardian-mask[`+++quarkus.langchain4j.watsonx.chat-model.moderations.granite-guardian.mask+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.moderations.granite-guardian.mask+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the detected entity value is removed from the text instead of being returned.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_GRANITE_GUARDIAN_MASK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_GRANITE_GUARDIAN_MASK+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-deployment-chat-model-tool-choice]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-deployment-chat-model-tool-choice[`+++quarkus.langchain4j.watsonx.deployment-chat-model.tool-choice+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.watsonx.deployment-chat-model.tool-choice+++[]
@@ -2918,31 +3109,6 @@ endif::add-copy-button-to-env-var[]
 |Map<String,String>
 |
 
-a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-embedding-model-model-name]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-embedding-model-model-name[`+++quarkus.langchain4j.watsonx.embedding-model.model-name+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.watsonx.embedding-model.model-name+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Specifies the ID of the model to be used.
-
-A list of all available models is provided in the IBM watsonx.ai documentation at the link:https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models-embed.html?context=wx&audience=wdp#ibm-provided[this link].
-
-To use a model, locate the `API model ID` column in the table and copy the corresponding model ID.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_EMBEDDING_MODEL_MODEL_NAME+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_EMBEDDING_MODEL_MODEL_NAME+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++ibm/granite-embedding-278m-multilingual+++`
-
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-embedding-model-log-requests]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-embedding-model-log-requests[`+++quarkus.langchain4j.watsonx.embedding-model.log-requests+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.watsonx.embedding-model.log-requests+++[]
@@ -3001,6 +3167,477 @@ Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_EM
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_EMBEDDING_MODEL_LOG_REQUESTS_CURL+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-embedding-model-model-name]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-embedding-model-model-name[`+++quarkus.langchain4j.watsonx.embedding-model.model-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.embedding-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Specifies the ID of the model to be used.
+
+A list of all available models is provided in the IBM watsonx.ai documentation at the link:https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models-embed.html?context=wx&audience=wdp#ibm-provided[this link].
+
+To use a model, locate the `API model ID` column in the table and copy the corresponding model ID.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_EMBEDDING_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_EMBEDDING_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++ibm/granite-embedding-278m-multilingual+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-log-requests]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-log-requests[`+++quarkus.langchain4j.watsonx.gateway-embedding-model.log-requests+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-embedding-model.log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether embedding model requests should be logged.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-log-responses]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-log-responses[`+++quarkus.langchain4j.watsonx.gateway-embedding-model.log-responses+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-embedding-model.log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether embedding model responses should be logged.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-log-requests-curl]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-log-requests-curl[`+++quarkus.langchain4j.watsonx.gateway-embedding-model.log-requests-curl+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-embedding-model.log-requests-curl+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the watsonx.ai client should log requests as cURL commands.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_LOG_REQUESTS_CURL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_LOG_REQUESTS_CURL+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-model-name]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-model-name[`+++quarkus.langchain4j.watsonx.gateway-embedding-model.model-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-embedding-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The identifier of the model to use, as configured in the Model Gateway (for example `openai/text-embedding-3-small`).
+
+Setting this property routes all embedding requests to the Model Gateway.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-dimensions]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-dimensions[`+++quarkus.langchain4j.watsonx.gateway-embedding-model.dimensions+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-embedding-model.dimensions+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The number of dimensions of the returned embeddings.
+
+Only the models that support it accept this value.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_DIMENSIONS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_DIMENSIONS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-encoding-format]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-encoding-format[`+++quarkus.langchain4j.watsonx.gateway-embedding-model.encoding-format+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-embedding-model.encoding-format+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The wire format used to return the embeddings.
+
+Both formats produce the same vectors, `base64` is decoded for you.
+
+*Allowable values:* `++[++float, base64++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_ENCODING_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_ENCODING_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`float`, `base64`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-user]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-user[`+++quarkus.langchain4j.watsonx.gateway-embedding-model.user+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-embedding-model.user+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+A stable identifier of the end user issuing the request, used by the backing provider to detect and prevent abuse.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_USER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-model-name]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-model-name[`+++quarkus.langchain4j.watsonx.gateway-image-model.model-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The identifier of the model to use, as configured in the Model Gateway.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-background]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-background[`+++quarkus.langchain4j.watsonx.gateway-image-model.background+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.background+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The background of the generated images.
+
+Transparency requires an output format that supports it, so `png` or `webp`.
+
+*Allowable values:* `++[++transparent, opaque, auto++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_BACKGROUND+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_BACKGROUND+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`transparent`, `opaque`, `auto`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-moderation]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-moderation[`+++quarkus.langchain4j.watsonx.gateway-image-model.moderation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.moderation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+How strictly the generated images are filtered, `low` being the least restrictive.
+
+*Allowable values:* `++[++low, auto++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_MODERATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_MODERATION+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`low`, `auto`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-output-compression]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-output-compression[`+++quarkus.langchain4j.watsonx.gateway-image-model.output-compression+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.output-compression+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The compression level of the generated images, from `0` to `100`.
+
+Only the `jpeg` and `webp` output formats accept it.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_OUTPUT_COMPRESSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_OUTPUT_COMPRESSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-output-format]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-output-format[`+++quarkus.langchain4j.watsonx.gateway-image-model.output-format+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.output-format+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The file format of the generated images.
+
+*Allowable values:* `++[++png, jpeg, webp, auto++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_OUTPUT_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_OUTPUT_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`png`, `jpeg`, `webp`, `auto`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-quality]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-quality[`+++quarkus.langchain4j.watsonx.gateway-image-model.quality+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.quality+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The quality of the generated images.
+
+*Allowable values:* `++[++auto, high, medium, low, hd, standard++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_QUALITY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_QUALITY+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`auto`, `high`, `medium`, `low`, `hd`, `standard`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-response-format]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-response-format[`+++quarkus.langchain4j.watsonx.gateway-image-model.response-format+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.response-format+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+How the generated images are returned, as a link with `url` or as Base64 data with `b64_json`.
+
+Only the models that support it accept this value.
+
+*Allowable values:* `++[++url, b64_json++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_RESPONSE_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_RESPONSE_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`url`, `b64-json`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-size]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-size[`+++quarkus.langchain4j.watsonx.gateway-image-model.size+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The dimensions of the generated images, for example `1024x1024`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-style]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-style[`+++quarkus.langchain4j.watsonx.gateway-image-model.style+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.style+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The visual style of the generated images.
+
+*Allowable values:* `++[++vivid, natural++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_STYLE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_STYLE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`vivid`, `natural`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-user]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-user[`+++quarkus.langchain4j.watsonx.gateway-image-model.user+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.user+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+A stable identifier of the end user issuing the request, used by the backing provider to detect and prevent abuse.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_USER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-log-requests]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-log-requests[`+++quarkus.langchain4j.watsonx.gateway-image-model.log-requests+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether image model requests should be logged.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-log-responses]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-log-responses[`+++quarkus.langchain4j.watsonx.gateway-image-model.log-responses+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether image model responses should be logged.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-log-requests-curl]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-log-requests-curl[`+++quarkus.langchain4j.watsonx.gateway-image-model.log-requests-curl+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.log-requests-curl+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the watsonx.ai client should log requests as cURL commands.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_LOG_REQUESTS_CURL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_LOG_REQUESTS_CURL+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
@@ -4999,6 +5636,176 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++ibm/granite-4-h-small+++`
 
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-hap-input]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-hap-input[`+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.hap.input+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.hap.input+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enables HAP detection on the input text, using the given threshold score.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_HAP_INPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_HAP_INPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-hap-output]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-hap-output[`+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.hap.output+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.hap.output+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enables HAP detection on the output text, using the given threshold score.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_HAP_OUTPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_HAP_OUTPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-hap-mask]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-hap-mask[`+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.hap.mask+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.hap.mask+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the detected entity value is removed from the text instead of being returned.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_HAP_MASK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_HAP_MASK+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-pii-input]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-pii-input[`+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.pii.input+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.pii.input+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether PII detection is applied to the input text.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_PII_INPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_PII_INPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-pii-output]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-pii-output[`+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.pii.output+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.pii.output+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether PII detection is applied to the output text.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_PII_OUTPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_PII_OUTPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-pii-mask]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-pii-mask[`+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.pii.mask+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.pii.mask+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the detected entity value is removed from the text instead of being returned.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_PII_MASK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_PII_MASK+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-granite-guardian-input]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-granite-guardian-input[`+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.granite-guardian.input+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.granite-guardian.input+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enables Granite Guardian detection on the input text, using the given threshold score.
+
+Granite Guardian is only applied to the input text.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_GRANITE_GUARDIAN_INPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_GRANITE_GUARDIAN_INPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-granite-guardian-mask]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-granite-guardian-mask[`+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.granite-guardian.mask+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.granite-guardian.mask+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the detected entity value is removed from the text instead of being returned.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_GRANITE_GUARDIAN_MASK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_GRANITE_GUARDIAN_MASK+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-deployment-chat-model-tool-choice]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-deployment-chat-model-tool-choice[`+++quarkus.langchain4j.watsonx."model-name".deployment-chat-model.tool-choice+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".deployment-chat-model.tool-choice+++[]
@@ -6268,31 +7075,6 @@ endif::add-copy-button-to-env-var[]
 |Map<String,String>
 |
 
-a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-embedding-model-model-name]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-embedding-model-model-name[`+++quarkus.langchain4j.watsonx."model-name".embedding-model.model-name+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".embedding-model.model-name+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Specifies the ID of the model to be used.
-
-A list of all available models is provided in the IBM watsonx.ai documentation at the link:https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models-embed.html?context=wx&audience=wdp#ibm-provided[this link].
-
-To use a model, locate the `API model ID` column in the table and copy the corresponding model ID.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__EMBEDDING_MODEL_MODEL_NAME+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__EMBEDDING_MODEL_MODEL_NAME+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++ibm/granite-embedding-278m-multilingual+++`
-
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-embedding-model-log-requests]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-embedding-model-log-requests[`+++quarkus.langchain4j.watsonx."model-name".embedding-model.log-requests+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".embedding-model.log-requests+++[]
@@ -6351,6 +7133,477 @@ Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__M
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__EMBEDDING_MODEL_LOG_REQUESTS_CURL+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-embedding-model-model-name]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-embedding-model-model-name[`+++quarkus.langchain4j.watsonx."model-name".embedding-model.model-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".embedding-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Specifies the ID of the model to be used.
+
+A list of all available models is provided in the IBM watsonx.ai documentation at the link:https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models-embed.html?context=wx&audience=wdp#ibm-provided[this link].
+
+To use a model, locate the `API model ID` column in the table and copy the corresponding model ID.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__EMBEDDING_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__EMBEDDING_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++ibm/granite-embedding-278m-multilingual+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-log-requests]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-log-requests[`+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.log-requests+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether embedding model requests should be logged.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-log-responses]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-log-responses[`+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.log-responses+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether embedding model responses should be logged.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-log-requests-curl]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-log-requests-curl[`+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.log-requests-curl+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.log-requests-curl+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the watsonx.ai client should log requests as cURL commands.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_LOG_REQUESTS_CURL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_LOG_REQUESTS_CURL+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-model-name]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-model-name[`+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.model-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The identifier of the model to use, as configured in the Model Gateway (for example `openai/text-embedding-3-small`).
+
+Setting this property routes all embedding requests to the Model Gateway.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-dimensions]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-dimensions[`+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.dimensions+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.dimensions+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The number of dimensions of the returned embeddings.
+
+Only the models that support it accept this value.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_DIMENSIONS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_DIMENSIONS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-encoding-format]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-encoding-format[`+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.encoding-format+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.encoding-format+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The wire format used to return the embeddings.
+
+Both formats produce the same vectors, `base64` is decoded for you.
+
+*Allowable values:* `++[++float, base64++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_ENCODING_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_ENCODING_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`float`, `base64`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-user]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-user[`+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.user+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.user+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+A stable identifier of the end user issuing the request, used by the backing provider to detect and prevent abuse.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_USER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-model-name]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-model-name[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.model-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The identifier of the model to use, as configured in the Model Gateway.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-background]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-background[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.background+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.background+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The background of the generated images.
+
+Transparency requires an output format that supports it, so `png` or `webp`.
+
+*Allowable values:* `++[++transparent, opaque, auto++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_BACKGROUND+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_BACKGROUND+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`transparent`, `opaque`, `auto`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-moderation]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-moderation[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.moderation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.moderation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+How strictly the generated images are filtered, `low` being the least restrictive.
+
+*Allowable values:* `++[++low, auto++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_MODERATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_MODERATION+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`low`, `auto`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-output-compression]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-output-compression[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.output-compression+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.output-compression+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The compression level of the generated images, from `0` to `100`.
+
+Only the `jpeg` and `webp` output formats accept it.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_OUTPUT_COMPRESSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_OUTPUT_COMPRESSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-output-format]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-output-format[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.output-format+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.output-format+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The file format of the generated images.
+
+*Allowable values:* `++[++png, jpeg, webp, auto++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_OUTPUT_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_OUTPUT_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`png`, `jpeg`, `webp`, `auto`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-quality]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-quality[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.quality+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.quality+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The quality of the generated images.
+
+*Allowable values:* `++[++auto, high, medium, low, hd, standard++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_QUALITY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_QUALITY+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`auto`, `high`, `medium`, `low`, `hd`, `standard`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-response-format]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-response-format[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.response-format+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.response-format+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+How the generated images are returned, as a link with `url` or as Base64 data with `b64_json`.
+
+Only the models that support it accept this value.
+
+*Allowable values:* `++[++url, b64_json++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_RESPONSE_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_RESPONSE_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`url`, `b64-json`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-size]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-size[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.size+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The dimensions of the generated images, for example `1024x1024`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-style]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-style[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.style+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.style+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The visual style of the generated images.
+
+*Allowable values:* `++[++vivid, natural++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_STYLE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_STYLE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`vivid`, `natural`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-user]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-user[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.user+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.user+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+A stable identifier of the end user issuing the request, used by the backing provider to detect and prevent abuse.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_USER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-log-requests]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-log-requests[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.log-requests+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether image model requests should be logged.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-log-responses]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-log-responses[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.log-responses+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether image model responses should be logged.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-log-requests-curl]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-log-requests-curl[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.log-requests-curl+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.log-requests-curl+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the watsonx.ai client should log requests as cURL commands.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_LOG_REQUESTS_CURL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_LOG_REQUESTS_CURL+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-watsonx_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-watsonx_quarkus.langchain4j.adoc
@@ -49,6 +49,27 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-enabled]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-enabled[`+++quarkus.langchain4j.watsonx.gateway-image-model.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the gateway image model should be enabled.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-scoring-model-enabled]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-scoring-model-enabled[`+++quarkus.langchain4j.watsonx.scoring-model.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.watsonx.scoring-model.enabled+++[]
@@ -1649,6 +1670,176 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++ibm/granite-4-h-small+++`
 
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-hap-input]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-hap-input[`+++quarkus.langchain4j.watsonx.chat-model.moderations.hap.input+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.moderations.hap.input+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enables HAP detection on the input text, using the given threshold score.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_HAP_INPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_HAP_INPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-hap-output]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-hap-output[`+++quarkus.langchain4j.watsonx.chat-model.moderations.hap.output+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.moderations.hap.output+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enables HAP detection on the output text, using the given threshold score.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_HAP_OUTPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_HAP_OUTPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-hap-mask]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-hap-mask[`+++quarkus.langchain4j.watsonx.chat-model.moderations.hap.mask+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.moderations.hap.mask+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the detected entity value is removed from the text instead of being returned.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_HAP_MASK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_HAP_MASK+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-pii-input]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-pii-input[`+++quarkus.langchain4j.watsonx.chat-model.moderations.pii.input+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.moderations.pii.input+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether PII detection is applied to the input text.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_PII_INPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_PII_INPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-pii-output]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-pii-output[`+++quarkus.langchain4j.watsonx.chat-model.moderations.pii.output+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.moderations.pii.output+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether PII detection is applied to the output text.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_PII_OUTPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_PII_OUTPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-pii-mask]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-pii-mask[`+++quarkus.langchain4j.watsonx.chat-model.moderations.pii.mask+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.moderations.pii.mask+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the detected entity value is removed from the text instead of being returned.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_PII_MASK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_PII_MASK+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-granite-guardian-input]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-granite-guardian-input[`+++quarkus.langchain4j.watsonx.chat-model.moderations.granite-guardian.input+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.moderations.granite-guardian.input+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enables Granite Guardian detection on the input text, using the given threshold score.
+
+Granite Guardian is only applied to the input text.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_GRANITE_GUARDIAN_INPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_GRANITE_GUARDIAN_INPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-granite-guardian-mask]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-chat-model-moderations-granite-guardian-mask[`+++quarkus.langchain4j.watsonx.chat-model.moderations.granite-guardian.mask+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.chat-model.moderations.granite-guardian.mask+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the detected entity value is removed from the text instead of being returned.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_GRANITE_GUARDIAN_MASK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_CHAT_MODEL_MODERATIONS_GRANITE_GUARDIAN_MASK+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-deployment-chat-model-tool-choice]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-deployment-chat-model-tool-choice[`+++quarkus.langchain4j.watsonx.deployment-chat-model.tool-choice+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.watsonx.deployment-chat-model.tool-choice+++[]
@@ -2918,31 +3109,6 @@ endif::add-copy-button-to-env-var[]
 |Map<String,String>
 |
 
-a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-embedding-model-model-name]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-embedding-model-model-name[`+++quarkus.langchain4j.watsonx.embedding-model.model-name+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.watsonx.embedding-model.model-name+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Specifies the ID of the model to be used.
-
-A list of all available models is provided in the IBM watsonx.ai documentation at the link:https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models-embed.html?context=wx&audience=wdp#ibm-provided[this link].
-
-To use a model, locate the `API model ID` column in the table and copy the corresponding model ID.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_EMBEDDING_MODEL_MODEL_NAME+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_EMBEDDING_MODEL_MODEL_NAME+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++ibm/granite-embedding-278m-multilingual+++`
-
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-embedding-model-log-requests]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-embedding-model-log-requests[`+++quarkus.langchain4j.watsonx.embedding-model.log-requests+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.watsonx.embedding-model.log-requests+++[]
@@ -3001,6 +3167,477 @@ Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_EM
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_EMBEDDING_MODEL_LOG_REQUESTS_CURL+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-embedding-model-model-name]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-embedding-model-model-name[`+++quarkus.langchain4j.watsonx.embedding-model.model-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.embedding-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Specifies the ID of the model to be used.
+
+A list of all available models is provided in the IBM watsonx.ai documentation at the link:https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models-embed.html?context=wx&audience=wdp#ibm-provided[this link].
+
+To use a model, locate the `API model ID` column in the table and copy the corresponding model ID.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_EMBEDDING_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_EMBEDDING_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++ibm/granite-embedding-278m-multilingual+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-log-requests]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-log-requests[`+++quarkus.langchain4j.watsonx.gateway-embedding-model.log-requests+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-embedding-model.log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether embedding model requests should be logged.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-log-responses]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-log-responses[`+++quarkus.langchain4j.watsonx.gateway-embedding-model.log-responses+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-embedding-model.log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether embedding model responses should be logged.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-log-requests-curl]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-log-requests-curl[`+++quarkus.langchain4j.watsonx.gateway-embedding-model.log-requests-curl+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-embedding-model.log-requests-curl+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the watsonx.ai client should log requests as cURL commands.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_LOG_REQUESTS_CURL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_LOG_REQUESTS_CURL+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-model-name]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-model-name[`+++quarkus.langchain4j.watsonx.gateway-embedding-model.model-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-embedding-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The identifier of the model to use, as configured in the Model Gateway (for example `openai/text-embedding-3-small`).
+
+Setting this property routes all embedding requests to the Model Gateway.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-dimensions]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-dimensions[`+++quarkus.langchain4j.watsonx.gateway-embedding-model.dimensions+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-embedding-model.dimensions+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The number of dimensions of the returned embeddings.
+
+Only the models that support it accept this value.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_DIMENSIONS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_DIMENSIONS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-encoding-format]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-encoding-format[`+++quarkus.langchain4j.watsonx.gateway-embedding-model.encoding-format+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-embedding-model.encoding-format+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The wire format used to return the embeddings.
+
+Both formats produce the same vectors, `base64` is decoded for you.
+
+*Allowable values:* `++[++float, base64++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_ENCODING_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_ENCODING_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`float`, `base64`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-user]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-embedding-model-user[`+++quarkus.langchain4j.watsonx.gateway-embedding-model.user+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-embedding-model.user+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+A stable identifier of the end user issuing the request, used by the backing provider to detect and prevent abuse.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_USER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_EMBEDDING_MODEL_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-model-name]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-model-name[`+++quarkus.langchain4j.watsonx.gateway-image-model.model-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The identifier of the model to use, as configured in the Model Gateway.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-background]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-background[`+++quarkus.langchain4j.watsonx.gateway-image-model.background+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.background+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The background of the generated images.
+
+Transparency requires an output format that supports it, so `png` or `webp`.
+
+*Allowable values:* `++[++transparent, opaque, auto++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_BACKGROUND+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_BACKGROUND+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`transparent`, `opaque`, `auto`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-moderation]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-moderation[`+++quarkus.langchain4j.watsonx.gateway-image-model.moderation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.moderation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+How strictly the generated images are filtered, `low` being the least restrictive.
+
+*Allowable values:* `++[++low, auto++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_MODERATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_MODERATION+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`low`, `auto`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-output-compression]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-output-compression[`+++quarkus.langchain4j.watsonx.gateway-image-model.output-compression+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.output-compression+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The compression level of the generated images, from `0` to `100`.
+
+Only the `jpeg` and `webp` output formats accept it.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_OUTPUT_COMPRESSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_OUTPUT_COMPRESSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-output-format]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-output-format[`+++quarkus.langchain4j.watsonx.gateway-image-model.output-format+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.output-format+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The file format of the generated images.
+
+*Allowable values:* `++[++png, jpeg, webp, auto++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_OUTPUT_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_OUTPUT_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`png`, `jpeg`, `webp`, `auto`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-quality]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-quality[`+++quarkus.langchain4j.watsonx.gateway-image-model.quality+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.quality+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The quality of the generated images.
+
+*Allowable values:* `++[++auto, high, medium, low, hd, standard++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_QUALITY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_QUALITY+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`auto`, `high`, `medium`, `low`, `hd`, `standard`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-response-format]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-response-format[`+++quarkus.langchain4j.watsonx.gateway-image-model.response-format+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.response-format+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+How the generated images are returned, as a link with `url` or as Base64 data with `b64_json`.
+
+Only the models that support it accept this value.
+
+*Allowable values:* `++[++url, b64_json++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_RESPONSE_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_RESPONSE_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`url`, `b64-json`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-size]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-size[`+++quarkus.langchain4j.watsonx.gateway-image-model.size+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The dimensions of the generated images, for example `1024x1024`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-style]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-style[`+++quarkus.langchain4j.watsonx.gateway-image-model.style+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.style+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The visual style of the generated images.
+
+*Allowable values:* `++[++vivid, natural++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_STYLE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_STYLE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`vivid`, `natural`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-user]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-user[`+++quarkus.langchain4j.watsonx.gateway-image-model.user+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.user+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+A stable identifier of the end user issuing the request, used by the backing provider to detect and prevent abuse.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_USER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-log-requests]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-log-requests[`+++quarkus.langchain4j.watsonx.gateway-image-model.log-requests+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether image model requests should be logged.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-log-responses]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-log-responses[`+++quarkus.langchain4j.watsonx.gateway-image-model.log-responses+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether image model responses should be logged.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-log-requests-curl]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-gateway-image-model-log-requests-curl[`+++quarkus.langchain4j.watsonx.gateway-image-model.log-requests-curl+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx.gateway-image-model.log-requests-curl+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the watsonx.ai client should log requests as cURL commands.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_LOG_REQUESTS_CURL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX_GATEWAY_IMAGE_MODEL_LOG_REQUESTS_CURL+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
@@ -4999,6 +5636,176 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++ibm/granite-4-h-small+++`
 
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-hap-input]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-hap-input[`+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.hap.input+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.hap.input+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enables HAP detection on the input text, using the given threshold score.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_HAP_INPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_HAP_INPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-hap-output]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-hap-output[`+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.hap.output+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.hap.output+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enables HAP detection on the output text, using the given threshold score.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_HAP_OUTPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_HAP_OUTPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-hap-mask]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-hap-mask[`+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.hap.mask+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.hap.mask+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the detected entity value is removed from the text instead of being returned.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_HAP_MASK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_HAP_MASK+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-pii-input]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-pii-input[`+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.pii.input+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.pii.input+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether PII detection is applied to the input text.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_PII_INPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_PII_INPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-pii-output]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-pii-output[`+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.pii.output+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.pii.output+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether PII detection is applied to the output text.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_PII_OUTPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_PII_OUTPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-pii-mask]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-pii-mask[`+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.pii.mask+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.pii.mask+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the detected entity value is removed from the text instead of being returned.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_PII_MASK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_PII_MASK+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-granite-guardian-input]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-granite-guardian-input[`+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.granite-guardian.input+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.granite-guardian.input+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enables Granite Guardian detection on the input text, using the given threshold score.
+
+Granite Guardian is only applied to the input text.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_GRANITE_GUARDIAN_INPUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_GRANITE_GUARDIAN_INPUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|double
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-granite-guardian-mask]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-chat-model-moderations-granite-guardian-mask[`+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.granite-guardian.mask+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".chat-model.moderations.granite-guardian.mask+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the detected entity value is removed from the text instead of being returned.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_GRANITE_GUARDIAN_MASK+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__CHAT_MODEL_MODERATIONS_GRANITE_GUARDIAN_MASK+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-deployment-chat-model-tool-choice]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-deployment-chat-model-tool-choice[`+++quarkus.langchain4j.watsonx."model-name".deployment-chat-model.tool-choice+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".deployment-chat-model.tool-choice+++[]
@@ -6268,31 +7075,6 @@ endif::add-copy-button-to-env-var[]
 |Map<String,String>
 |
 
-a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-embedding-model-model-name]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-embedding-model-model-name[`+++quarkus.langchain4j.watsonx."model-name".embedding-model.model-name+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".embedding-model.model-name+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Specifies the ID of the model to be used.
-
-A list of all available models is provided in the IBM watsonx.ai documentation at the link:https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models-embed.html?context=wx&audience=wdp#ibm-provided[this link].
-
-To use a model, locate the `API model ID` column in the table and copy the corresponding model ID.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__EMBEDDING_MODEL_MODEL_NAME+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__EMBEDDING_MODEL_MODEL_NAME+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|`+++ibm/granite-embedding-278m-multilingual+++`
-
 a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-embedding-model-log-requests]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-embedding-model-log-requests[`+++quarkus.langchain4j.watsonx."model-name".embedding-model.log-requests+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".embedding-model.log-requests+++[]
@@ -6351,6 +7133,477 @@ Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__M
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__EMBEDDING_MODEL_LOG_REQUESTS_CURL+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-embedding-model-model-name]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-embedding-model-model-name[`+++quarkus.langchain4j.watsonx."model-name".embedding-model.model-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".embedding-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Specifies the ID of the model to be used.
+
+A list of all available models is provided in the IBM watsonx.ai documentation at the link:https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models-embed.html?context=wx&audience=wdp#ibm-provided[this link].
+
+To use a model, locate the `API model ID` column in the table and copy the corresponding model ID.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__EMBEDDING_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__EMBEDDING_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++ibm/granite-embedding-278m-multilingual+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-log-requests]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-log-requests[`+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.log-requests+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether embedding model requests should be logged.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-log-responses]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-log-responses[`+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.log-responses+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether embedding model responses should be logged.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-log-requests-curl]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-log-requests-curl[`+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.log-requests-curl+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.log-requests-curl+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the watsonx.ai client should log requests as cURL commands.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_LOG_REQUESTS_CURL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_LOG_REQUESTS_CURL+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-model-name]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-model-name[`+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.model-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The identifier of the model to use, as configured in the Model Gateway (for example `openai/text-embedding-3-small`).
+
+Setting this property routes all embedding requests to the Model Gateway.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-dimensions]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-dimensions[`+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.dimensions+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.dimensions+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The number of dimensions of the returned embeddings.
+
+Only the models that support it accept this value.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_DIMENSIONS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_DIMENSIONS+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-encoding-format]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-encoding-format[`+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.encoding-format+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.encoding-format+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The wire format used to return the embeddings.
+
+Both formats produce the same vectors, `base64` is decoded for you.
+
+*Allowable values:* `++[++float, base64++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_ENCODING_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_ENCODING_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`float`, `base64`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-user]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-embedding-model-user[`+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.user+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-embedding-model.user+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+A stable identifier of the end user issuing the request, used by the backing provider to detect and prevent abuse.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_USER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_EMBEDDING_MODEL_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-model-name]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-model-name[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.model-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.model-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The identifier of the model to use, as configured in the Model Gateway.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_MODEL_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_MODEL_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-background]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-background[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.background+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.background+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The background of the generated images.
+
+Transparency requires an output format that supports it, so `png` or `webp`.
+
+*Allowable values:* `++[++transparent, opaque, auto++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_BACKGROUND+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_BACKGROUND+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`transparent`, `opaque`, `auto`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-moderation]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-moderation[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.moderation+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.moderation+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+How strictly the generated images are filtered, `low` being the least restrictive.
+
+*Allowable values:* `++[++low, auto++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_MODERATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_MODERATION+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`low`, `auto`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-output-compression]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-output-compression[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.output-compression+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.output-compression+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The compression level of the generated images, from `0` to `100`.
+
+Only the `jpeg` and `webp` output formats accept it.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_OUTPUT_COMPRESSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_OUTPUT_COMPRESSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-output-format]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-output-format[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.output-format+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.output-format+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The file format of the generated images.
+
+*Allowable values:* `++[++png, jpeg, webp, auto++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_OUTPUT_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_OUTPUT_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`png`, `jpeg`, `webp`, `auto`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-quality]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-quality[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.quality+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.quality+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The quality of the generated images.
+
+*Allowable values:* `++[++auto, high, medium, low, hd, standard++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_QUALITY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_QUALITY+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`auto`, `high`, `medium`, `low`, `hd`, `standard`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-response-format]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-response-format[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.response-format+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.response-format+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+How the generated images are returned, as a link with `url` or as Base64 data with `b64_json`.
+
+Only the models that support it accept this value.
+
+*Allowable values:* `++[++url, b64_json++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_RESPONSE_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_RESPONSE_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`url`, `b64-json`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-size]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-size[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.size+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.size+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The dimensions of the generated images, for example `1024x1024`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-style]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-style[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.style+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.style+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The visual style of the generated images.
+
+*Allowable values:* `++[++vivid, natural++]++`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_STYLE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_STYLE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`vivid`, `natural`
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-user]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-user[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.user+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.user+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+A stable identifier of the end user issuing the request, used by the backing provider to detect and prevent abuse.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_USER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-log-requests]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-log-requests[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.log-requests+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.log-requests+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether image model requests should be logged.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_LOG_REQUESTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_LOG_REQUESTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-log-responses]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-log-responses[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.log-responses+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.log-responses+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether image model responses should be logged.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_LOG_RESPONSES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_LOG_RESPONSES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a| [[quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-log-requests-curl]] [.property-path]##link:#quarkus-langchain4j-watsonx_quarkus-langchain4j-watsonx-model-name-gateway-image-model-log-requests-curl[`+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.log-requests-curl+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.watsonx."model-name".gateway-image-model.log-requests-curl+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether the watsonx.ai client should log requests as cURL commands.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_LOG_REQUESTS_CURL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_WATSONX__MODEL_NAME__GATEWAY_IMAGE_MODEL_LOG_REQUESTS_CURL+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean

--- a/docs/modules/ROOT/pages/watsonx-chat-model.adoc
+++ b/docs/modules/ROOT/pages/watsonx-chat-model.adoc
@@ -239,6 +239,61 @@ quarkus.langchain4j.watsonx.chat-model.strict-json-schema=false
 
 NOTE: `response-format` and `strict-json-schema` are available on the three chat backends (`chat-model`, `deployment-chat-model` and `gateway-chat-model`), and the strict mode is the default on all of them.
 
+=== Inline moderation
+
+IMPORTANT: Inline moderation is only available on the foundation backend (`chat-model`). Neither `deployment-chat-model` nor `gateway-chat-model` support it; configuring `moderations` on either of them fails at startup with `UnsupportedFeatureException`. For a standalone moderation call outside of chat, see <<_moderation_model,Moderation Model>>.
+
+While a chat request is served, watsonx.ai can run the same detectors described in <<_moderation_model,Moderation Model>> against the input and/or the output text, without a second network call. Each detector is opt-in: it is only sent to watsonx.ai when at least one of its `input`/`output` properties is set.
+
+[source,properties]
+----
+quarkus.langchain4j.watsonx.base-url=${BASE_URL}
+quarkus.langchain4j.watsonx.api-key=${API_KEY}
+quarkus.langchain4j.watsonx.project-id=${PROJECT_ID}
+
+# Detect HAP in both the input and the output, masking the flagged text
+quarkus.langchain4j.watsonx.chat-model.moderations.hap.input=0.8
+quarkus.langchain4j.watsonx.chat-model.moderations.hap.output=0.8
+quarkus.langchain4j.watsonx.chat-model.moderations.hap.mask=true
+
+# Detect PII in the input only
+quarkus.langchain4j.watsonx.chat-model.moderations.pii.input=true
+
+# Granite Guardian only ever looks at the input
+quarkus.langchain4j.watsonx.chat-model.moderations.granite-guardian.input=0.85
+----
+
+If watsonx.ai blocks the input before it reaches the model, `chat()` throws a `ContentFilteredException` instead of returning a response. Otherwise, any detection made on the input or the output is reported on the response metadata:
+
+[source,java]
+----
+ChatResponse response = chatModel.chat(...);
+var metadata = (WatsonxChatResponseMetadata) response.metadata();
+
+metadata.moderations(); // flagged spans grouped by detector (hap, pii, granite_guardian)
+metadata.detections();  // the same detections grouped by input/output instead
+----
+
+==== Overriding moderation per request
+
+The detectors can also be set on a single request through `WatsonxChatRequestParameters`, overriding whatever is configured under `chat-model.moderations`:
+
+[source,java]
+----
+import com.ibm.watsonx.ai.chat.ChatModeration;
+
+ChatRequest request = ChatRequest.builder()
+    .messages(UserMessage.from("My phone number is 555-123-4567"))
+    .parameters(WatsonxChatRequestParameters.builder()
+        .moderations(ChatModeration.builder()
+            .pii(p -> p.input(true).mask(true))
+            .build())
+        .build())
+    .build();
+
+ChatResponse response = chatModel.chat(request);
+----
+
 === Injection
 
 [source,java]
@@ -484,91 +539,7 @@ var scores = scoringModel.scoreAll(
 System.out.println(scores); // list of relevance scores
 ----
 
-== Moderation Model
-
-IBM watsonx.ai provides moderation capabilities through multiple detectors that can identify unsafe, sensitive, or policy-violating content.
-Quarkus integrates the LangChain4j `WatsonxModerationModel`, exposing each detector type as a dedicated configuration group.
-
-Supported detector types include:
-
-* *PII* - Detects Personally Identifiable Information
-* *HAP* - Detects hate, abuse, or profanity
-* *Granite Guardian* - Detects harmful or risky content
-
-Each detector can be enabled individually.
-
-=== Configuration
-
-Enable detectors in `application.properties` using their dedicated flags:
-
-[source,properties]
-----
-# Base Watsonx configuration
-quarkus.langchain4j.watsonx.base-url=${BASE_URL}
-quarkus.langchain4j.watsonx.api-key=${API_KEY}
-quarkus.langchain4j.watsonx.project-id=${PROJECT_ID}
-
-# Enable specific moderation detectors
-quarkus.langchain4j.watsonx.moderation-model.hap.enabled=true
-quarkus.langchain4j.watsonx.moderation-model.pii.enabled=true
-quarkus.langchain4j.watsonx.moderation-model.granite-guardian.enabled=true
-----
-
-Each detector configuration group may also expose additional settings depending on its capabilities.
-If an score model is configured, Quarkus will automatically create and register
-a `ModerationModel` bean.
-
-=== Injection
-
-[source,java]
-----
-@Inject
-ModerationModel moderationModel;
-----
-
-=== Usage
-
-[source,java]
-----
-var response = moderationModel.moderate("Some text to analyze");
-
-boolean flagged = response.content().flagged();
-Map<String, Object> metadata = response.metadata();
-
-System.out.println("Flagged? " + flagged);
-System.out.println("Metadata: " + metadata);
-----
-
-=== Metadata
-
-A moderation response includes metadata describing the detection:
-
-|===
-| Key | Description
-
-| detection
-| The assigned label for the detected content
-
-| detection_type
-| Detector that triggered the flag
-
-| start
-| Start index of the detected segment
-
-| end
-| End index of the detected segment
-
-| score
-| Confidence score
-|===
-
-Example:
-
-[source,java]
-----
-System.out.println(metadata.get("detection_type"));
-System.out.println(metadata.get("score"));
-----
+For the standalone moderation model (PII, HAP, Granite Guardian detectors), see xref:watsonx-moderation-model.adoc[IBM watsonx.ai Moderation Model].
 
 == Text Extraction
 

--- a/docs/modules/ROOT/pages/watsonx-embedding-model.adoc
+++ b/docs/modules/ROOT/pages/watsonx-embedding-model.adoc
@@ -80,6 +80,37 @@ var embeddings = embeddingModel.embedAll(
 );
 ----
 
+=== Using the Model Gateway
+
+The link:https://cloud.ibm.com/apidocs/watsonx-ai#model-gateway[watsonx.ai Model Gateway] exposes an OpenAI-compatible embeddings endpoint that can route requests to models hosted by multiple providers (for example OpenAI, Mistral, or any third-party provider registered in the gateway) behind a single watsonx.ai entry point. To use it, set `gateway-embedding-model.model-name`. Neither `project-id` nor `space-id` is required, and `embedding-model.model-name` is not used.
+
+[source,properties]
+----
+quarkus.langchain4j.watsonx.base-url=${BASE_URL}
+quarkus.langchain4j.watsonx.api-key=${API_KEY}
+
+# Route the requests through the Model Gateway
+quarkus.langchain4j.watsonx.gateway-embedding-model.model-name=openai/text-embedding-3-small
+----
+
+IMPORTANT: The gateway must be configured by an administrator before use. The value of `model-name` must be a model identifier that is already registered in the gateway, which means the alias defined by the administrator or, when there is no alias, the provider-side model identifier. The link:https://cloud.ibm.com/apidocs/watsonx-ai#gateway-models-list[model catalog of the gateway] returns the identifiers that can be used.
+
+Besides `model-name`, the gateway supports a set of provider-agnostic options:
+
+[source,properties]
+----
+# Number of dimensions of the returned embeddings, only honored by the models that support it
+quarkus.langchain4j.watsonx.gateway-embedding-model.dimensions=512
+
+# Wire format used to return the embeddings: float or base64 (decoded into a vector for you)
+quarkus.langchain4j.watsonx.gateway-embedding-model.encoding-format=float
+
+# Stable identifier of the end user, used by the provider to detect abuse
+quarkus.langchain4j.watsonx.gateway-embedding-model.user=user-1234
+----
+
+`embed` and `embedAll` are unchanged: the same `EmbeddingModel` bean is used regardless of which backend is configured.
+
 == Scoring Model
 
 IBM watsonx.ai provides scoring (reranking) models that evaluate the relevance between a query and a piece of text.

--- a/docs/modules/ROOT/pages/watsonx-image-model.adoc
+++ b/docs/modules/ROOT/pages/watsonx-image-model.adoc
@@ -1,0 +1,125 @@
+= IBM watsonx.ai Image Models
+
+include::./includes/attributes.adoc[]
+include::./includes/customization.adoc[]
+
+IBM watsonx.ai does not host image models directly, but its link:https://cloud.ibm.com/apidocs/watsonx-ai#model-gateway[Model Gateway] can route image generation requests to models hosted by multiple providers (for example OpenAI) behind a single watsonx.ai entry point.
+
+IMPORTANT: This extension supports IBM watsonx as a service on IBM Cloud only.
+
+== Prerequisites
+
+include::./watsonx-chat-model.adoc[tags=watsonx-prerequisites]
+
+NOTE: The image model only uses the Model Gateway, so neither `project-id` nor `space-id` is required.
+
+== Dependency
+
+Add the following dependency to your project:
+
+:provider-artifact: quarkus-langchain4j-watsonx
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[]
+
+If no other image model extension is installed, xref:ai-services.adoc[AI Services] will automatically use this provider.
+
+== Configuration
+
+Configure the image model by setting `gateway-image-model.model-name`:
+
+[source,properties]
+----
+quarkus.langchain4j.watsonx.base-url=${BASE_URL}
+quarkus.langchain4j.watsonx.api-key=${API_KEY}
+
+quarkus.langchain4j.watsonx.gateway-image-model.model-name=openai/gpt-image-1
+----
+
+If a `gateway-image-model.model-name` is configured, Quarkus automatically registers an `ImageModel` bean.
+
+IMPORTANT: The gateway must be configured by an administrator before use. The value of `model-name` must be a model identifier that is already registered in the gateway, which means the alias defined by the administrator or, when there is no alias, the provider-side model identifier. The link:https://cloud.ibm.com/apidocs/watsonx-ai#gateway-models-list[model catalog of the gateway] returns the identifiers that can be used.
+
+Besides `model-name`, the gateway supports a set of provider-agnostic options:
+
+[source,properties]
+----
+# Background of the generated images: transparent, opaque or auto
+quarkus.langchain4j.watsonx.gateway-image-model.background=opaque
+
+# How strictly the generated images are filtered: low or auto
+quarkus.langchain4j.watsonx.gateway-image-model.moderation=low
+
+# Compression level (0-100), only honored by the jpeg and webp output formats
+quarkus.langchain4j.watsonx.gateway-image-model.output-compression=80
+
+# File format of the generated images: png, jpeg, webp or auto
+quarkus.langchain4j.watsonx.gateway-image-model.output-format=png
+
+# Quality of the generated images: auto, high, medium, low, hd or standard
+quarkus.langchain4j.watsonx.gateway-image-model.quality=high
+
+# How the generated images are returned, only honored by the models that support it: url or b64_json
+quarkus.langchain4j.watsonx.gateway-image-model.response-format=b64_json
+
+# Dimensions of the generated images
+quarkus.langchain4j.watsonx.gateway-image-model.size=1024x1024
+
+# Visual style of the generated images: vivid or natural
+quarkus.langchain4j.watsonx.gateway-image-model.style=vivid
+
+# Stable identifier of the end user, used by the provider to detect abuse
+quarkus.langchain4j.watsonx.gateway-image-model.user=user-1234
+----
+
+NOTE: Not every option is supported by every model; a model ignores the options it does not support.
+
+include::includes/quarkus-langchain4j-watsonx.adoc[leveloffset=+1,opts=optional]
+
+== Using Image Models
+
+Once the extension is configured, you can access image generation capabilities either via an AI service interface or directly through the `ImageModel` API.
+
+For example, to declare an AI service that generates images:
+
+[source,java]
+----
+import dev.langchain4j.data.image.Image;
+import dev.langchain4j.service.UserMessage;
+import io.quarkiverse.langchain4j.RegisterAiService;
+
+@RegisterAiService
+public interface MyImageService {
+
+    @UserMessage("Generate an image of a futuristic city at sunset")
+    Image generateFuturisticCity();
+}
+----
+
+To use the model programmatically:
+
+[source,java]
+----
+import dev.langchain4j.model.image.ImageModel;
+import dev.langchain4j.data.image.Image;
+import jakarta.inject.Inject;
+
+@Inject
+ImageModel imageModel;
+
+// ...
+Image image = imageModel.generate("A majestic dragon flying over a medieval castle").content();
+----
+
+`Image` exposes `base64Data()` or `url()` depending on `response-format`, plus `mimeType()` and `revisedPrompt()` when the provider returns one.
+
+To generate more than one image at a time, pass the desired count:
+
+[source,java]
+----
+var images = imageModel.generate("A majestic dragon flying over a medieval castle", 3).content();
+----
+
+== Additional Resources
+
+[.lead]
+* Learn more about xref:models.adoc#_image_models[Image Models]
+* Explore xref:ai-services.adoc[AI Services] for orchestrating multiple models

--- a/docs/modules/ROOT/pages/watsonx-moderation-model.adoc
+++ b/docs/modules/ROOT/pages/watsonx-moderation-model.adoc
@@ -1,0 +1,100 @@
+= IBM watsonx.ai Moderation Model
+
+include::./includes/attributes.adoc[]
+include::./includes/customization.adoc[]
+
+IBM watsonx.ai provides moderation capabilities through multiple detectors that can identify unsafe, sensitive, or policy-violating content.
+Quarkus integrates the LangChain4j `WatsonxModerationModel`, exposing each detector type as a dedicated configuration group.
+
+Supported detector types include:
+
+* *PII* - Detects Personally Identifiable Information
+* *HAP* - Detects hate, abuse, or profanity
+* *Granite Guardian* - Detects harmful or risky content
+
+Each detector can be enabled individually.
+
+== Prerequisites
+
+include::./watsonx-chat-model.adoc[tag=watsonx-prerequisites]
+
+== Dependency
+
+Add the following dependency to your project:
+
+:provider-artifact: quarkus-langchain4j-watsonx
+include::./includes/quarkus-langchain4j-maven-dependencies.adoc[]
+
+== Configuration
+
+Enable detectors in `application.properties` using their dedicated flags:
+
+[source,properties]
+----
+# Base Watsonx configuration
+quarkus.langchain4j.watsonx.base-url=${BASE_URL}
+quarkus.langchain4j.watsonx.api-key=${API_KEY}
+quarkus.langchain4j.watsonx.project-id=${PROJECT_ID}
+
+# Enable specific moderation detectors
+quarkus.langchain4j.watsonx.moderation-model.hap.enabled=true
+quarkus.langchain4j.watsonx.moderation-model.pii.enabled=true
+quarkus.langchain4j.watsonx.moderation-model.granite-guardian.enabled=true
+----
+
+Each detector configuration group may also expose additional settings depending on its capabilities.
+If a moderation model is configured, Quarkus will automatically create and register a `ModerationModel` bean.
+
+== Injection
+
+[source,java]
+----
+@Inject
+ModerationModel moderationModel;
+----
+
+== Usage
+
+[source,java]
+----
+var response = moderationModel.moderate("Some text to analyze");
+
+boolean flagged = response.content().flagged();
+Map<String, Object> metadata = response.metadata();
+
+System.out.println("Flagged? " + flagged);
+System.out.println("Metadata: " + metadata);
+----
+
+== Metadata
+
+A moderation response includes metadata describing the detection:
+
+|===
+| Key | Description
+
+| detection
+| The assigned label for the detected content
+
+| detection_type
+| Detector that triggered the flag
+
+| start
+| Start index of the detected segment
+
+| end
+| End index of the detected segment
+
+| score
+| Confidence score
+|===
+
+Example:
+
+[source,java]
+----
+System.out.println(metadata.get("detection_type"));
+System.out.println(metadata.get("score"));
+----
+
+NOTE: For inline moderation within a chat request (without a second network call), see the xref:watsonx-chat-model.adoc#_inline_moderation[Inline moderation] section of the IBM watsonx.ai Chat Model page.

--- a/docs/src/main/resources/application.properties
+++ b/docs/src/main/resources/application.properties
@@ -2,6 +2,7 @@
 quarkus.langchain4j.chat-model.provider=openai
 quarkus.langchain4j.chroma.url=dummy
 quarkus.langchain4j.embedding-model.provider=openai
+quarkus.langchain4j.image-model.provider=openai
 quarkus.langchain4j.infinispan.dimension=180
 quarkus.langchain4j.openai.api-key=dummy-key
 quarkus.langchain4j.pgvector.dimension=180

--- a/model-providers/watsonx/deployment/src/main/java/io/quarkiverse/langchain4j/watsonx/deployment/GatewayImageModelBuildConfig.java
+++ b/model-providers/watsonx/deployment/src/main/java/io/quarkiverse/langchain4j/watsonx/deployment/GatewayImageModelBuildConfig.java
@@ -1,0 +1,16 @@
+package io.quarkiverse.langchain4j.watsonx.deployment;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigDocDefault;
+import io.quarkus.runtime.annotations.ConfigGroup;
+
+@ConfigGroup
+public interface GatewayImageModelBuildConfig {
+
+    /**
+     * Whether the gateway image model should be enabled.
+     */
+    @ConfigDocDefault("true")
+    Optional<Boolean> enabled();
+}

--- a/model-providers/watsonx/deployment/src/main/java/io/quarkiverse/langchain4j/watsonx/deployment/LangChain4jWatsonBuildConfig.java
+++ b/model-providers/watsonx/deployment/src/main/java/io/quarkiverse/langchain4j/watsonx/deployment/LangChain4jWatsonBuildConfig.java
@@ -20,6 +20,11 @@ public interface LangChain4jWatsonBuildConfig {
     EmbeddingModelBuildConfig embeddingModel();
 
     /**
+     * Gateway image model related settings.
+     */
+    GatewayImageModelBuildConfig gatewayImageModel();
+
+    /**
      * Scoring model related settings.
      */
     ScoringModelBuildConfig scoringModel();

--- a/model-providers/watsonx/deployment/src/main/java/io/quarkiverse/langchain4j/watsonx/deployment/WatsonxProcessor.java
+++ b/model-providers/watsonx/deployment/src/main/java/io/quarkiverse/langchain4j/watsonx/deployment/WatsonxProcessor.java
@@ -2,6 +2,7 @@ package io.quarkiverse.langchain4j.watsonx.deployment;
 
 import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.CHAT_MODEL;
 import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.EMBEDDING_MODEL;
+import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.IMAGE_MODEL;
 import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.MODERATION_MODEL;
 import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.SCORING_MODEL;
 import static io.quarkiverse.langchain4j.deployment.LangChain4jDotNames.STREAMING_CHAT_MODEL;
@@ -39,6 +40,8 @@ import dev.langchain4j.model.watsonx.WatsonxDeploymentChatModel;
 import dev.langchain4j.model.watsonx.WatsonxDeploymentStreamingChatModel;
 import dev.langchain4j.model.watsonx.WatsonxEmbeddingModel;
 import dev.langchain4j.model.watsonx.WatsonxGatewayChatModel;
+import dev.langchain4j.model.watsonx.WatsonxGatewayEmbeddingModel;
+import dev.langchain4j.model.watsonx.WatsonxGatewayImageModel;
 import dev.langchain4j.model.watsonx.WatsonxGatewayStreamingChatModel;
 import dev.langchain4j.model.watsonx.WatsonxModerationModel;
 import dev.langchain4j.model.watsonx.WatsonxScoringModel;
@@ -48,10 +51,12 @@ import io.quarkiverse.langchain4j.deployment.DotNames;
 import io.quarkiverse.langchain4j.deployment.LangChain4jDotNames;
 import io.quarkiverse.langchain4j.deployment.items.ChatModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.EmbeddingModelProviderCandidateBuildItem;
+import io.quarkiverse.langchain4j.deployment.items.ImageModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.ModerationModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.ScoringModelProviderCandidateBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedChatModelProviderBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedEmbeddingModelCandidateBuildItem;
+import io.quarkiverse.langchain4j.deployment.items.SelectedImageModelProviderBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedModerationModelProviderBuildItem;
 import io.quarkiverse.langchain4j.deployment.items.SelectedScoringModelProviderBuildItem;
 import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
@@ -74,6 +79,7 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.resteasy.reactive.spi.MessageBodyReaderOverrideBuildItem;
 import io.quarkus.resteasy.reactive.spi.MessageBodyWriterOverrideBuildItem;
 import io.smallrye.config.Priorities;
@@ -97,6 +103,10 @@ public class WatsonxProcessor {
             .createSimple(WatsonxGatewayStreamingChatModel.Builder.class);
     private static final DotName WATSONX_EMBEDDING_MODEL_BUILDER = DotName
             .createSimple(WatsonxEmbeddingModel.Builder.class);
+    private static final DotName WATSONX_GATEWAY_EMBEDDING_MODEL_BUILDER = DotName
+            .createSimple(WatsonxGatewayEmbeddingModel.Builder.class);
+    private static final DotName WATSONX_GATEWAY_IMAGE_MODEL_BUILDER = DotName
+            .createSimple(WatsonxGatewayImageModel.Builder.class);
     private static final DotName WATSONX_SCORING_MODEL_BUILDER = DotName
             .createSimple(WatsonxScoringModel.Builder.class);
     private static final DotName WATSONX_MODERATION_MODEL_BUILDER = DotName
@@ -125,6 +135,7 @@ public class WatsonxProcessor {
     @BuildStep
     public void providerCandidates(BuildProducer<ChatModelProviderCandidateBuildItem> chatProducer,
             BuildProducer<EmbeddingModelProviderCandidateBuildItem> embeddingProducer,
+            BuildProducer<ImageModelProviderCandidateBuildItem> imageProducer,
             BuildProducer<ScoringModelProviderCandidateBuildItem> scoringProducer,
             BuildProducer<ModerationModelProviderCandidateBuildItem> moderationProducer,
             LangChain4jWatsonBuildConfig config) {
@@ -135,6 +146,10 @@ public class WatsonxProcessor {
 
         if (config.embeddingModel().enabled().isEmpty() || config.embeddingModel().enabled().get()) {
             embeddingProducer.produce(new EmbeddingModelProviderCandidateBuildItem(PROVIDER));
+        }
+
+        if (config.gatewayImageModel().enabled().isEmpty() || config.gatewayImageModel().enabled().get()) {
+            imageProducer.produce(new ImageModelProviderCandidateBuildItem(PROVIDER));
         }
 
         if (config.scoringModel().enabled().isEmpty() || config.scoringModel().enabled().get()) {
@@ -280,6 +295,7 @@ public class WatsonxProcessor {
     void generateBeans(WatsonxRecorder recorder,
             List<SelectedChatModelProviderBuildItem> selectedChatItem,
             List<SelectedEmbeddingModelCandidateBuildItem> selectedEmbedding,
+            List<SelectedImageModelProviderBuildItem> selectedImage,
             List<SelectedScoringModelProviderBuildItem> selectedScoring,
             List<SelectedModerationModelProviderBuildItem> selectedModeration,
             List<TextExtractionClassBuildItem> selectedTextExtraction,
@@ -493,7 +509,30 @@ public class WatsonxProcessor {
                                 new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
                                         new Type[] { ClassType.create(WATSONX_EMBEDDING_MODEL_BUILDER) }, null) },
                                 null), ANY)
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(WATSONX_GATEWAY_EMBEDDING_MODEL_BUILDER) }, null) },
+                                null), ANY)
                         .createWith(recorder.embeddingModel(configName));
+                addQualifierIfNecessary(builder, configName);
+                beanProducer.produce(builder.done());
+            }
+        }
+
+        for (var selected : selectedImage) {
+            if (PROVIDER.equals(selected.getProvider())) {
+                String configName = selected.getConfigName();
+                var builder = SyntheticBeanBuildItem
+                        .configure(IMAGE_MODEL)
+                        .setRuntimeInit()
+                        .defaultBean()
+                        .unremovable()
+                        .scope(ApplicationScoped.class)
+                        .addInjectionPoint(ParameterizedType.create(DotNames.CDI_INSTANCE,
+                                new Type[] { ParameterizedType.create(DotNames.MODEL_BUILDER_CUSTOMIZER,
+                                        new Type[] { ClassType.create(WATSONX_GATEWAY_IMAGE_MODEL_BUILDER) }, null) },
+                                null), ANY)
+                        .createWith(recorder.imageModel(configName));
                 addQualifierIfNecessary(builder, configName);
                 beanProducer.produce(builder.done());
             }
@@ -535,6 +574,66 @@ public class WatsonxProcessor {
                 beanProducer.produce(builder.done());
             }
         }
+    }
+
+    @BuildStep
+    void registerServiceProviders(BuildProducer<ServiceProviderBuildItem> serviceProvider) {
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.core.auth.ibmcloud.IBMCloudRestClient$IBMCloudRestClientBuilderFactory"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.core.auth.cp4d.CP4DRestClient$CP4DLegacyRestClientBuilderFactory"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.core.auth.cp4d.CP4DRestClient$CP4DIAMRestClientBuilderFactory"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.core.auth.cp4d.CP4DRestClient$CP4DZenRestClientBuilderFactory"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.chat.ChatRestClient$ChatRestClientBuilderFactory"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.textgeneration.TextGenerationRestClient$TextGenerationRestClientBuilderFactory"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.embedding.EmbeddingRestClient$EmbeddingRestClientBuilderFactory"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.deployment.DeploymentRestClient$DeploymentRestClientBuilderFactory"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.detection.DetectionRestClient$DetectionRestClientBuilderFactory"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.rerank.RerankRestClient$RerankRestClientBuilderFactory"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.tokenization.TokenizationRestClient$TokenizationRestClientBuilderFactory"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.timeseries.TimeSeriesRestClient$TimeSeriesRestClientBuilderFactory"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.foundationmodel.FoundationModelRestClient$FoundationModelRestClientBuilderFactory"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.batch.BatchRestClient$BatchRestClientBuilderFactory"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.file.FileRestClient$FileRestClientBuilderFactory"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.tool.ToolRestClient$ToolRestClientBuilderFactory"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatRestClient$ModelGatewayChatRestClientBuilderFactory"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.gateway.embedding.ModelGatewayEmbeddingRestClient$ModelGatewayEmbeddingRestClientBuilderFactory"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.gateway.image.ModelGatewayImageRestClient$ModelGatewayImageRestClientBuilderFactory"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.gateway.catalog.ModelGatewayCatalogRestClient$ModelGatewayCatalogRestClientBuilderFactory"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.textprocessing.textextraction.TextExtractionRestClient$TextExtractionRestClientBuilderFactory"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.textprocessing.textclassification.TextClassificationRestClient$TextClassificationRestClientBuilderFactory"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.textprocessing.schema.create.CreateSchemaRestClient$CreateSchemaRestClientBuilderFactory"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.textprocessing.schema.improve.ImproveSchemaRestClient$ImproveSchemaRestClientBuilderFactory"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.textprocessing.schema.merge.MergeSchemaRestClient$MergeSchemaRestClientBuilderFactory"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.textprocessing.schema.cluster.ClusterSchemaRestClient$ClusterSchemaRestClientBuilderFactory"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.ibm.watsonx.ai.core.spi.json.JsonProvider"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(
+                "com.fasterxml.jackson.databind.Module"));
     }
 
     private void addQualifierIfNecessary(SyntheticBeanBuildItem.ExtendedBeanConfigurator builder, String configName) {

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ChatModerationTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ChatModerationTest.java
@@ -1,0 +1,220 @@
+package io.quarkiverse.langchain4j.watsonx.deployment;
+
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.API_KEY;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.DEFAULT_CHAT_MODEL;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.DEFAULT_TIME_LIMIT;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.PROJECT_ID;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_IAM_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_CHAT_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_SERVER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Date;
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.ibm.watsonx.ai.chat.ChatModeration;
+import com.ibm.watsonx.ai.chat.model.ChatMessage;
+import com.ibm.watsonx.ai.chat.model.SystemMessage;
+import com.ibm.watsonx.ai.chat.model.TextChatRequest;
+import com.ibm.watsonx.ai.chat.model.UserMessage;
+
+import dev.langchain4j.exception.ContentFilteredException;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.watsonx.WatsonxChatResponseMetadata;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ChatModerationTest extends WireMockAbstract {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", URL_WATSONX_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", URL_IAM_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", PROJECT_ID)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.moderations.hap.input", "0.8")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.moderations.hap.output", "0.9")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.moderations.hap.mask", "true")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.moderations.pii.input", "true")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.moderations.pii.output", "true")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.moderations.pii.mask", "false")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.moderations.granite-guardian.input", "0.85")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.chat-model.moderations.granite-guardian.mask", "true")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
+
+    @Override
+    void handlerBeforeEach() {
+        mockIAMBuilder(200)
+                .response("my_super_token", new Date())
+                .build();
+    }
+
+    @Inject
+    ChatModel chatModel;
+
+    @Test
+    void check_config() {
+        var moderations = langchain4jWatsonConfig.defaultConfig().chatModel().moderations().orElseThrow();
+
+        assertEquals(0.8, moderations.hap().orElseThrow().input().getAsDouble());
+        assertEquals(0.9, moderations.hap().orElseThrow().output().getAsDouble());
+        assertTrue(moderations.hap().orElseThrow().mask().orElseThrow());
+
+        assertTrue(moderations.pii().orElseThrow().input().orElseThrow());
+        assertTrue(moderations.pii().orElseThrow().output().orElseThrow());
+        assertFalse(moderations.pii().orElseThrow().mask().orElseThrow());
+
+        assertEquals(0.85, moderations.graniteGuardian().orElseThrow().input().getAsDouble());
+        assertTrue(moderations.graniteGuardian().orElseThrow().mask().orElseThrow());
+    }
+
+    @Test
+    void chat_sends_every_detector_in_the_moderations_payload() throws Exception {
+
+        var moderations = ChatModeration.builder()
+                .hap(h -> h.input(0.8f).output(0.9f).mask(true))
+                .pii(p -> p.input(true).output(true).mask(false))
+                .graniteGuardian(g -> g.input(0.85f).mask(true))
+                .build();
+
+        var messages = List.<ChatMessage> of(
+                SystemMessage.of("SystemMessage"),
+                UserMessage.text("UserMessage"));
+
+        var body = TextChatRequest.builder()
+                .modelId(DEFAULT_CHAT_MODEL)
+                .projectId(PROJECT_ID)
+                .messages(messages)
+                .maxCompletionTokens(1024)
+                .temperature(1.0)
+                .timeLimit(DEFAULT_TIME_LIMIT.toMillis())
+                .moderations(moderations)
+                .build();
+
+        mockWatsonxBuilder(URL_WATSONX_CHAT_API, 200)
+                .body(mapper.writeValueAsString(body))
+                .response(WireMockUtil.RESPONSE_WATSONX_CHAT_API)
+                .build();
+
+        var response = chatModel.chat(
+                dev.langchain4j.data.message.SystemMessage.from("SystemMessage"),
+                dev.langchain4j.data.message.UserMessage.from("UserMessage"));
+
+        assertEquals("AI Response", response.aiMessage().text());
+    }
+
+    @Test
+    void chat_response_exposes_moderations_and_detections_metadata() throws Exception {
+
+        var response = """
+                {
+                    "id": "cmpl-15475d0dea9b4429a55843c77997f8a9",
+                    "model_id": "mistralai/mistral-large",
+                    "created": 1689958352,
+                    "created_at": "2023-07-21T16:52:32.190Z",
+                    "choices": [{
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "AI Response"
+                        },
+                        "finish_reason": "stop"
+                    }],
+                    "usage": {
+                        "completion_tokens": 47,
+                        "prompt_tokens": 59,
+                        "total_tokens": 106
+                    },
+                    "moderations": {
+                        "pii": [
+                            {
+                                "score": 0.8,
+                                "input": false,
+                                "position": {"start": 7, "end": 19},
+                                "entity": "PhoneNumber",
+                                "word": "357-286-5321"
+                            }
+                        ]
+                    },
+                    "detections": {
+                        "output": [
+                            {
+                                "choice_index": 0,
+                                "results": [{
+                                    "detector_id": "en_syntax_rbr_pii",
+                                    "detection_type": "pii",
+                                    "detection": "PhoneNumber",
+                                    "score": 0.8,
+                                    "text": "357-286-5321",
+                                    "start": 7,
+                                    "end": 19
+                                }]
+                            }
+                        ]
+                    }
+                }""";
+
+        mockWatsonxBuilder(URL_WATSONX_CHAT_API, 200)
+                .response(response)
+                .build();
+
+        var chatResponse = chatModel.chat(
+                dev.langchain4j.data.message.SystemMessage.from("SystemMessage"),
+                dev.langchain4j.data.message.UserMessage.from("UserMessage"));
+
+        assertEquals("AI Response", chatResponse.aiMessage().text());
+
+        var metadata = assertInstanceOf(WatsonxChatResponseMetadata.class, chatResponse.metadata());
+
+        assertNotNull(metadata.moderations());
+        var pii = metadata.moderations().get("pii").get(0);
+        assertEquals("PhoneNumber", pii.entity());
+        assertEquals("357-286-5321", pii.word());
+
+        assertNotNull(metadata.detections());
+        assertEquals(1, metadata.detections().get("output").size());
+    }
+
+    @Test
+    void blocked_input_throws_content_filtered_exception() throws Exception {
+
+        var response = """
+                {
+                    "id": "cmpl-blocked",
+                    "model_id": "mistralai/mistral-large",
+                    "created": 1689958352,
+                    "created_at": "2023-07-21T16:52:32.190Z",
+                    "choices": [],
+                    "moderations": {
+                        "pii": [
+                            {
+                                "score": 0.95,
+                                "input": true,
+                                "position": {"start": 0, "end": 12},
+                                "entity": "PhoneNumber",
+                                "word": "555-123-4567"
+                            }
+                        ]
+                    }
+                }""";
+
+        mockWatsonxBuilder(URL_WATSONX_CHAT_API, 200)
+                .response(response)
+                .build();
+
+        assertThrows(ContentFilteredException.class, () -> chatModel.chat(
+                dev.langchain4j.data.message.SystemMessage.from("SystemMessage"),
+                dev.langchain4j.data.message.UserMessage.from("UserMessage")));
+    }
+}

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ChatStreamingCancellationTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/ChatStreamingCancellationTest.java
@@ -1,0 +1,132 @@
+package io.quarkiverse.langchain4j.watsonx.deployment;
+
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.API_KEY;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.PROJECT_ID;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_IAM_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_CHAT_STREAMING_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_SERVER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.PartialResponse;
+import dev.langchain4j.model.chat.response.PartialResponseContext;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ChatStreamingCancellationTest extends WireMockAbstract {
+
+    private static final int EVENTS = 6;
+    private static final String RESPONSE_STREAMING_TOKENS = """
+            id: 1
+            event: message
+            data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model_id":"my_super_model","model":"my_super_model","choices":[{"index":0,"finish_reason":null,"delta":{"role":"assistant","content":"one"}}],"created":1749736055}
+
+            id: 2
+            event: message
+            data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model_id":"my_super_model","model":"my_super_model","choices":[{"index":0,"finish_reason":null,"delta":{"content":"two"}}],"created":1749736055}
+
+            id: 3
+            event: message
+            data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model_id":"my_super_model","model":"my_super_model","choices":[{"index":0,"finish_reason":null,"delta":{"content":"three"}}],"created":1749736055}
+
+            id: 4
+            event: message
+            data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model_id":"my_super_model","model":"my_super_model","choices":[{"index":0,"finish_reason":null,"delta":{"content":"four"}}],"created":1749736055}
+
+            id: 5
+            event: message
+            data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model_id":"my_super_model","model":"my_super_model","choices":[{"index":0,"finish_reason":"stop","delta":{"content":""}}],"created":1749736055}
+
+            id: 6
+            event: message
+            data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model_id":"my_super_model","model":"my_super_model","choices":[],"created":1749736055,"usage":{"completion_tokens":4,"prompt_tokens":10,"total_tokens":14}}
+
+            """;
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", URL_WATSONX_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", URL_IAM_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.project-id", PROJECT_ID)
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
+
+    @Override
+    void handlerBeforeEach() {
+        mockIAMBuilder(200)
+                .response("my_super_token", new Date())
+                .build();
+    }
+
+    @Inject
+    StreamingChatModel streamingChatModel;
+
+    @Test
+    void cancel_stops_the_stream() {
+
+        var streamDuration = Duration.ofSeconds(3);
+
+        mockWatsonxBuilder(URL_WATSONX_CHAT_STREAMING_API, 200)
+                .responseMediaType(MediaType.SERVER_SENT_EVENTS)
+                .response(RESPONSE_STREAMING_TOKENS)
+                .chunkedDribbleDelay(EVENTS, streamDuration)
+                .build();
+
+        var partialResponses = new CopyOnWriteArrayList<String>();
+        var cancelled = new AtomicBoolean(false);
+        var completeResponse = new AtomicReference<ChatResponse>();
+        var error = new AtomicReference<Throwable>();
+
+        streamingChatModel.chat(List.of(UserMessage.from("UserMessage")), new StreamingChatResponseHandler() {
+
+            @Override
+            public void onPartialResponse(PartialResponse partialResponse, PartialResponseContext context) {
+                partialResponses.add(partialResponse.text());
+                context.streamingHandle().cancel();
+                cancelled.set(context.streamingHandle().isCancelled());
+            }
+
+            @Override
+            public void onCompleteResponse(ChatResponse chatResponse) {
+                completeResponse.set(chatResponse);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                error.set(throwable);
+            }
+        });
+
+        await().atMost(Duration.ofMinutes(1))
+                .pollInterval(Duration.ofMillis(100))
+                .until(() -> !partialResponses.isEmpty());
+
+        assertThat(cancelled).isTrue();
+
+        await().pollDelay(streamDuration.plusSeconds(1))
+                .atMost(Duration.ofMinutes(1))
+                .until(() -> true);
+
+        assertThat(partialResponses).hasSize(1);
+        assertThat(completeResponse.get()).isNull();
+        assertThat(error.get()).isNull();
+    }
+}

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/DeploymentChatModelTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/DeploymentChatModelTest.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.Duration;
 import java.util.Date;
@@ -28,14 +29,18 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.ibm.watsonx.ai.chat.ChatModeration;
 import com.ibm.watsonx.ai.chat.model.ChatMessage;
 import com.ibm.watsonx.ai.chat.model.SystemMessage;
 import com.ibm.watsonx.ai.chat.model.TextChatRequest;
 import com.ibm.watsonx.ai.chat.model.UserMessage;
 
+import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.watsonx.WatsonxChatRequestParameters;
 import dev.langchain4j.model.watsonx.WatsonxDeploymentChatModel;
 import dev.langchain4j.model.watsonx.WatsonxDeploymentStreamingChatModel;
 import io.quarkus.arc.ClientProxy;
@@ -122,6 +127,25 @@ public class DeploymentChatModelTest extends WireMockAbstract {
         assertEquals("chatcmpl-5d8c131decbb6978cba5df10267aa3ff", metadata.id());
         assertEquals("meta-llama/llama-4-maverick-17b-128e-instruct-fp8", metadata.modelName());
         assertEquals(41, metadata.tokenUsage().totalTokenCount());
+    }
+
+    @Test
+    void chat_with_moderations_throws_unsupported_feature_exception() {
+
+        var moderations = ChatModeration.builder()
+                .hap(h -> h.input(0.8f))
+                .build();
+
+        var chatRequest = ChatRequest.builder()
+                .messages(
+                        dev.langchain4j.data.message.SystemMessage.from("SystemMessage"),
+                        dev.langchain4j.data.message.UserMessage.from("UserMessage"))
+                .parameters(WatsonxChatRequestParameters.builder()
+                        .moderations(moderations)
+                        .build())
+                .build();
+
+        assertThrows(UnsupportedFeatureException.class, () -> chatModel.chat(chatRequest));
     }
 
     private TextChatRequest defaultRequest() {

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/GatewayEmbeddingModelTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/GatewayEmbeddingModelTest.java
@@ -1,0 +1,124 @@
+package io.quarkiverse.langchain4j.watsonx.deployment;
+
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.API_KEY;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.DEFAULT_GATEWAY_EMBEDDING_MODEL;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.RESPONSE_WATSONX_GATEWAY_EMBEDDING_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_IAM_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_GATEWAY_EMBEDDING_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_SERVER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Date;
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.ibm.watsonx.ai.gateway.embedding.ModelGatewayEmbeddingParameters.EncodingFormat;
+import com.ibm.watsonx.ai.gateway.embedding.ModelGatewayEmbeddingPayload;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.watsonx.WatsonxGatewayEmbeddingModel;
+import io.quarkiverse.langchain4j.ModelName;
+import io.quarkus.arc.ClientProxy;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class GatewayEmbeddingModelTest extends WireMockAbstract {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", URL_WATSONX_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", URL_IAM_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.gateway-embedding-model.model-name",
+                    DEFAULT_GATEWAY_EMBEDDING_MODEL)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"all-properties\".base-url", URL_WATSONX_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"all-properties\".iam.base-url", URL_IAM_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"all-properties\".api-key", API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"all-properties\".gateway-embedding-model.model-name",
+                    DEFAULT_GATEWAY_EMBEDDING_MODEL)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"all-properties\".gateway-embedding-model.dimensions",
+                    "512")
+            .overrideRuntimeConfigKey(
+                    "quarkus.langchain4j.watsonx.\"all-properties\".gateway-embedding-model.encoding-format", "base64")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"all-properties\".gateway-embedding-model.user",
+                    "my-user")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
+
+    @Override
+    void handlerBeforeEach() {
+        mockIAMBuilder(200)
+                .response("my_super_token", new Date())
+                .build();
+    }
+
+    @Inject
+    EmbeddingModel embeddingModel;
+
+    @Inject
+    @ModelName("all-properties")
+    EmbeddingModel allPropertiesEmbeddingModel;
+
+    @Test
+    void check_config() {
+        var gatewayConfig = langchain4jWatsonConfig.defaultConfig().gatewayEmbeddingModel();
+        assertEquals(DEFAULT_GATEWAY_EMBEDDING_MODEL, gatewayConfig.modelName().orElseThrow());
+        assertThat(gatewayConfig.dimensions()).isEmpty();
+        assertThat(gatewayConfig.encodingFormat()).isEmpty();
+        assertThat(gatewayConfig.user()).isEmpty();
+
+        var allProperties = langchain4jWatsonConfig.namedConfig().get("all-properties").gatewayEmbeddingModel();
+        assertEquals(512, allProperties.dimensions().orElseThrow());
+        assertEquals(EncodingFormat.BASE64, allProperties.encodingFormat().orElseThrow());
+        assertEquals("my-user", allProperties.user().orElseThrow());
+    }
+
+    @Test
+    void model_implementations() {
+        assertInstanceOf(WatsonxGatewayEmbeddingModel.class, ClientProxy.unwrap(embeddingModel));
+    }
+
+    @Test
+    void embed() throws Exception {
+
+        var input = "Embedding THIS!";
+        var body = new ModelGatewayEmbeddingPayload(DEFAULT_GATEWAY_EMBEDDING_MODEL, List.of(input), null, null, null);
+
+        mockWatsonxBuilder(URL_WATSONX_GATEWAY_EMBEDDING_API, 200)
+                .body(mapper.writeValueAsString(body))
+                .response(RESPONSE_WATSONX_GATEWAY_EMBEDDING_API)
+                .build();
+
+        Response<Embedding> response = embeddingModel.embed(input);
+        assertNotNull(response);
+        assertNotNull(response.content());
+        assertEquals(List.of(-0.006929283f, -0.005336422f, -0.024047505f), response.content().vectorAsList());
+    }
+
+    @Test
+    void embed_with_all_properties() throws Exception {
+
+        var input = "Embedding THIS!";
+        var body = new ModelGatewayEmbeddingPayload(DEFAULT_GATEWAY_EMBEDDING_MODEL, List.of(input), 512, "base64",
+                "my-user");
+
+        mockWatsonxBuilder(URL_WATSONX_GATEWAY_EMBEDDING_API, 200)
+                .body(mapper.writeValueAsString(body))
+                .response(RESPONSE_WATSONX_GATEWAY_EMBEDDING_API)
+                .build();
+
+        Response<Embedding> response = allPropertiesEmbeddingModel.embed(input);
+        assertNotNull(response);
+        assertNotNull(response.content());
+        assertEquals(List.of(-0.006929283f, -0.005336422f, -0.024047505f), response.content().vectorAsList());
+    }
+}

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/GatewayImageModelTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/GatewayImageModelTest.java
@@ -1,0 +1,229 @@
+package io.quarkiverse.langchain4j.watsonx.deployment;
+
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.API_KEY;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.DEFAULT_GATEWAY_IMAGE_MODEL;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.RESPONSE_WATSONX_GATEWAY_IMAGE_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.RESPONSE_WATSONX_GATEWAY_IMAGE_API_URL;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_IAM_SERVER;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_GATEWAY_IMAGE_API;
+import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.URL_WATSONX_SERVER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.net.URI;
+import java.util.Date;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageGenerationRequest;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.Background;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.Moderation;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.OutputFormat;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.Quality;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.ResponseFormat;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.Style;
+
+import dev.langchain4j.data.image.Image;
+import dev.langchain4j.model.image.ImageModel;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.watsonx.WatsonxGatewayImageModel;
+import io.quarkiverse.langchain4j.ModelName;
+import io.quarkus.arc.ClientProxy;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class GatewayImageModelTest extends WireMockAbstract {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.base-url", URL_WATSONX_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.iam.base-url", URL_IAM_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.api-key", API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.gateway-image-model.model-name",
+                    DEFAULT_GATEWAY_IMAGE_MODEL)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"all-properties\".base-url", URL_WATSONX_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"all-properties\".iam.base-url", URL_IAM_SERVER)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"all-properties\".api-key", API_KEY)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"all-properties\".gateway-image-model.model-name",
+                    DEFAULT_GATEWAY_IMAGE_MODEL)
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"all-properties\".gateway-image-model.background",
+                    "opaque")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"all-properties\".gateway-image-model.moderation",
+                    "low")
+            .overrideRuntimeConfigKey(
+                    "quarkus.langchain4j.watsonx.\"all-properties\".gateway-image-model.output-compression", "80")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"all-properties\".gateway-image-model.output-format",
+                    "png")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"all-properties\".gateway-image-model.quality", "high")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"all-properties\".gateway-image-model.response-format",
+                    "b64-json")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"all-properties\".gateway-image-model.size",
+                    "1024x1024")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"all-properties\".gateway-image-model.style", "vivid")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.watsonx.\"all-properties\".gateway-image-model.user", "my-user")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(WireMockUtil.class));
+
+    @Override
+    void handlerBeforeEach() {
+        mockIAMBuilder(200)
+                .response("my_super_token", new Date())
+                .build();
+    }
+
+    @Inject
+    ImageModel imageModel;
+
+    @Inject
+    @ModelName("all-properties")
+    ImageModel allPropertiesImageModel;
+
+    @Test
+    void check_config() {
+        var gatewayConfig = langchain4jWatsonConfig.defaultConfig().gatewayImageModel();
+        assertEquals(DEFAULT_GATEWAY_IMAGE_MODEL, gatewayConfig.modelName().orElseThrow());
+        assertThat(gatewayConfig.background()).isEmpty();
+        assertThat(gatewayConfig.moderation()).isEmpty();
+        assertThat(gatewayConfig.outputCompression()).isEmpty();
+        assertThat(gatewayConfig.outputFormat()).isEmpty();
+        assertThat(gatewayConfig.quality()).isEmpty();
+        assertThat(gatewayConfig.responseFormat()).isEmpty();
+        assertThat(gatewayConfig.size()).isEmpty();
+        assertThat(gatewayConfig.style()).isEmpty();
+        assertThat(gatewayConfig.user()).isEmpty();
+
+        var allProperties = langchain4jWatsonConfig.namedConfig().get("all-properties").gatewayImageModel();
+        assertEquals(Background.OPAQUE, allProperties.background().orElseThrow());
+        assertEquals(Moderation.LOW, allProperties.moderation().orElseThrow());
+        assertEquals(80, allProperties.outputCompression().orElseThrow());
+        assertEquals(OutputFormat.PNG, allProperties.outputFormat().orElseThrow());
+        assertEquals(Quality.HIGH, allProperties.quality().orElseThrow());
+        assertEquals(ResponseFormat.B64_JSON, allProperties.responseFormat().orElseThrow());
+        assertEquals("1024x1024", allProperties.size().orElseThrow());
+        assertEquals(Style.VIVID, allProperties.style().orElseThrow());
+        assertEquals("my-user", allProperties.user().orElseThrow());
+    }
+
+    @Test
+    void model_implementations() {
+        assertInstanceOf(WatsonxGatewayImageModel.class, ClientProxy.unwrap(imageModel));
+    }
+
+    @Test
+    void generate() throws Exception {
+
+        var prompt = "A futuristic city at sunset";
+        var body = new ModelGatewayImageGenerationRequest(
+                DEFAULT_GATEWAY_IMAGE_MODEL, prompt, null, null, null, null, null, null, null, null, null, null, null);
+
+        mockWatsonxBuilder(URL_WATSONX_GATEWAY_IMAGE_API, 200)
+                .body(mapper.writeValueAsString(body))
+                .response(RESPONSE_WATSONX_GATEWAY_IMAGE_API)
+                .build();
+
+        Response<Image> response = imageModel.generate(prompt);
+        assertNotNull(response);
+        assertEquals("aGVsbG8gd29ybGQ=", response.content().base64Data());
+        assertNull(response.content().url());
+        assertEquals("image/png", response.content().mimeType());
+        assertEquals("A futuristic city at sunset, revised", response.content().revisedPrompt());
+
+        assertEquals(10, response.tokenUsage().inputTokenCount());
+        assertEquals(20, response.tokenUsage().outputTokenCount());
+        assertEquals(30, response.tokenUsage().totalTokenCount());
+    }
+
+    @Test
+    void generate_returns_url_response() throws Exception {
+
+        var prompt = "A futuristic city at sunset";
+        var body = new ModelGatewayImageGenerationRequest(
+                DEFAULT_GATEWAY_IMAGE_MODEL, prompt, null, null, null, null, null, null, null, null, null, null, null);
+
+        mockWatsonxBuilder(URL_WATSONX_GATEWAY_IMAGE_API, 200)
+                .body(mapper.writeValueAsString(body))
+                .response(RESPONSE_WATSONX_GATEWAY_IMAGE_API_URL)
+                .build();
+
+        Response<Image> response = imageModel.generate(prompt);
+        assertNotNull(response);
+        assertNull(response.content().base64Data());
+        assertEquals(URI.create("https://example.com/image.png"), response.content().url());
+        assertEquals("image/png", response.content().mimeType());
+    }
+
+    @Test
+    void generate_with_all_properties() throws Exception {
+
+        var prompt = "A futuristic city at sunset";
+        var body = new ModelGatewayImageGenerationRequest(
+                DEFAULT_GATEWAY_IMAGE_MODEL, prompt, "opaque", "low", null, 80, "png", null, "high", "b64_json",
+                "1024x1024", "vivid", "my-user");
+
+        mockWatsonxBuilder(URL_WATSONX_GATEWAY_IMAGE_API, 200)
+                .body(mapper.writeValueAsString(body))
+                .response(RESPONSE_WATSONX_GATEWAY_IMAGE_API)
+                .build();
+
+        Response<Image> response = allPropertiesImageModel.generate(prompt);
+        assertNotNull(response);
+        assertEquals("aGVsbG8gd29ybGQ=", response.content().base64Data());
+    }
+
+    @Test
+    void generate_multiple_images() throws Exception {
+
+        var prompt = "A futuristic city at sunset";
+        var body = new ModelGatewayImageGenerationRequest(
+                DEFAULT_GATEWAY_IMAGE_MODEL, prompt, null, null, 2, null, null, null, null, null, null, null, null);
+
+        var response = """
+                {
+                    "created": 1689958352,
+                    "background": "opaque",
+                    "output_format": "png",
+                    "quality": "high",
+                    "size": "1024x1024",
+                    "data": [
+                        {"b64_json": "aGVsbG8gd29ybGQ=", "revised_prompt": "Revised 1"},
+                        {"url": "https://example.com/image2.png", "revised_prompt": "Revised 2"}
+                    ],
+                    "usage": {
+                        "input_tokens": 10,
+                        "output_tokens": 40,
+                        "total_tokens": 50,
+                        "input_tokens_details": {
+                            "image_tokens": 0,
+                            "text_tokens": 10
+                        }
+                    }
+                }""";
+
+        mockWatsonxBuilder(URL_WATSONX_GATEWAY_IMAGE_API, 200)
+                .body(mapper.writeValueAsString(body))
+                .response(response)
+                .build();
+
+        Response<java.util.List<Image>> images = imageModel.generate(prompt, 2);
+        assertNotNull(images);
+        assertEquals(2, images.content().size());
+
+        var first = images.content().get(0);
+        assertEquals("aGVsbG8gd29ybGQ=", first.base64Data());
+        assertNull(first.url());
+        assertEquals("Revised 1", first.revisedPrompt());
+
+        var second = images.content().get(1);
+        assertNull(second.base64Data());
+        assertEquals(URI.create("https://example.com/image2.png"), second.url());
+        assertEquals("Revised 2", second.revisedPrompt());
+
+        assertEquals(50, images.tokenUsage().totalTokenCount());
+    }
+}

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/HttpErrorTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/HttpErrorTest.java
@@ -311,8 +311,8 @@ public class HttpErrorTest extends WireMockAbstract {
                 .responseMediaType(MediaType.TEXT_PLAIN)
                 .response("SUPER FATAL ERROR!")
                 .build();
-        RuntimeException ex = assertThrowsExactly(LangChain4jException.class,
-                () -> chatModel.chat("message"));
+
+        LangChain4jException ex = assertThrowsExactly(LangChain4jException.class, () -> chatModel.chat("message"));
         assertTrue(ex.getMessage().contains("SUPER FATAL ERROR!"));
     }
 }

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/QuarkusCustomRestClientTest.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/QuarkusCustomRestClientTest.java
@@ -20,6 +20,8 @@ import com.ibm.watsonx.ai.file.FileService;
 import com.ibm.watsonx.ai.foundationmodel.FoundationModelService;
 import com.ibm.watsonx.ai.gateway.catalog.ModelGatewayCatalogService;
 import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatService;
+import com.ibm.watsonx.ai.gateway.embedding.ModelGatewayEmbeddingService;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageService;
 import com.ibm.watsonx.ai.rerank.RerankService;
 import com.ibm.watsonx.ai.textgeneration.TextGenerationService;
 import com.ibm.watsonx.ai.textprocessing.schema.cluster.ClusterSchemaService;
@@ -47,7 +49,9 @@ import io.quarkiverse.langchain4j.watsonx.runtime.client.impl.QuarkusIBMCloudRes
 import io.quarkiverse.langchain4j.watsonx.runtime.client.impl.QuarkusImproveSchemaRestClient;
 import io.quarkiverse.langchain4j.watsonx.runtime.client.impl.QuarkusMergeSchemaRestClient;
 import io.quarkiverse.langchain4j.watsonx.runtime.client.impl.QuarkusModelGatewayCatalogRestClient;
-import io.quarkiverse.langchain4j.watsonx.runtime.client.impl.QuarkusModelGatewayRestClient;
+import io.quarkiverse.langchain4j.watsonx.runtime.client.impl.QuarkusModelGatewayChatRestClient;
+import io.quarkiverse.langchain4j.watsonx.runtime.client.impl.QuarkusModelGatewayEmbeddingRestClient;
+import io.quarkiverse.langchain4j.watsonx.runtime.client.impl.QuarkusModelGatewayImageRestClient;
 import io.quarkiverse.langchain4j.watsonx.runtime.client.impl.QuarkusRerankRestClient;
 import io.quarkiverse.langchain4j.watsonx.runtime.client.impl.QuarkusTextClassificationRestClient;
 import io.quarkiverse.langchain4j.watsonx.runtime.client.impl.QuarkusTextExtractionRestClient;
@@ -181,7 +185,39 @@ public class QuarkusCustomRestClientTest {
         var clientField = clazz.getDeclaredField("client");
         clientField.setAccessible(true);
         var client = clientField.get(modelGatewayService);
-        assertThat(client).isInstanceOf(QuarkusModelGatewayRestClient.class);
+        assertThat(client).isInstanceOf(QuarkusModelGatewayChatRestClient.class);
+    }
+
+    @Test
+    public void model_gateway_embedding_client() throws Exception {
+
+        ModelGatewayEmbeddingService modelGatewayEmbeddingService = ModelGatewayEmbeddingService.builder()
+                .apiKey("test")
+                .modelId("openai/text-embedding-3-small")
+                .baseUrl("http://localhost")
+                .build();
+
+        Class<ModelGatewayEmbeddingService> clazz = ModelGatewayEmbeddingService.class;
+        var clientField = clazz.getDeclaredField("client");
+        clientField.setAccessible(true);
+        var client = clientField.get(modelGatewayEmbeddingService);
+        assertThat(client).isInstanceOf(QuarkusModelGatewayEmbeddingRestClient.class);
+    }
+
+    @Test
+    public void model_gateway_image_client() throws Exception {
+
+        ModelGatewayImageService modelGatewayImageService = ModelGatewayImageService.builder()
+                .apiKey("test")
+                .modelId("openai/gpt-image-1")
+                .baseUrl("http://localhost")
+                .build();
+
+        Class<ModelGatewayImageService> clazz = ModelGatewayImageService.class;
+        var clientField = clazz.getDeclaredField("client");
+        clientField.setAccessible(true);
+        var client = clientField.get(modelGatewayImageService);
+        assertThat(client).isInstanceOf(QuarkusModelGatewayImageRestClient.class);
     }
 
     @Test

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/WireMockAbstract.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/WireMockAbstract.java
@@ -28,6 +28,7 @@ import static io.quarkiverse.langchain4j.watsonx.deployment.WireMockUtil.VERSION
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
+import java.time.Duration;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
@@ -42,6 +43,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
@@ -168,6 +170,8 @@ public abstract class WireMockAbstract {
         private String responseMediaType = MediaType.APPLICATION_JSON;
         private String response;
         private int status;
+        private Integer dribbleChunks;
+        private Duration dribbleDuration;
 
         protected ServerBuilder(RequestMethod method, String apiURL, int status, String version) {
             this.builder = switch (method.getName()) {
@@ -229,6 +233,24 @@ public abstract class WireMockAbstract {
         public ServerBuilder response(String response) {
             this.response = response;
             return this;
+        }
+
+        public ServerBuilder chunkedDribbleDelay(int chunks, Duration duration) {
+            this.dribbleChunks = chunks;
+            this.dribbleDuration = duration;
+            return this;
+        }
+
+        protected ResponseDefinitionBuilder responseDefinition() {
+            var responseDefinition = aResponse()
+                    .withStatus(status)
+                    .withHeader("Content-Type", responseMediaType)
+                    .withBody(response);
+
+            if (nonNull(dribbleChunks))
+                responseDefinition.withChunkedDribbleDelay(dribbleChunks, (int) dribbleDuration.toMillis());
+
+            return responseDefinition;
         }
 
         public abstract StubMapping build();
@@ -311,10 +333,7 @@ public abstract class WireMockAbstract {
             return watsonxServer.stubFor(
                     super.builder
                             .withHeader("Authorization", equalTo("Bearer %s".formatted(super.token)))
-                            .willReturn(aResponse()
-                                    .withStatus(super.status)
-                                    .withHeader("Content-Type", super.responseMediaType)
-                                    .withBody(super.response)));
+                            .willReturn(super.responseDefinition()));
         }
     }
 

--- a/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/WireMockUtil.java
+++ b/model-providers/watsonx/deployment/src/test/java/io/quarkiverse/langchain4j/watsonx/deployment/WireMockUtil.java
@@ -36,6 +36,8 @@ public class WireMockUtil {
     public static final String URL_WATSONX_GATEWAY_CHAT_API = "/ml/gateway/v1/chat/completions";
     public static final String URL_WATSONX_GATEWAY_MODELS_API = "/ml/gateway/v1/models";
     public static final String URL_WATSONX_GATEWAY_MODEL_API = "/ml/gateway/v1/models/%s";
+    public static final String URL_WATSONX_GATEWAY_EMBEDDING_API = "/ml/gateway/v1/embeddings";
+    public static final String URL_WATSONX_GATEWAY_IMAGE_API = "/ml/gateway/v1/images/generations";
     public static final String URL_WATSONX_DEPLOYMENT_CHAT_API = "/ml/v1/deployments/%s/text/chat";
     public static final String URL_WATSONX_DEPLOYMENT_CHAT_STREAMING_API = "/ml/v1/deployments/%s/text/chat_stream";
 
@@ -59,6 +61,8 @@ public class WireMockUtil {
     public static final String DEFAULT_GATEWAY_CHAT_MODEL = "openai/gpt-4o-mini";
     public static final String DEFAULT_DEPLOYMENT_ID = "my-deployment-id";
     public static final String DEFAULT_EMBEDDING_MODEL = "ibm/granite-embedding-278m-multilingual";
+    public static final String DEFAULT_GATEWAY_EMBEDDING_MODEL = "openai/text-embedding-3-small";
+    public static final String DEFAULT_GATEWAY_IMAGE_MODEL = "openai/gpt-image-1";
     public static final String DEFAULT_SCORING_MODEL = "cross-encoder/ms-marco-minilm-l-12-v2";
     public static final String IAM_200_RESPONSE = """
             {
@@ -208,6 +212,75 @@ public class WireMockUtil {
             event: message
             data: [DONE]
 
+            """;
+    public static String RESPONSE_WATSONX_GATEWAY_EMBEDDING_API = """
+            {
+                "object": "list",
+                "model": "openai/text-embedding-3-small",
+                "data": [
+                  {
+                    "object": "embedding",
+                    "index": 0,
+                    "embedding": [
+                      -0.006929283,
+                      -0.005336422,
+                      -0.024047505
+                    ]
+                  }
+                ],
+                "usage": {
+                    "prompt_tokens": 10,
+                    "total_tokens": 10
+                }
+            }
+            """;
+    public static String RESPONSE_WATSONX_GATEWAY_IMAGE_API = """
+            {
+                "created": 1689958352,
+                "background": "opaque",
+                "output_format": "png",
+                "quality": "high",
+                "size": "1024x1024",
+                "data": [
+                  {
+                    "b64_json": "aGVsbG8gd29ybGQ=",
+                    "revised_prompt": "A futuristic city at sunset, revised"
+                  }
+                ],
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 20,
+                    "total_tokens": 30,
+                    "input_tokens_details": {
+                        "image_tokens": 0,
+                        "text_tokens": 10
+                    }
+                }
+            }
+            """;
+    public static String RESPONSE_WATSONX_GATEWAY_IMAGE_API_URL = """
+            {
+                "created": 1689958352,
+                "background": "opaque",
+                "output_format": "png",
+                "quality": "high",
+                "size": "1024x1024",
+                "data": [
+                  {
+                    "url": "https://example.com/image.png",
+                    "revised_prompt": "A futuristic city at sunset, revised"
+                  }
+                ],
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 20,
+                    "total_tokens": 30,
+                    "input_tokens_details": {
+                        "image_tokens": 0,
+                        "text_tokens": 10
+                    }
+                }
+            }
             """;
     public static final String RESPONSE_WATSONX_TOKENIZER_API = """
               {

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/QuarkusChatSubscriber.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/QuarkusChatSubscriber.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.langchain4j.watsonx.runtime;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.ibm.watsonx.ai.chat.ChatHandler;
 import com.ibm.watsonx.ai.chat.ChatResponse;
@@ -9,12 +10,33 @@ import com.ibm.watsonx.ai.chat.streaming.ChatSubscriber;
 
 public class QuarkusChatSubscriber extends ChatSubscriber {
 
+    private final AtomicBoolean cancelled = new AtomicBoolean(false);
+
     public QuarkusChatSubscriber(SseEventProcessor processor, ChatHandler handler) {
         super(processor, handler);
     }
 
+    public void cancel() {
+        cancelled.set(true);
+    }
+
+    public boolean isCancelled() {
+        return cancelled.get();
+    }
+
+    @Override
+    public void onNext(String partialMessage) {
+        if (isCancelled())
+            return;
+
+        super.onNext(partialMessage);
+    }
+
     @Override
     public CompletableFuture<ChatResponse> onComplete() {
+        if (isCancelled())
+            return CompletableFuture.completedFuture(null);
+
         var response = processor.buildResponse();
         handler.onCompleteResponse(response);
         return CompletableFuture.completedFuture(response);
@@ -22,6 +44,9 @@ public class QuarkusChatSubscriber extends ChatSubscriber {
 
     @Override
     public CompletableFuture<Void> onError(Throwable throwable) {
+        if (isCancelled())
+            return CompletableFuture.completedFuture(null);
+
         handler.onError(throwable);
         return CompletableFuture.failedFuture(throwable);
     }

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/WatsonxRecorder.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/WatsonxRecorder.java
@@ -9,13 +9,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.util.TypeLiteral;
 
+import com.ibm.watsonx.ai.chat.ChatModeration;
 import com.ibm.watsonx.ai.chat.model.ExtractionTags;
 import com.ibm.watsonx.ai.chat.model.ExtractionTags.Response;
 import com.ibm.watsonx.ai.chat.model.ExtractionTags.Think;
@@ -43,12 +46,16 @@ import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.embedding.DisabledEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.image.DisabledImageModel;
+import dev.langchain4j.model.image.ImageModel;
 import dev.langchain4j.model.scoring.ScoringModel;
 import dev.langchain4j.model.watsonx.WatsonxChatModel;
 import dev.langchain4j.model.watsonx.WatsonxDeploymentChatModel;
 import dev.langchain4j.model.watsonx.WatsonxDeploymentStreamingChatModel;
 import dev.langchain4j.model.watsonx.WatsonxEmbeddingModel;
 import dev.langchain4j.model.watsonx.WatsonxGatewayChatModel;
+import dev.langchain4j.model.watsonx.WatsonxGatewayEmbeddingModel;
+import dev.langchain4j.model.watsonx.WatsonxGatewayImageModel;
 import dev.langchain4j.model.watsonx.WatsonxGatewayStreamingChatModel;
 import dev.langchain4j.model.watsonx.WatsonxModerationModel;
 import dev.langchain4j.model.watsonx.WatsonxScoringModel;
@@ -67,6 +74,8 @@ import io.quarkiverse.langchain4j.watsonx.runtime.config.FoundationChatModelConf
 import io.quarkiverse.langchain4j.watsonx.runtime.config.FoundationChatModelConfig.ThinkingConfig;
 import io.quarkiverse.langchain4j.watsonx.runtime.config.GatewayChatModelConfig;
 import io.quarkiverse.langchain4j.watsonx.runtime.config.GatewayChatModelConfig.CacheConfig;
+import io.quarkiverse.langchain4j.watsonx.runtime.config.GatewayEmbeddingModelConfig;
+import io.quarkiverse.langchain4j.watsonx.runtime.config.GatewayImageModelConfig;
 import io.quarkiverse.langchain4j.watsonx.runtime.config.ImproveSchemaConfig;
 import io.quarkiverse.langchain4j.watsonx.runtime.config.LangChain4jWatsonxConfig;
 import io.quarkiverse.langchain4j.watsonx.runtime.config.LangChain4jWatsonxConfig.WatsonxConfig;
@@ -74,6 +83,7 @@ import io.quarkiverse.langchain4j.watsonx.runtime.config.MergeSchemaConfig;
 import io.quarkiverse.langchain4j.watsonx.runtime.config.ModerationModelConfig;
 import io.quarkiverse.langchain4j.watsonx.runtime.config.ModerationModelConfig.GraniteGuardianConfig;
 import io.quarkiverse.langchain4j.watsonx.runtime.config.ModerationModelConfig.HapConfig;
+import io.quarkiverse.langchain4j.watsonx.runtime.config.ModerationsConfig;
 import io.quarkiverse.langchain4j.watsonx.runtime.config.ScoringModelConfig;
 import io.quarkiverse.langchain4j.watsonx.runtime.config.TextClassificationConfig;
 import io.quarkiverse.langchain4j.watsonx.runtime.config.TextExtractionConfig;
@@ -101,6 +111,10 @@ public class WatsonxRecorder {
     private static final TypeLiteral<Instance<ModelBuilderCustomizer<WatsonxGatewayStreamingChatModel.Builder>>> GATEWAY_STREAMING_CHAT_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
     };
     private static final TypeLiteral<Instance<ModelBuilderCustomizer<WatsonxEmbeddingModel.Builder>>> EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<WatsonxGatewayEmbeddingModel.Builder>>> GATEWAY_EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
+    };
+    private static final TypeLiteral<Instance<ModelBuilderCustomizer<WatsonxGatewayImageModel.Builder>>> GATEWAY_IMAGE_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
     };
     private static final TypeLiteral<Instance<ModelBuilderCustomizer<WatsonxScoringModel.Builder>>> SCORING_MODEL_CUSTOMIZER_TYPE_LITERAL = new TypeLiteral<>() {
     };
@@ -184,6 +198,7 @@ public class WatsonxRecorder {
                 .modelName(chatModelConfig.modelName())
                 .projectId(firstOrDefault(defaultConfig.projectId().orElse(null), specificConfig.projectId()))
                 .spaceId(firstOrDefault(defaultConfig.spaceId().orElse(null), specificConfig.spaceId()))
+                .moderations(resolveModerations(chatModelConfig))
                 .guidedGrammar(chatModelConfig.guidedGrammar().orElse(null))
                 .guidedRegex(chatModelConfig.guidedRegex().orElse(null))
                 .lengthPenalty(chatModelConfig.lengthPenalty().orElse(null))
@@ -245,6 +260,7 @@ public class WatsonxRecorder {
                 .modelName(chatModelConfig.modelName())
                 .projectId(firstOrDefault(defaultConfig.projectId().orElse(null), specificConfig.projectId()))
                 .spaceId(firstOrDefault(defaultConfig.spaceId().orElse(null), specificConfig.spaceId()))
+                .moderations(resolveModerations(chatModelConfig))
                 .guidedGrammar(chatModelConfig.guidedGrammar().orElse(null))
                 .guidedRegex(chatModelConfig.guidedRegex().orElse(null))
                 .lengthPenalty(chatModelConfig.lengthPenalty().orElse(null))
@@ -611,6 +627,21 @@ public class WatsonxRecorder {
         return ChatBackend.STANDARD;
     }
 
+    /**
+     * Deduces which watsonx.ai embedding service must serve the requests of the given configuration.
+     * <p>
+     * Setting {@code gateway-embedding-model.model-name} selects the Model Gateway, otherwise the foundation-model API of
+     * {@code embedding-model} is used.
+     */
+    private EmbeddingBackend resolveEmbeddingBackend(String configName) {
+        WatsonxConfig watsonxConfig = correspondingWatsonxRuntimeConfig(configName);
+
+        if (watsonxConfig.gatewayEmbeddingModel().modelName().isPresent())
+            return EmbeddingBackend.GATEWAY;
+
+        return EmbeddingBackend.STANDARD;
+    }
+
     private static URI resolveBaseUrl(WatsonxConfig specificConfig, WatsonxConfig defaultConfig) {
         return specificConfig.baseUrl()
                 .or(new Supplier<Optional<String>>() {
@@ -670,6 +701,97 @@ public class WatsonxRecorder {
                 .build();
     }
 
+    /**
+     * Builds the {@link ChatModeration} requested by the {@code chat-model.moderations} configuration, or {@code null} when
+     * no detector is configured.
+     * <p>
+     * A detector is only sent to watsonx.ai when at least one of its {@code input} or {@code output} properties is set:
+     * {@code mask} alone is not enough, because it only tells watsonx.ai what to do with the matches of a detector that is
+     * already running.
+     */
+    private static ChatModeration resolveModerations(ChatModelConfig chatModelConfig) {
+        if (chatModelConfig.moderations().isEmpty())
+            return null;
+
+        ModerationsConfig config = chatModelConfig.moderations().get();
+        Optional<ModerationsConfig.HapConfig> hap = config.hap()
+                .filter(new Predicate<ModerationsConfig.HapConfig>() {
+                    @Override
+                    public boolean test(ModerationsConfig.HapConfig hapConfig) {
+                        return hapConfig.input().isPresent() || hapConfig.output().isPresent();
+                    }
+                });
+        Optional<ModerationsConfig.PiiConfig> pii = config.pii()
+                .filter(new Predicate<ModerationsConfig.PiiConfig>() {
+                    @Override
+                    public boolean test(ModerationsConfig.PiiConfig piiConfig) {
+                        return piiConfig.input().isPresent() || piiConfig.output().isPresent();
+                    }
+                });
+        Optional<ModerationsConfig.GraniteGuardianConfig> graniteGuardian = config.graniteGuardian()
+                .filter(new Predicate<ModerationsConfig.GraniteGuardianConfig>() {
+                    @Override
+                    public boolean test(ModerationsConfig.GraniteGuardianConfig graniteGuardianConfig) {
+                        return graniteGuardianConfig.input().isPresent();
+                    }
+                });
+
+        if (hap.isEmpty() && pii.isEmpty() && graniteGuardian.isEmpty())
+            return null;
+
+        ChatModeration.Builder builder = ChatModeration.builder();
+
+        hap.ifPresent(new Consumer<ModerationsConfig.HapConfig>() {
+            @Override
+            public void accept(ModerationsConfig.HapConfig hapConfig) {
+                builder.hap(new Consumer<ChatModeration.Hap.Builder>() {
+                    @Override
+                    public void accept(ChatModeration.Hap.Builder hapBuilder) {
+                        if (hapConfig.input().isPresent())
+                            hapBuilder.input((float) hapConfig.input().getAsDouble());
+                        if (hapConfig.output().isPresent())
+                            hapBuilder.output((float) hapConfig.output().getAsDouble());
+                        if (hapConfig.mask().isPresent())
+                            hapBuilder.mask(hapConfig.mask().get());
+                    }
+                });
+            }
+        });
+
+        pii.ifPresent(new Consumer<ModerationsConfig.PiiConfig>() {
+            @Override
+            public void accept(ModerationsConfig.PiiConfig piiConfig) {
+                builder.pii(new Consumer<ChatModeration.Pii.Builder>() {
+                    @Override
+                    public void accept(ChatModeration.Pii.Builder piiBuilder) {
+                        if (piiConfig.input().isPresent())
+                            piiBuilder.input(piiConfig.input().get());
+                        if (piiConfig.output().isPresent())
+                            piiBuilder.output(piiConfig.output().get());
+                        if (piiConfig.mask().isPresent())
+                            piiBuilder.mask(piiConfig.mask().get());
+                    }
+                });
+            }
+        });
+
+        graniteGuardian.ifPresent(new Consumer<ModerationsConfig.GraniteGuardianConfig>() {
+            @Override
+            public void accept(ModerationsConfig.GraniteGuardianConfig graniteGuardianConfig) {
+                builder.graniteGuardian(new Consumer<ChatModeration.GraniteGuardian.Builder>() {
+                    @Override
+                    public void accept(ChatModeration.GraniteGuardian.Builder graniteGuardianBuilder) {
+                        graniteGuardianBuilder.input((float) graniteGuardianConfig.input().getAsDouble());
+                        if (graniteGuardianConfig.mask().isPresent())
+                            graniteGuardianBuilder.mask(graniteGuardianConfig.mask().get());
+                    }
+                });
+            }
+        });
+
+        return builder.build();
+    }
+
     private static Cache resolveCache(GatewayChatModelConfig chatModelConfig) {
         return chatModelConfig.cache()
                 .map(new Function<CacheConfig, Cache>() {
@@ -680,10 +802,6 @@ public class WatsonxRecorder {
                 }).orElse(null);
     }
 
-    /**
-     * Returns the {@link ResponseFormat} to set on the builder, or {@code null} when the configured response format is
-     * expressed as a {@link Capability} instead.
-     */
     private static ResponseFormat resolveResponseFormat(CommonChatModelConfig chatModelConfig) {
         if (chatModelConfig.responseFormat().isEmpty())
             return null;
@@ -698,10 +816,6 @@ public class WatsonxRecorder {
         };
     }
 
-    /**
-     * Returns the {@link Capability} required by the configured response format, or {@code null} when the response format
-     * is set directly on the builder.
-     */
     private static Capability resolveCapability(CommonChatModelConfig chatModelConfig) {
         if (chatModelConfig.responseFormat().isEmpty())
             return null;
@@ -716,9 +830,7 @@ public class WatsonxRecorder {
     }
 
     public Function<SyntheticCreationalContext<EmbeddingModel>, EmbeddingModel> embeddingModel(String configName) {
-        WatsonxConfig defaultConfig = runtimeConfig.getValue().defaultConfig();
         WatsonxConfig watsonxConfig = correspondingWatsonxRuntimeConfig(configName);
-        EmbeddingModelConfig embeddingModelConfig = watsonxConfig.embeddingModel();
 
         if (!watsonxConfig.enableIntegration()) {
             return new Function<>() {
@@ -728,6 +840,17 @@ public class WatsonxRecorder {
                 }
             };
         }
+
+        return switch (resolveEmbeddingBackend(configName)) {
+            case STANDARD -> standardEmbeddingModel(configName);
+            case GATEWAY -> gatewayEmbeddingModel(configName);
+        };
+    }
+
+    private Function<SyntheticCreationalContext<EmbeddingModel>, EmbeddingModel> standardEmbeddingModel(String configName) {
+        WatsonxConfig defaultConfig = runtimeConfig.getValue().defaultConfig();
+        WatsonxConfig watsonxConfig = correspondingWatsonxRuntimeConfig(configName);
+        EmbeddingModelConfig embeddingModelConfig = watsonxConfig.embeddingModel();
 
         var configProblems = checkConfigurations(configName);
 
@@ -790,6 +913,139 @@ public class WatsonxRecorder {
             }
         };
 
+    }
+
+    private Function<SyntheticCreationalContext<EmbeddingModel>, EmbeddingModel> gatewayEmbeddingModel(String configName) {
+        WatsonxConfig defaultConfig = runtimeConfig.getValue().defaultConfig();
+        WatsonxConfig watsonxConfig = correspondingWatsonxRuntimeConfig(configName);
+        GatewayEmbeddingModelConfig embeddingModelConfig = watsonxConfig.gatewayEmbeddingModel();
+
+        // The Model Gateway resolves the credentials of the backing provider on its own, so neither the project nor the
+        // space is validated here.
+        var configProblems = checkConnectionConfigurations(configName);
+
+        if (!configProblems.isEmpty())
+            throw new ConfigValidationException(configProblems.toArray(EMPTY_PROBLEMS));
+
+        var apiKey = firstOrDefault(defaultConfig.apiKey().orElse(null), watsonxConfig.apiKey());
+
+        WatsonxGatewayEmbeddingModel.Builder builder = WatsonxGatewayEmbeddingModel.builder()
+                .baseUrl(resolveBaseUrl(watsonxConfig, defaultConfig))
+                .timeout(watsonxConfig.timeout().orElse(null))
+                .version(watsonxConfig.version().orElse(null))
+                .modelName(embeddingModelConfig.modelName().orElseThrow())
+                .dimensions(embeddingModelConfig.dimensions().orElse(null))
+                .encodingFormat(embeddingModelConfig.encodingFormat().orElse(null))
+                .user(embeddingModelConfig.user().orElse(null));
+
+        builder.logRequests(
+                firstOrDefault(
+                        defaultConfig.logRequests().orElse(false),
+                        embeddingModelConfig.logRequests(),
+                        watsonxConfig.logRequests()));
+
+        builder.logResponses(
+                firstOrDefault(
+                        defaultConfig.logResponses().orElse(false),
+                        embeddingModelConfig.logResponses(),
+                        watsonxConfig.logResponses()));
+
+        return new Function<>() {
+            @Override
+            public EmbeddingModel apply(SyntheticCreationalContext<EmbeddingModel> context) {
+                var authenticator = getOrCreateTokenGenerator(watsonxConfig.iam().baseUrl().orElse(null), apiKey);
+                QuarkusRestClientConfig.setLogCurl(
+                        firstOrDefault(
+                                defaultConfig.logRequestsCurl().orElse(false),
+                                embeddingModelConfig.logRequestsCurl(),
+                                watsonxConfig.logRequestsCurl()));
+                try {
+                    builder.authenticator(authenticator);
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(GATEWAY_EMBEDDING_MODEL_CUSTOMIZER_TYPE_LITERAL,
+                                    Any.Literal.INSTANCE),
+                            builder, configName);
+                    return builder.build();
+                } finally {
+                    QuarkusRestClientConfig.clear();
+                }
+            }
+        };
+    }
+
+    public Function<SyntheticCreationalContext<ImageModel>, ImageModel> imageModel(String configName) {
+        WatsonxConfig defaultConfig = runtimeConfig.getValue().defaultConfig();
+        WatsonxConfig watsonxConfig = correspondingWatsonxRuntimeConfig(configName);
+        GatewayImageModelConfig imageModelConfig = watsonxConfig.gatewayImageModel();
+
+        if (!watsonxConfig.enableIntegration()) {
+            return new Function<>() {
+                @Override
+                public ImageModel apply(SyntheticCreationalContext<ImageModel> context) {
+                    return new DisabledImageModel();
+                }
+            };
+        }
+
+        // Images are only served through the Model Gateway, which resolves the credentials of the backing provider on its
+        // own, so neither the project nor the space is validated here.
+        var configProblems = checkConnectionConfigurations(configName);
+
+        if (imageModelConfig.modelName().isEmpty())
+            configProblems.add(createConfigProblem("gateway-image-model.model-name", configName));
+
+        if (!configProblems.isEmpty())
+            throw new ConfigValidationException(configProblems.toArray(EMPTY_PROBLEMS));
+
+        var apiKey = firstOrDefault(defaultConfig.apiKey().orElse(null), watsonxConfig.apiKey());
+
+        WatsonxGatewayImageModel.Builder builder = WatsonxGatewayImageModel.builder()
+                .baseUrl(resolveBaseUrl(watsonxConfig, defaultConfig))
+                .timeout(watsonxConfig.timeout().orElse(null))
+                .version(watsonxConfig.version().orElse(null))
+                .modelName(imageModelConfig.modelName().orElseThrow())
+                .background(imageModelConfig.background().orElse(null))
+                .moderation(imageModelConfig.moderation().orElse(null))
+                .outputCompression(imageModelConfig.outputCompression().orElse(null))
+                .outputFormat(imageModelConfig.outputFormat().orElse(null))
+                .quality(imageModelConfig.quality().orElse(null))
+                .responseFormat(imageModelConfig.responseFormat().orElse(null))
+                .size(imageModelConfig.size().orElse(null))
+                .style(imageModelConfig.style().orElse(null))
+                .user(imageModelConfig.user().orElse(null));
+
+        builder.logRequests(
+                firstOrDefault(
+                        defaultConfig.logRequests().orElse(false),
+                        imageModelConfig.logRequests(),
+                        watsonxConfig.logRequests()));
+
+        builder.logResponses(
+                firstOrDefault(
+                        defaultConfig.logResponses().orElse(false),
+                        imageModelConfig.logResponses(),
+                        watsonxConfig.logResponses()));
+
+        return new Function<>() {
+            @Override
+            public ImageModel apply(SyntheticCreationalContext<ImageModel> context) {
+                var authenticator = getOrCreateTokenGenerator(watsonxConfig.iam().baseUrl().orElse(null), apiKey);
+                QuarkusRestClientConfig.setLogCurl(
+                        firstOrDefault(
+                                defaultConfig.logRequestsCurl().orElse(false),
+                                imageModelConfig.logRequestsCurl(),
+                                watsonxConfig.logRequestsCurl()));
+                try {
+                    builder.authenticator(authenticator);
+                    ModelBuilderCustomizer.applyCustomizers(
+                            context.getInjectedReference(GATEWAY_IMAGE_MODEL_CUSTOMIZER_TYPE_LITERAL, Any.Literal.INSTANCE),
+                            builder, configName);
+                    return builder.build();
+                } finally {
+                    QuarkusRestClientConfig.clear();
+                }
+            }
+        };
     }
 
     public Function<SyntheticCreationalContext<ScoringModel>, ScoringModel> scoringModel(String configName) {
@@ -1452,6 +1708,20 @@ public class WatsonxRecorder {
         DEPLOYMENT,
         /**
          * The Model Gateway ({@code /ml/gateway/v1/chat/completions}), configured via {@code gateway-chat-model}.
+         */
+        GATEWAY
+    }
+
+    /**
+     * The watsonx.ai service used to serve the embedding requests, deduced from the configuration.
+     */
+    private enum EmbeddingBackend {
+        /**
+         * The foundation model embedding api ({@code /ml/v1/text/embeddings}), configured via {@code embedding-model}.
+         */
+        STANDARD,
+        /**
+         * The Model Gateway ({@code /ml/gateway/v1/embeddings}), configured via {@code gateway-embedding-model}.
          */
         GATEWAY
     }

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/client/GatewayChatRestApi.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/client/GatewayChatRestApi.java
@@ -26,7 +26,7 @@ import io.quarkus.rest.client.reactive.jackson.ClientObjectMapper;
 import io.smallrye.mutiny.Multi;
 
 @Path("/ml/gateway/v1")
-public interface GatewayRestApi {
+public interface GatewayChatRestApi {
 
     @POST
     @Path("chat/completions")

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/client/GatewayEmbeddingRestApi.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/client/GatewayEmbeddingRestApi.java
@@ -1,0 +1,45 @@
+package io.quarkiverse.langchain4j.watsonx.runtime.client;
+
+import static io.quarkiverse.langchain4j.watsonx.runtime.client.WatsonxRestClientUtils.REQUEST_ID_HEADER;
+import static io.quarkiverse.langchain4j.watsonx.runtime.client.WatsonxRestClientUtils.responseToWatsonxException;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ibm.watsonx.ai.core.exception.WatsonxException;
+import com.ibm.watsonx.ai.gateway.embedding.ModelGatewayEmbeddingPayload;
+import com.ibm.watsonx.ai.gateway.embedding.ModelGatewayEmbeddingResponse;
+
+import io.quarkiverse.langchain4j.watsonx.runtime.spi.JsonProvider;
+import io.quarkus.rest.client.reactive.ClientExceptionMapper;
+import io.quarkus.rest.client.reactive.jackson.ClientObjectMapper;
+
+@Path("/ml/gateway/v1")
+public interface GatewayEmbeddingRestApi {
+
+    @POST
+    @Path("embeddings")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    ModelGatewayEmbeddingResponse embed(
+            @HeaderParam(REQUEST_ID_HEADER) String requestId,
+            @QueryParam("version") String version,
+            ModelGatewayEmbeddingPayload request);
+
+    @ClientObjectMapper
+    static ObjectMapper objectMapper(ObjectMapper defaultObjectMapper) {
+        return JsonProvider.MAPPER;
+    }
+
+    @ClientExceptionMapper
+    static WatsonxException toException(Response response) {
+        return responseToWatsonxException(response);
+    }
+}

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/client/GatewayImageRestApi.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/client/GatewayImageRestApi.java
@@ -1,0 +1,45 @@
+package io.quarkiverse.langchain4j.watsonx.runtime.client;
+
+import static io.quarkiverse.langchain4j.watsonx.runtime.client.WatsonxRestClientUtils.REQUEST_ID_HEADER;
+import static io.quarkiverse.langchain4j.watsonx.runtime.client.WatsonxRestClientUtils.responseToWatsonxException;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ibm.watsonx.ai.core.exception.WatsonxException;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageGenerationRequest;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageResponse;
+
+import io.quarkiverse.langchain4j.watsonx.runtime.spi.JsonProvider;
+import io.quarkus.rest.client.reactive.ClientExceptionMapper;
+import io.quarkus.rest.client.reactive.jackson.ClientObjectMapper;
+
+@Path("/ml/gateway/v1")
+public interface GatewayImageRestApi {
+
+    @POST
+    @Path("images/generations")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    ModelGatewayImageResponse generate(
+            @HeaderParam(REQUEST_ID_HEADER) String requestId,
+            @QueryParam("version") String version,
+            ModelGatewayImageGenerationRequest request);
+
+    @ClientObjectMapper
+    static ObjectMapper objectMapper(ObjectMapper defaultObjectMapper) {
+        return JsonProvider.MAPPER;
+    }
+
+    @ClientExceptionMapper
+    static WatsonxException toException(Response response) {
+        return responseToWatsonxException(response);
+    }
+}

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/client/WatsonxRestClientUtils.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/client/WatsonxRestClientUtils.java
@@ -6,6 +6,8 @@ import static java.util.Objects.nonNull;
 import java.time.Duration;
 import java.util.StringJoiner;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 
 import jakarta.ws.rs.WebApplicationException;
@@ -19,6 +21,7 @@ import com.ibm.watsonx.ai.core.exception.model.WatsonxError;
 import com.ibm.watsonx.ai.core.http.BaseHttpClient;
 import com.ibm.watsonx.ai.core.http.interceptors.RetryInterceptor;
 
+import io.quarkiverse.langchain4j.watsonx.runtime.QuarkusChatSubscriber;
 import io.quarkus.logging.Log;
 
 public final class WatsonxRestClientUtils {
@@ -58,6 +61,22 @@ public final class WatsonxRestClientUtils {
 
     public static boolean shouldRetry(Throwable e) {
         return TOKEN_EXPIRED.test(e) || ON_RETRYABLE_STATUS_CODES.test(e);
+    }
+
+    public static void cancelStreamOn(
+            CompletableFuture<?> future,
+            QuarkusChatSubscriber subscriber,
+            CompletableFuture<Void> streamFuture) {
+
+        future.whenComplete(new BiConsumer<Object, Throwable>() {
+            @Override
+            public void accept(Object response, Throwable throwable) {
+                if (future.isCancelled()) {
+                    subscriber.cancel();
+                    streamFuture.cancel(true);
+                }
+            }
+        });
     }
 
     public static <T> T retryOn(String requestId, Callable<T> action) {

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/client/impl/QuarkusChatRestClient.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/client/impl/QuarkusChatRestClient.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.langchain4j.watsonx.runtime.client.impl;
 
+import static io.quarkiverse.langchain4j.watsonx.runtime.client.WatsonxRestClientUtils.cancelStreamOn;
 import static io.quarkiverse.langchain4j.watsonx.runtime.client.WatsonxRestClientUtils.retryOn;
 import static java.util.Objects.nonNull;
 
@@ -81,7 +82,7 @@ public final class QuarkusChatRestClient extends ChatRestClient {
 
         CompletableFuture<ChatResponse> future = new CompletableFuture<>();
 
-        client.chatStreaming(requestId, transactionId, version, textChatRequest)
+        var streamFuture = client.chatStreaming(requestId, transactionId, version, textChatRequest)
                 .onItem().invoke(new Consumer<String>() {
                     @Override
                     public void accept(String message) {
@@ -104,6 +105,7 @@ public final class QuarkusChatRestClient extends ChatRestClient {
                 .collect().asList().replaceWithVoid()
                 .subscribeAsCompletionStage();
 
+        cancelStreamOn(future, subscriber, streamFuture);
         return future;
     }
 

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/client/impl/QuarkusDeploymentRestClient.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/client/impl/QuarkusDeploymentRestClient.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.langchain4j.watsonx.runtime.client.impl;
 
+import static io.quarkiverse.langchain4j.watsonx.runtime.client.WatsonxRestClientUtils.cancelStreamOn;
 import static io.quarkiverse.langchain4j.watsonx.runtime.client.WatsonxRestClientUtils.retryOn;
 import static java.util.Objects.nonNull;
 
@@ -144,7 +145,7 @@ public final class QuarkusDeploymentRestClient extends DeploymentRestClient {
 
         CompletableFuture<ChatResponse> future = new CompletableFuture<>();
 
-        client.chatStreaming(deploymentId, requestId, transactionId, version, textChatRequest)
+        var streamFuture = client.chatStreaming(deploymentId, requestId, transactionId, version, textChatRequest)
                 .onItem().invoke(new Consumer<String>() {
                     @Override
                     public void accept(String message) {
@@ -167,6 +168,7 @@ public final class QuarkusDeploymentRestClient extends DeploymentRestClient {
                 .collect().asList().replaceWithVoid()
                 .subscribeAsCompletionStage();
 
+        cancelStreamOn(future, subscriber, streamFuture);
         return future;
     }
 

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/client/impl/QuarkusModelGatewayChatRestClient.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/client/impl/QuarkusModelGatewayChatRestClient.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.langchain4j.watsonx.runtime.client.impl;
 
+import static io.quarkiverse.langchain4j.watsonx.runtime.client.WatsonxRestClientUtils.cancelStreamOn;
 import static io.quarkiverse.langchain4j.watsonx.runtime.client.WatsonxRestClientUtils.retryOn;
 import static java.util.Objects.nonNull;
 
@@ -23,18 +24,18 @@ import com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatRestClient;
 import com.ibm.watsonx.ai.gateway.chat.ModelGatewayTextChatRequest;
 
 import io.quarkiverse.langchain4j.watsonx.runtime.QuarkusChatSubscriber;
-import io.quarkiverse.langchain4j.watsonx.runtime.client.GatewayRestApi;
+import io.quarkiverse.langchain4j.watsonx.runtime.client.GatewayChatRestApi;
 import io.quarkiverse.langchain4j.watsonx.runtime.client.QuarkusRestClientConfig;
 import io.quarkiverse.langchain4j.watsonx.runtime.client.WatsonxRestClientUtils;
 import io.quarkiverse.langchain4j.watsonx.runtime.client.filter.BearerTokenHeaderFactory;
 import io.quarkiverse.langchain4j.watsonx.runtime.client.logger.WatsonxClientLogger;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 
-public final class QuarkusModelGatewayRestClient extends ModelGatewayChatRestClient {
+public final class QuarkusModelGatewayChatRestClient extends ModelGatewayChatRestClient {
 
-    private final GatewayRestApi client;
+    private final GatewayChatRestApi client;
 
-    QuarkusModelGatewayRestClient(Builder builder) {
+    QuarkusModelGatewayChatRestClient(Builder builder) {
         super(builder);
         try {
 
@@ -50,7 +51,7 @@ public final class QuarkusModelGatewayRestClient extends ModelGatewayChatRestCli
                 restClientBuilder.clientLogger(new WatsonxClientLogger(logRequests, logResponses, logCurl));
             }
 
-            client = restClientBuilder.build(GatewayRestApi.class);
+            client = restClientBuilder.build(GatewayChatRestApi.class);
 
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -84,7 +85,7 @@ public final class QuarkusModelGatewayRestClient extends ModelGatewayChatRestCli
 
         CompletableFuture<ChatResponse> future = new CompletableFuture<>();
 
-        client.chatStreaming(requestId, transactionId, version, gatewayRequest)
+        var streamFuture = client.chatStreaming(requestId, transactionId, version, gatewayRequest)
                 .onItem().invoke(new Consumer<String>() {
                     @Override
                     public void accept(String message) {
@@ -107,20 +108,22 @@ public final class QuarkusModelGatewayRestClient extends ModelGatewayChatRestCli
                 .collect().asList().replaceWithVoid()
                 .subscribeAsCompletionStage();
 
+        cancelStreamOn(future, subscriber, streamFuture);
         return future;
     }
 
-    public static final class QuarkusModelGatewayRestClientBuilderFactory implements ModelGatewayChatRestClientBuilderFactory {
+    public static final class QuarkusModelGatewayChatRestClientBuilderFactory
+            implements ModelGatewayChatRestClientBuilderFactory {
         @Override
         public Builder get() {
-            return new QuarkusModelGatewayRestClient.Builder();
+            return new QuarkusModelGatewayChatRestClient.Builder();
         }
     }
 
     static final class Builder extends ModelGatewayChatRestClient.Builder {
         @Override
         public ModelGatewayChatRestClient build() {
-            return new QuarkusModelGatewayRestClient(this);
+            return new QuarkusModelGatewayChatRestClient(this);
         }
     }
 }

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/client/impl/QuarkusModelGatewayEmbeddingRestClient.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/client/impl/QuarkusModelGatewayEmbeddingRestClient.java
@@ -1,0 +1,74 @@
+package io.quarkiverse.langchain4j.watsonx.runtime.client.impl;
+
+import static io.quarkiverse.langchain4j.watsonx.runtime.client.WatsonxRestClientUtils.retryOn;
+
+import java.net.URI;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.resteasy.reactive.client.api.LoggingScope;
+
+import com.ibm.watsonx.ai.gateway.embedding.ModelGatewayEmbeddingPayload;
+import com.ibm.watsonx.ai.gateway.embedding.ModelGatewayEmbeddingResponse;
+import com.ibm.watsonx.ai.gateway.embedding.ModelGatewayEmbeddingRestClient;
+
+import io.quarkiverse.langchain4j.watsonx.runtime.client.GatewayEmbeddingRestApi;
+import io.quarkiverse.langchain4j.watsonx.runtime.client.QuarkusRestClientConfig;
+import io.quarkiverse.langchain4j.watsonx.runtime.client.filter.BearerTokenHeaderFactory;
+import io.quarkiverse.langchain4j.watsonx.runtime.client.logger.WatsonxClientLogger;
+import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
+
+public final class QuarkusModelGatewayEmbeddingRestClient extends ModelGatewayEmbeddingRestClient {
+
+    private final GatewayEmbeddingRestApi client;
+
+    QuarkusModelGatewayEmbeddingRestClient(Builder builder) {
+        super(builder);
+        try {
+
+            var logCurl = QuarkusRestClientConfig.isLogCurl();
+            var restClientBuilder = QuarkusRestClientBuilder.newBuilder()
+                    .baseUrl(URI.create(baseUrl).toURL())
+                    .clientHeadersFactory(new BearerTokenHeaderFactory(authenticator))
+                    .connectTimeout(timeout.toSeconds(), TimeUnit.SECONDS)
+                    .readTimeout(timeout.toSeconds(), TimeUnit.SECONDS);
+
+            if (logRequests || logResponses || logCurl) {
+                restClientBuilder.loggingScope(LoggingScope.REQUEST_RESPONSE);
+                restClientBuilder.clientLogger(new WatsonxClientLogger(logRequests, logResponses, logCurl));
+            }
+
+            client = restClientBuilder.build(GatewayEmbeddingRestApi.class);
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public ModelGatewayEmbeddingResponse embed(ModelGatewayEmbeddingPayload request) {
+        var requestId = UUID.randomUUID().toString();
+        return retryOn(requestId, new Callable<ModelGatewayEmbeddingResponse>() {
+            @Override
+            public ModelGatewayEmbeddingResponse call() throws Exception {
+                return client.embed(requestId, version, request);
+            }
+        });
+    }
+
+    public static final class QuarkusModelGatewayEmbeddingRestClientBuilderFactory
+            implements ModelGatewayEmbeddingRestClientBuilderFactory {
+        @Override
+        public Builder get() {
+            return new QuarkusModelGatewayEmbeddingRestClient.Builder();
+        }
+    }
+
+    static final class Builder extends ModelGatewayEmbeddingRestClient.Builder {
+        @Override
+        public ModelGatewayEmbeddingRestClient build() {
+            return new QuarkusModelGatewayEmbeddingRestClient(this);
+        }
+    }
+}

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/client/impl/QuarkusModelGatewayImageRestClient.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/client/impl/QuarkusModelGatewayImageRestClient.java
@@ -1,0 +1,74 @@
+package io.quarkiverse.langchain4j.watsonx.runtime.client.impl;
+
+import static io.quarkiverse.langchain4j.watsonx.runtime.client.WatsonxRestClientUtils.retryOn;
+
+import java.net.URI;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.resteasy.reactive.client.api.LoggingScope;
+
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageGenerationRequest;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageResponse;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageRestClient;
+
+import io.quarkiverse.langchain4j.watsonx.runtime.client.GatewayImageRestApi;
+import io.quarkiverse.langchain4j.watsonx.runtime.client.QuarkusRestClientConfig;
+import io.quarkiverse.langchain4j.watsonx.runtime.client.filter.BearerTokenHeaderFactory;
+import io.quarkiverse.langchain4j.watsonx.runtime.client.logger.WatsonxClientLogger;
+import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
+
+public final class QuarkusModelGatewayImageRestClient extends ModelGatewayImageRestClient {
+
+    private final GatewayImageRestApi client;
+
+    QuarkusModelGatewayImageRestClient(Builder builder) {
+        super(builder);
+        try {
+
+            var logCurl = QuarkusRestClientConfig.isLogCurl();
+            var restClientBuilder = QuarkusRestClientBuilder.newBuilder()
+                    .baseUrl(URI.create(baseUrl).toURL())
+                    .clientHeadersFactory(new BearerTokenHeaderFactory(authenticator))
+                    .connectTimeout(timeout.toSeconds(), TimeUnit.SECONDS)
+                    .readTimeout(timeout.toSeconds(), TimeUnit.SECONDS);
+
+            if (logRequests || logResponses || logCurl) {
+                restClientBuilder.loggingScope(LoggingScope.REQUEST_RESPONSE);
+                restClientBuilder.clientLogger(new WatsonxClientLogger(logRequests, logResponses, logCurl));
+            }
+
+            client = restClientBuilder.build(GatewayImageRestApi.class);
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public ModelGatewayImageResponse generate(ModelGatewayImageGenerationRequest request) {
+        var requestId = UUID.randomUUID().toString();
+        return retryOn(requestId, new Callable<ModelGatewayImageResponse>() {
+            @Override
+            public ModelGatewayImageResponse call() throws Exception {
+                return client.generate(requestId, version, request);
+            }
+        });
+    }
+
+    public static final class QuarkusModelGatewayImageRestClientBuilderFactory
+            implements ModelGatewayImageRestClientBuilderFactory {
+        @Override
+        public Builder get() {
+            return new QuarkusModelGatewayImageRestClient.Builder();
+        }
+    }
+
+    static final class Builder extends ModelGatewayImageRestClient.Builder {
+        @Override
+        public ModelGatewayImageRestClient build() {
+            return new QuarkusModelGatewayImageRestClient(this);
+        }
+    }
+}

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/client/logger/WatsonxClientLogger.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/client/logger/WatsonxClientLogger.java
@@ -28,7 +28,11 @@ public class WatsonxClientLogger implements ClientLogger {
     private static final Logger log = Logger.getLogger(WatsonxClientLogger.class);
     private static final Pattern AUTHORIZATION_PATTERN = Pattern.compile("(\\w+\\s)(\\w{4})(\\w+)(\\w{4})");
     private static final Pattern BASE64_IMAGE_PATTERN = Pattern.compile("(data:[\\w\\/+]+;base64,)(.{15})([^\"]+)");
-    private static final Pattern API_KEY_PATTERN = Pattern.compile("\"(api-key|apiKey)\"\\s*:\\s*\"([^\"]+\")",
+    private static final Pattern JSON_SECRET_PATTERN = Pattern.compile(
+            "\"([^\"]*(?:api[_-]?key|password|secret|access_token|refresh_token)[^\"]*)\"\\s*:\\s*\"[^\"]*\"",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern FORM_SECRET_PATTERN = Pattern.compile(
+            "(api[_-]?key|password|secret|access_token|refresh_token)=([^&\\s]*)",
             Pattern.CASE_INSENSITIVE);
 
     private final boolean logRequests;
@@ -70,8 +74,8 @@ public class WatsonxClientLogger implements ClientLogger {
                 if (nonNull(request.headers())) {
                     headers = inOneLine(request.headers());
                     joiner.add("- headers: " + headers);
-                    if (nonNull(body)) {
-                        body = maskApiKeysInJsonBody(body);
+                    if (nonNull(body) && !body.isBlank()) {
+                        body = maskSecrets(body);
 
                         var contentType = ofNullable(request.headers().get("Content-Type"));
                         if (contentType.isPresent() && contentType.get().contains("application/json"))
@@ -115,19 +119,15 @@ public class WatsonxClientLogger implements ClientLogger {
                     if (nonNull(response.headers())) {
                         joiner.add("- headers: " + inOneLine(response.headers()));
 
-                        var contentType = Optional.<String> empty();
-
-                        if (response.headers().contains("Content-Type"))
-                            contentType = ofNullable(response.headers().get("Content-Type"));
-                        else if (response.headers().contains("content-type"))
-                            contentType = ofNullable(response.headers().get("content-type"));
-
+                        var contentType = ofNullable(response.headers().get("Content-Type"));
                         if (contentType.isPresent() && contentType.get().contains("application/json"))
                             prettyPrint = true;
                     }
 
                     if (nonNull(bufferBody)) {
-                        var body = prettyPrint ? Json.prettyPrint(bodyToString(bufferBody)) : bodyToString(bufferBody);
+                        var body = bodyToString(bufferBody);
+                        body = maskSecrets(body);
+                        body = prettyPrint ? Json.prettyPrint(body) : body;
                         joiner.add("- body: " + body);
                     }
 
@@ -186,14 +186,12 @@ public class WatsonxClientLogger implements ClientLogger {
                 return body;
 
             Matcher matcher = BASE64_IMAGE_PATTERN.matcher(body);
-
             StringBuilder sb = new StringBuilder();
-            while (matcher.find()) {
-                matcher.appendReplacement(sb,
-                        matcher.group(1) + matcher.group(2) + "..." + matcher.group(4) + matcher.group(5));
-            }
+            while (matcher.find())
+                matcher.appendReplacement(sb, matcher.group(1) + matcher.group(2) + "...");
+            matcher.appendTail(sb);
+            return sb.toString();
 
-            return sb.isEmpty() ? body : sb.toString();
         } catch (Exception e) {
             return "Failed to format the base64 image value.";
         }
@@ -212,18 +210,23 @@ public class WatsonxClientLogger implements ClientLogger {
         }
     }
 
-    private String maskApiKeysInJsonBody(String body) {
+    private String maskSecrets(String body) {
 
         if (body == null || body.isBlank())
             return body;
 
-        Matcher matcher = API_KEY_PATTERN.matcher(body);
-
+        Matcher jsonMatcher = JSON_SECRET_PATTERN.matcher(body);
         StringBuilder sb = new StringBuilder();
-        while (matcher.find())
-            matcher.appendReplacement(sb, "\"" + matcher.group(1) + "\": \"***\"");
+        while (jsonMatcher.find())
+            jsonMatcher.appendReplacement(sb, Matcher.quoteReplacement("\"" + jsonMatcher.group(1) + "\": \"***\""));
+        jsonMatcher.appendTail(sb);
+        body = sb.toString();
 
-        matcher.appendTail(sb);
-        return sb.isEmpty() ? body : sb.toString();
+        Matcher formMatcher = FORM_SECRET_PATTERN.matcher(body);
+        sb = new StringBuilder();
+        while (formMatcher.find())
+            formMatcher.appendReplacement(sb, Matcher.quoteReplacement(formMatcher.group(1) + "=***"));
+        formMatcher.appendTail(sb);
+        return sb.toString();
     }
 }

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/ChatModelConfig.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/ChatModelConfig.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.langchain4j.watsonx.runtime.config;
 
+import java.util.Optional;
+
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
@@ -17,4 +19,17 @@ public interface ChatModelConfig extends FoundationChatModelConfig {
      */
     @WithDefault("ibm/granite-4-h-small")
     String modelName();
+
+    /**
+     * Moderation applied by watsonx.ai while the chat request is served.
+     * <p>
+     * Unlike the standalone moderation model, these detectors run inside the chat request itself: the input is checked before
+     * the model is called and
+     * the output is checked before it is returned.
+     * <p>
+     * This is only supported by the models served directly by watsonx.ai, so it is not available when using the Model Gateway
+     * or an on-demand
+     * deployment.
+     */
+    Optional<ModerationsConfig> moderations();
 }

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/CommonEmbeddingModelConfig.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/CommonEmbeddingModelConfig.java
@@ -1,0 +1,29 @@
+package io.quarkiverse.langchain4j.watsonx.runtime.config;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigDocDefault;
+
+/**
+ * Settings shared by every embedding backend of the watsonx.ai provider.
+ */
+public interface CommonEmbeddingModelConfig {
+
+    /**
+     * Whether embedding model requests should be logged.
+     */
+    @ConfigDocDefault("false")
+    Optional<Boolean> logRequests();
+
+    /**
+     * Whether embedding model responses should be logged.
+     */
+    @ConfigDocDefault("false")
+    Optional<Boolean> logResponses();
+
+    /**
+     * Whether the watsonx.ai client should log requests as cURL commands.
+     */
+    @ConfigDocDefault("false")
+    Optional<Boolean> logRequestsCurl();
+}

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/EmbeddingModelConfig.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/EmbeddingModelConfig.java
@@ -1,13 +1,10 @@
 package io.quarkiverse.langchain4j.watsonx.runtime.config;
 
-import java.util.Optional;
-
-import io.quarkus.runtime.annotations.ConfigDocDefault;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.smallrye.config.WithDefault;
 
 @ConfigGroup
-public interface EmbeddingModelConfig {
+public interface EmbeddingModelConfig extends CommonEmbeddingModelConfig {
 
     /**
      * Specifies the ID of the model to be used.
@@ -21,22 +18,4 @@ public interface EmbeddingModelConfig {
      */
     @WithDefault("ibm/granite-embedding-278m-multilingual")
     String modelName();
-
-    /**
-     * Whether embedding model requests should be logged.
-     */
-    @ConfigDocDefault("false")
-    Optional<Boolean> logRequests();
-
-    /**
-     * Whether embedding model responses should be logged.
-     */
-    @ConfigDocDefault("false")
-    Optional<Boolean> logResponses();
-
-    /**
-     * Whether the watsonx.ai client should log requests as cURL commands.
-     */
-    @ConfigDocDefault("false")
-    Optional<Boolean> logRequestsCurl();
 }

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/GatewayEmbeddingModelConfig.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/GatewayEmbeddingModelConfig.java
@@ -1,0 +1,40 @@
+package io.quarkiverse.langchain4j.watsonx.runtime.config;
+
+import java.util.Optional;
+
+import com.ibm.watsonx.ai.gateway.embedding.ModelGatewayEmbeddingParameters.EncodingFormat;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+
+@ConfigGroup
+public interface GatewayEmbeddingModelConfig extends CommonEmbeddingModelConfig {
+
+    /**
+     * The identifier of the model to use, as configured in the Model Gateway (for example
+     * <code>openai/text-embedding-3-small</code>).
+     * <p>
+     * Setting this property routes all embedding requests to the Model Gateway.
+     */
+    Optional<String> modelName();
+
+    /**
+     * The number of dimensions of the returned embeddings.
+     * <p>
+     * Only the models that support it accept this value.
+     */
+    Optional<Integer> dimensions();
+
+    /**
+     * The wire format used to return the embeddings.
+     * <p>
+     * Both formats produce the same vectors, <code>base64</code> is decoded for you.
+     * <p>
+     * <strong>Allowable values:</strong> <code>[float, base64]</code>
+     */
+    Optional<EncodingFormat> encodingFormat();
+
+    /**
+     * A stable identifier of the end user issuing the request, used by the backing provider to detect and prevent abuse.
+     */
+    Optional<String> user();
+}

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/GatewayImageModelConfig.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/GatewayImageModelConfig.java
@@ -1,0 +1,103 @@
+package io.quarkiverse.langchain4j.watsonx.runtime.config;
+
+import java.util.Optional;
+
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.Background;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.Moderation;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.OutputFormat;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.Quality;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.ResponseFormat;
+import com.ibm.watsonx.ai.gateway.image.ModelGatewayImageParameters.Style;
+
+import io.quarkus.runtime.annotations.ConfigDocDefault;
+import io.quarkus.runtime.annotations.ConfigGroup;
+
+@ConfigGroup
+public interface GatewayImageModelConfig {
+
+    /**
+     * The identifier of the model to use, as configured in the Model Gateway.
+     */
+    Optional<String> modelName();
+
+    /**
+     * The background of the generated images.
+     * <p>
+     * Transparency requires an output format that supports it, so <code>png</code> or <code>webp</code>.
+     * <p>
+     * <strong>Allowable values:</strong> <code>[transparent, opaque, auto]</code>
+     */
+    Optional<Background> background();
+
+    /**
+     * How strictly the generated images are filtered, <code>low</code> being the least restrictive.
+     * <p>
+     * <strong>Allowable values:</strong> <code>[low, auto]</code>
+     */
+    Optional<Moderation> moderation();
+
+    /**
+     * The compression level of the generated images, from <code>0</code> to <code>100</code>.
+     * <p>
+     * Only the <code>jpeg</code> and <code>webp</code> output formats accept it.
+     */
+    Optional<Integer> outputCompression();
+
+    /**
+     * The file format of the generated images.
+     * <p>
+     * <strong>Allowable values:</strong> <code>[png, jpeg, webp, auto]</code>
+     */
+    Optional<OutputFormat> outputFormat();
+
+    /**
+     * The quality of the generated images.
+     * <p>
+     * <strong>Allowable values:</strong> <code>[auto, high, medium, low, hd, standard]</code>
+     */
+    Optional<Quality> quality();
+
+    /**
+     * How the generated images are returned, as a link with <code>url</code> or as Base64 data with <code>b64_json</code>.
+     * <p>
+     * Only the models that support it accept this value.
+     * <p>
+     * <strong>Allowable values:</strong> <code>[url, b64_json]</code>
+     */
+    Optional<ResponseFormat> responseFormat();
+
+    /**
+     * The dimensions of the generated images, for example <code>1024x1024</code>.
+     */
+    Optional<String> size();
+
+    /**
+     * The visual style of the generated images.
+     * <p>
+     * <strong>Allowable values:</strong> <code>[vivid, natural]</code>
+     */
+    Optional<Style> style();
+
+    /**
+     * A stable identifier of the end user issuing the request, used by the backing provider to detect and prevent abuse.
+     */
+    Optional<String> user();
+
+    /**
+     * Whether image model requests should be logged.
+     */
+    @ConfigDocDefault("false")
+    Optional<Boolean> logRequests();
+
+    /**
+     * Whether image model responses should be logged.
+     */
+    @ConfigDocDefault("false")
+    Optional<Boolean> logResponses();
+
+    /**
+     * Whether the watsonx.ai client should log requests as cURL commands.
+     */
+    @ConfigDocDefault("false")
+    Optional<Boolean> logRequestsCurl();
+}

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/LangChain4jWatsonxConfig.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/LangChain4jWatsonxConfig.java
@@ -156,6 +156,16 @@ public interface LangChain4jWatsonxConfig {
         EmbeddingModelConfig embeddingModel();
 
         /**
+         * Gateway embedding model related settings.
+         */
+        GatewayEmbeddingModelConfig gatewayEmbeddingModel();
+
+        /**
+         * Gateway image model related settings.
+         */
+        GatewayImageModelConfig gatewayImageModel();
+
+        /**
          * Scoring model related settings.
          */
         ScoringModelConfig scoringModel();

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/ModerationsConfig.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/config/ModerationsConfig.java
@@ -1,0 +1,85 @@
+package io.quarkiverse.langchain4j.watsonx.runtime.config;
+
+import java.util.Optional;
+import java.util.OptionalDouble;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+
+/**
+ * Inline moderation applied by watsonx.ai while the chat request is served.
+ * <p>
+ * Every detector is opt-in: a detector is only sent to watsonx.ai when at least one of its <code>input</code> or
+ * <code>output</code> properties is set.
+ */
+@ConfigGroup
+public interface ModerationsConfig {
+
+    /**
+     * Hate, abuse and profanity (HAP) detection.
+     */
+    Optional<HapConfig> hap();
+
+    /**
+     * Personally identifiable information (PII) detection.
+     */
+    Optional<PiiConfig> pii();
+
+    /**
+     * Granite Guardian detection.
+     */
+    Optional<GraniteGuardianConfig> graniteGuardian();
+
+    @ConfigGroup
+    interface HapConfig {
+
+        /**
+         * Enables HAP detection on the input text, using the given threshold score.
+         */
+        OptionalDouble input();
+
+        /**
+         * Enables HAP detection on the output text, using the given threshold score.
+         */
+        OptionalDouble output();
+
+        /**
+         * Whether the detected entity value is removed from the text instead of being returned.
+         */
+        Optional<Boolean> mask();
+    }
+
+    @ConfigGroup
+    interface PiiConfig {
+
+        /**
+         * Whether PII detection is applied to the input text.
+         */
+        Optional<Boolean> input();
+
+        /**
+         * Whether PII detection is applied to the output text.
+         */
+        Optional<Boolean> output();
+
+        /**
+         * Whether the detected entity value is removed from the text instead of being returned.
+         */
+        Optional<Boolean> mask();
+    }
+
+    @ConfigGroup
+    interface GraniteGuardianConfig {
+
+        /**
+         * Enables Granite Guardian detection on the input text, using the given threshold score.
+         * <p>
+         * Granite Guardian is only applied to the input text.
+         */
+        OptionalDouble input();
+
+        /**
+         * Whether the detected entity value is removed from the text instead of being returned.
+         */
+        Optional<Boolean> mask();
+    }
+}

--- a/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/spi/JsonProvider.java
+++ b/model-providers/watsonx/runtime/src/main/java/io/quarkiverse/langchain4j/watsonx/runtime/spi/JsonProvider.java
@@ -13,8 +13,12 @@ import io.quarkiverse.langchain4j.QuarkusJsonCodecFactory;
 
 public class JsonProvider implements com.ibm.watsonx.ai.core.spi.json.JsonProvider {
 
-    public static final ObjectMapper MAPPER = QuarkusJsonCodecFactory.SnakeCaseObjectMapperHolder.MAPPER
-            .copy().registerModule(new WatsonxJacksonModule());
+    private static class MapperHolder {
+        static final ObjectMapper INSTANCE = QuarkusJsonCodecFactory.SnakeCaseObjectMapperHolder.MAPPER
+                .copy().registerModule(new WatsonxJacksonModule());
+    }
+
+    public static ObjectMapper MAPPER = MapperHolder.INSTANCE;
 
     @Override
     public <T> T fromJson(String json, Class<T> type) {

--- a/model-providers/watsonx/runtime/src/main/resources/META-INF/services/com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatRestClient$ModelGatewayChatRestClientBuilderFactory
+++ b/model-providers/watsonx/runtime/src/main/resources/META-INF/services/com.ibm.watsonx.ai.gateway.chat.ModelGatewayChatRestClient$ModelGatewayChatRestClientBuilderFactory
@@ -1,1 +1,1 @@
-io.quarkiverse.langchain4j.watsonx.runtime.client.impl.QuarkusModelGatewayRestClient$QuarkusModelGatewayRestClientBuilderFactory
+io.quarkiverse.langchain4j.watsonx.runtime.client.impl.QuarkusModelGatewayChatRestClient$QuarkusModelGatewayChatRestClientBuilderFactory

--- a/model-providers/watsonx/runtime/src/main/resources/META-INF/services/com.ibm.watsonx.ai.gateway.embedding.ModelGatewayEmbeddingRestClient$ModelGatewayEmbeddingRestClientBuilderFactory
+++ b/model-providers/watsonx/runtime/src/main/resources/META-INF/services/com.ibm.watsonx.ai.gateway.embedding.ModelGatewayEmbeddingRestClient$ModelGatewayEmbeddingRestClientBuilderFactory
@@ -1,0 +1,1 @@
+io.quarkiverse.langchain4j.watsonx.runtime.client.impl.QuarkusModelGatewayEmbeddingRestClient$QuarkusModelGatewayEmbeddingRestClientBuilderFactory

--- a/model-providers/watsonx/runtime/src/main/resources/META-INF/services/com.ibm.watsonx.ai.gateway.image.ModelGatewayImageRestClient$ModelGatewayImageRestClientBuilderFactory
+++ b/model-providers/watsonx/runtime/src/main/resources/META-INF/services/com.ibm.watsonx.ai.gateway.image.ModelGatewayImageRestClient$ModelGatewayImageRestClientBuilderFactory
@@ -1,0 +1,1 @@
+io.quarkiverse.langchain4j.watsonx.runtime.client.impl.QuarkusModelGatewayImageRestClient$QuarkusModelGatewayImageRestClientBuilderFactory


### PR DESCRIPTION
This PR extends the `quarkus-langchain4j-watsonx` extension to align with the new features introduced in `langchain4j-watsonx` 1.20.0 (tracked in [langchain4j#6209](https://github.com/langchain4j/langchain4j/pull/6209)).

## Changes

### 1. Streaming cancellation via `StreamingHandle`

All three streaming chat models (`WatsonxStreamingChatModel`, `WatsonxDeploymentStreamingChatModel`, `WatsonxGatewayStreamingChatModel`) now implement the `StreamingHandle` contract. Calling `cancel()` propagates the cancellation to the underlying SDK future, aborting the in-flight HTTP stream immediately.

### 2. Model Gateway embedding model

New `WatsonxGatewayEmbeddingModel` backed by the `ModelGatewayEmbeddingService` of the watsonx.ai SDK, configurable under `quarkus.langchain4j.watsonx.gateway-embedding-model.*`.

### 3. Model Gateway image model

New `WatsonxGatewayImageModel` backed by the `ModelGatewayImageService`, configurable under `quarkus.langchain4j.watsonx.gateway-image-model.*`.

### 4. Inline chat moderation for foundation model chat

`WatsonxChatModel` and `WatsonxStreamingChatModel` now accept a `moderations` setting (both on the builder and as a per-request override in `WatsonxChatRequestParameters`).

### 5. Rename `ModelGatewayRestClient` → `ModelGatewayChatRestClient`

Aligns with the SDK rename of `ModelGatewayParameters.*` → `ModelGatewayChatParameters.*`.

### 6. Broader secret masking in `WatsonxClientLogger`

A wider set of sensitive fields is now masked in request/response logs.

### 7. Native image fix

`JsonProvider.MAPPER` is now lazily initialized via a holder class to avoid GraalVM build-time class initialization failures, and service providers for all watsonx.ai REST clients are explicitly registered for `ServiceLoader` support in native image.