### PR TITLE
Guard against null initializationFinished in SseSubscriber

### DIFF
--- a/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/http/SseSubscriber.java
+++ b/mcp/runtime/src/main/java/io/quarkiverse/langchain4j/mcp/runtime/http/SseSubscriber.java
@@ -47,6 +47,13 @@ public class SseSubscriber implements Consumer<SseEvent<String>> {
                 log.warn("Failed to handle MCP message: {}", data, e);
             }
         } else if (name.equals("endpoint")) {
+            if (initializationFinished == null) {
+                // The streamable HTTP transport does not use 'endpoint' events
+                // (they belong to the legacy HTTP+SSE transport), so there is
+                // nothing to complete here.
+                log.debug("Received unexpected 'endpoint' event, ignoring");
+                return;
+            }
             if (initializationFinished.isDone()) {
                 log.warn("Received endpoint event after initialization");
                 return;


### PR DESCRIPTION
A tiny hardening as suggested by claude...

The streamable HTTP transport constructs SseSubscriber with a null initializationFinished future, since it does not rely on 'endpoint' SSE events (those belong to the legacy HTTP+SSE transport). Without this guard, an unexpected 'endpoint' event would trigger a NullPointerException inside the Vert.x buffer handler, leaving the pending operation's future uncompleted until it times out. Ignore such events instead.


