### PR TITLE
docs: distinguish document store from embedding store #1372

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -91,7 +91,7 @@
 ** xref:rag-easy-rag.adoc[EasyRAG]
 ** xref:rag-contextual-rag.adoc[Contextual RAG]
 ** xref:reranking.adoc[Reranking]
-** Document and Vector Stores
+** Embedding Stores
 *** xref:rag-chroma-store.adoc[Chroma]
 *** xref:rag-infinispan-store.adoc[Infinispan]
 *** xref:rag-milvus-store.adoc[Milvus]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -44,7 +44,7 @@ Use it to:
 *Build chat-based assistants* that can guide users, invoke tools, or answer questions based on custom knowledge.
 
 [.lead]
-*Implement intelligent search* using Retrieval-Augmented Generation (RAG), combining LLMs with vector-based document stores for context-aware responses.
+*Implement intelligent search* using Retrieval-Augmented Generation (RAG), combining LLMs with embedding stores for context-aware responses.
 
 == Where to Go Next?
 

--- a/docs/modules/ROOT/pages/rag-chroma-store.adoc
+++ b/docs/modules/ROOT/pages/rag-chroma-store.adoc
@@ -1,12 +1,12 @@
-= Chroma Document Store
+= Chroma Embedding Store
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
 
 Chroma is a lightweight, open-source vector database designed for embedding-based search.
-It can be used as a document store in Retrieval-Augmented Generation (RAG) pipelines with Quarkus LangChain4j.
+It can be used as an embedding store in Retrieval-Augmented Generation (RAG) pipelines with Quarkus LangChain4j.
 
-This guide explains how to configure and use Chroma as an embedding-aware document store.
+This guide explains how to configure and use Chroma as an embedding store.
 
 == Dependency
 
@@ -31,7 +31,7 @@ Refer to the configuration section below for more options.
 
 == Usage Example
 
-Once the extension is installed and the dev service (or external Chroma instance) is available, you can use the Chroma document store as follows:
+Once the extension is installed and the dev service (or external Chroma instance) is available, you can use the Chroma embedding store as follows:
 
 [source,java]
 ----

--- a/docs/modules/ROOT/pages/rag-neo4j.adoc
+++ b/docs/modules/ROOT/pages/rag-neo4j.adoc
@@ -4,7 +4,7 @@ include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
 
 Neo4j is a graph database that also supports vector search starting from version 5.x.
-With Quarkus LangChain4j, you can use Neo4j as a vector-capable document store for implementing Retrieval-Augmented Generation (RAG) pipelines.
+With Quarkus LangChain4j, you can use Neo4j as a vector-capable embedding store for implementing Retrieval-Augmented Generation (RAG) pipelines.
 
 [IMPORTANT]
 ====

--- a/docs/modules/ROOT/pages/rag-oracle-store.adoc
+++ b/docs/modules/ROOT/pages/rag-oracle-store.adoc
@@ -1,4 +1,4 @@
-= Oracle Database Document Store
+= Oracle Database Embedding Store
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
@@ -8,7 +8,7 @@ It leverages https://docs.oracle.com/en/database/oracle/oracle-database/23/vecse
 
 == Prerequisites
 
-To use Oracle Database as a document store:
+To use Oracle Database as an embedding store:
 
 * An Oracle Database 23ai (or later) instance is required, since AI Vector Search is only available from that version.
 * A Quarkus datasource must be configured.
@@ -157,7 +157,7 @@ quarkus.langchain4j.oracle.default-store-enabled=false
 
 == Summary
 
-To use Oracle Database as a document store with Quarkus LangChain4j:
+To use Oracle Database as an embedding store with Quarkus LangChain4j:
 
 * Use an Oracle Database 23ai instance, which provides AI Vector Search.
 * Add the extension dependency.

--- a/docs/modules/ROOT/pages/rag-pgvector-store.adoc
+++ b/docs/modules/ROOT/pages/rag-pgvector-store.adoc
@@ -1,4 +1,4 @@
-= PGVector Document Store
+= PGVector Embedding Store
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
@@ -13,7 +13,7 @@ to this, which supports additional database kinds, features and customizations.
 
 == Prerequisites
 
-To use PGVector as a document store:
+To use PGVector as an embedding store:
 
 * A PostgreSQL instance with the `pgvector` extension installed is required.
 * A Quarkus datasource must be configured.
@@ -148,7 +148,7 @@ quarkus.langchain4j.pgvector.default-store-enabled=false
 
 == Summary
 
-To use PostgreSQL and PGVector as a document store with Quarkus LangChain4j:
+To use PostgreSQL and PGVector as an embedding store with Quarkus LangChain4j:
 
 * Ensure the `pgvector` extension is installed in your PostgreSQL instance.
 * Add the extension dependency.

--- a/docs/modules/ROOT/pages/rag-pinecone-store.adoc
+++ b/docs/modules/ROOT/pages/rag-pinecone-store.adoc
@@ -1,4 +1,4 @@
-= Pinecone Vector Store
+= Pinecone Embedding Store
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
@@ -6,7 +6,7 @@ include::./includes/customization.adoc[]
 Pinecone is a fully managed, scalable vector database optimized for similarity search.
 With Quarkus LangChain4j, you can use Pinecone as a vector store to implement Retrieval-Augmented Generation (RAG) pipelines.
 
-This guide explains how to configure and use Pinecone as a document store for embedded vectors.
+This guide explains how to configure and use Pinecone as an embedding store for embedded vectors.
 
 == Prerequisites
 

--- a/docs/modules/ROOT/pages/rag-redis.adoc
+++ b/docs/modules/ROOT/pages/rag-redis.adoc
@@ -1,10 +1,10 @@
-= Redis Document Store
+= Redis Embedding Store
 
 include::./includes/attributes.adoc[]
 include::./includes/customization.adoc[]
 
