### PR TITLE
Return String tool results as-is instead of JSON-encoding them

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ToolExecutorTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ToolExecutorTest.java
@@ -28,6 +28,7 @@ import io.quarkiverse.langchain4j.runtime.ToolsRecorder;
 import io.quarkiverse.langchain4j.runtime.tool.QuarkusToolExecutor;
 import io.quarkiverse.langchain4j.runtime.tool.ToolMethodCreateInfo;
 import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Uni;
 
 class ToolExecutorTest {
 
@@ -141,6 +142,30 @@ class ToolExecutorTest {
         @Tool
         String mappedEnum(Map<String, SortBy> arg0) {
             return arg0.get("first").name();
+        }
+
+        @Tool
+        String markdownDocument() {
+            return "# Title\nKind: file\n\nBody.";
+        }
+
+        @Tool
+        String nullDocument() {
+            return null;
+        }
+
+        @Tool
+        Uni<String> markdownDocumentUni() {
+            return Uni.createFrom().item("# Title\nKind: file\n\nBody.");
+        }
+
+        @Tool
+        ArgObject objectResult() {
+            return new ArgObject("ABC", SortBy.DATE);
+        }
+
+        @Tool
+        void voidResult() {
         }
     }
 
@@ -316,13 +341,13 @@ class ToolExecutorTest {
 
     @Test
     void should_deserialize_generic_tool_arguments() {
-        executeAndAssert("{\"arg0\":[\"DATE\"]}", "listOfEnum", "\"DATE\"");
+        executeAndAssert("{\"arg0\":[\"DATE\"]}", "listOfEnum", "DATE");
 
-        executeAndAssert("{\"arg0\":[\"A\",\"B\"]}", "listOfString", "\"A,B\"");
+        executeAndAssert("{\"arg0\":[\"A\",\"B\"]}", "listOfString", "A,B");
 
-        executeAndAssert("{\"arg0\":[{\"name\":\"ABC\",\"sortBy\":\"DATE\"}]}", "listOfObject", "\"ABC:DATE\"");
+        executeAndAssert("{\"arg0\":[{\"name\":\"ABC\",\"sortBy\":\"DATE\"}]}", "listOfObject", "ABC:DATE");
 
-        executeAndAssert("{\"arg0\":{\"first\":\"DATE\"}}", "mappedEnum", "\"DATE\"");
+        executeAndAssert("{\"arg0\":{\"first\":\"DATE\"}}", "mappedEnum", "DATE");
     }
 
     @ParameterizedTest
@@ -343,7 +368,7 @@ class ToolExecutorTest {
 
         String result = toolExecutor.execute(request, null);
 
-        assertThat(result).isEqualTo("\"test:10\"");
+        assertThat(result).isEqualTo("test:10");
     }
 
     @Test
@@ -356,7 +381,7 @@ class ToolExecutorTest {
 
         String result = toolExecutor.execute(request, null);
 
-        assertThat(result).isEqualTo("\"test:25\"");
+        assertThat(result).isEqualTo("test:25");
     }
 
     @Test
@@ -369,7 +394,7 @@ class ToolExecutorTest {
 
         String result = toolExecutor.execute(request, null);
 
-        assertThat(result).isEqualTo("\"test:USD\"");
+        assertThat(result).isEqualTo("test:USD");
     }
 
     @Test
@@ -382,7 +407,7 @@ class ToolExecutorTest {
 
         String result = toolExecutor.execute(request, null);
 
-        assertThat(result).isEqualTo("\"test:RELEVANCE\"");
+        assertThat(result).isEqualTo("test:RELEVANCE");
     }
 
     @Test
@@ -395,7 +420,7 @@ class ToolExecutorTest {
 
         String result = toolExecutor.execute(request, null);
 
-        assertThat(result).isEqualTo("\"test:true\"");
+        assertThat(result).isEqualTo("test:true");
     }
 
     @Test
@@ -408,7 +433,7 @@ class ToolExecutorTest {
 
         String result = toolExecutor.execute(request, null);
 
-        assertThat(result).isEqualTo("\"5:DESC\"");
+        assertThat(result).isEqualTo("5:DESC");
     }
 
     @Test
@@ -424,6 +449,35 @@ class ToolExecutorTest {
         JsonObjectSchema schema = withDefaultInt.toolSpecification().parameters();
         assertThat(schema.required()).containsExactly("query");
         assertThat(schema.properties().keySet()).containsExactlyInAnyOrder("query", "limit");
+    }
+
+    @Test
+    void should_return_string_result_as_is() {
+        executeAndAssert("{}", "markdownDocument", "# Title\nKind: file\n\nBody.");
+    }
+
+    @Test
+    void should_return_string_result_of_uni_as_is() {
+        executeAndAssert("{}", "markdownDocumentUni", "# Title\nKind: file\n\nBody.");
+    }
+
+    @Test
+    void should_render_null_string_result_as_null_literal() {
+        executeAndAssert("{}", "nullDocument", "null");
+    }
+
+    @Test
+    void should_json_encode_non_string_result() {
+        ToolExecutionRequest request = ToolExecutionRequest.builder().arguments("{}").build();
+
+        String result = getToolExecutor("objectResult").execute(request, null);
+
+        assertThat(result.replaceAll("\\s", "")).isEqualTo("{\"name\":\"ABC\",\"sortBy\":\"DATE\"}");
+    }
+
+    @Test
+    void should_report_success_for_void_result() {
+        executeAndAssert("{}", "voidResult", "Success");
     }
 
     private void executeAndAssert(String arguments, String methodName,

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolresolution/ExplicitToolBoxAndProviderSupplierTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolresolution/ExplicitToolBoxAndProviderSupplierTest.java
@@ -46,7 +46,7 @@ public class ExplicitToolBoxAndProviderSupplierTest {
     @ActivateRequestContext
     void testCall() {
         String answer = service.chat("hello", 1);
-        assertEquals("\"EXPLICIT TOOL\"", answer);
+        assertEquals("EXPLICIT TOOL", answer);
 
     }
 

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolresolution/ExplicitToolsAndNoBeanToolProviderTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolresolution/ExplicitToolsAndNoBeanToolProviderTest.java
@@ -42,7 +42,7 @@ public class ExplicitToolsAndNoBeanToolProviderTest {
     @ActivateRequestContext
     void testCall() {
         String answer = service.chat("hello", 1);
-        assertEquals("\"EXPLICIT TOOL\"", answer);
+        assertEquals("EXPLICIT TOOL", answer);
     }
 
 }

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolresolution/ExplicitToolsAndProviderSupplierTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolresolution/ExplicitToolsAndProviderSupplierTest.java
@@ -44,7 +44,7 @@ public class ExplicitToolsAndProviderSupplierTest {
     @ActivateRequestContext
     void testCall() {
         String answer = service.chat("hello", 1);
-        assertEquals("\"EXPLICIT TOOL\"", answer);
+        assertEquals("EXPLICIT TOOL", answer);
 
     }
 

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolresolution/ExplicitToolsWhenBeanToolProviderExistsTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/toolresolution/ExplicitToolsWhenBeanToolProviderExistsTest.java
@@ -42,7 +42,7 @@ public class ExplicitToolsWhenBeanToolProviderExistsTest {
     @ActivateRequestContext
     void testCall() {
         String answer = service.chat("hello", 1);
-        assertEquals("\"EXPLICIT TOOL\"", answer);
+        assertEquals("EXPLICIT TOOL", answer);
     }
 
 }

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ImmediateReturnToolCommitsChatMemoryTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/ImmediateReturnToolCommitsChatMemoryTest.java
@@ -75,7 +75,7 @@ public class ImmediateReturnToolCommitsChatMemoryTest {
         assertNull(result.content());
         assertThat(result.finishReason()).isEqualTo(FinishReason.TOOL_EXECUTION);
         assertThat(result.toolExecutions()).hasSize(1);
-        assertThat(result.toolExecutions().get(0).result()).isEqualTo("\"immediate-result\"");
+        assertThat(result.toolExecutions().get(0).result()).isEqualTo("immediate-result");
 
         // The key assertion: the chat memory store must have received an update,
         // meaning committableChatMemory.commit() was called

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/StaticImmediateReturnToolTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/tools/StaticImmediateReturnToolTest.java
@@ -53,7 +53,7 @@ public class StaticImmediateReturnToolTest {
         assertNull(result.content()); // No LLM-generated text
         assertThat(result.finishReason()).isEqualTo(FinishReason.TOOL_EXECUTION);
         assertThat(result.toolExecutions()).hasSize(1);
-        assertThat(result.toolExecutions().get(0).result()).isEqualTo("\"42\""); // Direct tool result
+        assertThat(result.toolExecutions().get(0).result()).isEqualTo("42"); // Direct tool result
 
         // LLM was called only once (to decide to use the tool)
         assertThat(SimpleChatModel.callCount).isEqualTo(1);
@@ -68,7 +68,7 @@ public class StaticImmediateReturnToolTest {
         Result<String> result = aiService.chat("call-processor");
 
         // The LLM processes the tool result and returns a final answer
-        assertThat(result.content()).isEqualTo("The processor returned: \"42\"");
+        assertThat(result.content()).isEqualTo("The processor returned: 42");
 
         // LLM was called twice:
         // 1st call: decide to use tool

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/QuarkusToolExecutor.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/QuarkusToolExecutor.java
@@ -144,9 +144,18 @@ public class QuarkusToolExecutor implements ToolExecutor {
         throw (E) e;
     }
 
+    /**
+     * Converts a tool invocation result into the text sent back to the model, mirroring
+     * {@code DefaultToolExecutor}: {@code void} becomes {@code "Success"}, a {@link String} is passed through
+     * unchanged, anything else is JSON-encoded. A {@code Uni<String>} is passed through as well, since it has
+     * already been resolved to its item by the time this is called.
+     */
     private static String handleResult(ToolInvoker invokerInstance, Object invocationResult) {
         if (invokerInstance.methodMetadata().isReturnsVoid()) {
             return "Success";
+        }
+        if (invocationResult instanceof String string) {
+            return string;
         }
         return Json.toJson(invocationResult);
     }

--- a/integration-tests/ai-gemini/src/main/java/org/acme/example/gemini/aiservices/GeminiResource.java
+++ b/integration-tests/ai-gemini/src/main/java/org/acme/example/gemini/aiservices/GeminiResource.java
@@ -7,6 +7,7 @@ import jakarta.ws.rs.Produces;
 
 import org.jboss.resteasy.reactive.RestQuery;
 
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -44,7 +45,7 @@ public class GeminiResource {
                          "totalTokenCount": 48
                        }
                      }
-                    """.formatted(toolRole);
+                    """.formatted(Json.encode(toolRole));
         } else {
             return """
                      {

--- a/integration-tests/vertex-ai-gemini/src/main/java/org/acme/example/gemini/aiservices/GeminiResource.java
+++ b/integration-tests/vertex-ai-gemini/src/main/java/org/acme/example/gemini/aiservices/GeminiResource.java
@@ -7,6 +7,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -44,7 +45,7 @@ public class GeminiResource {
                          "totalTokenCount": 48
                        }
                      }
-                    """.formatted(toolRole);
+                    """.formatted(Json.encode(toolRole));
         } else {
             return """
                      {


### PR DESCRIPTION
`QuarkusToolExecutor.handleResult` applied `Json.toJson` unconditionally, so a `@Tool` method returning `String` reached the model JSON-quoted with escaped newlines. `DefaultToolExecutor`, which this executor replaces through the `AiServicesFactory` SPI, returns a `String` result unchanged, so the text differed for every AI service built inside Quarkus.

A `String` result now passes through untouched. `Uni<String>` is covered as well, since it is resolved to its item before the result is converted. The check is `instanceof` rather than the declared return type, both to stay reflection-free and because a `Uni<String>` tool would otherwise still be encoded.

Existing tests that asserted the JSON-quoted form are updated.

- Closes: #2799
