### PR TITLE
docs: clarify Ollama enabled, integration, and logging (#766)

### DIFF
--- a/docs/modules/ROOT/pages/enable-disable-integrations.adoc
+++ b/docs/modules/ROOT/pages/enable-disable-integrations.adoc
@@ -10,6 +10,9 @@ You can disable any provider at runtime using the corresponding configuration pr
 - `quarkus.langchain4j.openai.enable-integration`
 - `quarkus.langchain4j.huggingface.enable-integration`
 - `quarkus.langchain4j.azure-openai.enable-integration`
+- `quarkus.langchain4j.ollama.enable-integration`
+
+Other providers follow the same `quarkus.langchain4j.<provider>.enable-integration` pattern.
 
 Setting this property to `false` will prevent any live call to the model, and a call to the provider will result in a `dev.langchain4j.model.ModelDisabledException` being thrown.
 

--- a/docs/modules/ROOT/pages/in-process-embedding.adoc
+++ b/docs/modules/ROOT/pages/in-process-embedding.adoc
@@ -92,5 +92,15 @@ EmbeddingModel model;
 
 This allows for more flexibility and simplifies configuration in small applications.
 
+When another embedding provider is also on the classpath (for example `quarkus-langchain4j-ollama`), either inject the concrete type from the table above or select the in-process model with its fully qualified class name:
+
+[source,properties]
+----
+quarkus.langchain4j.embedding-model.provider=dev.langchain4j.model.embedding.onnx.bgesmallenv15q.BgeSmallEnV15QuantizedEmbeddingModel
+----
+
+Use the *Injected Type* column that matches the dependency you added.
+If the class cannot be found, the matching `langchain4j-embeddings-*` artifact is missing from the classpath.
+
 TIP: In-process embedding models work well for local development, edge environments, and production use cases where low-latency and data privacy are critical.
 

--- a/docs/modules/ROOT/pages/ollama-chat-model.adoc
+++ b/docs/modules/ROOT/pages/ollama-chat-model.adoc
@@ -92,6 +92,35 @@ xref:./function-calling.adoc[Function calling] is supported in Ollama since vers
 Not all models support function calling (tools).
 Refer to https://ollama.com/search?c=tools[this list] to find compatible ones.
 
+== Enabling the chat model vs disabling the integration
+
+`quarkus.langchain4j.ollama.chat-model.enabled` is a build-time switch.
+Leave it at the default (`true`) when Ollama is the only chat provider on the classpath.
+Set it to `false` when several provider extensions are present (Ollama, OpenAI, Mistral, Anthropic, and so on) and you want AI Services to use a different chat provider.
+Disabling the model here means Quarkus does not produce the Ollama chat model bean; it does not contact Ollama.
+
+`quarkus.langchain4j.ollama.embedding-model.enabled` does the same for the embedding model.
+
+`quarkus.langchain4j.ollama.enable-integration` is a runtime switch.
+When `false`, every call to the Ollama models throws `dev.langchain4j.model.ModelDisabledException` instead of contacting the Ollama server.
+The application still starts.
+Use this with xref:enable-disable-integrations.adoc[fault-tolerance fallbacks] so you can run without a local LLM (dev, CI) or return a canned response.
+
+The two properties are not interchangeable: `*.enabled` controls whether the bean exists, `enable-integration` controls whether calls are actually made.
+
+== Request logging
+
+Two layers exist:
+
+* `quarkus.langchain4j.ollama.log-requests` / `log-responses` — Ollama *client* logging for all HTTP calls (chat and embedding).
+* `quarkus.langchain4j.ollama.chat-model.log-requests` / `log-responses` — chat-model traffic only.
+
+If the chat-model properties are set, they take precedence for chat calls.
+Use the client properties when you want one switch for every Ollama request.
+Use the chat-model properties when you only want chat traffic logged.
+
+The same split exists for `embedding-model.log-requests` / `log-responses`.
+
 == Configuration Reference
 
 include::includes/quarkus-langchain4j-ollama.adoc[leveloffset=+1,opts=optional]


### PR DESCRIPTION
I was reading the Ollama config page and the enabled / enable-integration / log-requests properties were still unclear.

This adds those explanations on the Ollama chat model page, links enable-integration to the existing disable-integrations guide (and lists Ollama there), and shows how to pick an in-process embedding model with quarkus.langchain4j.embedding-model.provider when another provider is on the classpath.

- Fixes: #766
