### PR TITLE
Enhance documentation on customizing streaming and non-streaming chat models

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/ModelBuilderCustomizer.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/ModelBuilderCustomizer.java
@@ -22,6 +22,11 @@ import io.quarkiverse.langchain4j.runtime.NamedConfigUtil;
  * Customizers are applied in priority order (higher priority values first).
  * Override {@link #priority()} to control ordering. The default priority is {@link #DEFAULT_PRIORITY} (0).
  * <p>
+ * Note that streaming and non-streaming chat models are distinct model types with distinct builders.
+ * A customizer for the non-streaming builder (e.g. {@code OpenAiChatModel.OpenAiChatModelBuilder}) does not apply
+ * to AI services returning {@code Multi}, which use the streaming chat model. To customize those, implement this
+ * interface with the streaming builder type (e.g. {@code OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder}).
+ * <p>
  * An example could be:
  *
  * <pre>

--- a/docs/modules/ROOT/pages/guide-streamed-responses.adoc
+++ b/docs/modules/ROOT/pages/guide-streamed-responses.adoc
@@ -90,6 +90,13 @@ Quarkus uses https://smallrye.io/smallrye-mutiny/latest/[Mutiny] under the hood.
 In Quarkus, methods returning Multi are considered non-blocking.
 Do not use blocking code inside streaming pipelines. For details, refer to the https://quarkus.io/guides/quarkus-reactive-architecture[Quarkus Reactive Architecture].
 
+[NOTE]
+====
+Streaming AI services use the provider's _streaming_ chat model, which is a different model type from the one used by non-streaming services.
+If you customize the model with a `ModelBuilderCustomizer`, target the streaming builder type (for example `OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder`) rather than the non-streaming one.
+See xref:models.adoc#_customizing_streaming_chat_models[Customizing Streaming Chat Models] for details.
+====
+
 == Streaming with Server-Sent Events (SSE)
 
 SSE is a simple way to stream text over HTTP. Let’s expose an endpoint returning `Multi<String>` as an event stream:

--- a/docs/modules/ROOT/pages/models.adoc
+++ b/docs/modules/ROOT/pages/models.adoc
@@ -203,6 +203,49 @@ public class MyCustomizer implements ModelBuilderCustomizer<OpenAiChatModel.Open
 
 This customizer applies to the _default_ (unnamed) model configuration.
 
+=== Customizing Streaming Chat Models
+
+Streaming and non-streaming chat models are distinct model types, each built with its own builder.
+When an AI service method returns `Multi<String>` (or `Multi<ChatEvent>`), Quarkus LangChain4j uses the provider's _streaming_ chat model, so a customizer targeting the non-streaming builder (for example `OpenAiChatModel.OpenAiChatModelBuilder`) has no effect on that call.
+
+To customize the streaming chat model, implement `ModelBuilderCustomizer` parameterized with the streaming builder type:
+
+[source,java]
+----
+@ApplicationScoped
+public class MyStreamingCustomizer implements ModelBuilderCustomizer<OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder> {
+
+    @Override
+    public void customize(OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder builder) {
+        builder.customHeaders(Map.of("X-Custom-Header", "value"));
+    }
+}
+----
+
+If your application uses both streaming and non-streaming AI services and the customization must apply to both, register two customizers, one per builder type.
+Since Java does not allow a class to implement the same generic interface twice with different type arguments, use two separate classes and share any common logic through a helper:
+
+[source,java]
+----
+@ApplicationScoped
+public class MyChatCustomizer implements ModelBuilderCustomizer<OpenAiChatModel.OpenAiChatModelBuilder> {
+
+    @Override
+    public void customize(OpenAiChatModel.OpenAiChatModelBuilder builder) {
+        builder.customHeaders(CommonHeaders.get());
+    }
+}
+
+@ApplicationScoped
+public class MyStreamingChatCustomizer implements ModelBuilderCustomizer<OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder> {
+
+    @Override
+    public void customize(OpenAiStreamingChatModel.OpenAiStreamingChatModelBuilder builder) {
+        builder.customHeaders(CommonHeaders.get());
+    }
+}
+----
+
 === Targeting Named Model Configurations
 
 If you have multiple model configurations (e.g., `quarkus.langchain4j.openai.my-model.chat-model.model-name=...`), you can target a specific one using the `@ModelName` qualifier:


### PR DESCRIPTION

Closes: #2830


Streaming and non-streaming chat models are distinct model types built with distinct builders, so a `ModelBuilderCustomizer<OpenAiChatModel.OpenAiChatModelBuilder>` is never applied to AI services returning `Multi`, which use `OpenAiStreamingChatModel`. This is expected behavior, but it was not documented.