### PR TITLE
Fix A2A agent discovery from Apicurio Registry always returning no agents

### DIFF
--- a/a2a-apicurio-registry/deployment/src/test/java/io/quarkiverse/langchain4j/a2a/test/apicurio/ApicurioRegistryA2AToolsTest.java
+++ b/a2a-apicurio-registry/deployment/src/test/java/io/quarkiverse/langchain4j/a2a/test/apicurio/ApicurioRegistryA2AToolsTest.java
@@ -36,11 +36,12 @@ import io.quarkus.test.QuarkusUnitTest;
  * Integration test verifying that ApicurioAgentsRegistry can connect to
  * a real Apicurio Registry and search for AGENT_CARD artifacts.
  *
- * Note: allAgents() returns empty because the registered agent card URLs
- * (localhost:9999, localhost:9998) are not reachable — the A2A client builder
- * fails to fetch /.well-known/agent-card.json. This is expected in tests
- * without live A2A servers. The registry connectivity itself is verified
- * by querying the search API directly.
+ * Note: allAgents() returns empty here because the registered agent card URLs
+ * (localhost:9999, localhost:9998) are not reachable, so the A2A client builder
+ * fails to fetch /.well-known/agent-card.json before an agent can be built. That
+ * is the only reason left: the input keys the builder requires are resolved by
+ * ApicurioAgentsRegistryInputKeysTest in the runtime module. The registry
+ * connectivity itself is verified by querying the search API directly.
  */
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class ApicurioRegistryA2AToolsTest {

--- a/a2a-apicurio-registry/runtime/pom.xml
+++ b/a2a-apicurio-registry/runtime/pom.xml
@@ -46,6 +46,11 @@
             <artifactId>apicurio-registry-java-sdk-adapter-jdk</artifactId>
             <version>${apicurio-registry-sdk.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/a2a-apicurio-registry/runtime/src/main/java/io/quarkiverse/langchain4j/a2a/runtime/apicurio/A2AApicurioRegistryRecorder.java
+++ b/a2a-apicurio-registry/runtime/src/main/java/io/quarkiverse/langchain4j/a2a/runtime/apicurio/A2AApicurioRegistryRecorder.java
@@ -28,7 +28,7 @@ public class A2AApicurioRegistryRecorder {
             public ApicurioAgentsRegistry apply(SyntheticCreationalContext<ApicurioAgentsRegistry> context) {
                 A2AApicurioRegistryRuntimeConfig config = runtimeConfig.getValue();
                 RegistryClient registryClient = createRegistryClient(config);
-                return new ApicurioAgentsRegistry(registryClient);
+                return new ApicurioAgentsRegistry(registryClient, config.defaultInputKeys());
             }
         };
     }

--- a/a2a-apicurio-registry/runtime/src/main/java/io/quarkiverse/langchain4j/a2a/runtime/apicurio/ApicurioAgentsRegistry.java
+++ b/a2a-apicurio-registry/runtime/src/main/java/io/quarkiverse/langchain4j/a2a/runtime/apicurio/ApicurioAgentsRegistry.java
@@ -1,7 +1,10 @@
 package io.quarkiverse.langchain4j.a2a.runtime.apicurio;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.jboss.logging.Logger;
 
@@ -9,17 +12,29 @@ import dev.langchain4j.agentic.AgenticServices;
 import dev.langchain4j.agentic.planner.AgentInstance;
 import dev.langchain4j.agentic.planner.AgentsRegistry;
 import io.apicurio.registry.rest.client.RegistryClient;
+import io.apicurio.registry.rest.client.models.SearchedArtifact;
 
 public class ApicurioAgentsRegistry implements AgentsRegistry {
 
     private static final Logger log = Logger.getLogger(ApicurioAgentsRegistry.class);
     private static final String AGENT_CARD_TYPE = "AGENT_CARD";
     private static final int DEFAULT_LIMIT = 100;
+    private static final String AGENT_URL_LABEL = "a2a-agent-url";
+    private static final String INPUT_KEYS_LABEL = "a2a-input-keys";
+    private static final List<String> FALLBACK_INPUT_KEYS = List.of("input");
 
     private final RegistryClient registryClient;
+    private final List<String> defaultInputKeys;
 
     public ApicurioAgentsRegistry(RegistryClient registryClient) {
+        this(registryClient, FALLBACK_INPUT_KEYS);
+    }
+
+    public ApicurioAgentsRegistry(RegistryClient registryClient, List<String> defaultInputKeys) {
         this.registryClient = registryClient;
+        this.defaultInputKeys = defaultInputKeys == null || defaultInputKeys.isEmpty()
+                ? FALLBACK_INPUT_KEYS
+                : List.copyOf(defaultInputKeys);
     }
 
     @Override
@@ -62,12 +77,20 @@ public class ApicurioAgentsRegistry implements AgentsRegistry {
                     }
 
                     String name = artifact.getName() != null ? artifact.getName() : artifact.getArtifactId();
+                    // Agent cards carry no input schema, so discovered agents are untyped and the input keys
+                    // must be supplied explicitly. They are both the arguments exposed to a supervisor and the
+                    // keys read from the AgenticScope on invocation. Note that this is unrelated to the
+                    // @V("input") parameter of UntypedAgent#invoke, which is the whole argument map.
+                    String[] inputKeys = resolveInputKeys(artifact);
+
                     AgentInstance a2aAgent = (AgentInstance) AgenticServices.a2aBuilder(agentUrl)
+                            .inputKeys(inputKeys)
                             .outputKey(name)
                             .build();
 
                     discovered.put(name, a2aAgent);
-                    log.debugf("Discovered A2A agent '%s' at %s", name, agentUrl);
+                    log.debugf("Discovered A2A agent '%s' at %s with input keys %s",
+                            name, agentUrl, Arrays.toString(inputKeys));
                 } catch (Exception e) {
                     log.warnf(e, "Failed to create A2A agent from artifact %s/%s",
                             artifact.getGroupId(), artifact.getArtifactId());
@@ -80,7 +103,28 @@ public class ApicurioAgentsRegistry implements AgentsRegistry {
         return Map.copyOf(discovered);
     }
 
-    private String extractAgentUrl(io.apicurio.registry.rest.client.models.SearchedArtifact artifact) {
+    // visible for testing
+    String[] resolveInputKeys(SearchedArtifact artifact) {
+        String declared = extractLabel(artifact, INPUT_KEYS_LABEL);
+        if (declared != null && !declared.isBlank()) {
+            String[] keys = Stream.of(declared.split(","))
+                    .map(String::trim)
+                    .filter(key -> !key.isEmpty())
+                    .toArray(String[]::new);
+            if (keys.length > 0) {
+                return keys;
+            }
+            log.warnf("Artifact %s/%s declares an empty '%s' label, falling back to %s",
+                    artifact.getGroupId(), artifact.getArtifactId(), INPUT_KEYS_LABEL, defaultInputKeys);
+        }
+        return defaultInputKeys.toArray(String[]::new);
+    }
+
+    private String extractAgentUrl(SearchedArtifact artifact) {
+        return extractLabel(artifact, AGENT_URL_LABEL);
+    }
+
+    private String extractLabel(SearchedArtifact artifact, String key) {
         var labels = artifact.getLabels();
         if (labels == null) {
             return null;
@@ -89,7 +133,7 @@ public class ApicurioAgentsRegistry implements AgentsRegistry {
         if (labelData == null) {
             return null;
         }
-        Object url = labelData.get("a2a-agent-url");
-        return url != null ? url.toString() : null;
+        Object value = labelData.get(key);
+        return value != null ? value.toString() : null;
     }
 }

--- a/a2a-apicurio-registry/runtime/src/main/java/io/quarkiverse/langchain4j/a2a/runtime/apicurio/config/A2AApicurioRegistryRuntimeConfig.java
+++ b/a2a-apicurio-registry/runtime/src/main/java/io/quarkiverse/langchain4j/a2a/runtime/apicurio/config/A2AApicurioRegistryRuntimeConfig.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.langchain4j.a2a.runtime.apicurio.config;
 
+import java.util.List;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -32,4 +33,15 @@ public interface A2AApicurioRegistryRuntimeConfig {
      * The base URL of this application's A2A server endpoint, used when publishing the agent card.
      */
     Optional<String> agentUrl();
+
+    /**
+     * The input keys used for agents discovered from the registry whose agent card artifact does not
+     * declare an {@code a2a-input-keys} label.
+     * <p>
+     * A2A agent cards carry no input schema, so discovered agents are built as untyped agents and these
+     * keys define both the arguments exposed to a supervisor or planner and the keys read from the
+     * {@code AgenticScope} when invoking the remote agent.
+     */
+    @WithDefault("input")
+    List<String> defaultInputKeys();
 }

--- a/a2a-apicurio-registry/runtime/src/test/java/io/quarkiverse/langchain4j/a2a/runtime/apicurio/ApicurioAgentsRegistryInputKeysTest.java
+++ b/a2a-apicurio-registry/runtime/src/test/java/io/quarkiverse/langchain4j/a2a/runtime/apicurio/ApicurioAgentsRegistryInputKeysTest.java
@@ -1,0 +1,80 @@
+package io.quarkiverse.langchain4j.a2a.runtime.apicurio;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.apicurio.registry.rest.client.models.Labels;
+import io.apicurio.registry.rest.client.models.SearchedArtifact;
+
+/**
+ * A2A agent cards carry no input schema, so agents discovered from the registry are built as
+ * untyped agents and their input keys have to be supplied explicitly, otherwise
+ * {@code DefaultA2AClientBuilder#build()} rejects them and discovery silently yields nothing.
+ * These tests cover the resolution order of those keys.
+ */
+class ApicurioAgentsRegistryInputKeysTest {
+
+    @Test
+    void usesInputKeysDeclaredByTheArtifactLabel() {
+        ApicurioAgentsRegistry registry = new ApicurioAgentsRegistry(null, List.of("configured"));
+
+        assertArrayEquals(new String[] { "topic", "style" },
+                registry.resolveInputKeys(artifactWithLabels(Map.of("a2a-input-keys", "topic,style"))));
+    }
+
+    @Test
+    void trimsAndSkipsBlankEntriesInTheArtifactLabel() {
+        ApicurioAgentsRegistry registry = new ApicurioAgentsRegistry(null, List.of("configured"));
+
+        assertArrayEquals(new String[] { "topic", "style" },
+                registry.resolveInputKeys(artifactWithLabels(Map.of("a2a-input-keys", " topic , , style "))));
+    }
+
+    @Test
+    void fallsBackToTheConfiguredKeysWhenTheLabelIsAbsent() {
+        ApicurioAgentsRegistry registry = new ApicurioAgentsRegistry(null, List.of("question", "language"));
+
+        assertArrayEquals(new String[] { "question", "language" },
+                registry.resolveInputKeys(artifactWithLabels(Map.of("a2a-agent-url", "http://localhost:9999/a2a"))));
+    }
+
+    @Test
+    void fallsBackToTheConfiguredKeysWhenTheLabelIsBlank() {
+        ApicurioAgentsRegistry registry = new ApicurioAgentsRegistry(null, List.of("question"));
+
+        assertArrayEquals(new String[] { "question" },
+                registry.resolveInputKeys(artifactWithLabels(Map.of("a2a-input-keys", " , "))));
+    }
+
+    @Test
+    void fallsBackToInputWhenNothingIsDeclaredOrConfigured() {
+        ApicurioAgentsRegistry registry = new ApicurioAgentsRegistry(null);
+
+        assertArrayEquals(new String[] { "input" }, registry.resolveInputKeys(artifactWithLabels(Map.of())));
+        assertArrayEquals(new String[] { "input" }, registry.resolveInputKeys(new SearchedArtifact()));
+    }
+
+    @Test
+    void fallsBackToInputWhenTheConfiguredKeysAreEmpty() {
+        assertArrayEquals(new String[] { "input" },
+                new ApicurioAgentsRegistry(null, List.of()).resolveInputKeys(new SearchedArtifact()));
+        assertArrayEquals(new String[] { "input" },
+                new ApicurioAgentsRegistry(null, null).resolveInputKeys(new SearchedArtifact()));
+    }
+
+    private static SearchedArtifact artifactWithLabels(Map<String, Object> labelData) {
+        Labels labels = new Labels();
+        labels.setAdditionalData(new HashMap<>(labelData));
+
+        SearchedArtifact artifact = new SearchedArtifact();
+        artifact.setGroupId("default");
+        artifact.setArtifactId("some-agent");
+        artifact.setLabels(labels);
+        return artifact;
+    }
+}

--- a/docs/modules/ROOT/pages/includes/quarkus-all-config.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-all-config.adoc
@@ -1428,6 +1428,29 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
+a| [[quarkus-langchain4j-a2a-apicurio-registry_quarkus-langchain4j-a2a-apicurio-registry-default-input-keys]] [.property-path]##link:#quarkus-langchain4j-a2a-apicurio-registry_quarkus-langchain4j-a2a-apicurio-registry-default-input-keys[`+++quarkus.langchain4j.a2a.apicurio-registry.default-input-keys+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.a2a.apicurio-registry.default-input-keys+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The input keys used for agents discovered from the registry whose agent card artifact does not declare an `a2a-input-keys` label.
+
+A2A agent cards carry no input schema, so discovered agents are built as untyped agents and these keys define both the arguments exposed to a supervisor or planner and the keys read from the `AgenticScope` when invoking the remote agent.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_A2A_APICURIO_REGISTRY_DEFAULT_INPUT_KEYS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_A2A_APICURIO_REGISTRY_DEFAULT_INPUT_KEYS+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|`+++input+++`
+
 
 h|[.extension-name]##Quarkus LangChain4j - AI Gemini##
 h|Type

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-a2a-apicurio-registry.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-a2a-apicurio-registry.adoc
@@ -112,5 +112,28 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
+a| [[quarkus-langchain4j-a2a-apicurio-registry_quarkus-langchain4j-a2a-apicurio-registry-default-input-keys]] [.property-path]##link:#quarkus-langchain4j-a2a-apicurio-registry_quarkus-langchain4j-a2a-apicurio-registry-default-input-keys[`+++quarkus.langchain4j.a2a.apicurio-registry.default-input-keys+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.a2a.apicurio-registry.default-input-keys+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The input keys used for agents discovered from the registry whose agent card artifact does not declare an `a2a-input-keys` label.
+
+A2A agent cards carry no input schema, so discovered agents are built as untyped agents and these keys define both the arguments exposed to a supervisor or planner and the keys read from the `AgenticScope` when invoking the remote agent.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_A2A_APICURIO_REGISTRY_DEFAULT_INPUT_KEYS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_A2A_APICURIO_REGISTRY_DEFAULT_INPUT_KEYS+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|`+++input+++`
+
 |===
 

--- a/docs/modules/ROOT/pages/includes/quarkus-langchain4j-a2a-apicurio-registry_quarkus.langchain4j.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-langchain4j-a2a-apicurio-registry_quarkus.langchain4j.adoc
@@ -112,5 +112,28 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
+a| [[quarkus-langchain4j-a2a-apicurio-registry_quarkus-langchain4j-a2a-apicurio-registry-default-input-keys]] [.property-path]##link:#quarkus-langchain4j-a2a-apicurio-registry_quarkus-langchain4j-a2a-apicurio-registry-default-input-keys[`+++quarkus.langchain4j.a2a.apicurio-registry.default-input-keys+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.langchain4j.a2a.apicurio-registry.default-input-keys+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The input keys used for agents discovered from the registry whose agent card artifact does not declare an `a2a-input-keys` label.
+
+A2A agent cards carry no input schema, so discovered agents are built as untyped agents and these keys define both the arguments exposed to a supervisor or planner and the keys read from the `AgenticScope` when invoking the remote agent.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LANGCHAIN4J_A2A_APICURIO_REGISTRY_DEFAULT_INPUT_KEYS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LANGCHAIN4J_A2A_APICURIO_REGISTRY_DEFAULT_INPUT_KEYS+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|`+++input+++`
+
 |===
 


### PR DESCRIPTION
### Problem

`ApicurioAgentsRegistry#allAgents()` always returns an empty map, regardless of
how many agent cards are published in the registry or whether the corresponding
A2A servers are reachable.

Agents are built through `AgenticServices.a2aBuilder(agentUrl)`, whose
single-argument overload resolves to `UntypedAgent`. `DefaultA2AClientBuilder#build()`
rejects an `UntypedAgent` that has no input keys:

```java
if (agentServiceClass == UntypedAgent.class && inputKeys == null) {
    throw new IllegalArgumentException("Input names must be provided for UntypedAgent.");
}
```

Since .inputKeys(...) was never called, every agent card threw, the exception
was swallowed by the surrounding catch and logged as a warning, and discovery
silently yielded nothing. getAgent(name) consequently always failed with
No agent found with name: ....

Why input keys are required

They are not an optional detail of the builder. For untyped agents they are used
in two places:

- DefaultA2AClientBuilder#invokeAgent reads them from the argument map to build
  the TextParts of the A2A message;
- A2AClientAgentInvoker#arguments turns them into the AgentArguments exposed
  to a supervisor or planner, i.e. they are the discovered agent's signature.

Solution

A2A agent cards carry no input schema, so the keys cannot be derived from the
card itself. They are resolved with a fallback chain:

1. the artifact's a2a-input-keys label (comma separated), symmetric with the
   existing a2a-agent-url and a2a-agent-skills labels written by
   A2AAgentCardPublisher;
2. the new quarkus.langchain4j.a2a.apicurio-registry.default-input-keys
   property, which also covers agents with more than one input;
3. input.

The existing single-argument ApicurioAgentsRegistry constructor keeps input
as its default, so direct instantiation is unaffected.

Note that input matching the @V("input") parameter of UntypedAgent#invoke
is a coincidence of naming: @V("input") is the whole argument map, while an
input key is a key within that map. A comment in the code says so, to keep the
two from being "simplified" into one later.

- Fixes:  #2796