### PR TITLE
Ignore dev.langchain4j by dependabot for 1.13 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,7 @@ updates:
       interval: "daily"
     ignore:
       - dependency-name: io.quarkus:*
+      - dependency-name: dev.langchain4j:*
   - package-ecosystem: "maven"
     directory: "/samples"
     schedule:


### PR DESCRIPTION
I forgot that this can't work because dependabot doesn't know it has to update `docs/modules/ROOT/pages/includes/attributes.adoc`...