### PR TITLE
[1.13] QUARKUS-9022 Fix module name duplicity Quarkus LangChain4j - Chat Scopes - Websocket

### DIFF
--- a/chat-scopes/websocket/runtime/pom.xml
+++ b/chat-scopes/websocket/runtime/pom.xml
@@ -8,7 +8,7 @@
     <version>999-SNAPSHOT</version>
   </parent>
   <artifactId>quarkus-langchain4j-chat-scopes-websocket</artifactId>
-  <name>Quarkus LangChain4j - Chat Scopes - Runtime</name>
+  <name>Quarkus LangChain4j - Chat Scopes - Websocket</name>
   <dependencies>
         <dependency>
             <groupId>io.quarkiverse.langchain4j</groupId>


### PR DESCRIPTION
Ticket: https://redhat.atlassian.net/browse/QUARKUS-9022

Fixes the Maven module name for quarkus-langchain4j-chat-scopes-websocket.

Backport of: https://github.com/quarkiverse/quarkus-langchain4j/pull/2850