### PR TITLE
Fix NPE when Anthropic client timeout is not configured

### DIFF
--- a/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/QuarkusAnthropicClient.java
+++ b/model-providers/anthropic/runtime/src/main/java/io/quarkiverse/langchain4j/anthropic/QuarkusAnthropicClient.java
@@ -13,6 +13,7 @@ import static java.util.stream.StreamSupport.stream;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -83,11 +84,12 @@ public class QuarkusAnthropicClient extends AnthropicClient {
         this.anthropicVersion = builder.version;
         this.configuredBeta = builder.beta;
         this.disableBetaHeader = builder.disableBetaHeader;
+        Duration timeout = resolveTimeout(builder.timeout);
 
         try {
             var restApiBuilder = QuarkusRestClientBuilder.newBuilder().baseUri(new URI(builder.baseUrl))
-                    .connectTimeout(builder.timeout.toSeconds(), TimeUnit.SECONDS)
-                    .readTimeout(builder.timeout.toSeconds(), TimeUnit.SECONDS);
+                    .connectTimeout(timeout.toSeconds(), TimeUnit.SECONDS)
+                    .readTimeout(timeout.toSeconds(), TimeUnit.SECONDS);
 
             if (builder.logRequests || builder.logResponses || builder.logCurl) {
                 restApiBuilder.loggingScope(LoggingScope.REQUEST_RESPONSE).clientLogger(
@@ -99,6 +101,10 @@ public class QuarkusAnthropicClient extends AnthropicClient {
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    static Duration resolveTimeout(Duration timeout) {
+        return timeout != null ? timeout : Duration.ofSeconds(15);
     }
 
     @Override

--- a/model-providers/anthropic/runtime/src/test/java/io/quarkiverse/langchain4j/anthropic/QuarkusAnthropicClientTest.java
+++ b/model-providers/anthropic/runtime/src/test/java/io/quarkiverse/langchain4j/anthropic/QuarkusAnthropicClientTest.java
@@ -1,0 +1,24 @@
+package io.quarkiverse.langchain4j.anthropic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+class QuarkusAnthropicClientTest {
+
+    @Test
+    void usesDefaultTimeoutWhenItIsNotConfigured() {
+        assertThat(QuarkusAnthropicClient.resolveTimeout(null))
+                .isEqualTo(Duration.ofSeconds(15));
+    }
+
+    @Test
+    void keepsConfiguredTimeout() {
+        Duration timeout = Duration.ofSeconds(30);
+
+        assertThat(QuarkusAnthropicClient.resolveTimeout(timeout))
+                .isSameAs(timeout);
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes a NullPointerException in `QuarkusAnthropicClient` when the builder does not configure a timeout. The client now uses a 15-second default timeout, while preserving explicitly configured timeout values.

## Why is this needed?

`AnthropicClient.Builder.timeout` is optional. The Quarkus client previously dereferenced it unconditionally while configuring the REST client.

## How was this tested?

- `QuarkusAnthropicClientTest` verifies the default and explicit timeout paths.
- `AnthropicCacheTokenUsageExtractorTest` continues to pass.

Fixes #2798