### PR TITLE
Add support for reasoningEffort in the Azure OpenAI model provider

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-all-config.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-all-config.adoc
@@ -4544,6 +4544,27 @@ endif::add-copy-button-to-env-var[]
 |int
 |
 
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-reasoning-effort]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-reasoning-effort[`+++quarkus.langchain4j.azure-openai.chat-model.reasoning-effort+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.chat-model.reasoning-effort+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Constrains effort on reasoning for reasoning models. Supported values depend on the model used. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_CHAT_MODEL_REASONING_EFFORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_CHAT_MODEL_REASONING_EFFORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-presence-penalty]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-presence-penalty[`+++quarkus.langchain4j.azure-openai.chat-model.presence-penalty+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.azure-openai.chat-model.presence-penalty+++[]
@@ -5977,6 +5998,27 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__CHAT_MOD
 endif::add-copy-button-to-env-var[]
 --
 |int
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-reasoning-effort]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-reasoning-effort[`+++quarkus.langchain4j.azure-openai."model-name".chat-model.reasoning-effort+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".chat-model.reasoning-effort+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Constrains effort on reasoning for reasoning models. Supported values depend on the model used. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__CHAT_MODEL_REASONING_EFFORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__CHAT_MODEL_REASONING_EFFORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
 |
 
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-presence-penalty]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-presence-penalty[`+++quarkus.langchain4j.azure-openai."model-name".chat-model.presence-penalty+++`]##

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-azure-openai.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-azure-openai.adoc
@@ -691,6 +691,27 @@ endif::add-copy-button-to-env-var[]
 |int
 |
 
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-reasoning-effort]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-reasoning-effort[`+++quarkus.langchain4j.azure-openai.chat-model.reasoning-effort+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.chat-model.reasoning-effort+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Constrains effort on reasoning for reasoning models. Supported values depend on the model used. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_CHAT_MODEL_REASONING_EFFORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_CHAT_MODEL_REASONING_EFFORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-presence-penalty]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-presence-penalty[`+++quarkus.langchain4j.azure-openai.chat-model.presence-penalty+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.azure-openai.chat-model.presence-penalty+++[]
@@ -2124,6 +2145,27 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__CHAT_MOD
 endif::add-copy-button-to-env-var[]
 --
 |int
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-reasoning-effort]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-reasoning-effort[`+++quarkus.langchain4j.azure-openai."model-name".chat-model.reasoning-effort+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".chat-model.reasoning-effort+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Constrains effort on reasoning for reasoning models. Supported values depend on the model used. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__CHAT_MODEL_REASONING_EFFORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__CHAT_MODEL_REASONING_EFFORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
 |
 
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-presence-penalty]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-presence-penalty[`+++quarkus.langchain4j.azure-openai."model-name".chat-model.presence-penalty+++`]##

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-azure-openai_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-azure-openai_quarkus.langchain4j.adoc
@@ -691,6 +691,27 @@ endif::add-copy-button-to-env-var[]
 |int
 |
 
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-reasoning-effort]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-reasoning-effort[`+++quarkus.langchain4j.azure-openai.chat-model.reasoning-effort+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai.chat-model.reasoning-effort+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Constrains effort on reasoning for reasoning models. Supported values depend on the model used. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_CHAT_MODEL_REASONING_EFFORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI_CHAT_MODEL_REASONING_EFFORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-presence-penalty]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-chat-model-presence-penalty[`+++quarkus.langchain4j.azure-openai.chat-model.presence-penalty+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.langchain4j.azure-openai.chat-model.presence-penalty+++[]
@@ -2124,6 +2145,27 @@ Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__CHAT_MOD
 endif::add-copy-button-to-env-var[]
 --
 |int
+|
+
+a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-reasoning-effort]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-reasoning-effort[`+++quarkus.langchain4j.azure-openai."model-name".chat-model.reasoning-effort+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.azure-openai."model-name".chat-model.reasoning-effort+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Constrains effort on reasoning for reasoning models. Supported values depend on the model used. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__CHAT_MODEL_REASONING_EFFORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_AZURE_OPENAI__MODEL_NAME__CHAT_MODEL_REASONING_EFFORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
 |
 
 a| [[quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-presence-penalty]] [.property-path]##link:#quarkus-langchain4j-azure-openai_quarkus-langchain4j-azure-openai-model-name-chat-model-presence-penalty[`+++quarkus.langchain4j.azure-openai."model-name".chat-model.presence-penalty+++`]##

--- a/model-providers/openai/azure-openai/deployment/src/test/java/io/quarkiverse/langchain4j/azure/openai/test/AzureOpenAiChatModelExplicitSamplingParamsTest.java
+++ b/model-providers/openai/azure-openai/deployment/src/test/java/io/quarkiverse/langchain4j/azure/openai/test/AzureOpenAiChatModelExplicitSamplingParamsTest.java
@@ -31,6 +31,7 @@ public class AzureOpenAiChatModelExplicitSamplingParamsTest extends OpenAiBaseTe
             .overrideRuntimeConfigKey("quarkus.langchain4j.azure-openai.api-key", "whatever")
             .overrideRuntimeConfigKey("quarkus.langchain4j.azure-openai.chat-model.temperature", "0.3")
             .overrideRuntimeConfigKey("quarkus.langchain4j.azure-openai.chat-model.top-p", "0.8")
+            .overrideRuntimeConfigKey("quarkus.langchain4j.azure-openai.chat-model.reasoning-effort", "medium")
             .overrideRuntimeConfigKey("quarkus.langchain4j.azure-openai.endpoint",
                     WiremockAware.wiremockUrlForConfig("/v1"));
 
@@ -50,7 +51,10 @@ public class AzureOpenAiChatModelExplicitSamplingParamsTest extends OpenAiBaseTe
         chatModel.chat("hello");
 
         Map<String, Object> requestBody = getRequestAsMap();
-        assertThat(requestBody).containsEntry("temperature", 0.3).containsEntry("top_p", 0.8);
+        assertThat(requestBody)
+                .containsEntry("temperature", 0.3)
+                .containsEntry("top_p", 0.8)
+                .containsEntry("reasoning_effort", "medium");
     }
 
     @Test
@@ -74,6 +78,9 @@ public class AzureOpenAiChatModelExplicitSamplingParamsTest extends OpenAiBaseTe
         latch.await(1, TimeUnit.MINUTES);
 
         Map<String, Object> requestBody = getRequestAsMap();
-        assertThat(requestBody).containsEntry("temperature", 0.3).containsEntry("top_p", 0.8);
+        assertThat(requestBody)
+                .containsEntry("temperature", 0.3)
+                .containsEntry("top_p", 0.8)
+                .containsEntry("reasoning_effort", "medium");
     }
 }

--- a/model-providers/openai/azure-openai/deployment/src/test/java/io/quarkiverse/langchain4j/azure/openai/test/AzureOpenAiChatModelSamplingParamsOmittedTest.java
+++ b/model-providers/openai/azure-openai/deployment/src/test/java/io/quarkiverse/langchain4j/azure/openai/test/AzureOpenAiChatModelSamplingParamsOmittedTest.java
@@ -30,10 +30,13 @@ public class AzureOpenAiChatModelSamplingParamsOmittedTest extends OpenAiBaseTes
     ChatModel chatModel;
 
     @Test
-    void temperatureAndTopPAreNotSentWhenUnconfigured() throws IOException {
+    void samplingAndReasoningParametersAreNotSentWhenUnconfigured() throws IOException {
         chatModel.chat("hello");
 
         Map<String, Object> requestBody = getRequestAsMap();
-        assertThat(requestBody).doesNotContainKey("temperature").doesNotContainKey("top_p");
+        assertThat(requestBody)
+                .doesNotContainKey("temperature")
+                .doesNotContainKey("top_p")
+                .doesNotContainKey("reasoning_effort");
     }
 }

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/AzureOpenAiChatModel.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/AzureOpenAiChatModel.java
@@ -76,6 +76,7 @@ public class AzureOpenAiChatModel implements ChatModel {
     private final Integer seed;
     private final Double topP;
     private final Integer maxTokens;
+    private final String reasoningEffort;
     private final Double presencePenalty;
     private final Double frequencyPenalty;
     private final Integer maxRetries;
@@ -93,6 +94,7 @@ public class AzureOpenAiChatModel implements ChatModel {
             Integer seed,
             Double topP,
             Integer maxTokens,
+            String reasoningEffort,
             Double presencePenalty,
             Double frequencyPenalty,
             Duration timeout,
@@ -130,6 +132,7 @@ public class AzureOpenAiChatModel implements ChatModel {
         this.seed = seed;
         this.topP = topP;
         this.maxTokens = maxTokens;
+        this.reasoningEffort = reasoningEffort;
         this.presencePenalty = presencePenalty;
         this.frequencyPenalty = frequencyPenalty;
         this.maxRetries = getOrDefault(maxRetries, 1);
@@ -154,6 +157,7 @@ public class AzureOpenAiChatModel implements ChatModel {
                 .seed(seed)
                 .topP(topP)
                 .maxTokens(maxTokens)
+                .reasoningEffort(reasoningEffort)
                 .presencePenalty(presencePenalty)
                 .frequencyPenalty(frequencyPenalty)
                 .responseFormat(responseFormat);
@@ -286,6 +290,7 @@ public class AzureOpenAiChatModel implements ChatModel {
         private Integer seed;
         private Double topP;
         private Integer maxTokens;
+        private String reasoningEffort;
         private Double presencePenalty;
         private Double frequencyPenalty;
         private Duration timeout;
@@ -372,6 +377,11 @@ public class AzureOpenAiChatModel implements ChatModel {
             return this;
         }
 
+        public Builder reasoningEffort(String reasoningEffort) {
+            this.reasoningEffort = reasoningEffort;
+            return this;
+        }
+
         public Builder presencePenalty(Double presencePenalty) {
             this.presencePenalty = presencePenalty;
             return this;
@@ -433,6 +443,7 @@ public class AzureOpenAiChatModel implements ChatModel {
                     seed,
                     topP,
                     maxTokens,
+                    reasoningEffort,
                     presencePenalty,
                     frequencyPenalty,
                     timeout,

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/AzureOpenAiStreamingChatModel.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/AzureOpenAiStreamingChatModel.java
@@ -81,6 +81,7 @@ public class AzureOpenAiStreamingChatModel implements StreamingChatModel {
     private final Double temperature;
     private final Double topP;
     private final Integer maxTokens;
+    private final String reasoningEffort;
     private final Double presencePenalty;
     private final Double frequencyPenalty;
     private final TokenCountEstimator tokenizer;
@@ -96,6 +97,7 @@ public class AzureOpenAiStreamingChatModel implements StreamingChatModel {
             Double temperature,
             Double topP,
             Integer maxTokens,
+            String reasoningEffort,
             Double presencePenalty,
             Double frequencyPenalty,
             Duration timeout,
@@ -130,6 +132,7 @@ public class AzureOpenAiStreamingChatModel implements StreamingChatModel {
         this.temperature = temperature;
         this.topP = topP;
         this.maxTokens = maxTokens;
+        this.reasoningEffort = reasoningEffort;
         this.presencePenalty = presencePenalty;
         this.frequencyPenalty = frequencyPenalty;
         this.tokenizer = tokenizer;
@@ -151,6 +154,7 @@ public class AzureOpenAiStreamingChatModel implements StreamingChatModel {
                 .temperature(temperature)
                 .topP(topP)
                 .maxTokens(maxTokens)
+                .reasoningEffort(reasoningEffort)
                 .presencePenalty(presencePenalty)
                 .frequencyPenalty(frequencyPenalty)
                 .responseFormat(responseFormat);
@@ -318,6 +322,7 @@ public class AzureOpenAiStreamingChatModel implements StreamingChatModel {
         private Double temperature;
         private Double topP;
         private Integer maxTokens;
+        private String reasoningEffort;
         private Double presencePenalty;
         private Double frequencyPenalty;
         private Duration timeout;
@@ -393,6 +398,11 @@ public class AzureOpenAiStreamingChatModel implements StreamingChatModel {
             return this;
         }
 
+        public Builder reasoningEffort(String reasoningEffort) {
+            this.reasoningEffort = reasoningEffort;
+            return this;
+        }
+
         public Builder presencePenalty(Double presencePenalty) {
             this.presencePenalty = presencePenalty;
             return this;
@@ -453,6 +463,7 @@ public class AzureOpenAiStreamingChatModel implements StreamingChatModel {
                     temperature,
                     topP,
                     maxTokens,
+                    reasoningEffort,
                     presencePenalty,
                     frequencyPenalty,
                     timeout,

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorder.java
@@ -100,6 +100,7 @@ public class AzureOpenAiRecorder {
                     .logCurl(firstOrDefault(false, azureAiConfig.logRequestsCurl()))
                     .temperature(chatModelConfig.temperature().orElse(null))
                     .topP(chatModelConfig.topP().orElse(null))
+                    .reasoningEffort(chatModelConfig.reasoningEffort().orElse(null))
                     .presencePenalty(chatModelConfig.presencePenalty())
                     .frequencyPenalty(chatModelConfig.frequencyPenalty())
                     .responseFormat(chatModelConfig.responseFormat().orElse(null));
@@ -163,6 +164,7 @@ public class AzureOpenAiRecorder {
                     .logCurl(firstOrDefault(false, azureAiConfig.logRequestsCurl()))
                     .temperature(chatModelConfig.temperature().orElse(null))
                     .topP(chatModelConfig.topP().orElse(null))
+                    .reasoningEffort(chatModelConfig.reasoningEffort().orElse(null))
                     .presencePenalty(chatModelConfig.presencePenalty())
                     .frequencyPenalty(chatModelConfig.frequencyPenalty())
                     .responseFormat(chatModelConfig.responseFormat().orElse(null));

--- a/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/ChatModelConfig.java
+++ b/model-providers/openai/azure-openai/runtime/src/main/java/io/quarkiverse/langchain4j/azure/openai/runtime/config/ChatModelConfig.java
@@ -92,6 +92,13 @@ public interface ChatModelConfig {
     Optional<Integer> maxTokens();
 
     /**
+     * Constrains effort on reasoning for reasoning models.
+     * Supported values depend on the model used.
+     * Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
+     */
+    Optional<String> reasoningEffort();
+
+    /**
      * Number between -2.0 and 2.0.
      * Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to
      * talk about new topics.

--- a/model-providers/openai/azure-openai/runtime/src/test/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorderEndpointTests.java
+++ b/model-providers/openai/azure-openai/runtime/src/test/java/io/quarkiverse/langchain4j/azure/openai/runtime/AzureOpenAiRecorderEndpointTests.java
@@ -276,6 +276,11 @@ class AzureOpenAiRecorderEndpointTests {
                 }
 
                 @Override
+                public Optional<String> reasoningEffort() {
+                    return Optional.empty();
+                }
+
+                @Override
                 public Double presencePenalty() {
                     return null;
                 }


### PR DESCRIPTION
Adds support for the reasoningEffort config parameter in the Azure OpenAI model provider.

Its description voluntarily doesn't mention possible values as they vary between models.

Related to:
- https://github.com/quarkiverse/quarkus-langchain4j/issues/1870
- https://github.com/quarkiverse/quarkus-langchain4j/pull/1887