-Redis can serve as an efficient document store for Retrieval-Augmented Generation (RAG) applications using Quarkus LangChain4j.
-This guide explains how to configure and use Redis as a vector-capable document store.
+Redis can serve as an efficient embedding store for Retrieval-Augmented Generation (RAG) applications using Quarkus LangChain4j.
+This guide explains how to configure and use Redis as a vector-capable embedding store.
 
 [NOTE]
 ====
@@ -14,7 +14,7 @@ This page focuses on the integration of Redis as a vector store, allowing you to
 
 == Prerequisites
 
-To use Redis as a document store, the following conditions must be met:
+To use Redis as an embedding store, the following conditions must be met:
 
 * Redis must support both the **RedisJSON** and **RedisSearch** modules.
 * We recommend using **Redis Stack**, which bundles these modules.
@@ -72,7 +72,7 @@ If you switch to a different embedding model, ensure the `dimension` value is up
 
 == Usage Example
 
-Once the extension is installed and configured, you can use the Redis document store as shown below:
+Once the extension is installed and configured, you can use the Redis embedding store as shown below:
 
 [source,java]
 ----
@@ -99,7 +99,7 @@ Retrieval operations use `FT.SEARCH` combined with KNN (k-nearest neighbor) quer
 
 == Metadata Filtering
 
-The Redis document store supports limited metadata filtering with the following constraints:
+The Redis embedding store supports limited metadata filtering with the following constraints:
 
 * Only **numeric fields** can be used in filters.
 * Only **AND** conditions are supported (no `OR`, `NOT`, or nested logic).

--- a/docs/modules/ROOT/pages/rag.adoc
+++ b/docs/modules/ROOT/pages/rag.adoc
@@ -44,14 +44,21 @@ These concepts are foundational to any RAG-based application:
 |Concept |Description
 
 |Text Splitter |Divides documents into smaller overlapping or non-overlapping segments for processing.
+|Document |A unit of text you ingest (file, article, ticket). Documents are the source material, not the store.
+|Document Store |A store of documents. This is a broader idea than RAG: it does not have to use embeddings or vectors.
 |Embedding |A dense vector representation of a text segment computed by an embedding model.
 |Embedding Model |A model trained to convert text into embeddings preserving semantic meaning.
-|Vector Store |A database that allows similarity search over embeddings (e.g., PGVector, Chroma, Weaviate).
+|Embedding Store |The LangChain4j API (`EmbeddingStore`) these extensions implement. It stores embeddings of text segments for similarity search, and usually the original text as well.
+|Vector Store |A synonym for an embedding store; a database optimized for similarity search over embeddings (e.g., PGVector, Chroma, Weaviate).
 |Query Embedding |The embedding computed from the user’s question.
 |Retriever |A component responsible for finding relevant segments given a query embedding.
 |Augmentor |Optional logic used to enhance the retrieved content (e.g., filtering, re-ranking, transformation).
 |Prompt Injection |Final step of merging query and retrieved content into a prompt for the model.
 |===
+
+Older pages in this guide sometimes called the same extensions *document stores*.
+That name is not wrong — most embedding stores also keep the original document text — but it is broader than what the code does.
+When you inject a store in Quarkus LangChain4j, you inject `EmbeddingStore` (or a provider type such as `PgVectorEmbeddingStore` or `ChromaEmbeddingStore`), not a separate document-store type.
 
 == Visual Overview
 
@@ -70,4 +77,4 @@ To go deeper, visit the following sections:
 * xref:rag-query.adoc[Query-Time Augmentation]
 * xref:rag-easy-rag.adoc[EasyRAG]
 * xref:rag-contextual-rag.adoc[Contextual RAG (Advanced Techniques)]
-* You can see supported document and vector stores in the menu
+* You can see supported embedding stores in the menu

--- a/docs/modules/ROOT/pages/rag.adoc
+++ b/docs/modules/ROOT/pages/rag.adoc
@@ -44,8 +44,6 @@ These concepts are foundational to any RAG-based application:
 |Concept |Description
 
 |Text Splitter |Divides documents into smaller overlapping or non-overlapping segments for processing.
-|Document |A unit of text you ingest (file, article, ticket). Documents are the source material, not the store.
-|Document Store |A store of documents. This is a broader idea than RAG: it does not have to use embeddings or vectors.
 |Embedding |A dense vector representation of a text segment computed by an embedding model.
 |Embedding Model |A model trained to convert text into embeddings preserving semantic meaning.
 |Embedding Store |The LangChain4j API (`EmbeddingStore`) these extensions implement. It stores embeddings of text segments for similarity search, and usually the original text as well.
@@ -55,10 +53,6 @@ These concepts are foundational to any RAG-based application:
 |Augmentor |Optional logic used to enhance the retrieved content (e.g., filtering, re-ranking, transformation).
 |Prompt Injection |Final step of merging query and retrieved content into a prompt for the model.
 |===
-
-Older pages in this guide sometimes called the same extensions *document stores*.
-That name is not wrong — most embedding stores also keep the original document text — but it is broader than what the code does.
-When you inject a store in Quarkus LangChain4j, you inject `EmbeddingStore` (or a provider type such as `PgVectorEmbeddingStore` or `ChromaEmbeddingStore`), not a separate document-store type.
 
 == Visual Overview
 


### PR DESCRIPTION
Document store is broader than embeddings — a store of documents does not have to be vector-based. The API these extensions implement is EmbeddingStore.

I spelled that out on the RAG overview and aligned the leftover store pages (Chroma, PGVector, Redis, Oracle, Pinecone, Neo4j) plus the nav and index wording.

- Fixes: #1372