### PR TITLE
Add skip_tests option to release preparation workflow

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,6 +1,7 @@
 name: Quarkiverse Prepare Release
 
 on:
+  workflow_dispatch: 
   pull_request:
     types: [ closed ]
     paths:
@@ -16,7 +17,7 @@ concurrency:
 jobs:
   prepare-release:
     name: Prepare Release
-    if: ${{ github.event.pull_request.merged == true}}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true}}
     uses: quarkiverse/.github/.github/workflows/prepare-release.yml@main
     with:
       skip_tests: true

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -19,5 +19,6 @@ jobs:
     if: ${{ github.event.pull_request.merged == true}}
     uses: quarkiverse/.github/.github/workflows/prepare-release.yml@main
     with:
+      skip_tests: true
       java_version: 23 # use 23 so we can support running the Llama3 module on anything 21+
     secrets: inherit


### PR DESCRIPTION
This should avoid the token expiration when the build takes longer than 1h